### PR TITLE
fix: Updated utils.py to fix stop token issue

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/utils.py
+++ b/skyrl-train/skyrl_train/inference_engines/utils.py
@@ -1,5 +1,5 @@
 from typing import Dict, Any
-from omegaconf import DictConfig
+from omegaconf import DictConfig, ListConfig
 
 
 def get_vllm_sampling_params(sampling_params: DictConfig) -> Dict[str, Any]:
@@ -16,6 +16,9 @@ def get_vllm_sampling_params(sampling_params: DictConfig) -> Dict[str, Any]:
     exclude_keys = ["max_generate_length"]
     for key, value in sampling_params.items():
         if key not in vllm_sampling_params and key not in exclude_keys:
+            # Convert OmegaConf ListConfig to regular list if needed
+            if isinstance(value, ListConfig):
+                value = list(value)
             vllm_sampling_params[key] = value
     return vllm_sampling_params
 
@@ -33,6 +36,9 @@ def get_sglang_sampling_params(sampling_params: DictConfig) -> Dict[str, Any]:
     exclude_keys = ["max_generate_length"]
     for key, value in sampling_params.items():
         if key not in sglang_sampling_params and key not in exclude_keys:
+            # Convert OmegaConf ListConfig to regular list if needed
+            if isinstance(value, ListConfig):
+                value = list(value)
             sglang_sampling_params[key] = value
     return sglang_sampling_params
 


### PR DESCRIPTION
I was getting this error when passing adding stop tokens to generator config by passing a `"stop": [token1, token2, ...]`
```
(VLLMInferenceEngine pid=132934)   File "/home/ubuntu/.cache/uv/builds-v0/.tmpqd4VTJ/lib/python3.12/site-packages/vllm/sampling_params.py", line 378, in __post_init__
(VLLMInferenceEngine pid=132934)     self._verify_args()
(VLLMInferenceEngine pid=132934)   File "/home/ubuntu/.cache/uv/builds-v0/.tmpqd4VTJ/lib/python3.12/site-packages/vllm/sampling_params.py", line 444, in _verify_args
(VLLMInferenceEngine pid=132934)     assert isinstance(self.stop, list)
(VLLMInferenceEngine pid=132934)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VLLMInferenceEngine pid=132934) AssertionError
```

this change fixes it, stop tokens can be added to generator config