### PR TITLE
[Installation] Update docs to include `libnuma` installation

### DIFF
--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -43,15 +43,16 @@ For installation without the Dockerfile, make sure you meet the pre-requisities:
 - `uv <https://docs.astral.sh/uv/>`_
 - `ray <https://docs.ray.io/en/latest/>`_ 2.44.0
 
-Apt packages
-~~~~~~~~~~~~
+System Dependencies
+~~~~~~~~~~~~~~~~~~~
 
-The only package required is `libnuma <https://github.com/numactl/numactl>`_.
+The only packages required are `build-essential` and `libnuma <https://github.com/numactl/numactl>`_. You can install them using the following command:
 
 .. code-block:: bash
-    sudo apt update && sudo apt-get install numactl libnuma-dev
 
-At this time, this will require sudo privileges. If you are running on a machine without sudo access, we recommend using the Dockerfile.
+    sudo apt update && sudo apt-get install build-essential libnuma-dev
+
+This will require sudo privileges. If you are running on a machine without sudo access, we recommend using the Dockerfile.
 
 All project dependencies are managed by `uv`.
 

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -43,6 +43,16 @@ For installation without the Dockerfile, make sure you meet the pre-requisities:
 - `uv <https://docs.astral.sh/uv/>`_
 - `ray <https://docs.ray.io/en/latest/>`_ 2.44.0
 
+Apt packages
+~~~~~~~~~~~~
+
+The only package required is `libnuma <https://github.com/numactl/numactl>`_.
+
+.. code-block:: bash
+    sudo apt update && sudo apt-get install numactl libnuma-dev
+
+At this time, this will require sudo privileges. If you are running on a machine without sudo access, we recommend using the Dockerfile.
+
 All project dependencies are managed by `uv`.
 
 Clone the repo and `cd` into the `skyrl` directory:

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -50,7 +50,7 @@ The only packages required are `build-essential` and `libnuma <https://github.co
 
 .. code-block:: bash
 
-    sudo apt update && sudo apt-get install build-essential libnuma-dev
+    sudo apt update && sudo apt-get install build-essential numactl libnuma-dev
 
 This will require sudo privileges. If you are running on a machine without sudo access, we recommend using the Dockerfile.
 


### PR DESCRIPTION
# What does this PR do?

Updates the installation docs to include `libnuma`. Currently, the installation without dockerfile can fail if the user is missing the `libnuma-dev` package. 

I've added a "system dependencies" section with `build-essential` and `libnuma`.  