### PR TITLE
[fix] In docs and scripts, test->validation.parquet, and ["x"] -> "['x']"

### DIFF
--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -8,7 +8,7 @@ Data Configuration
 
     data:
     train_data: ["${oc.env:HOME}/data/gsm8k/train.parquet"]
-    val_data: ["${oc.env:HOME}/data/gsm8k/test.parquet"]
+    val_data: ["${oc.env:HOME}/data/gsm8k/validation.parquet"]
 
 - ``data.train_data``: A list of files for the training dataset in parquet format. 
 - ``data.val_data``: A list of files for evaluation in parquet format. 

--- a/skyrl-train/docs/examples/ppo.rst
+++ b/skyrl-train/docs/examples/ppo.rst
@@ -21,8 +21,8 @@ Next, let's set up the training configuration. You can find a complete example i
 
    uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base \
       # Data setup
-      data.train_data=["$HOME/data/gsm8k/train.parquet"] \
-      data.val_data=["$HOME/data/gsm8k/test.parquet"] \
+      data.train_data="['$HOME/data/gsm8k/train.parquet']" \
+      data.val_data="['$HOME/data/gsm8k/validation.parquet']" \
 
       # Trainer and training algorithm
       trainer.algorithm.advantage_estimator="gae" \

--- a/skyrl-train/docs/examples/remote_server.rst
+++ b/skyrl-train/docs/examples/remote_server.rst
@@ -77,8 +77,8 @@ To start training, we need to set up our training script. You can find a complet
         generator.sampling_params.top_p=0.95 \
 
         # Data setup
-        data.train_data=["$HOME/data/gsm8k/train.parquet"] \
-        data.val_data=["$HOME/data/gsm8k/test.parquet"] \
+        data.train_data="['$HOME/data/gsm8k/train.parquet']" \
+        data.val_data="['$HOME/data/gsm8k/validation.parquet']" \
 
         # Policy model - make sure this is the same model used to launch the inference engine server
         trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \

--- a/skyrl-train/docs/getting-started/quickstart.rst
+++ b/skyrl-train/docs/getting-started/quickstart.rst
@@ -23,8 +23,8 @@ Next, let's set up the training configuration. You can find a complete example i
 
    uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base \
       # Data setup
-      data.train_data=["$HOME/data/gsm8k/train.parquet"] \
-      data.val_data=["$HOME/data/gsm8k/test.parquet"] \
+      data.train_data="['$HOME/data/gsm8k/train.parquet']" \
+      data.val_data="['$HOME/data/gsm8k/validation.parquet']" \
 
       # Trainer and training algorithm
       trainer.algorithm.advantage_estimator="grpo" \

--- a/skyrl-train/examples/multiply/run_multiply.sh
+++ b/skyrl-train/examples/multiply/run_multiply.sh
@@ -8,8 +8,8 @@ set -x
 DATA_DIR="$HOME/data/multiply"
 
 uv run --isolated --extra vllm -m examples.multiply.main_multiply \
-  data.train_data=["$DATA_DIR/train.parquet"] \
-  data.val_data=["$DATA_DIR/validation.parquet"] \
+  data.train_data="['$DATA_DIR/train.parquet']" \
+  data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \
   trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \
   trainer.placement.colocate_all=true \

--- a/skyrl-train/scripts/full_context/run_full_ctx.sh
+++ b/skyrl-train/scripts/full_context/run_full_ctx.sh
@@ -7,8 +7,8 @@ set -x
 DATA_DIR="$HOME/data/gsm8k"
 
 uv run --isolated --extra vllm -m scripts.full_context.main_full_ctx \
-  data.train_data=["$DATA_DIR/train.parquet"] \
-  data.val_data=["$DATA_DIR/test.parquet"] \
+  data.train_data="['$DATA_DIR/train.parquet']" \
+  data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \
   trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \
   trainer.placement.colocate_all=true \

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -6,7 +6,7 @@ defaults:
 
 data:
   train_data: ["${oc.env:HOME}/data/gsm8k/train.parquet"]
-  val_data: ["${oc.env:HOME}/data/gsm8k/test.parquet"]
+  val_data: ["${oc.env:HOME}/data/gsm8k/validation.parquet"]
 
 trainer:
   placement:


### PR DESCRIPTION
Change `test.parquet` to `validation.parquet` across scripts and docs to stay consistent.

Change `["x"]` to `"['x']"` which is needed for bash to interpret lists with multiple items (we already do it in most places, only a few places missing)