### PR TITLE
Add pre-commit hook for gitleaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,4 +18,3 @@ repos:
     rev: v8.24.2
     hooks:
       - id: gitleaks
-        args: [--verbose]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,10 @@ repos:
     hooks:
       - id: black
         exclude: (^skyagent/.*)$
+
+  # Detect secrets and sensitive information
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks
+        args: [--verbose]


### PR DESCRIPTION
# What does this PR do?

Adds a pre-commit hook for gitleaks. We currently commit certain example `.env` files, like `.env.example` , and this hook ensures that developers don't accidentally commit secret keys. 


I've tested whether this works by using a real WandB API Key and I got the following error:

```bash
(base) ray@ip-10-0-155-108:~/default/torchupdate$ git commit -s -m "x"
ruff.................................................(no files to check)Skipped
black................................................(no files to check)Skipped
Detect hardcoded secrets.................................................Failed
- hook id: gitleaks
- exit code: 1

○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     WANDB_API_KEY=REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     3.625071
File:        skyrl-train/.env.example
Line:        3
Fingerprint: skyrl-train/.env.example:generic-api-key:3

8:15PM INF 1 commits scanned.
8:15PM INF scanned ~74 bytes (74 bytes) in 33.3ms
8:15PM WRN leaks found: 1
****
```

using a dummy entry, such as `WANDB_API_KEY=1` doesn't trigger any error