### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,32 @@
 
 </div>
 
+# Overview
+
+SkyRL is a full-stack RL framework that provides the following components:
+
+- [`skyagent`](./skyagent): Our agent layer for training long-horizon, real-world agents. Contains code for [SkyRL-v0](https://novasky-ai.notion.site/skyrl-v0).
+- (**NEW**) [`skyrl-train`](./skyrl-train): Our modular, performant training framework for RL.
+- (**NEW**) [`skyrl-gym`](./skyrl-gym): Our gynasium of tool-use tasks, including a library of math, coding, search and SQL environments implemented in the Gymnasium API.
+
+# Getting Started
+
+For model training, checkout [`skyrl-train`](./skyrl-train) to start using, modifying, or building on top of the SkyRL training stack. See our [quickstart docs](https://skyrl.readthedocs.io/en/latest/index.html) to ramp up!
+
+For building environments, checkout [`skyrl-gym`](./skyrl-gym) to integrate your task in the simple gymnasium interface.
+
+For agentic pipelines, checkout [`skyagent`](./skyagent) for our work on optimizing and scaling pipelines for multi-turn tool use LLMs on long-horizon, real-environment tasks.
+
 
 # News
-- **[2025/06/24]** 🎉 We released SkyRL-Train: A flexible RL training framework. Modular, easy to use, and performant!
+- **[2025/06/25]** 🎉 We released SkyRL-v0.1: A highly-modular, performant RL training framework.
+- **[2025/06/25]** 🎉 We released SkyRL-Gym: A library of RL environments for LLMs implemented with the Gymnasium API.
 - **[2025/05/20]** 🎉 We released SkyRL-SQL: a multi-turn RL training pipeline for Text-to-SQL, along with SkyRL-SQL-7B — a model trained on just 653 samples that outperforms both GPT-4o and o4-mini!
 - **[2025/05/06]** 🎉 We released SkyRL-v0: our open RL training pipeline for multi-turn tool use LLMs, optimized for long-horizon, real-environment tasks like SWE-Bench!
 
 # Links
 - 📜 [SkyRL-SQL Blog Post](https://novasky-ai.notion.site/skyrl-sql)
 - 📜 [SkyRL-v0 Blog Post](https://novasky-ai.notion.site/skyrl-v0)
-
-# Overview
-
-SkyRL provides the following components:
-
-- [`skyagent`](./skyagent): Our agent layer for training long-horizon, real-world agents. Contains code for [SkyRL-v0](https://novasky-ai.notion.site/skyrl-v0).
-- (NEW!) [`skyrl-train`](./skyrl-train): Our flexible training framework for RL.
-- (NEW!) [`skyrl-gym`](./skyrl-gym): Our library of math, coding, search and SQL environments implemented with the Gymnasium API.
 
 # Acknowledgement
 

--- a/skyrl-gym/README.md
+++ b/skyrl-gym/README.md
@@ -2,6 +2,13 @@
 
 A library of RL environments for LLMs implemented with the Gymnasium API.
 
+## Key Features
+
+- Simple `Environment` interface following the Gynasium API. 
+- Library of ready-built environments for math, code, search, and text-to-SQL.
+- A reusable `tool` interface. Developers can implement a tool once, and use it across any environment.
+- Supports multi-tool environments
+
 ## Installation
 
 You can install the latest release from PyPI:
@@ -20,4 +27,6 @@ pip install -e .
 
 ## Documentation
 
-Docs are available at [https://skyrl.readthedocs.io/en/latest/](https://skyrl.readthedocs.io/en/latest/).
+To build your first environment, see our [example](https://skyrl.readthedocs.io/en/latest/examples/new_env.html).
+
+All docs are available at [https://skyrl.readthedocs.io/en/latest/](https://skyrl.readthedocs.io/en/latest/).

--- a/skyrl-train/README.md
+++ b/skyrl-train/README.md
@@ -1,17 +1,42 @@
 # SkyRL-Train: A modular, performant RL framework for post-training LLMs
+<div align="center">
 
-SkyRL-Train is a highly modular, performant RL framework for post-training LLMs. With a focus on modularity, SkyRL makes it easy to prototype new training algorithms, environments, and execution plans—without compromising usability or speed. 
+[![🌐 NovaSky](https://img.shields.io/badge/-Visit%20Website-5865F2?style=for-the-badge)](https://novasky-ai.github.io/) [![Github](https://img.shields.io/badge/SkyRL-000000?style=for-the-badge&logo=github&logoColor=000&logoColor=white)](https://github.com/NovaSky-AI/SkyRL) [![Twitter](https://img.shields.io/badge/NovaSky-white?style=for-the-badge&logo=X&logoColor=000&color=000&labelColor=white)](https://x.com/NovaSkyAI) [![Hugging Face Collection](https://img.shields.io/badge/NovaSky-fcd022?style=for-the-badge&logo=huggingface&logoColor=000&labelColor)](https://huggingface.co/NovaSky-AI) [![Discord](https://img.shields.io/badge/NovaSky-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/RBAjeWSA)
 
-SkyRL-train is **for users who want to modify anything:**
+</div>
+
+# Overview
+
+`skyrl-train` is SkyRL's highly modular, performant RL framework for post-training LLMs. With a focus on modularity, SkyRL makes it easy to prototype new training algorithms, environments, and execution plans—without compromising usability or speed. 
+
+`skyrl-train` is **for users who want to modify anything:**
 
 - **Quickly develop new environments** without modifying or understanding the training code .
 - **Modify the training execution plan** such as model placement, colocation or disaggregation of training and generation, and async RL.
 - **Implement custom trajectory generation** specific to your use-case, such as custom sampling methods, tree search, etc.
 - … make any other flexible modifications to the RL workflow!
 
+
+## Key Features
+The `skyrl-train` package supports:
+- PPO and GRPO
+- Training Backends: FSDP, FSDP2, and DeepSpeed
+- Inference backends: vLLM, SGLang, and any custom OpenAI API compatible endpoint that exposes a method to perform weight sync
+- Ulysses sequence parallelism for long-context training
+- Colocated or disaggregated training and generation (including on heterogeneous hardware)
+- Synchronous RL or async one-off pipelining
+- Asynchronous rollouts, batched rollouts, multi-turn conversations
+- Weight sync via NCCL, gloo, or checkpoint-and-load
+- Integration with `skyrl-gym` to run any environment in the gynasium
+- Sequence packing and Flash Attention 2
+
+## Documentation
+
+Find `skyrl-train` documentation at: [skyrl.readthedocs.io/en/latest/](https://skyrl.readthedocs.io/en/latest/)
+
 ## Quick Start
 
-A quick start guide is provided below.
+A quick start guide for installation and your first training run is provided below.
 
 ### Requirements
 

--- a/skyrl-train/README.md
+++ b/skyrl-train/README.md
@@ -25,7 +25,7 @@ The `skyrl-train` package supports:
 - Ulysses sequence parallelism for long-context training
 - Colocated or disaggregated training and generation (including on heterogeneous hardware)
 - Synchronous RL or async one-off pipelining
-- Asynchronous rollouts, batched rollouts, multi-turn conversations
+- Simple batched rollouts or Asynchronous rollouts for multi-turn conversations
 - Weight sync via NCCL, gloo, or checkpoint-and-load
 - Integration with `skyrl-gym` to run any environment in the gynasium
 - Sequence packing and Flash Attention 2


### PR DESCRIPTION
* Reorganize SkyRL readme to pull up the overview so it's immediately clear what's in this repo.
* Add a "getting started" page for direct pointers to sub-packages. It's slightly awkward because this immediately follows the overview section which already calls out all three sub-packages, but actually I do think it's helpful to first see what these things are, then be routed accordingly.
* Update the gym readme to add some key features and the best entrypoint doc for understanding how to built environments
* updated sky-train readme to add key features