### PR TITLE
[generator] Add `max_env_workers` argument for generator thread pool executor

### DIFF
--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -193,9 +193,10 @@ generator:
   # TODO (erictang000): Show clear ablations for benefits of this on GSM8K or SQL.
   zero_reward_on_non_stop: false 
 
-environment:
-  env_class: "gsm8k"
   # number of background workers for env step calls. Set to 0 to disable background workers.
   max_env_workers: 10
+
+environment:
+  env_class: "gsm8k"
   # NOTE: environment specific defaults for environment.skyrl_gym are set at the following path:
   # skyrl_gym: config/skyrl_gym_config/default.yaml

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -193,9 +193,6 @@ generator:
   # TODO (erictang000): Show clear ablations for benefits of this on GSM8K or SQL.
   zero_reward_on_non_stop: false 
 
-  # number of background workers for env step calls. Set to 0 to disable background workers.
-  max_env_workers: 32
-
 environment:
   env_class: "gsm8k"
   # NOTE: environment specific defaults for environment.skyrl_gym are set at the following path:

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -195,5 +195,6 @@ generator:
 
 environment:
   env_class: "gsm8k"
+  max_env_workers: 10
   # NOTE: environment specific defaults for environment.skyrl_gym are set at the following path:
   # skyrl_gym: config/skyrl_gym_config/default.yaml

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -195,6 +195,7 @@ generator:
 
 environment:
   env_class: "gsm8k"
+  # number of background workers for env step calls. Set to 0 to disable background workers.
   max_env_workers: 10
   # NOTE: environment specific defaults for environment.skyrl_gym are set at the following path:
   # skyrl_gym: config/skyrl_gym_config/default.yaml

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -194,7 +194,7 @@ generator:
   zero_reward_on_non_stop: false 
 
   # number of background workers for env step calls. Set to 0 to disable background workers.
-  max_env_workers: 10
+  max_env_workers: 32
 
 environment:
   env_class: "gsm8k"

--- a/skyrl-train/skyrl_train/config/skyrl_gym_config/default.yaml
+++ b/skyrl-train/skyrl_train/config/skyrl_gym_config/default.yaml
@@ -1,6 +1,5 @@
 # @package environment.skyrl_gym
-generator:
-  # number of background workers for env step calls. Set to 0 to disable background workers.
-  max_env_workers: 32
+# number of background workers for env step calls. Set to 0 to disable background workers.
+max_env_workers: 32
 text2sql:
   db_path: "/home/ray/default/sql_data"

--- a/skyrl-train/skyrl_train/config/skyrl_gym_config/default.yaml
+++ b/skyrl-train/skyrl_train/config/skyrl_gym_config/default.yaml
@@ -1,3 +1,6 @@
 # @package environment.skyrl_gym
+generator:
+  # number of background workers for env step calls. Set to 0 to disable background workers.
+  max_env_workers: 32
 text2sql:
   db_path: "/home/ray/default/sql_data"

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -41,9 +41,9 @@ class SkyRLGymGenerator(GeneratorInterface):
         self.custom_chat_template = get_custom_chat_template(model_name)
         # get generation prompt ids for the tokenizer if needed
         self.generation_prompt_ids = get_generation_prompt_ids(tokenizer) if self.use_conversation_multi_turn else None
-        if self.skyrl_gym_cfg.generator.max_env_workers > 0:
+        if self.skyrl_gym_cfg.max_env_workers > 0:
             self.env_executor = ThreadPoolExecutor(
-                max_workers=self.skyrl_gym_cfg.generator.max_env_workers, thread_name_prefix="skyrl-gym-env-"
+                max_workers=self.skyrl_gym_cfg.max_env_workers, thread_name_prefix="skyrl-gym-env-"
             )
         else:
             self.env_executor = None

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 import skyrl_gym
 from typing import List, Dict, Any, Optional
 import numpy as np
+from concurrent.futures import ThreadPoolExecutor
 
 from skyrl_train.generators.base import GeneratorInterface, GeneratorInput, GeneratorOutput
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
@@ -40,6 +41,12 @@ class SkyRLGymGenerator(GeneratorInterface):
         self.custom_chat_template = get_custom_chat_template(model_name)
         # get generation prompt ids for the tokenizer if needed
         self.generation_prompt_ids = get_generation_prompt_ids(tokenizer) if self.use_conversation_multi_turn else None
+        if self.skyrl_gym_cfg.max_env_workers > 0:
+            self.env_executor = ThreadPoolExecutor(
+                max_workers=self.skyrl_gym_cfg.max_env_workers, thread_name_prefix="skyrl-gym-env-"
+            )
+        else:
+            self.env_executor = None
 
     def _update_engine_input_chat_history(
         self,
@@ -266,7 +273,11 @@ class SkyRLGymGenerator(GeneratorInterface):
             engine_output = await self.inference_engine_client.generate(engine_input)
             output = engine_output["responses"][0]
             stop_reason = engine_output["stop_reasons"][0]
-            env_step_output: BaseTextEnvStepOutput = env.step(output)
+            if self.env_executor is not None:
+                loop = asyncio.get_running_loop()
+                env_step_output: BaseTextEnvStepOutput = await loop.run_in_executor(self.env_executor, env.step, output)
+            else:
+                env_step_output: BaseTextEnvStepOutput = env.step(output)
             new_obs = env_step_output["observations"]
             reward = env_step_output["reward"]
             done = env_step_output["done"]
@@ -431,6 +442,9 @@ class SkyRLGymGenerator(GeneratorInterface):
         # TODO (erictang000): this is still synchronous RL - come back to this
         # for supporting fully async RL
         all_outputs = await asyncio.gather(*tasks)
+        # shutdown the executor
+        if self.env_executor is not None:
+            self.env_executor.shutdown(wait=True)
 
         responses = sum([[output[0]] for output in all_outputs], [])
         rewards = sum([[output[1]] for output in all_outputs], [])

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -41,9 +41,9 @@ class SkyRLGymGenerator(GeneratorInterface):
         self.custom_chat_template = get_custom_chat_template(model_name)
         # get generation prompt ids for the tokenizer if needed
         self.generation_prompt_ids = get_generation_prompt_ids(tokenizer) if self.use_conversation_multi_turn else None
-        if self.generator_cfg.max_env_workers > 0:
+        if self.skyrl_gym_cfg.generator.max_env_workers > 0:
             self.env_executor = ThreadPoolExecutor(
-                max_workers=self.generator_cfg.max_env_workers, thread_name_prefix="skyrl-gym-env-"
+                max_workers=self.skyrl_gym_cfg.generator.max_env_workers, thread_name_prefix="skyrl-gym-env-"
             )
         else:
             self.env_executor = None

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -442,9 +442,6 @@ class SkyRLGymGenerator(GeneratorInterface):
         # TODO (erictang000): this is still synchronous RL - come back to this
         # for supporting fully async RL
         all_outputs = await asyncio.gather(*tasks)
-        # shutdown the executor
-        if self.env_executor is not None:
-            self.env_executor.shutdown(wait=True)
 
         responses = sum([[output[0]] for output in all_outputs], [])
         rewards = sum([[output[1]] for output in all_outputs], [])

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -41,9 +41,9 @@ class SkyRLGymGenerator(GeneratorInterface):
         self.custom_chat_template = get_custom_chat_template(model_name)
         # get generation prompt ids for the tokenizer if needed
         self.generation_prompt_ids = get_generation_prompt_ids(tokenizer) if self.use_conversation_multi_turn else None
-        if self.skyrl_gym_cfg.max_env_workers > 0:
+        if self.generator_cfg.max_env_workers > 0:
             self.env_executor = ThreadPoolExecutor(
-                max_workers=self.skyrl_gym_cfg.max_env_workers, thread_name_prefix="skyrl-gym-env-"
+                max_workers=self.generator_cfg.max_env_workers, thread_name_prefix="skyrl-gym-env-"
             )
         else:
             self.env_executor = None

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -79,7 +79,7 @@ def mock_generator_cfg():
 @pytest.fixture
 def mock_env_cfg():
     cfg = MagicMock()
-    cfg.generator.max_env_workers = 0
+    cfg.max_env_workers = 0
     cfg.env_class = "gsm8k"
     return cfg
 

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -80,6 +80,7 @@ def mock_generator_cfg():
 def mock_env_cfg():
     cfg = MagicMock()
     cfg.env_class = "gsm8k"
+    cfg.max_env_workers = 0
     return cfg
 
 

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -73,13 +73,13 @@ def mock_generator_cfg():
     cfg.max_input_length = 512
     cfg.batched = True
     cfg.max_turns = 1
-    cfg.max_env_workers = 0
     return cfg
 
 
 @pytest.fixture
 def mock_env_cfg():
     cfg = MagicMock()
+    cfg.generator.max_env_workers = 0
     cfg.env_class = "gsm8k"
     return cfg
 

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -73,6 +73,7 @@ def mock_generator_cfg():
     cfg.max_input_length = 512
     cfg.batched = True
     cfg.max_turns = 1
+    cfg.max_env_workers = 0
     return cfg
 
 
@@ -80,7 +81,6 @@ def mock_generator_cfg():
 def mock_env_cfg():
     cfg = MagicMock()
     cfg.env_class = "gsm8k"
-    cfg.max_env_workers = 0
     return cfg
 
 

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py
@@ -71,11 +71,11 @@ async def test_skyrl_gym_generator_chat_templating_exact(model_name):
             "max_turns": 3,
             "zero_reward_on_non_stop": False,
             "use_conversation_multi_turn": True,
-            "max_env_workers": 0,
         }
     )
     env_cfg = DictConfig(
         {
+            "generator": {"max_env_workers": 0},
             "env_class": "cpu_test_env",
         }
     )

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py
@@ -71,12 +71,12 @@ async def test_skyrl_gym_generator_chat_templating_exact(model_name):
             "max_turns": 3,
             "zero_reward_on_non_stop": False,
             "use_conversation_multi_turn": True,
+            "max_env_workers": 0,
         }
     )
     env_cfg = DictConfig(
         {
             "env_class": "cpu_test_env",
-            "max_env_workers": 0,
         }
     )
     generator = SkyRLGymGenerator(

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py
@@ -75,7 +75,7 @@ async def test_skyrl_gym_generator_chat_templating_exact(model_name):
     )
     env_cfg = DictConfig(
         {
-            "generator": {"max_env_workers": 0},
+            "max_env_workers": 0,
             "env_class": "cpu_test_env",
         }
     )

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py
@@ -76,6 +76,7 @@ async def test_skyrl_gym_generator_chat_templating_exact(model_name):
     env_cfg = DictConfig(
         {
             "env_class": "cpu_test_env",
+            "max_env_workers": 0,
         }
     )
     generator = SkyRLGymGenerator(

--- a/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
@@ -116,13 +116,13 @@ async def run_generator_end_to_end(
             "max_turns": max_turns,
             "zero_reward_on_non_stop": False,
             "use_conversation_multi_turn": use_conversation_multi_turn,
+            "max_env_workers": max_env_workers,
         }
     )
 
     env_cfg = DictConfig(
         {
             "env_class": env_class,
-            "max_env_workers": max_env_workers,
             "text2sql": {
                 "db_path": "/home/ray/default/sql_data",
             },

--- a/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
@@ -117,7 +117,6 @@ async def run_generator_end_to_end(
             "max_turns": max_turns,
             "zero_reward_on_non_stop": False,
             "use_conversation_multi_turn": use_conversation_multi_turn,
-            "max_env_workers": max_env_workers,
         }
     )
 
@@ -127,6 +126,7 @@ async def run_generator_end_to_end(
             "text2sql": {
                 "db_path": os.path.expanduser("~/default/sql_data"),
             },
+            "generator": {"max_env_workers": max_env_workers},
         }
     )
 

--- a/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
@@ -122,11 +122,10 @@ async def run_generator_end_to_end(
 
     env_cfg = DictConfig(
         {
-            "env_class": env_class,
             "text2sql": {
                 "db_path": os.path.expanduser("~/default/sql_data"),
             },
-            "generator": {"max_env_workers": max_env_workers},
+            "max_env_workers": max_env_workers,
         }
     )
 

--- a/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
@@ -1,5 +1,5 @@
 """
-uv run --extra dev --extra vllm --isolated pytest tests/gpu/test_generator.py
+uv run --extra dev --extra vllm --isolated pytest tests/gpu/test_skyrl_gym_generator.py
 """
 
 import pytest
@@ -40,12 +40,12 @@ class TestEnv(BaseTextEnv):
 
 register(
     id="test_env",
-    entry_point="tests.gpu.test_generator:TestEnv",
+    entry_point="tests.gpu.test_skyrl_gym_generator:TestEnv",
 )
 
 MODEL_TO_GENERATION_PROMPT = {
     "Qwen/Qwen2.5-0.5B-Instruct": "<|im_start|>assistant\n",
-    "meta-llama/Llama-3.2-1B-Instruct": "<|start_header_id|>assistant<|end_header_id|>\n\n",
+    "unsloth/Llama-3.2-1B-Instruct": "<|start_header_id|>assistant<|end_header_id|>\n\n",
     "Qwen/Qwen3-0.6B": "<|im_start|>assistant\n",
 }
 
@@ -60,11 +60,12 @@ async def run_generator_end_to_end(
     max_prompt_length=512,
     max_input_length=2048,
     max_generate_length=1024,
-    data_path="./data/gsm8k/validation.parquet",
+    data_path="/home/ray/data/gsm8k/validation.parquet",
     env_class="gsm8k",
     num_prompts=2,
     max_turns=1,
     use_conversation_multi_turn=True,
+    max_env_workers=10,
 ):
     """
     End to end generator test - requires minimum 2 GPUs
@@ -121,6 +122,7 @@ async def run_generator_end_to_end(
     env_cfg = DictConfig(
         {
             "env_class": env_class,
+            "max_env_workers": max_env_workers,
             "text2sql": {
                 "db_path": "/home/ray/default/sql_data",
             },
@@ -226,7 +228,7 @@ async def test_generator_multi_turn_text2sql():
             max_prompt_length=6000,
             max_input_length=29048,
             max_generate_length=3000,
-            data_path="./data/sql/train.parquet",
+            data_path="/home/ray/data/sql/train.parquet",
             env_class="text2sql",
             num_prompts=2,
             max_turns=6,
@@ -238,7 +240,7 @@ async def test_generator_multi_turn_text2sql():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "model_name", ["meta-llama/Llama-3.2-1B-Instruct", "Qwen/Qwen2.5-0.5B-Instruct", "Qwen/Qwen3-0.6B"]
+    "model_name", ["unsloth/Llama-3.2-1B-Instruct", "Qwen/Qwen2.5-0.5B-Instruct", "Qwen/Qwen3-0.6B"]
 )
 async def test_generator_formatting_use_conversation_multi_turn(model_name):
     """
@@ -296,7 +298,7 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "model_name", ["meta-llama/Llama-3.2-1B-Instruct", "Qwen/Qwen2.5-0.5B-Instruct", "Qwen/Qwen3-0.6B"]
+    "model_name", ["unsloth/Llama-3.2-1B-Instruct", "Qwen/Qwen2.5-0.5B-Instruct", "Qwen/Qwen3-0.6B"]
 )
 async def test_generator_formatting_no_use_conversation_multi_turn(model_name):
     """

--- a/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
@@ -2,6 +2,7 @@
 uv run --extra dev --extra vllm --isolated pytest tests/gpu/test_skyrl_gym_generator.py
 """
 
+import os
 import pytest
 import ray
 from transformers import AutoTokenizer
@@ -60,7 +61,7 @@ async def run_generator_end_to_end(
     max_prompt_length=512,
     max_input_length=2048,
     max_generate_length=1024,
-    data_path="/home/ray/data/gsm8k/validation.parquet",
+    data_path=os.path.expanduser("~/data/gsm8k/validation.parquet"),
     env_class="gsm8k",
     num_prompts=2,
     max_turns=1,
@@ -124,7 +125,7 @@ async def run_generator_end_to_end(
         {
             "env_class": env_class,
             "text2sql": {
-                "db_path": "/home/ray/default/sql_data",
+                "db_path": os.path.expanduser("~/default/sql_data"),
             },
         }
     )
@@ -228,7 +229,7 @@ async def test_generator_multi_turn_text2sql():
             max_prompt_length=6000,
             max_input_length=29048,
             max_generate_length=3000,
-            data_path="/home/ray/data/sql/train.parquet",
+            data_path=os.path.expanduser("~/data/sql/train.parquet"),
             env_class="text2sql",
             num_prompts=2,
             max_turns=6,


### PR DESCRIPTION
# What does this PR do
Previously, we were blocking the asyncio event loop on each `env.step()` call

https://github.com/NovaSky-AI/SkyRL/blob/160291f048fa719ba90ca14773102165c9b34eaa/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py#L269

This PR updates the `SkyRLGymGenerator` to use a simple `ThreadPoolExecutor` to allow trajectories to call synchronous env.step without blocking the main event loop

### Simple Test
Using a basic multi-turn env with 3 max turns that just calls time.sleep(3)
```
class TestEnv(BaseTextEnv):
    ...
    def step(self, action: str):
        ...
        time.sleep(3)
        ...
```
we see a speedup from > 30 mins (3s * 3 turns * 256 samples) to < 4 min
Before: 
<img width="352" alt="image" src="https://github.com/user-attachments/assets/ab5959d0-abda-4282-af0f-b641a7c0d23a" />
After:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/2be30a54-23c4-47b6-b65d-1c13a473451f" />


