### PR TITLE
[eval] fix eval batch < dp_size edge case

### DIFF
--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -233,8 +233,6 @@ class RayPPOTrainer:
 
                     # 0. truncate data to have even shards
                     rand_prompts = self._remove_tail_data(rand_prompts)
-                    if len(rand_prompts) == 0:  # case where size of batch is less than dp_size
-                        continue
                     generator_input, uids = self._prepare_generator_input(
                         self.cfg.generator.n_samples_per_prompt, rand_prompts
                     )


### PR DESCRIPTION
# What does this PR do
- removes call to `_remove_tail_data` from eval loop

Previously, we called `_remove_tail_data` for every batch in the eval loop 

```python
for _, prompts in enumerate(self.eval_dataloader):
            prompts = self._remove_tail_data(prompts)
...
```

this caused len(prompts) to be 0 if len(prompts) < dp_size, since we do floor division here: 

https://github.com/NovaSky-AI/SkyRL/blob/8053c905f275352f7160a5f2fedc57b0247d6380/skyrl-train/skyrl_train/trainer.py#L351

We don't need to `_remove_tail_data` in the eval loop, since we are just doing generation, which doesn't require explicit sharding, even for batched generation case, where this is handled cleanly here:

https://github.com/NovaSky-AI/SkyRL/blob/8053c905f275352f7160a5f2fedc57b0247d6380/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py#L96