### PR TITLE
[Bugfix] Disable vllm compilation cache due to compilation issues

### DIFF
--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -254,6 +254,10 @@ def initialize_ray(cfg: DictConfig):
         # NOTE (sumanthrh): In vllm >= 0.9.0, we need to explicitly allow for serialization via pickle for collective RPCs.
         # During weight transfer, we use IPC handles, which contains a `function` object and requires pickling.
         env_vars["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
+        
+        # NOTE (sumanthrh): In vLLM 0.9.2, we've observed compilatiion issues with torch compile. removing the compilation directory and trying
+        # again does not fix the issue. Temporarily, we disable compilation cache. This should not have any effect on performance
+        env_vars["VLLM_DISABLE_COMPILE_CACHE"] = 1
 
         if not os.environ.get("VLLM_USE_V1", False):
             logger.info(

--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -254,9 +254,10 @@ def initialize_ray(cfg: DictConfig):
         # NOTE (sumanthrh): In vllm >= 0.9.0, we need to explicitly allow for serialization via pickle for collective RPCs.
         # During weight transfer, we use IPC handles, which contains a `function` object and requires pickling.
         env_vars["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
-        
-        # NOTE (sumanthrh): In vLLM 0.9.2, we've observed compilatiion issues with torch compile. removing the compilation directory and trying
-        # again does not fix the issue. Temporarily, we disable compilation cache. This should not have any effect on performance
+
+        # NOTE (sumanthrh): In vLLM >= 0.9.0, we've observed compilatiion failures with torch compile. removing the compilation directory and trying
+        # again does not fix the issue. Temporarily we disable compilation cache, which seems to fix the issue.
+        # This should not have any effect on performance - compilation will still happen, it's just not cached
         env_vars["VLLM_DISABLE_COMPILE_CACHE"] = 1
 
         if not os.environ.get("VLLM_USE_V1", False):


### PR DESCRIPTION
# What does this PR do?

Disables vLLM compilation cache : https://docs.vllm.ai/en/v0.9.0/design/v1/torch_compile.html#compilation-cache

We've seen issues especially in multi-node settings where the vLLM initialization fails for version >= 0.9.0 at compilation time: 

[compilation_error_multinode.log](https://github.com/user-attachments/files/21282993/compilation_error_multinode.log)


The error has been hard to track down - since in single-node settings things have worked fine. There's likely a bug during cache write or so in vLLM.

For now, we disable compilation cache with `VLLM_DISABLE_COMPILE_CACHE` . 
