### PR TITLE
[trainer] Fix fsdp warmup steps + move warmup to optimizer config

### DIFF
--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -51,7 +51,6 @@ General Training Configuration
     micro_train_batch_size_per_gpu: 1 
     micro_forward_batch_size_per_gpu: 1  
     update_ref_every_epoch: false
-    num_warmup_steps: 0
     use_sample_packing: true
     max_prompt_length: 512
     gradient_checkpointing: true
@@ -66,7 +65,6 @@ General Training Configuration
 - ``micro_train_batch_size_per_gpu``: Micro batch size during training step. This is common for both policy and critic models. Each mini batch is split into micro batches of this size, gradients are computed and accumulated over these micro batches. 
 - ``micro_forward_batch_size_per_gpu``: Micro batch size during forward pass (i.e., for log probability or value computation). This is common for both policy and critic models. Each mini batch is split into micro batches of this size, model forward pass is performed over these micro batches.
 - ``update_ref_every_epoch``: Whether to update the reference model every epoch. 
-- ``num_warmup_steps``: Number of warmup steps for the policy and (if applicable) critic model.
 - ``use_sample_packing``: Whether to use sample packing during model forward pass (common for all models).
 - ``max_prompt_length``: Maximum prompt length during training. Longer prompts will be truncated.
 - ``gradient_checkpointing``: Whether to use gradient checkpointing.
@@ -182,12 +180,14 @@ For both the critic and policy model, we provide a common optimizer configuratio
        weight_decay: 1e-2
        max_grad_norm: 1.0
        offload_after_step: true
+       num_warmup_steps: 0
 
 - ``optimizer_config.lr``: Learning rate for the optimizer
 - ``optimizer_config.adam_betas``: Betas for AdamW optimizer.
 - ``optimizer_config.weight_decay``: L2 regularization strength for AdamW.
 - ``optimizer_config.max_grad_norm``: Gradient clipping parameter. The total L2 norm of the model gradients will be scaled to this value during training.
 - ``optimizer_config.offload_after_step``: Whether to offload optimizer state to CPU after step if colocated. When generation and training workers are colocated, we recommend using the default setting of ``true``. In some cases with non-colocation, it can be desirable to leave optimizer state on GPU memory to avoid offloading costs as well as additional CPU memory usage.
+- ``optimizer_config.num_warmup_steps``: Number of warmup steps for the learning rate scheduler.
 
 Policy Configuration
 --------------------

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -33,6 +33,7 @@ trainer:
       weight_decay: 1e-2
       max_grad_norm: 1.0 # gradient clipping
       offload_after_step: true # offload optimizer state to cpu after each step. Applicable only when `colocate_all=true`
+      num_warmup_steps: 0
     fsdp_config:
       cpu_offload: false # offload params + optimizer state to cpu during fwd pass
       reshard_after_forward: true # fsdp2 only, [True, False, int between 1 and fsdp_size]
@@ -59,6 +60,7 @@ trainer:
       weight_decay: 1e-2
       max_grad_norm: 1.0 # gradient clipping
       offload_after_step: true # offload optimizer state to cpu after each step. Applicable only when `colocate_all=true`
+      num_warmup_steps: 0
     fsdp_config:
       cpu_offload: false
       reshard_after_forward: true
@@ -119,7 +121,6 @@ trainer:
   micro_train_batch_size_per_gpu: 1 
   micro_forward_batch_size_per_gpu: 1  
   update_ref_every_epoch: false
-  num_warmup_steps: 0
   use_sample_packing: true
   eval_batch_size: 1024
   eval_before_train: true

--- a/skyrl-train/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl-train/skyrl_train/distributed/fsdp_strategy.py
@@ -274,7 +274,9 @@ class FSDPStrategy(DistributedStrategy):
             )
 
             #  TODO(csy): add other schedulers, add more to config
-            actor_lr_scheduler = get_constant_schedule_with_warmup(optimizer=actor_optimizer, num_warmup_steps=-1)
+            actor_lr_scheduler = get_constant_schedule_with_warmup(
+                optimizer=actor_optimizer, num_warmup_steps=optim_config.num_warmup_steps
+            )
         else:
             actor_optimizer = None
             actor_lr_scheduler = None

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -139,17 +139,17 @@ class RayPPOTrainer:
         concat_env_extras: List[Dict[str, Any]] = []
         concat_uids: List[str] = []
         sampling_params = self.cfg.generator.eval_sampling_params
-        for _, prompts in enumerate(self.eval_dataloader):
-            prompts = self._remove_tail_data(prompts)
-            generator_input, uids = self._prepare_generator_input(
-                self.cfg.generator.eval_n_samples_per_prompt, prompts, sampling_params
-            )
-            with Timer("generate"):
+        with Timer("generate"):
+            for _, prompts in enumerate(self.eval_dataloader):
+                prompts = self._remove_tail_data(prompts)
+                generator_input, uids = self._prepare_generator_input(
+                    self.cfg.generator.eval_n_samples_per_prompt, prompts, sampling_params
+                )
                 generator_output: GeneratorOutput = await self.generate(generator_input)
-            generator_outputs.append(generator_output)
-            concat_all_envs.extend(generator_input["env_classes"])
-            concat_env_extras.extend(generator_input["env_extras"])
-            concat_uids.extend(uids)
+                generator_outputs.append(generator_output)
+                concat_all_envs.extend(generator_input["env_classes"])
+                concat_env_extras.extend(generator_input["env_extras"])
+                concat_uids.extend(uids)
         concat_generator_outputs: GeneratorOutput = concatenate_generator_outputs(generator_outputs)
 
         # Extract data_sources from env_extras

--- a/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
+++ b/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
@@ -75,7 +75,9 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
         )
 
         actor_scheduler = get_scheduler(
-            "constant_with_warmup", actor_optim, num_warmup_steps=self.cfg.trainer.num_warmup_steps
+            "constant_with_warmup",
+            actor_optim,
+            num_warmup_steps=self.cfg.trainer.policy.optimizer_config.num_warmup_steps,
         )
 
         if self.cfg.trainer.gradient_checkpointing:
@@ -272,7 +274,7 @@ class DeepSpeedCriticWorkerBase(CriticWorkerBase):
         critic_scheduler = get_scheduler(
             "constant_with_warmup",
             critic_optim,
-            num_warmup_steps=self.cfg.trainer.num_warmup_steps,
+            num_warmup_steps=self.cfg.trainer.critic.optimizer_config.num_warmup_steps,
         )
 
         if self.cfg.trainer.gradient_checkpointing:


### PR DESCRIPTION
# What does this PR do

Previously we weren't setting warmup steps correctly for FSDP: https://github.com/NovaSky-AI/SkyRL/blob/bafdbb5db6986e3ef844127c7b9608d3d4396779/skyrl-train/skyrl_train/distributed/fsdp_strategy.py#L277

This PR fixes that, and additionally updates warmup steps to be part of the optimizer config for policy/critic. Also moves the timer for eval out of the dataloader loop.