### PR TITLE
[Generator] Add FastAPI server for inference engine client

### DIFF
--- a/skyrl-train/examples/http_server/rollout_with_http_server_litellm.py
+++ b/skyrl-train/examples/http_server/rollout_with_http_server_litellm.py
@@ -1,10 +1,9 @@
 """
-Example of using LiteLLM with SkyRL's HTTP inference server.
+Example of using LiteLLM with SkyRL's HTTP inference server. This simulates what your custom
+generator looks like when posting requests to the server (as opposed to using `skyrl_gym_generator.py`).
 
-Note that `init_to_simulate_trainer()` is not needed in your custom generator, we
-do it here to simulate what the trainer will instantiate.
-
-Set the following configs in your bash script:
+When you want to use the HTTP server, set the following configs in your bash script, as shown in
+`run_gsm8k_with_http_server.sh`:
 ```
 generator:
   use_http_server_inference_engine_client: true
@@ -12,10 +11,13 @@ generator:
   http_server_inference_engine_client_port: 8000
 ```
 
+Note that `init_to_simulate_trainer()` is not needed in your custom generator, we
+do it here to simulate what the trainer will instantiate.
+
 Also note that `trajectory_id` is important for better trajectory routing for prefix cache reuse.
 
 Run with:
-`uv run --isolated --extra dev --extra vllm --extra litellm python examples/rollout_with_http_server_litellm.py`
+`uv run --isolated --extra dev --extra vllm --extra litellm python examples/http_server/rollout_with_http_server_litellm.py`
 """
 
 import threading

--- a/skyrl-train/examples/http_server/run_gsm8k_with_http_server.sh
+++ b/skyrl-train/examples/http_server/run_gsm8k_with_http_server.sh
@@ -1,0 +1,61 @@
+set -x
+
+# Colocated GRPO training+generation for Qwen2.5-0.5B-Instruct on GSM8K with HTTP server.
+
+# uv run examples/http_server/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
+# bash examples/http_server/run_gsm8k_with_http_server.sh
+
+# NOTE (charlie): The only difference between this and the original run_gsm8k.sh is that we set
+# `generator.use_http_server_inference_engine_client` to true and set the HTTP server host and port.
+# You should add your own custom generator that posts requests to the HTTP server. Running this
+# script will still use `skyrl_gym_generator.py` as the generator and post requests to the HTTP
+# server with `generate_with_http_server()`, which is only for testing purposes.
+
+# NOTE (sumanthrh): `micro_train_batch_size_per_gpu` and `micro_forward_batch_size_per_gpu` can be tuned
+
+DATA_DIR="$HOME/data/gsm8k"
+NUM_GPUS=1
+LOGGER="console"  # change to "console" to print to stdout
+
+uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base \
+  data.train_data="['$DATA_DIR/train.parquet']" \
+  data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.algorithm.advantage_estimator="grpo" \
+  trainer.policy.model.path="Qwen/Qwen2.5-0.5B-Instruct" \
+  trainer.placement.colocate_all=true \
+  trainer.strategy=fsdp2 \
+  trainer.placement.policy_num_gpus_per_node=$NUM_GPUS \
+  trainer.placement.ref_num_gpus_per_node=$NUM_GPUS \
+  generator.num_inference_engines=$NUM_GPUS \
+  generator.inference_engine_tensor_parallel_size=1 \
+  trainer.epochs=20 \
+  trainer.eval_batch_size=1024 \
+  trainer.eval_before_train=true \
+  trainer.eval_interval=5 \
+  trainer.update_epochs_per_batch=1 \
+  trainer.train_batch_size=1024 \
+  trainer.policy_mini_batch_size=256 \
+  trainer.micro_forward_batch_size_per_gpu=16 \
+  trainer.micro_train_batch_size_per_gpu=16 \
+  trainer.ckpt_interval=10 \
+  trainer.max_prompt_length=512 \
+  generator.sampling_params.max_generate_length=1024 \
+  trainer.policy.optimizer_config.lr=1.0e-6 \
+  trainer.algorithm.use_kl_loss=true \
+  generator.backend=vllm \
+  generator.run_engines_locally=true \
+  generator.weight_sync_backend=nccl \
+  generator.async_engine=true \
+  generator.batched=true \
+  environment.env_class=gsm8k \
+  generator.n_samples_per_prompt=5 \
+  generator.gpu_memory_utilization=0.8 \
+  generator.use_http_server_inference_engine_client=true \
+  generator.http_server_inference_engine_client_host="127.0.0.1" \
+  generator.http_server_inference_engine_client_port=8000 \
+  trainer.logger="$LOGGER" \
+  trainer.project_name="gsm8k" \
+  trainer.run_name="gsm8k_test" \
+  trainer.resume_mode=null \
+  trainer.ckpt_path="$HOME/ckpts/gsm8k_1.5B_ckpt" \
+  $@

--- a/skyrl-train/examples/rollout_with_http_server_litellm.py
+++ b/skyrl-train/examples/rollout_with_http_server_litellm.py
@@ -38,6 +38,7 @@ TP_SIZE = 1
 SERVER_PORT = 8123
 SERVER_HOST = "127.0.0.1"
 
+
 def get_test_actor_config() -> DictConfig:
     """Get base config with test-specific overrides."""
     with hydra.initialize_config_dir(config_dir=config_dir):
@@ -79,7 +80,6 @@ def init_to_simulate_trainer():
 
     # Wait for server to be ready using the helper method
     wait_for_server_ready(host=SERVER_HOST, port=SERVER_PORT, max_wait_seconds=30)
-
 
 
 def agent_loop(prompt: str, base_url: str):
@@ -128,12 +128,12 @@ def main():
         print(f"outputs[0]: {outputs[0]}")
         for output in outputs:
             assert len(output) == 3 * 2
-        
 
     finally:
         # You do not need to call this in your custom generator either.
         shutdown_server(host=SERVER_HOST, port=SERVER_PORT, max_wait_seconds=5)
         ray.shutdown()
+
 
 if __name__ == "__main__":
     main()

--- a/skyrl-train/examples/rollout_with_http_server_litellm.py
+++ b/skyrl-train/examples/rollout_with_http_server_litellm.py
@@ -4,6 +4,14 @@ Example of using LiteLLM with SkyRL's HTTP inference server.
 Note that `init_to_simulate_trainer()` is not needed in your custom generator, we
 do it here to simulate what the trainer will instantiate.
 
+Set the following configs in your bash script:
+```
+generator:
+  use_http_server_inference_engine_client: true
+  http_server_inference_engine_client_host: "127.0.0.1"
+  http_server_inference_engine_client_port: 8000
+```
+
 Also note that `trajectory_id` is important for better trajectory routing for prefix cache reuse.
 
 Run with:

--- a/skyrl-train/examples/rollout_with_http_server_litellm.py
+++ b/skyrl-train/examples/rollout_with_http_server_litellm.py
@@ -1,0 +1,131 @@
+"""
+Example of using LiteLLM with SkyRL's HTTP inference server.
+
+Note that `init_to_simulate_trainer()` is not needed in your custom generator, we
+do it here to simulate what the trainer will instantiate.
+
+Also note that `trajectory_id` is important for better trajectory routing for prefix cache reuse.
+
+Run with:
+`uv run --isolated --extra dev --extra vllm --extra litellm python examples/rollout_with_http_server_litellm.py`
+"""
+
+import threading
+import ray
+import hydra
+from omegaconf import DictConfig
+from litellm import completion
+from concurrent.futures import ThreadPoolExecutor
+from skyrl_train.inference_engines.launch_inference_engine_http_server import (
+    serve,
+    wait_for_server_ready,
+    shutdown_server,
+)
+from skyrl_train.entrypoints.main_base import config_dir
+from tests.gpu.test_policy_vllm_e2e import init_inference_engines
+from uuid import uuid4
+
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+TP_SIZE = 1
+SERVER_PORT = 8123
+SERVER_HOST = "127.0.0.1"
+
+def get_test_actor_config() -> DictConfig:
+    """Get base config with test-specific overrides."""
+    with hydra.initialize_config_dir(config_dir=config_dir):
+        cfg = hydra.compose(config_name="ppo_base_config")
+
+        # Override specific parameters
+        cfg.trainer.policy.model.path = MODEL
+        cfg.trainer.critic.model.path = ""
+        cfg.trainer.placement.policy_num_gpus_per_node = TP_SIZE
+        cfg.generator.async_engine = True
+        cfg.generator.num_inference_engines = 1
+        cfg.generator.inference_engine_tensor_parallel_size = TP_SIZE
+        cfg.generator.run_engines_locally = True
+
+        return cfg
+
+
+def init_to_simulate_trainer():
+    cfg = get_test_actor_config()
+    cfg.trainer.placement.colocate_all = True  # Use colocate for simplicity
+    cfg.generator.weight_sync_backend = "nccl"
+    cfg.trainer.strategy = "fsdp2"
+
+    client, _ = init_inference_engines(
+        cfg=cfg,
+        v1=True,
+        use_local=True,
+        async_engine=cfg.generator.async_engine,
+        tp_size=cfg.generator.inference_engine_tensor_parallel_size,
+        colocate_all=cfg.trainer.placement.colocate_all,
+    )
+
+    # Start server in background thread using serve function directly
+    def run_server():
+        serve(client, host=SERVER_HOST, port=SERVER_PORT, log_level="warning")
+
+    server_thread = threading.Thread(target=run_server, daemon=True)
+    server_thread.start()
+
+    # Wait for server to be ready using the helper method
+    wait_for_server_ready(host=SERVER_HOST, port=SERVER_PORT, max_wait_seconds=30)
+
+
+
+def agent_loop(prompt: str, base_url: str):
+    chat_history = [
+        {"role": "user", "content": prompt},
+    ]
+    max_turns = 3
+    trajectory_id = uuid4().hex
+
+    while True:
+        response = completion(
+            model=f"openai/{MODEL}",  # Add openai/ prefix for custom endpoints
+            messages=chat_history,
+            api_base=base_url,
+            temperature=0.7,
+            max_tokens=100,
+            # NOTE(Charlie): this is needed for better trajectory routing for prefix cache reuse
+            trajectory_id=trajectory_id,
+        )
+        chat_history.append(response.choices[0].message)
+        # dummy multi-turn chat
+        max_turns -= 1
+        if max_turns <= 0:
+            break
+        else:
+            chat_history.append({"role": "user", "content": "Repeat what you just said."})
+    return chat_history
+
+
+def main():
+    try:
+        # 1. This method simulates what the trainer will do. When you set
+        # `generator.use_http_server_inference_engine_client=True` in bash script,
+        # you do not need to write these code at all. In your custom generator,
+        # you can simply post request to `base_url`. The server will be ready automatically
+        # before `CustomGenerator.generate()` is called.
+        init_to_simulate_trainer()
+        base_url = f"http://{SERVER_HOST}:{SERVER_PORT}/v1"
+
+        # 2. Pretend we have 500 tasks, and run one agent loop for each task parallely.
+        prompts = ["Hello, how are you?"] * 500
+        with ThreadPoolExecutor() as executor:
+            output_tasks = [executor.submit(agent_loop, prompt, base_url) for prompt in prompts]
+            outputs = [task.result() for task in output_tasks]
+        print(f"len(outputs): {len(outputs)}")
+        print(f"outputs[0]: {outputs[0]}")
+        for output in outputs:
+            assert len(output) == 3 * 2
+        
+
+    finally:
+        # You do not need to call this in your custom generator either.
+        shutdown_server(host=SERVER_HOST, port=SERVER_PORT, max_wait_seconds=5)
+        ray.shutdown()
+
+if __name__ == "__main__":
+    main()

--- a/skyrl-train/pyproject.toml
+++ b/skyrl-train/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
     "tensordict",
     "jaxtyping",
     "skyrl-gym",
+    "fastapi",
+    "uvicorn",
 ]
 
 [tool.uv]

--- a/skyrl-train/pyproject.toml
+++ b/skyrl-train/pyproject.toml
@@ -75,6 +75,9 @@ docs = [
     "sphinx-copybutton>=0.5.0",
     "sphinx-autobuild>=2021.3.14"
 ]
+litellm = [
+    "litellm>=1.67.5",
+]
 vllm = [
     "vllm==0.9.2",
     # NOTE (sumanthrh): We explictly use a flashinfer wheel from their index. 

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -140,6 +140,7 @@ trainer:
 
 
 generator:
+  model_name: ${trainer.policy.model.path}
   model_dtype: "bfloat16" # should match dtype for inference engine
   run_engines_locally: true
   num_inference_engines: 1

--- a/skyrl-train/skyrl_train/entrypoints/main_base.py
+++ b/skyrl-train/skyrl_train/entrypoints/main_base.py
@@ -248,7 +248,7 @@ class BasePPOExp:
         else:
             inference_engines = create_remote_inference_engines_from_config(self.cfg)
 
-        inference_engine_client = InferenceEngineClient(inference_engines)
+        inference_engine_client = InferenceEngineClient(inference_engines, self.cfg.generator)
 
         generator: GeneratorInterface = self.get_generator(self.cfg, tokenizer, inference_engine_client)
 

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -51,6 +51,9 @@ class SkyRLGymGenerator(GeneratorInterface):
         )
 
         if self.use_http_server_inference_engine_client:
+            assert (
+                self.use_conversation_multi_turn
+            ), "HTTP server inference engine client in SkyRLGymGenerator does not support use_conversation_multi_turn being False."
             # Store the base URL for direct HTTP requests
             self.base_url = f"http://{self.http_server_inference_engine_client_host}:{self.http_server_inference_engine_client_port}"
         else:

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -77,7 +77,6 @@ class SkyRLGymGenerator(GeneratorInterface):
             )
         return await self.inference_engine_client.generate(engine_input)
 
-
     async def agent_loop(
         self,
         prompt: ConversationType,

--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -65,6 +65,9 @@ class InferenceEngineClient(InferenceEngineInterface):
         """
         Destructor to shut down the HTTP server if it was started.
         """
+        # TODO(Charlie): __del__ is not guaranteed to be called in general. Add to `teardown` method
+        # when the `_handle_termination` flow is implemented. See `worker.py` comments on
+        # `_handle_termination` for more details.
         if self.use_http_server_inference_engine_client:
             try:
                 from skyrl_train.inference_engines.launch_inference_engine_http_server import shutdown_server

--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -5,6 +5,7 @@ from skyrl_train.inference_engines.base import (
     NamedWeightUpdateRequest,
 )
 import asyncio
+import threading
 from typing import List, Any, Dict
 
 
@@ -19,7 +20,74 @@ class InferenceEngineClient(InferenceEngineInterface):
         self.engines = engines
         self.generator_config = generator_config
         self.model_name = generator_config.get("model_name")
+        self.backend = generator_config.get("backend")
+
+        self.use_http_server_inference_engine_client = generator_config.get(
+            "use_http_server_inference_engine_client", False
+        )
+        self.http_server_inference_engine_client_host = generator_config.get(
+            "http_server_inference_engine_client_host", "127.0.0.1"
+        )
+        self.http_server_inference_engine_client_port = generator_config.get(
+            "http_server_inference_engine_client_port", 8000
+        )
+
+        if self.use_http_server_inference_engine_client:
+            self._spin_up_http_server()
+
         print(f"InferenceEngineClient initialized with {len(engines)} engines.")
+
+    def _spin_up_http_server(self):
+        from skyrl_train.inference_engines.launch_inference_engine_http_server import serve, wait_for_server_ready
+
+        self._server_thread = threading.Thread(
+            target=serve,
+            args=(self,),
+            kwargs={
+                "host": self.http_server_inference_engine_client_host,
+                "port": self.http_server_inference_engine_client_port,
+                "log_level": "warning",
+                "backend": self.backend,
+            },
+            daemon=True,
+        )
+        self._server_thread.start()
+        wait_for_server_ready(
+            host=self.http_server_inference_engine_client_host,
+            port=self.http_server_inference_engine_client_port,
+            max_wait_seconds=30,
+        )
+        print(
+            f"InferenceEngineClient HTTP server started on {self.http_server_inference_engine_client_host}:{self.http_server_inference_engine_client_port}"
+        )
+
+    def __del__(self):
+        """
+        Destructor to shut down the HTTP server if it was started.
+        """
+        if self.use_http_server_inference_engine_client:
+            try:
+                from skyrl_train.inference_engines.launch_inference_engine_http_server import shutdown_server
+
+                shutdown_server(
+                    host=self.http_server_inference_engine_client_host,
+                    port=self.http_server_inference_engine_client_port,
+                    max_wait_seconds=5,
+                )
+                if hasattr(self, "_server_thread") and self._server_thread.is_alive():
+                    self._server_thread.join(timeout=5)
+            except Exception as e:
+                print(f"Error shutting down HTTP server: {e}")
+
+    def __getstate__(self):
+        """
+        Override to avoid pickling the server thread.
+        Needed when passing InferenceEngineClient as an argument to async_run_ray_method().
+        """
+        state = self.__dict__.copy()
+        # Thread objects are not picklable – just drop the reference.
+        state["_server_thread"] = None
+        return state
 
     async def _run_on_all_engines(self, method_name: str, *args, **kwargs):
         """

--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -68,7 +68,12 @@ class InferenceEngineClient(InferenceEngineInterface):
         # TODO(Charlie): __del__ is not guaranteed to be called in general. Add to `teardown` method
         # when the `_handle_termination` flow is implemented. See `worker.py` comments on
         # `_handle_termination` for more details.
-        if self.use_http_server_inference_engine_client:
+        if (
+            self.use_http_server_inference_engine_client
+            # don't want to shut down the server when it is pickled as a ray method argument.
+            and hasattr(self, "_server_thread")
+            and self._server_thread is not None
+        ):
             try:
                 from skyrl_train.inference_engines.launch_inference_engine_http_server import shutdown_server
 

--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -5,7 +5,7 @@ from skyrl_train.inference_engines.base import (
     NamedWeightUpdateRequest,
 )
 import asyncio
-from typing import List, Any
+from typing import List, Any, Dict
 
 
 class InferenceEngineClient(InferenceEngineInterface):
@@ -15,8 +15,10 @@ class InferenceEngineClient(InferenceEngineInterface):
     Note that InferenceEngineClient sub-classes InferenceEngineInterface so it can be used as if talking to a single engine.
     """
 
-    def __init__(self, engines: List[InferenceEngineInterface]):
+    def __init__(self, engines: List[InferenceEngineInterface], generator_config: Dict[str, Any]):
         self.engines = engines
+        self.generator_config = generator_config
+        self.model_name = generator_config.get("model_name")
         print(f"InferenceEngineClient initialized with {len(engines)} engines.")
 
     async def _run_on_all_engines(self, method_name: str, *args, **kwargs):

--- a/skyrl-train/skyrl_train/inference_engines/launch_inference_engine_http_server.py
+++ b/skyrl-train/skyrl_train/inference_engines/launch_inference_engine_http_server.py
@@ -55,6 +55,7 @@ def set_global_state(inference_engine_client: InferenceEngineClient, uvicorn_ser
     _global_uvicorn_server = uvicorn_server
     _global_backend = backend
 
+
 def convert_openai_to_inference_input(request: ChatCompletionRequest, backend: str) -> InferenceEngineInput:
     """Convert OpenAI request to InferenceEngineInput format."""
     # Convert messages to our ConversationType format
@@ -99,7 +100,8 @@ async def handle_chat_completion(request: ChatCompletionRequest, raw_request: Re
         )
     if _global_inference_engine_client.model_name != request.model:
         raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail=f"Model name mismatch: loaded model name {_global_inference_engine_client.model_name} != model name in request {request.model}"
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"Model name mismatch: loaded model name {_global_inference_engine_client.model_name} != model name in request {request.model}",
         )
 
     try:

--- a/skyrl-train/skyrl_train/inference_engines/launch_inference_engine_http_server.py
+++ b/skyrl-train/skyrl_train/inference_engines/launch_inference_engine_http_server.py
@@ -74,9 +74,7 @@ def convert_openai_to_inference_input(request: ChatCompletionRequest, backend: s
     return engine_input
 
 
-def convert_inference_output_to_openai(
-    engine_output: InferenceEngineOutput, request: ChatCompletionRequest
-) -> ChatCompletionResponse:
+def convert_inference_output_to_openai(engine_output: InferenceEngineOutput) -> ChatCompletionResponse:
     """Convert InferenceEngineOutput to OpenAI response format."""
     response_text = engine_output["responses"][0]
     stop_reason = engine_output["stop_reasons"][0]
@@ -89,7 +87,6 @@ def convert_inference_output_to_openai(
 
     return ChatCompletionResponse(
         id=f"chatcmpl-{uuid.uuid4().hex[:8]}",
-        model=request.model,
         choices=[choice],
     )
 
@@ -110,7 +107,7 @@ async def handle_chat_completion(request: ChatCompletionRequest, raw_request: Re
         engine_output = await _global_inference_engine_client.generate(engine_input)
 
         # Convert back to OpenAI format
-        response = convert_inference_output_to_openai(engine_output, request)
+        response = convert_inference_output_to_openai(engine_output)
 
         return response
 

--- a/skyrl-train/skyrl_train/inference_engines/launch_inference_engine_http_server.py
+++ b/skyrl-train/skyrl_train/inference_engines/launch_inference_engine_http_server.py
@@ -1,0 +1,296 @@
+"""
+OpenAI-compatible HTTP server using InferenceEngineClient as backend.
+
+This module provides a FastAPI-based HTTP server that exposes OpenAI's chat completion API
+while routing requests to our internal InferenceEngineClient system.
+
+Main functions:
+- serve(): Start the HTTP server
+- wait_for_server_ready(): Wait for server to be ready (useful for testing)
+- shutdown_server(): Shutdown the server
+"""
+
+import asyncio
+import logging
+import time
+import requests
+import traceback
+import uuid
+from contextlib import asynccontextmanager
+from typing import Optional
+
+import fastapi
+import uvicorn
+from fastapi import HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
+from skyrl_train.inference_engines.base import InferenceEngineInput, ConversationType
+from skyrl_train.inference_engines.openai_api_protocol import ChatCompletionRequest, ChatCompletionResponse, ChatCompletionResponseChoice, ChatMessage, UsageInfo, ErrorResponse
+
+logger = logging.getLogger(__name__)
+
+# Global state to hold the inference engine client
+_global_inference_engine_client: Optional[InferenceEngineClient] = None
+_global_uvicorn_server: Optional[uvicorn.Server] = None
+
+
+def set_global_state(inference_engine_client: InferenceEngineClient, uvicorn_server: uvicorn.Server):
+    """Set the global inference engine client."""
+    global _global_inference_engine_client
+    global _global_uvicorn_server
+    _global_inference_engine_client = inference_engine_client
+    _global_uvicorn_server = uvicorn_server
+
+
+def convert_openai_to_inference_input(request: ChatCompletionRequest) -> InferenceEngineInput:
+    """Convert OpenAI request to InferenceEngineInput format."""
+    # Convert messages to our ConversationType format
+    conversation: ConversationType = []
+    for msg in request.messages:
+        conversation.append({"role": msg.role, "content": msg.content})
+    
+    # Build sampling parameters
+    sampling_params = {}
+    
+    if request.temperature is not None:
+        sampling_params["temperature"] = request.temperature
+    if request.max_tokens is not None:
+        sampling_params["max_tokens"] = request.max_tokens
+    if request.top_p is not None:
+        sampling_params["top_p"] = request.top_p
+    if request.frequency_penalty is not None:
+        sampling_params["frequency_penalty"] = request.frequency_penalty
+    if request.presence_penalty is not None:
+        sampling_params["presence_penalty"] = request.presence_penalty
+    if request.stop is not None:
+        sampling_params["stop"] = request.stop
+    if request.seed is not None:
+        sampling_params["seed"] = request.seed
+    if request.top_k is not None:
+        sampling_params["top_k"] = request.top_k
+    if request.repetition_penalty is not None:
+        sampling_params["repetition_penalty"] = request.repetition_penalty
+    if request.min_p is not None:
+        sampling_params["min_p"] = request.min_p
+    
+    engine_input: InferenceEngineInput = {
+        "prompts": [conversation],
+        "prompt_token_ids": None,
+        "sampling_params": sampling_params if sampling_params else None,
+        "trajectory_ids": None
+    }
+    return engine_input
+
+
+def convert_inference_output_to_openai(engine_output, request: ChatCompletionRequest) -> ChatCompletionResponse:
+    """Convert InferenceEngineOutput to OpenAI response format."""
+    response_text = engine_output["responses"][0]
+    stop_reason = engine_output["stop_reasons"][0]
+    
+    # Map stop reasons to OpenAI format
+    finish_reason = None
+    if stop_reason == "stop":
+        finish_reason = "stop"
+    elif stop_reason == "length":
+        finish_reason = "length"
+    else:
+        finish_reason = "stop"  # Default fallback
+    
+    choice = ChatCompletionResponseChoice(
+        index=0,
+        message=ChatMessage(role="assistant", content=response_text),
+        finish_reason=finish_reason
+    )
+    
+    # For minimal version, we'll provide basic usage stats
+    usage = UsageInfo(
+        prompt_tokens=0,  # We don't track these in minimal version
+        completion_tokens=0,
+        total_tokens=0
+    )
+    
+    return ChatCompletionResponse(
+        id=f"chatcmpl-{uuid.uuid4().hex[:8]}",
+        model=request.model,
+        choices=[choice],
+        usage=usage
+    )
+
+
+async def handle_chat_completion(request: ChatCompletionRequest, raw_request: Request) -> ChatCompletionResponse:
+    """Handle chat completion request."""
+    if _global_inference_engine_client is None:
+        raise HTTPException(status_code=500, detail="Inference engine client not initialized")
+    
+    try:
+        # Convert to our internal format
+        engine_input = convert_openai_to_inference_input(request)
+        
+        # Call the inference engine
+        engine_output = await _global_inference_engine_client.generate(engine_input)
+        
+        # Convert back to OpenAI format
+        response = convert_inference_output_to_openai(engine_output, request)
+        
+        return response
+        
+    except Exception as e:
+        logger.error(f"Error in chat completion: {str(e)}\n{traceback.format_exc()}")
+        # Re-raise as a general Exception so our custom handler catches it
+        # instead of HTTPException which FastAPI handles differently
+        raise e
+
+def shutdown_server(host: str = "127.0.0.1", port: int = 8000, max_wait_seconds: int = 30) -> None:
+    """Shutdown the server.
+
+    Args:
+        host: Server host.
+        port: Server port.
+        max_wait_seconds: How long to wait until the server stops listening.
+
+    Raises:
+        Exception: If the server is still responding after *max_wait_seconds*.
+    """
+    if _global_uvicorn_server is not None:
+        _global_uvicorn_server.should_exit = True
+
+    health_url = f"http://{host}:{port}/health"
+
+    for i in range(max_wait_seconds):
+        try:
+            # If this succeeds, server is still alive
+            requests.get(health_url, timeout=1)
+        except requests.exceptions.RequestException:
+            # A network error / connection refused means server is down.
+            logger.info(f"Server shut down after {i+1} seconds")
+            return
+        time.sleep(1)
+
+    raise Exception(f"Server failed to shut down within {max_wait_seconds} seconds")
+
+
+def wait_for_server_ready(host: str = "127.0.0.1", port: int = 8000, max_wait_seconds: int = 30) -> None:
+    """
+    Wait for the HTTP server to be ready by polling the health endpoint.
+    
+    Args:
+        host: Host where the server is running
+        port: Port where the server is running  
+        max_wait_seconds: Maximum time to wait in seconds
+        
+    Raises:
+        Exception: If server doesn't become ready within max_wait_seconds
+    """
+    max_retries = max_wait_seconds
+    health_url = f"http://{host}:{port}/health"
+    
+    for i in range(max_retries):
+        try:
+            response = requests.get(health_url, timeout=1)
+            if response.status_code == 200:
+                logger.info(f"Server ready after {i+1} attempts ({i+1} seconds)")
+                return
+        except (requests.exceptions.RequestException, requests.exceptions.ConnectionError):
+            if i == max_retries - 1:
+                raise Exception(f"Server failed to start within {max_wait_seconds} seconds")
+            time.sleep(1)  # Wait 1 second between retries
+
+
+def create_app() -> fastapi.FastAPI:
+    """Create the FastAPI application."""
+    @asynccontextmanager
+    async def lifespan(app: fastapi.FastAPI):
+        logger.info("Starting inference engine HTTP server...")
+        yield
+    
+    app = fastapi.FastAPI(
+        title="InferenceEngine OpenAI-Compatible API",
+        description="OpenAI-compatible chat completion API using InferenceEngineClient",
+        version="1.0.0",
+        lifespan=lifespan
+    )
+    
+    # Add CORS middleware
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    
+    # Chat completion endpoint
+    @app.post("/v1/chat/completions", response_model=ChatCompletionResponse)
+    async def chat_completion(request: ChatCompletionRequest, raw_request: Request):
+        return await handle_chat_completion(request, raw_request)
+    
+    # Health check endpoint
+    @app.get("/health")
+    async def health_check():
+        return {"status": "healthy"}
+
+    
+    # Exception handler for unhandled server errors
+    # Note: Pydantic validation errors (400-level) are handled automatically by FastAPI
+    # This handler only catches unexpected server-side exceptions
+    @app.exception_handler(Exception)
+    async def general_exception_handler(request: Request, exc: Exception):
+        logger.error(f"Unhandled exception: {str(exc)}\n{traceback.format_exc()}")
+        return JSONResponse(
+            status_code=500,
+            content=ErrorResponse(error={
+                "message": f"Internal server error: {str(exc)}",
+                "type": "server_error", 
+                "code": "internal_error"
+            }).model_dump()
+        )
+    
+    return app
+
+
+def serve(
+    inference_engine_client: InferenceEngineClient,
+    host: str = "0.0.0.0",
+    port: int = 8000,
+    log_level: str = "info"
+):
+    """
+    Start the HTTP server.
+    
+    Args:
+        inference_engine_client: The InferenceEngineClient to use as backend
+        host: Host to bind to (default: "0.0.0.0")
+        port: Port to bind to (default: 8000)
+        log_level: Logging level (default: "info")
+    """
+    # Create app
+    app = create_app()
+    
+    # Configure logging
+    logging.basicConfig(level=getattr(logging, log_level.upper()))
+    
+    logger.info(f"Starting server on {host}:{port}")
+    
+    # Run server
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        log_level=log_level,
+        access_log=True
+    )
+    server = uvicorn.Server(config)
+    
+    # Expose server for external shutdown control (tests)
+    set_global_state(inference_engine_client, server)
+
+    try:
+        # Run until shutdown
+        asyncio.run(server.serve())
+    except KeyboardInterrupt:
+        logger.info("Received keyboard interrupt, shutting down...")
+    except Exception as e:
+        logger.error(f"Server error: {e}")
+        raise

--- a/skyrl-train/skyrl_train/inference_engines/launch_inference_engine_http_server.py
+++ b/skyrl-train/skyrl_train/inference_engines/launch_inference_engine_http_server.py
@@ -259,6 +259,8 @@ def create_app() -> fastapi.FastAPI:
         return await handle_chat_completion(request, raw_request)
 
     # Health check endpoint
+    # All inference engine replicas are initialized before creating `InferenceEngineClient`, and thus
+    # we can start receiving requests as soon as the FastAPI server starts
     @app.get("/health")
     async def health_check():
         return {"status": "healthy"}

--- a/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
+++ b/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
@@ -3,32 +3,70 @@ A minimal set of OpenAI API protocol for inference engine http server.
 """
 
 import time
-from typing import List, Optional, Hashable
+from typing import List, Optional, Hashable, Union, Dict, Any
 
 from pydantic import BaseModel, Field, field_validator
 
 
 class ChatMessage(BaseModel):
     """OpenAI chat message format."""
+
     role: str
     content: str
 
 
 class ChatCompletionRequest(BaseModel):
     """OpenAI chat completion request model (minimal version)."""
+
     model: str  # We'll ignore this
     messages: List[ChatMessage]
 
+    # Common sampling parameters
+    max_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    min_p: Optional[float] = None
+    repetition_penalty: Optional[float] = None
+    length_penalty: Optional[float] = None
+    seed: Optional[int] = None
+    stop: Optional[Union[str, List[str]]] = None
+    stop_token_ids: Optional[List[int]] = None
+    presence_penalty: Optional[float] = None
+    frequency_penalty: Optional[float] = None
+    ignore_eos: Optional[bool] = None
+    skip_special_tokens: Optional[bool] = None
+    include_stop_str_in_output: Optional[bool] = None
+    min_tokens: Optional[int] = None
+    best_of: Optional[int] = None
+    use_beam_search: Optional[bool] = None
+    logprobs: Optional[bool] = None
+    top_logprobs: Optional[int] = None
+
+    # Unsupported parameters that we still parse for error reporting
+    tools: Optional[List[Dict[str, Any]]] = None
+    tool_choice: Optional[Any] = None
+    n: Optional[int] = None
+
     # SkyRL-specific parameters
     trajectory_id: Optional[Hashable] = None
+
+    @field_validator("n")
+    @classmethod
+    def validate_n(cls, v):
+        if v is not None and v != 1:
+            raise ValueError("Only n=1 is supported")
+        return v
 
     # TODO(Charlie): we currently ignore all other parameters. Will revisit
     # once we figure out the workflow for users to use inference engine http server.
     # The curernt behavior is that we will use the sampling parameters defined in
     # ppo_base_config.yaml for all requests.
 
+
 class ChatCompletionResponseChoice(BaseModel):
     """OpenAI chat completion response choice."""
+
     index: int
     message: ChatMessage
     finish_reason: Optional[str] = None
@@ -37,6 +75,7 @@ class ChatCompletionResponseChoice(BaseModel):
 
 class ChatCompletionResponse(BaseModel):
     """OpenAI chat completion response (minimal version)."""
+
     id: str
     object: str = "chat.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
@@ -50,3 +89,53 @@ class ErrorResponse(BaseModel):
     type: str
     param: Optional[str] = None
     code: int
+
+
+UNSUPPORTED_FIELDS = ["tools", "tool_choice"]
+
+
+def check_unsupported_fields(request: ChatCompletionRequest) -> None:
+    """Raise ValueError if unsupported fields are provided."""
+    unsupported = []
+    for field in UNSUPPORTED_FIELDS:
+        if getattr(request, field) is not None:
+            unsupported.append(field)
+    if request.n not in (None, 1):
+        unsupported.append("n")
+    if unsupported:
+        raise ValueError(f"Unsupported fields: {', '.join(unsupported)}")
+
+
+def build_sampling_params(request: ChatCompletionRequest, backend: str) -> Dict[str, Any]:
+    """Convert request sampling params to backend specific sampling params."""
+    params: Dict[str, Any] = {}
+
+    def set_param(name: str, value: Any, target_name: Optional[str] = None) -> None:
+        if value is not None:
+            params[target_name or name] = value
+
+    # map common params
+    set_param("temperature", request.temperature)
+    set_param("top_p", request.top_p)
+    set_param("top_k", request.top_k)
+    set_param("min_p", request.min_p)
+    set_param("repetition_penalty", request.repetition_penalty)
+    set_param("length_penalty", request.length_penalty)
+    set_param("seed", request.seed)
+    set_param("stop", request.stop)
+    set_param("stop_token_ids", request.stop_token_ids)
+    set_param("presence_penalty", request.presence_penalty)
+    set_param("frequency_penalty", request.frequency_penalty)
+    set_param("ignore_eos", request.ignore_eos)
+    set_param("skip_special_tokens", request.skip_special_tokens)
+    set_param("include_stop_str_in_output", request.include_stop_str_in_output)
+    set_param("min_tokens", request.min_tokens)
+    set_param("best_of", request.best_of)
+    set_param("use_beam_search", request.use_beam_search)
+    set_param("logprobs", request.logprobs)
+    set_param("top_logprobs", request.top_logprobs)
+
+    max_token_key = "max_tokens" if backend == "vllm" else "max_new_tokens"
+    set_param(max_token_key, request.max_tokens)
+
+    return params

--- a/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
+++ b/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
@@ -59,6 +59,7 @@ class ChatCompletionRequest(BaseModel):
     trajectory_id: Optional[Hashable] = None
 
     # Unsupported parameters that we still parse for error reporting
+    stream: bool = False
     tools: Optional[List[Dict[str, Any]]] = None
     tool_choice: Optional[Any] = None
     logprobs: Optional[bool] = None
@@ -70,6 +71,13 @@ class ChatCompletionRequest(BaseModel):
     def validate_n(cls, v):
         if v is not None and v != 1:
             raise ValueError("Only n=1 is supported")
+        return v
+    
+    @field_validator("stream")
+    @classmethod
+    def validate_stream(cls, v):
+        if v:
+            raise ValueError("Streaming is not supported")
         return v
 
 

--- a/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
+++ b/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
@@ -1,5 +1,9 @@
+"""
+A minimal set of OpenAI API protocol for inference engine http server.
+"""
+
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional, Hashable
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -14,88 +18,21 @@ class ChatCompletionRequest(BaseModel):
     """OpenAI chat completion request model (minimal version)."""
     model: str  # We'll ignore this
     messages: List[ChatMessage]
-    
-    # Standard OpenAI sampling parameters
-    temperature: Optional[float] = 0.7
-    max_tokens: Optional[int] = None
-    top_p: Optional[float] = 1.0
-    frequency_penalty: Optional[float] = 0.0
-    presence_penalty: Optional[float] = 0.0
-    n: Optional[int] = 1
-    stop: Optional[Union[str, List[str]]] = None
-    seed: Optional[int] = None
-    
-    # Extended parameters
-    top_k: Optional[int] = None
-    repetition_penalty: Optional[float] = 1.0
-    min_p: Optional[float] = 0.0
-    
-    # User field
-    user: Optional[str] = None
-    
-    # Unsupported fields that should cause errors
-    stream: Optional[bool] = False
-    tools: Optional[List[Any]] = None
-    tool_choice: Optional[Any] = None
-    response_format: Optional[Any] = None
-    logprobs: Optional[bool] = None
-    top_logprobs: Optional[int] = None
-    
-    @field_validator("messages")
-    @classmethod
-    def validate_messages_not_empty(cls, v):
-        if len(v) == 0:
-            raise ValueError("Messages array cannot be empty")
-        return v
-    
-    @field_validator("stream")
-    @classmethod
-    def validate_stream_not_supported(cls, v):
-        if v is True:
-            raise ValueError("Streaming is not supported")
-        return v
-    
-    @field_validator("tools")
-    @classmethod
-    def validate_tools_not_supported(cls, v):
-        if v is not None:
-            raise ValueError("Tools are not supported")
-        return v
-    
-    @field_validator("tool_choice")
-    @classmethod
-    def validate_tool_choice_not_supported(cls, v):
-        if v is not None and v != "none":
-            raise ValueError("Tool choice is not supported")
-        return v
-    
-    @field_validator("response_format")
-    @classmethod
-    def validate_response_format_not_supported(cls, v):
-        if v is not None:
-            raise ValueError("Response format constraints are not supported")
-        return v
-    
-    @field_validator("n")
-    @classmethod
-    def validate_n_equals_one(cls, v):
-        if v != 1:
-            raise ValueError("Only n=1 is supported")
-        return v
 
+    # SkyRL-specific parameters
+    trajectory_id: Optional[Hashable] = None
+
+    # TODO(Charlie): we currently ignore all other parameters. Will revisit
+    # once we figure out the workflow for users to use inference engine http server.
+    # The curernt behavior is that we will use the sampling parameters defined in
+    # ppo_base_config.yaml for all requests.
 
 class ChatCompletionResponseChoice(BaseModel):
     """OpenAI chat completion response choice."""
     index: int
     message: ChatMessage
     finish_reason: Optional[str] = None
-
-
-class UsageInfo(BaseModel):
-    """Usage statistics (minimal version)."""
-    prompt_tokens: int = 0
-    completion_tokens: int = 0
-    total_tokens: int = 0
+    # NOTE: Not including logprobs for now.
 
 
 class ChatCompletionResponse(BaseModel):
@@ -105,9 +42,11 @@ class ChatCompletionResponse(BaseModel):
     created: int = Field(default_factory=lambda: int(time.time()))
     model: str
     choices: List[ChatCompletionResponseChoice]
-    usage: UsageInfo
 
 
 class ErrorResponse(BaseModel):
-    """Error response format."""
-    error: Dict[str, Any]
+    object: str = "error"
+    message: str
+    type: str
+    param: Optional[str] = None
+    code: int

--- a/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
+++ b/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
@@ -18,6 +18,7 @@ class ChatMessage(BaseModel):
 class ChatCompletionRequest(BaseModel):
     """OpenAI chat completion request model (minimal version)."""
 
+    model: str
     messages: List[ChatMessage]
 
     # Common sampling parameters
@@ -46,7 +47,6 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: Optional[Any] = None
     logprobs: Optional[bool] = None
     top_logprobs: Optional[int] = None
-    model: Optional[str] = None
     best_of: Optional[int] = None
 
     @field_validator("n")
@@ -73,7 +73,7 @@ class ChatCompletionResponse(BaseModel):
     object: str = "chat.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
     choices: List[ChatCompletionResponseChoice]
-    # model: str  # since we do not support model in request, we do not include it here
+    model: str
 
 
 class ErrorResponse(BaseModel):
@@ -84,7 +84,7 @@ class ErrorResponse(BaseModel):
     code: int
 
 
-UNSUPPORTED_FIELDS = ["tools", "tool_choice", "logprobs", "top_logprobs", "model", "best_of"]
+UNSUPPORTED_FIELDS = ["tools", "tool_choice", "logprobs", "top_logprobs", "best_of"]
 
 
 def check_unsupported_fields(request: ChatCompletionRequest) -> None:
@@ -117,6 +117,7 @@ def build_sampling_params(request: ChatCompletionRequest, backend: str) -> Dict[
         "frequency_penalty",
         "ignore_eos",
         "skip_special_tokens",
+        "n",
     ]
 
     params = {field: request_dict[field] for field in sampling_fields if field in request_dict}

--- a/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
+++ b/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
@@ -72,7 +72,7 @@ class ChatCompletionRequest(BaseModel):
         if v is not None and v != 1:
             raise ValueError("Only n=1 is supported")
         return v
-    
+
     @field_validator("stream")
     @classmethod
     def validate_stream(cls, v):

--- a/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
+++ b/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
@@ -1,0 +1,113 @@
+import time
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ChatMessage(BaseModel):
+    """OpenAI chat message format."""
+    role: str
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    """OpenAI chat completion request model (minimal version)."""
+    model: str  # We'll ignore this
+    messages: List[ChatMessage]
+    
+    # Standard OpenAI sampling parameters
+    temperature: Optional[float] = 0.7
+    max_tokens: Optional[int] = None
+    top_p: Optional[float] = 1.0
+    frequency_penalty: Optional[float] = 0.0
+    presence_penalty: Optional[float] = 0.0
+    n: Optional[int] = 1
+    stop: Optional[Union[str, List[str]]] = None
+    seed: Optional[int] = None
+    
+    # Extended parameters
+    top_k: Optional[int] = None
+    repetition_penalty: Optional[float] = 1.0
+    min_p: Optional[float] = 0.0
+    
+    # User field
+    user: Optional[str] = None
+    
+    # Unsupported fields that should cause errors
+    stream: Optional[bool] = False
+    tools: Optional[List[Any]] = None
+    tool_choice: Optional[Any] = None
+    response_format: Optional[Any] = None
+    logprobs: Optional[bool] = None
+    top_logprobs: Optional[int] = None
+    
+    @field_validator("messages")
+    @classmethod
+    def validate_messages_not_empty(cls, v):
+        if len(v) == 0:
+            raise ValueError("Messages array cannot be empty")
+        return v
+    
+    @field_validator("stream")
+    @classmethod
+    def validate_stream_not_supported(cls, v):
+        if v is True:
+            raise ValueError("Streaming is not supported")
+        return v
+    
+    @field_validator("tools")
+    @classmethod
+    def validate_tools_not_supported(cls, v):
+        if v is not None:
+            raise ValueError("Tools are not supported")
+        return v
+    
+    @field_validator("tool_choice")
+    @classmethod
+    def validate_tool_choice_not_supported(cls, v):
+        if v is not None and v != "none":
+            raise ValueError("Tool choice is not supported")
+        return v
+    
+    @field_validator("response_format")
+    @classmethod
+    def validate_response_format_not_supported(cls, v):
+        if v is not None:
+            raise ValueError("Response format constraints are not supported")
+        return v
+    
+    @field_validator("n")
+    @classmethod
+    def validate_n_equals_one(cls, v):
+        if v != 1:
+            raise ValueError("Only n=1 is supported")
+        return v
+
+
+class ChatCompletionResponseChoice(BaseModel):
+    """OpenAI chat completion response choice."""
+    index: int
+    message: ChatMessage
+    finish_reason: Optional[str] = None
+
+
+class UsageInfo(BaseModel):
+    """Usage statistics (minimal version)."""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+class ChatCompletionResponse(BaseModel):
+    """OpenAI chat completion response (minimal version)."""
+    id: str
+    object: str = "chat.completion"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: List[ChatCompletionResponseChoice]
+    usage: UsageInfo
+
+
+class ErrorResponse(BaseModel):
+    """Error response format."""
+    error: Dict[str, Any]

--- a/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
+++ b/skyrl-train/skyrl_train/inference_engines/openai_api_protocol.py
@@ -72,8 +72,8 @@ class ChatCompletionResponse(BaseModel):
     id: str
     object: str = "chat.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
-    model: str
     choices: List[ChatCompletionResponseChoice]
+    # model: str  # since we do not support model in request, we do not include it here
 
 
 class ErrorResponse(BaseModel):
@@ -101,6 +101,8 @@ def check_unsupported_fields(request: ChatCompletionRequest) -> None:
 
 def build_sampling_params(request: ChatCompletionRequest, backend: str) -> Dict[str, Any]:
     """Convert request sampling params to backend specific sampling params."""
+    assert backend in ["vllm", "sglang"], f"Unsupported backend: {backend}"
+
     request_dict = request.model_dump(exclude_unset=True)
 
     sampling_fields = [

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -73,6 +73,17 @@ def mock_generator_cfg():
     cfg.max_input_length = 512
     cfg.batched = True
     cfg.max_turns = 1
+
+    # Mock the new HTTP server configuration options from PR #101
+    # Set use_http_server_inference_engine_client to False by default to avoid HTTP server
+    cfg.get = MagicMock(
+        side_effect=lambda key, default=None: {
+            "use_http_server_inference_engine_client": False,
+            "http_server_inference_engine_client_host": "127.0.0.1",
+            "http_server_inference_engine_client_port": 8000,
+        }.get(key, default)
+    )
+
     return cfg
 
 

--- a/skyrl-train/tests/cpu/http/test_openai_request_utils.py
+++ b/skyrl-train/tests/cpu/http/test_openai_request_utils.py
@@ -1,0 +1,35 @@
+import pytest
+from skyrl_train.inference_engines.openai_api_protocol import (
+    ChatCompletionRequest,
+    ChatMessage,
+    check_unsupported_fields,
+    build_sampling_params,
+)
+
+
+def _basic_request(**kwargs):
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[ChatMessage(role="user", content="hi")],
+        **kwargs,
+    )
+
+
+def test_check_unsupported_fields():
+    req = _basic_request(tools=[{"type": "function", "function": {"name": "t"}}])
+    with pytest.raises(ValueError):
+        check_unsupported_fields(req)
+
+    req_ok = _basic_request()
+    check_unsupported_fields(req_ok)
+
+
+def test_build_sampling_params():
+    req = _basic_request(max_tokens=5, temperature=0.5)
+    params_vllm = build_sampling_params(req, "vllm")
+    assert params_vllm["max_tokens"] == 5
+    assert params_vllm["temperature"] == 0.5
+
+    params_sglang = build_sampling_params(req, "sglang")
+    assert params_sglang["max_new_tokens"] == 5
+    assert params_sglang["temperature"] == 0.5

--- a/skyrl-train/tests/cpu/http/test_openai_request_utils.py
+++ b/skyrl-train/tests/cpu/http/test_openai_request_utils.py
@@ -1,3 +1,10 @@
+"""
+# Run only vllm tests (requires vllm extra):
+uv run --isolated --extra dev --extra vllm pytest tests/cpu/http/test_openai_request_utils.py -m "vllm"
+# Run only sglang tests (requires sglang extra):
+uv run --isolated --extra dev --extra sglang pytest tests/cpu/http/test_openai_request_utils.py -m "sglang"
+"""
+
 import pytest
 from skyrl_train.inference_engines.openai_api_protocol import (
     ChatCompletionRequest,
@@ -9,9 +16,30 @@ from skyrl_train.inference_engines.openai_api_protocol import (
 
 def _basic_request(**kwargs):
     return ChatCompletionRequest(
-        model="test-model",
         messages=[ChatMessage(role="user", content="hi")],
         **kwargs,
+    )
+
+def _full_request():
+    return ChatCompletionRequest(
+        messages=[ChatMessage(role="user", content="hi")],
+        max_tokens=10,
+        temperature=0.5,
+        top_p=0.9,
+        top_k=40,
+        min_p=0.0,
+        repetition_penalty=1.0,
+        seed=42,
+        stop=["\n"],
+        stop_token_ids=[2, 3],
+        presence_penalty=0.0,
+        frequency_penalty=0.0,
+        ignore_eos=True,
+        skip_special_tokens=True,
+        include_stop_str_in_output=True,
+        min_tokens=1,
+        n=1,
+        trajectory_id="test_trajectory_id",
     )
 
 
@@ -24,7 +52,7 @@ def test_check_unsupported_fields():
     check_unsupported_fields(req_ok)
 
 
-def test_build_sampling_params():
+def test_basic_build_sampling_params():
     req = _basic_request(max_tokens=5, temperature=0.5)
     params_vllm = build_sampling_params(req, "vllm")
     assert params_vllm["max_tokens"] == 5
@@ -33,3 +61,43 @@ def test_build_sampling_params():
     params_sglang = build_sampling_params(req, "sglang")
     assert params_sglang["max_new_tokens"] == 5
     assert params_sglang["temperature"] == 0.5
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param("vllm", marks=pytest.mark.vllm),
+        pytest.param("sglang", marks=pytest.mark.sglang),
+    ]
+)
+def test_full_build_sampling_params(backend: str):
+    full_req = _full_request()
+    if backend == "vllm":
+        from vllm import SamplingParams as VLLMSamplingParams
+        full_params_vllm = build_sampling_params(full_req, "vllm")
+        vllm_sampling_params = VLLMSamplingParams(**full_params_vllm)  # has __post_init__ to check validity
+        assert vllm_sampling_params is not None
+    elif backend == "sglang":
+        from sglang.srt.sampling.sampling_params import SamplingParams as SGLangSamplingParams
+        # makes sure that the inclusion of `include_stop_str_in_output` will raise an error
+        with pytest.raises(ValueError):
+            full_params_sglang = build_sampling_params(full_req, "sglang")
+        full_req.include_stop_str_in_output = None
+
+        # makes sure that the inclusion of `seed` will raise an error
+        with pytest.raises(ValueError):
+            # makes sure that the inclusion of `seed` will raise an error
+            full_params_sglang = build_sampling_params(full_req, "sglang")
+        full_req.seed = None
+
+        # makes sure that the inclusion of `min_tokens` will raise an error
+        with pytest.raises(ValueError):
+            full_params_sglang = build_sampling_params(full_req, "sglang")
+        full_req.min_tokens = None
+
+        # Now no errors should be raised
+        full_params_sglang = build_sampling_params(full_req, "sglang")
+        sglang_sampling_params = SGLangSamplingParams(**full_params_sglang)
+        sglang_sampling_params.verify()  # checks validty
+        assert sglang_sampling_params is not None
+    else:
+        raise ValueError(f"Unsupported backend: {backend}")

--- a/skyrl-train/tests/cpu/http/test_openai_request_utils.py
+++ b/skyrl-train/tests/cpu/http/test_openai_request_utils.py
@@ -17,6 +17,8 @@ from skyrl_train.inference_engines.launch_inference_engine_http_server import (
 
 
 MODEL_NAME = "Qwen/Qwen2.5-1.5B-Instruct"
+
+
 def _basic_request(**kwargs):
     return ChatCompletionRequest(
         model=MODEL_NAME,
@@ -48,16 +50,16 @@ def test_convert_openai_to_inference_input():
         temperature=0.5,
         trajectory_id="test_trajectory_123",
     )
-    
+
     for backend in ["vllm", "sglang"]:
         result = convert_openai_to_inference_input(req, backend)
-        
+
         expected_conversation = [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "What is the capital of France?"},
             {"role": "assistant", "content": "The capital of France is Paris."},
         ]
-        
+
         assert result["prompts"] == [expected_conversation]
         assert result["trajectory_ids"] == ["test_trajectory_123"]
         assert result["sampling_params"] is not None
@@ -76,7 +78,7 @@ def test_convert_inference_output_to_openai():
         responses=[response],
         stop_reasons=[stop_reason],
     )
-    
+
     result = convert_inference_output_to_openai(engine_output, MODEL_NAME)
     assert result.model == MODEL_NAME
 
@@ -85,7 +87,7 @@ def test_convert_inference_output_to_openai():
     assert result.object == "chat.completion"
     assert isinstance(result.created, int)
     assert result.id.startswith("chatcmpl-")
-    
+
     # Check choices
     assert len(result.choices) == 1
     choice = result.choices[0]
@@ -93,4 +95,3 @@ def test_convert_inference_output_to_openai():
     assert choice.message.role == "assistant"
     assert choice.message.content == response
     assert choice.finish_reason == stop_reason
-

--- a/skyrl-train/tests/cpu/http/test_openai_request_utils.py
+++ b/skyrl-train/tests/cpu/http/test_openai_request_utils.py
@@ -16,8 +16,10 @@ from skyrl_train.inference_engines.launch_inference_engine_http_server import (
 )
 
 
+MODEL_NAME = "Qwen/Qwen2.5-1.5B-Instruct"
 def _basic_request(**kwargs):
     return ChatCompletionRequest(
+        model=MODEL_NAME,
         messages=[ChatMessage(role="user", content="hi")],
         **kwargs,
     )
@@ -40,6 +42,7 @@ def test_convert_openai_to_inference_input():
         ChatMessage(role="assistant", content="The capital of France is Paris."),
     ]
     req = ChatCompletionRequest(
+        model=MODEL_NAME,
         messages=messages,
         max_tokens=10,
         temperature=0.5,
@@ -74,8 +77,9 @@ def test_convert_inference_output_to_openai():
         stop_reasons=[stop_reason],
     )
     
-    result = convert_inference_output_to_openai(engine_output)
-    
+    result = convert_inference_output_to_openai(engine_output, MODEL_NAME)
+    assert result.model == MODEL_NAME
+
     # Check response structure
     assert isinstance(result, ChatCompletionResponse)
     assert result.object == "chat.completion"

--- a/skyrl-train/tests/gpu/test_engine_generation.py
+++ b/skyrl-train/tests/gpu/test_engine_generation.py
@@ -83,7 +83,7 @@ def init_remote_vinference_engines(tp_size):
         ),
     )
 
-    return InferenceEngineClient(engines), vllm_process
+    return InferenceEngineClient(engines, generator_config=DictConfig({"model_name": model})), vllm_process
 
 
 def init_ray_vllm_engines():
@@ -108,7 +108,7 @@ def init_ray_vllm_engines():
         ),
         tokenizer=AutoTokenizer.from_pretrained(model),
     )
-    client = InferenceEngineClient(engine)
+    client = InferenceEngineClient(engine, generator_config=DictConfig({"model_name": model}))
     return client
 
 

--- a/skyrl-train/tests/gpu/test_http_inference_engine_client.py
+++ b/skyrl-train/tests/gpu/test_http_inference_engine_client.py
@@ -58,6 +58,7 @@ def get_test_actor_config() -> DictConfig:
 
         return cfg
 
+
 @pytest.mark.vllm
 @pytest.mark.parametrize("test_type", ["chat_completions_create", "request_posting", "aiohttp_client_session"])
 def test_http_server_openai_api_with_weight_sync(test_type):
@@ -211,22 +212,25 @@ def _full_request():
         trajectory_id="test_trajectory_id",
     )
 
+
 @pytest.mark.parametrize(
     "backend",
     [
         pytest.param("vllm", marks=pytest.mark.vllm),
         pytest.param("sglang", marks=pytest.mark.sglang),
-    ]
+    ],
 )
 def test_full_build_sampling_params(backend: str):
     full_req = _full_request()
     if backend == "vllm":
         from vllm import SamplingParams as VLLMSamplingParams
+
         full_params_vllm = build_sampling_params(full_req, "vllm")
         vllm_sampling_params = VLLMSamplingParams(**full_params_vllm)  # has __post_init__ to check validity
         assert vllm_sampling_params is not None
     elif backend == "sglang":
         from sglang.srt.sampling.sampling_params import SamplingParams as SGLangSamplingParams
+
         # makes sure that the inclusion of `include_stop_str_in_output` will raise an error
         with pytest.raises(ValueError):
             full_params_sglang = build_sampling_params(full_req, "sglang")

--- a/skyrl-train/tests/gpu/test_http_inference_engine_client.py
+++ b/skyrl-train/tests/gpu/test_http_inference_engine_client.py
@@ -4,8 +4,10 @@ Test the HTTP server with OpenAI client and policy weight sync.
 This uses the same workflow as test_policy_vllm_e2e.py, but with the HTTP server instead of
 the inference client engine.
 
-Run with:
-uv run --isolated --extra dev --extra vllm pytest tests/gpu/test_http_inference_engine_client.py
+# Run only vllm tests (requires vllm extra):
+uv run --isolated --extra dev --extra vllm pytest tests/gpu/test_http_inference_engine_client.py -m "vllm"
+# Run only sglang tests (requires sglang extra):
+uv run --isolated --extra dev --extra sglang pytest tests/gpu/test_http_inference_engine_client.py -m "sglang"
 """
 
 import pytest
@@ -27,6 +29,11 @@ from skyrl_train.inference_engines.launch_inference_engine_http_server import (
 from openai import OpenAI
 from .test_policy_vllm_e2e import init_inference_engines
 from concurrent.futures import ThreadPoolExecutor
+from skyrl_train.inference_engines.openai_api_protocol import (
+    ChatCompletionRequest,
+    ChatMessage,
+    build_sampling_params,
+)
 
 
 MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
@@ -51,7 +58,7 @@ def get_test_actor_config() -> DictConfig:
 
         return cfg
 
-
+@pytest.mark.vllm
 @pytest.mark.parametrize("test_type", ["chat_completions_create", "request_posting", "aiohttp_client_session"])
 def test_http_server_openai_api_with_weight_sync(test_type):
     """
@@ -179,6 +186,69 @@ def test_http_server_openai_api_with_weight_sync(test_type):
     finally:
         shutdown_server(host=SERVER_HOST, port=SERVER_PORT, max_wait_seconds=5)
         ray.shutdown()
+
+
+def _full_request():
+    return ChatCompletionRequest(
+        messages=[ChatMessage(role="user", content="hi")],
+        max_tokens=10,
+        temperature=0.5,
+        top_p=0.9,
+        top_k=40,
+        min_p=0.0,
+        repetition_penalty=1.0,
+        seed=42,
+        stop=["\n"],
+        stop_token_ids=[2, 3],
+        presence_penalty=0.0,
+        frequency_penalty=0.0,
+        ignore_eos=True,
+        skip_special_tokens=True,
+        include_stop_str_in_output=True,
+        min_tokens=1,
+        n=1,
+        trajectory_id="test_trajectory_id",
+    )
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param("vllm", marks=pytest.mark.vllm),
+        pytest.param("sglang", marks=pytest.mark.sglang),
+    ]
+)
+def test_full_build_sampling_params(backend: str):
+    full_req = _full_request()
+    if backend == "vllm":
+        from vllm import SamplingParams as VLLMSamplingParams
+        full_params_vllm = build_sampling_params(full_req, "vllm")
+        vllm_sampling_params = VLLMSamplingParams(**full_params_vllm)  # has __post_init__ to check validity
+        assert vllm_sampling_params is not None
+    elif backend == "sglang":
+        from sglang.srt.sampling.sampling_params import SamplingParams as SGLangSamplingParams
+        # makes sure that the inclusion of `include_stop_str_in_output` will raise an error
+        with pytest.raises(ValueError):
+            full_params_sglang = build_sampling_params(full_req, "sglang")
+        full_req.include_stop_str_in_output = None
+
+        # makes sure that the inclusion of `seed` will raise an error
+        with pytest.raises(ValueError):
+            # makes sure that the inclusion of `seed` will raise an error
+            full_params_sglang = build_sampling_params(full_req, "sglang")
+        full_req.seed = None
+
+        # makes sure that the inclusion of `min_tokens` will raise an error
+        with pytest.raises(ValueError):
+            full_params_sglang = build_sampling_params(full_req, "sglang")
+        full_req.min_tokens = None
+
+        # Now no errors should be raised
+        full_params_sglang = build_sampling_params(full_req, "sglang")
+        sglang_sampling_params = SGLangSamplingParams(**full_params_sglang)
+        sglang_sampling_params.verify()  # checks validty
+        assert sglang_sampling_params is not None
+    else:
+        raise ValueError(f"Unsupported backend: {backend}")
 
 
 # def test_http_server_error_handling():

--- a/skyrl-train/tests/gpu/test_http_inference_engine_client.py
+++ b/skyrl-train/tests/gpu/test_http_inference_engine_client.py
@@ -190,6 +190,7 @@ def test_http_server_openai_api_with_weight_sync(test_type):
 
 def _full_request():
     return ChatCompletionRequest(
+        model=MODEL,
         messages=[ChatMessage(role="user", content="hi")],
         max_tokens=10,
         temperature=0.5,

--- a/skyrl-train/tests/gpu/test_http_inference_engine_client.py
+++ b/skyrl-train/tests/gpu/test_http_inference_engine_client.py
@@ -268,6 +268,7 @@ def test_full_build_sampling_params(backend: str):
     else:
         raise ValueError(f"Unsupported backend: {backend}")
 
+
 @pytest.mark.vllm
 def test_structured_generation():
     try:
@@ -334,6 +335,7 @@ def test_structured_generation():
     finally:
         shutdown_server(host=SERVER_HOST, port=SERVER_PORT, max_wait_seconds=5)
         ray.shutdown()
+
 
 # def test_http_server_error_handling():
 #     """

--- a/skyrl-train/tests/gpu/test_http_inference_engine_client.py
+++ b/skyrl-train/tests/gpu/test_http_inference_engine_client.py
@@ -337,6 +337,7 @@ def test_structured_generation():
         shutdown_server(host=SERVER_HOST, port=SERVER_PORT, max_wait_seconds=5)
         ray.shutdown()
 
+
 @pytest.mark.vllm
 def test_http_server_error_handling():
     """
@@ -374,11 +375,7 @@ def test_http_server_error_handling():
         # Test 1: Invalid request - streaming not supported
         response = requests.post(
             f"{base_url}/v1/chat/completions",
-            json={
-                "model": MODEL,
-                "messages": [{"role": "user", "content": "Hello"}],
-                "stream": True
-            }
+            json={"model": MODEL, "messages": [{"role": "user", "content": "Hello"}], "stream": True},
         )
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY  # 422
         error_data = response.json()
@@ -393,8 +390,8 @@ def test_http_server_error_handling():
             json={
                 "model": MODEL,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "tools": [{"type": "function", "function": {"name": "test"}}]
-            }
+                "tools": [{"type": "function", "function": {"name": "test"}}],
+            },
         )
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR  # 500
         error_data = response.json()
@@ -404,11 +401,7 @@ def test_http_server_error_handling():
         # Test 3: OAI can take fields not listed in the protocol.
         response = requests.post(
             f"{base_url}/v1/chat/completions",
-            json={
-                "model": MODEL,
-                "messages": [{"role": "user", "content": "Hello"}],
-                "xxx": "yyy"
-            }
+            json={"model": MODEL, "messages": [{"role": "user", "content": "Hello"}], "xxx": "yyy"},
         )
         assert response.status_code == HTTPStatus.OK  # 200
 
@@ -418,7 +411,7 @@ def test_http_server_error_handling():
             json={
                 "model": MODEL,
                 # Missing messages field
-            }
+            },
         )
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY  # 422
         error_data = response.json()
@@ -427,20 +420,12 @@ def test_http_server_error_handling():
 
         # Test 5: Invalid request - malformed JSON
         response = requests.post(
-            f"{base_url}/v1/chat/completions",
-            data="invalid json",
-            headers={"Content-Type": "application/json"}
+            f"{base_url}/v1/chat/completions", data="invalid json", headers={"Content-Type": "application/json"}
         )
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY  # 422
 
         # Test 6: Invalid request - empty messages array
-        response = requests.post(
-            f"{base_url}/v1/chat/completions",
-            json={
-                "model": MODEL,
-                "messages": []
-            }
-        )
+        response = requests.post(f"{base_url}/v1/chat/completions", json={"model": MODEL, "messages": []})
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR  # 500
 
         # Test 7: Health check endpoint should work

--- a/skyrl-train/tests/gpu/test_http_inference_engine_client.py
+++ b/skyrl-train/tests/gpu/test_http_inference_engine_client.py
@@ -1,0 +1,285 @@
+"""
+Test the HTTP server with OpenAI client and policy weight sync.
+
+This uses the same workflow as test_policy_vllm_e2e.py, but with the HTTP server instead of
+the inference client engine.
+
+Run with:
+uv run --isolated --extra dev --extra vllm pytest tests/gpu/test_http_inference_engine_client.py
+"""
+
+import pytest
+import asyncio
+import ray
+import hydra
+import threading
+import requests
+from omegaconf import DictConfig
+
+from tests.gpu.utils import init_worker_with_type, get_test_prompts
+from skyrl_train.inference_engines.ray_wrapped_inference_engine import create_ray_wrapped_inference_engines
+from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
+from transformers import AutoTokenizer
+from ray.util.placement_group import placement_group
+from skyrl_train.utils import get_ray_pg_ready_with_timeout
+from skyrl_train.inference_engines.utils import get_sampling_params_for_backend
+from skyrl_train.inference_engines.base import InferenceEngineInput
+from skyrl_train.entrypoints.main_base import config_dir
+from skyrl_train.inference_engines.launch_inference_engine_http_server import serve, wait_for_server_ready, shutdown_server
+from openai import OpenAI
+from .test_policy_vllm_e2e import init_inference_engines
+
+
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+TP_SIZE = 1
+SERVER_PORT = 8123
+SERVER_HOST = "127.0.0.1"
+
+def get_test_actor_config() -> DictConfig:
+    """Get base config with test-specific overrides."""
+    with hydra.initialize_config_dir(config_dir=config_dir):
+        cfg = hydra.compose(config_name="ppo_base_config")
+
+        # Override specific parameters
+        cfg.trainer.policy.model.path = MODEL
+        cfg.trainer.critic.model.path = ""
+        cfg.trainer.placement.policy_num_gpus_per_node = TP_SIZE
+        cfg.generator.async_engine = True
+        cfg.generator.num_inference_engines = 1
+        cfg.generator.inference_engine_tensor_parallel_size = TP_SIZE
+        cfg.generator.run_engines_locally = True
+
+        return cfg
+
+@pytest.mark.parametrize("test_type", ["chat_completions_create", "request_posting"])
+def test_http_server_openai_api_with_weight_sync(test_type):
+    """
+    Test the HTTP server with OpenAI client and policy weight sync.
+    """
+    try:
+        cfg = get_test_actor_config()
+        cfg.trainer.placement.colocate_all = True  # Use colocate for simplicity
+        cfg.generator.weight_sync_backend = "nccl"
+        cfg.trainer.strategy = "fsdp2"
+
+        client, pg = init_inference_engines(
+            cfg=cfg,
+            v1=True,
+            use_local=True,
+            async_engine=cfg.generator.async_engine,
+            tp_size=cfg.generator.inference_engine_tensor_parallel_size,
+            colocate_all=cfg.trainer.placement.colocate_all,
+        )
+        
+        # Start server in background thread using serve function directly
+        def run_server():
+            serve(client, host=SERVER_HOST, port=SERVER_PORT, log_level="warning")
+        
+        server_thread = threading.Thread(target=run_server, daemon=True)
+        server_thread.start()
+        
+        # Wait for server to be ready using the helper method
+        wait_for_server_ready(host=SERVER_HOST, port=SERVER_PORT, max_wait_seconds=30)
+        base_url = f"http://{SERVER_HOST}:{SERVER_PORT}/v1"
+
+        # Weight sync as before
+        policy = init_worker_with_type(
+            "policy",
+            shared_pg=pg,
+            colocate_all=cfg.trainer.placement.colocate_all,
+            num_gpus_per_node=cfg.generator.inference_engine_tensor_parallel_size,
+            cfg=cfg,
+        )
+        ray.get(policy.async_run_ray_method("pass_through", "init_weight_sync_state", client))
+        asyncio.run(client.reset_prefix_cache())
+        ray.get(policy.async_run_ray_method("pass_through", "broadcast_to_inference_engines", client))
+
+        test_prompts = get_test_prompts(MODEL, num_samples=2)
+
+        # Generate outputs
+        if test_type == "chat_completions_create":
+            # 1.1 Test chat.completions.create
+            # Create OpenAI client (with dummy API key since we don't authenticate)
+            openai_client = OpenAI(
+                base_url=base_url,
+                api_key="dummy-key"  # Our server doesn't authenticate, but OpenAI client requires a key
+            )
+            outputs = []
+            for prompt in test_prompts:
+                # Convert our ConversationType to OpenAI format
+                messages = [{"role": msg["role"], "content": msg["content"]} for msg in prompt]
+                
+                response = openai_client.chat.completions.create(
+                    model=MODEL,
+                    messages=messages,
+                    max_tokens=50,
+                    temperature=0.7,
+                    top_p=0.9,
+                    frequency_penalty=0.1,
+                    presence_penalty=0.2,
+                )
+                print(f"Generated response: {response.choices[0].message.content[:100]}...")
+                # Use model_dump() instead of deprecated json() method
+                outputs.append(response.model_dump())
+
+        else:
+            # 1.2 Test request posting
+            outputs = []
+            for prompt in test_prompts:
+                messages = [{"role": msg["role"], "content": msg["content"]} for msg in prompt]
+                response = requests.post(
+                    f"{base_url}/chat/completions",
+                    json={
+                        "model": MODEL,
+                        "messages": messages,
+                        "max_tokens": 50,
+                        "temperature": 0.7,
+                        "top_p": 0.9,
+                        "frequency_penalty": 0.1,
+                        "presence_penalty": 0.2,
+                    }
+                )
+                assert response.status_code == 200, f"Response: {response.text}"
+                response_data = response.json()
+                print(f"Generated response: {response_data['choices'][0]['message']['content'][:100]}...")
+                outputs.append(response_data)
+
+        # 2. Check response structure
+        for response_data in outputs:
+            for key in ["id", "object", "created", "model", "choices", "usage"]:
+                assert key in response_data
+                assert response_data[key] is not None
+
+            for choice in response_data["choices"]:
+                assert "index" in choice and "message" in choice and "finish_reason" in choice
+                assert choice["index"] == 0 and choice["finish_reason"] in ["stop", "length"]
+                message = choice["message"]
+                assert "role" in message and "content" in message and message["role"] == "assistant"
+
+        # Shutdown server
+        shutdown_server(host=SERVER_HOST, port=SERVER_PORT, max_wait_seconds=5)
+        if server_thread.is_alive():
+            server_thread.join(timeout=5)
+
+    finally:
+        ray.shutdown()
+
+
+# def test_http_server_error_handling():
+#     """
+#     Test error handling for various invalid requests.
+#     """
+#     try:
+#         cfg = get_test_actor_config()
+#         cfg.trainer.placement.colocate_all = True
+#         cfg.generator.weight_sync_backend = "nccl"
+#         cfg.trainer.strategy = "fsdp2"
+
+#         client, policy, pg = init_inference_engines(
+#             cfg=cfg,
+#             v1=True,
+#             use_local=True,
+#             async_engine=cfg.generator.async_engine,
+#             tp_size=cfg.generator.inference_engine_tensor_parallel_size,
+#             colocate_all=cfg.trainer.placement.colocate_all,
+#         )
+
+#         from skyrl_train.inference_engines.launch_inference_engine_http_server import serve, wait_for_server_ready
+        
+#         # Start server in background thread
+#         def run_server():
+#             serve(client, host=SERVER_HOST, port=SERVER_PORT, log_level="warning")
+        
+#         server_thread = threading.Thread(target=run_server, daemon=True)
+#         server_thread.start()
+        
+#         # Wait for server to be ready
+#         wait_for_server_ready(host=SERVER_HOST, port=SERVER_PORT, max_wait_seconds=30)
+        
+#         base_url = f"http://{SERVER_HOST}:{SERVER_PORT}"
+        
+#         # Test 1: Invalid request - streaming not supported
+#         response = requests.post(
+#             f"{base_url}/v1/chat/completions",
+#             json={
+#                 "model": "test-model",
+#                 "messages": [{"role": "user", "content": "Hello"}],
+#                 "stream": True
+#             }
+#         )
+#         assert response.status_code == 422
+#         error_data = response.json()
+#         assert "detail" in error_data
+#         # Pydantic returns detailed field validation errors
+#         assert any("stream" in str(detail) for detail in error_data["detail"])
+        
+#         # Test 2: Invalid request - tools not supported
+#         response = requests.post(
+#             f"{base_url}/v1/chat/completions",
+#             json={
+#                 "model": "test-model", 
+#                 "messages": [{"role": "user", "content": "Hello"}],
+#                 "tools": [{"type": "function", "function": {"name": "test"}}]
+#             }
+#         )
+#         assert response.status_code == 422
+#         error_data = response.json()
+#         assert "detail" in error_data
+#         assert any("tools" in str(detail) for detail in error_data["detail"])
+        
+#         # Test 3: Invalid request - response_format not supported
+#         response = requests.post(
+#             f"{base_url}/v1/chat/completions",
+#             json={
+#                 "model": "test-model",
+#                 "messages": [{"role": "user", "content": "Hello"}],
+#                 "response_format": {"type": "json_object"}
+#             }
+#         )
+#         assert response.status_code == 422
+#         error_data = response.json()
+#         assert "detail" in error_data
+#         assert any("response_format" in str(detail) for detail in error_data["detail"])
+        
+#         # Test 4: Invalid request - missing required fields
+#         response = requests.post(
+#             f"{base_url}/v1/chat/completions",
+#             json={
+#                 "model": "test-model"
+#                 # Missing messages field
+#             }
+#         )
+#         assert response.status_code == 422
+#         error_data = response.json()
+#         assert "detail" in error_data
+#         assert any("messages" in str(detail) for detail in error_data["detail"])
+        
+#         # Test 5: Invalid request - malformed JSON
+#         response = requests.post(
+#             f"{base_url}/v1/chat/completions",
+#             data="invalid json",
+#             headers={"Content-Type": "application/json"}
+#         )
+#         assert response.status_code == 422
+        
+#         # Test 6: Invalid request - empty messages array
+#         response = requests.post(
+#             f"{base_url}/v1/chat/completions",
+#             json={
+#                 "model": "test-model",
+#                 "messages": []
+#             }
+#         )
+#         assert response.status_code == 422
+#         error_data = response.json()
+#         assert "detail" in error_data
+        
+#         # Test 7: Health check endpoint should work
+#         response = requests.get(f"{base_url}/health")
+#         assert response.status_code == 200
+#         health_data = response.json()
+#         assert health_data["status"] == "healthy"
+        
+#     finally:
+#         ray.shutdown()
+

--- a/skyrl-train/tests/gpu/test_http_inference_engine_client.py
+++ b/skyrl-train/tests/gpu/test_http_inference_engine_client.py
@@ -112,14 +112,8 @@ def test_http_server_openai_api_with_weight_sync(test_type):
                 response = openai_client.chat.completions.create(
                     model=MODEL,
                     messages=messages,
-                    max_tokens=50,
-                    temperature=0.7,
-                    top_p=0.9,
-                    frequency_penalty=0.1,
-                    presence_penalty=0.2,
                 )
                 print(f"Generated response: {response.choices[0].message.content[:100]}...")
-                # Use model_dump() instead of deprecated json() method
                 outputs.append(response.model_dump())
 
         else:
@@ -132,11 +126,6 @@ def test_http_server_openai_api_with_weight_sync(test_type):
                     json={
                         "model": MODEL,
                         "messages": messages,
-                        "max_tokens": 50,
-                        "temperature": 0.7,
-                        "top_p": 0.9,
-                        "frequency_penalty": 0.1,
-                        "presence_penalty": 0.2,
                     }
                 )
                 assert response.status_code == 200, f"Response: {response.text}"
@@ -146,7 +135,7 @@ def test_http_server_openai_api_with_weight_sync(test_type):
 
         # 2. Check response structure
         for response_data in outputs:
-            for key in ["id", "object", "created", "model", "choices", "usage"]:
+            for key in ["id", "object", "created", "model", "choices"]:
                 assert key in response_data
                 assert response_data[key] is not None
 

--- a/skyrl-train/tests/gpu/test_policy_vllm_e2e.py
+++ b/skyrl-train/tests/gpu/test_policy_vllm_e2e.py
@@ -18,7 +18,7 @@ from skyrl_train.inference_engines.utils import get_sampling_params_for_backend
 from skyrl_train.inference_engines.base import InferenceEngineInput
 from skyrl_train.entrypoints.main_base import config_dir
 
-model = "Qwen/Qwen2.5-1.5B-Instruct"
+MODEL = "Qwen/Qwen2.5-1.5B-Instruct"
 tp_size = 2
 
 
@@ -28,7 +28,7 @@ def get_test_actor_config() -> DictConfig:
         cfg = hydra.compose(config_name="ppo_base_config")
 
         # Override specific parameters
-        cfg.trainer.policy.model.path = model
+        cfg.trainer.policy.model.path = MODEL
         cfg.trainer.critic.model.path = ""
         cfg.trainer.placement.policy_num_gpus_per_node = 2
         cfg.generator.async_engine = True
@@ -56,6 +56,7 @@ def init_inference_engines(cfg, v1, use_local, async_engine, tp_size, colocate_a
                 "VLLM_USE_V1": "1" if v1 else "0",
                 "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
                 "PYTORCH_NVML_BASED_CUDA_CHECK": "1",
+                "VLLM_ALLOW_INSECURE_SERIALIZATION": "1",
             }
         },
     )
@@ -70,7 +71,7 @@ def init_inference_engines(cfg, v1, use_local, async_engine, tp_size, colocate_a
         num_inference_engines=1,
         tensor_parallel_size=tp_size,
         model_dtype="bfloat16",
-        pretrain=model,
+        pretrain=cfg.trainer.policy.model.path,
         seed=42,
         vllm_v1_disable_multiproc=True,
         enable_prefix_caching=True,
@@ -83,7 +84,7 @@ def init_inference_engines(cfg, v1, use_local, async_engine, tp_size, colocate_a
         max_num_batched_tokens=8192,
         max_num_seqs=1024,
         sampling_params=get_sampling_params_for_backend("vllm", cfg.generator.sampling_params),
-        tokenizer=AutoTokenizer.from_pretrained(model),
+        tokenizer=AutoTokenizer.from_pretrained(cfg.trainer.policy.model.path),
     )
     client = InferenceEngineClient(eps)
     if sleep:
@@ -143,6 +144,6 @@ def test_policy_vllm_e2e(colocate_all, weight_sync_backend, strategy):
         ray.get(policy.async_run_ray_method("pass_through", "init_weight_sync_state", client))
         asyncio.run(client.reset_prefix_cache())
         ray.get(policy.async_run_ray_method("pass_through", "broadcast_to_inference_engines", client))
-        asyncio.run(run_vllm_inference(client, get_test_prompts(model)))
+        asyncio.run(run_vllm_inference(client, get_test_prompts(MODEL)))
     finally:
         ray.shutdown()

--- a/skyrl-train/tests/gpu/test_policy_vllm_e2e.py
+++ b/skyrl-train/tests/gpu/test_policy_vllm_e2e.py
@@ -86,7 +86,7 @@ def init_inference_engines(cfg, v1, use_local, async_engine, tp_size, colocate_a
         sampling_params=get_sampling_params_for_backend("vllm", cfg.generator.sampling_params),
         tokenizer=AutoTokenizer.from_pretrained(cfg.trainer.policy.model.path),
     )
-    client = InferenceEngineClient(eps)
+    client = InferenceEngineClient(eps, generator_config=cfg.generator)
     if sleep:
         asyncio.run(client.wake_up())
     return client, pg

--- a/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
@@ -72,6 +72,17 @@ async def run_generator_end_to_end(
     End to end generator test - requires minimum 2 GPUs
     """
     tokenizer = AutoTokenizer.from_pretrained(model)
+    # Create a mock generator config
+    generator_cfg = DictConfig(
+        {
+            "sampling_params": {"max_generate_length": max_generate_length},
+            "max_input_length": max_input_length,
+            "batched": batched,
+            "max_turns": max_turns,
+            "zero_reward_on_non_stop": False,
+            "use_conversation_multi_turn": use_conversation_multi_turn,
+        }
+    )
 
     inference_engine_client = InferenceEngineClient(
         create_ray_wrapped_inference_engines(
@@ -103,22 +114,11 @@ async def run_generator_end_to_end(
                 ),
             ),
             tokenizer=tokenizer,
-        )
+        ),
+        generator_config=generator_cfg,
     )
 
     await inference_engine_client.wake_up()
-
-    # Create a mock generator config
-    generator_cfg = DictConfig(
-        {
-            "sampling_params": {"max_generate_length": max_generate_length},
-            "max_input_length": max_input_length,
-            "batched": batched,
-            "max_turns": max_turns,
-            "zero_reward_on_non_stop": False,
-            "use_conversation_multi_turn": use_conversation_multi_turn,
-        }
-    )
 
     env_cfg = DictConfig(
         {

--- a/skyrl-train/tests/sglang/test_policy_sglang_e2e.py
+++ b/skyrl-train/tests/sglang/test_policy_sglang_e2e.py
@@ -50,7 +50,7 @@ async def run_generation(client, prompts):
     await client.generate(engine_input)
 
 
-def init_sglang_engines(use_local, tp_size, colocate_all, sampling_params):
+def init_sglang_engines(cfg, use_local, tp_size, colocate_all, sampling_params):
     assert not use_local, "SGLang currently does not support local engines"
     assert not colocate_all, "SGLang currently does not support colocation"
 
@@ -128,7 +128,7 @@ def init_sglang_engines(use_local, tp_size, colocate_all, sampling_params):
         tensor_parallel_size=tp_size,
         sampling_params=sampling_params,
     )
-    client = InferenceEngineClient(engines)
+    client = InferenceEngineClient(engines, generator_config=cfg.generator)
     if sleep:
         asyncio.run(client.wake_up())
 
@@ -154,6 +154,7 @@ def test_policy_sglang_e2e(weight_sync_backend):
     cfg.generator.weight_sync_backend = weight_sync_backend
 
     llm_client, pg, server_actor = init_sglang_engines(
+        cfg=cfg,
         use_local=cfg.generator.run_engines_locally,
         tp_size=cfg.generator.inference_engine_tensor_parallel_size,
         colocate_all=cfg.trainer.placement.colocate_all,

--- a/skyrl-train/uv.lock
+++ b/skyrl-train/uv.lock
@@ -2711,6 +2711,7 @@ dependencies = [
     { name = "accelerate" },
     { name = "datasets" },
     { name = "debugpy" },
+    { name = "fastapi" },
     { name = "flash-attn" },
     { name = "func-timeout" },
     { name = "hf-transfer" },
@@ -2727,6 +2728,7 @@ dependencies = [
     { name = "tqdm" },
     { name = "transformers", version = "4.52.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-skyrl-train-sglang'" },
     { name = "transformers", version = "4.53.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-skyrl-train-vllm' or extra != 'extra-11-skyrl-train-sglang'" },
+    { name = "uvicorn" },
     { name = "wandb" },
 ]
 
@@ -2771,6 +2773,7 @@ requires-dist = [
     { name = "datasets" },
     { name = "debugpy", specifier = "==1.8.0" },
     { name = "deepspeed", marker = "extra == 'deepspeed'", specifier = "==0.16.5" },
+    { name = "fastapi" },
     { name = "flash-attn", url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.0.post2/flash_attn-2.8.0.post2+cu12torch2.7cxx11abiFALSE-cp312-cp312-linux_x86_64.whl" },
     { name = "flashinfer-python", marker = "extra == 'sglang'", url = "https://download.pytorch.org/whl/cu128/flashinfer/flashinfer_python-0.2.6.post1%2Bcu128torch2.7-cp39-abi3-linux_x86_64.whl" },
     { name = "flashinfer-python", marker = "extra == 'vllm'", url = "https://download.pytorch.org/whl/cu128/flashinfer/flashinfer_python-0.2.6.post1%2Bcu128torch2.7-cp39-abi3-linux_x86_64.whl" },
@@ -2803,6 +2806,7 @@ requires-dist = [
     { name = "torchvision", marker = "extra == 'vllm'", index = "https://download.pytorch.org/whl/cu128" },
     { name = "tqdm" },
     { name = "transformers", specifier = ">=4.51.0" },
+    { name = "uvicorn" },
     { name = "vllm", marker = "extra == 'vllm'", specifier = "==0.9.2" },
     { name = "wandb" },
 ]

--- a/skyrl-train/uv.lock
+++ b/skyrl-train/uv.lock
@@ -1061,6 +1061,29 @@ wheels = [
 ]
 
 [[package]]
+name = "litellm"
+version = "1.74.9.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai", version = "1.90.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-skyrl-train-vllm'" },
+    { name = "openai", version = "1.91.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-skyrl-train-sglang' or extra != 'extra-11-skyrl-train-vllm'" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/39/60a16cfa5aa43498f35538aa2c4608f303eaa60396e862e38ecdc5c85681/litellm-1.74.9.post1.tar.gz", hash = "sha256:968cc4ef2afa701a3da78389d1fd1514ace1574c09e46785972c1e1d594547f1", size = 9660690, upload-time = "2025-07-29T00:53:32.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/0b/3951fc38b726a1a72fa806ab46fc64bbf2b92cbed69be856dd768196e16a/litellm-1.74.9.post1-py3-none-any.whl", hash = "sha256:9247808f90247073cb63657fb23e00d8ec2c46af8792476f61d9517e7c9633ae", size = 8740465, upload-time = "2025-07-29T00:53:29.976Z" },
+]
+
+[[package]]
 name = "llguidance"
 version = "0.7.30"
 source = { registry = "https://pypi.org/simple" }
@@ -1661,14 +1684,14 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "extra == 'extra-11-skyrl-train-vllm'" },
+    { name = "distro", marker = "extra == 'extra-11-skyrl-train-vllm'" },
+    { name = "httpx", marker = "extra == 'extra-11-skyrl-train-vllm'" },
+    { name = "jiter", marker = "extra == 'extra-11-skyrl-train-vllm'" },
+    { name = "pydantic", marker = "extra == 'extra-11-skyrl-train-vllm'" },
+    { name = "sniffio", marker = "extra == 'extra-11-skyrl-train-vllm'" },
+    { name = "tqdm", marker = "extra == 'extra-11-skyrl-train-vllm'" },
+    { name = "typing-extensions", marker = "extra == 'extra-11-skyrl-train-vllm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2d/30/0bdb712f5e25e823a76828136de6043f28bd69363886c417e05d7021420e/openai-1.90.0.tar.gz", hash = "sha256:9771982cdd5b6631af68c6a603da72ed44cd2caf73b49f717a72b71374bc565b", size = 471896, upload-time = "2025-06-20T20:22:18.349Z" }
 wheels = [
@@ -1680,9 +1703,11 @@ name = "openai"
 version = "1.91.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "sys_platform != 'linux'",
+    "platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-11-skyrl-train-sglang' and extra != 'extra-11-skyrl-train-vllm'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'extra-11-skyrl-train-sglang' and extra != 'extra-11-skyrl-train-vllm'",
+    "sys_platform != 'linux' and extra == 'extra-11-skyrl-train-sglang' and extra != 'extra-11-skyrl-train-vllm'",
+    "sys_platform == 'linux' and extra != 'extra-11-skyrl-train-sglang' and extra != 'extra-11-skyrl-train-vllm'",
+    "sys_platform != 'linux' and extra != 'extra-11-skyrl-train-sglang' and extra != 'extra-11-skyrl-train-vllm'",
 ]
 dependencies = [
     { name = "anyio" },
@@ -2751,6 +2776,9 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-rtd-theme" },
 ]
+litellm = [
+    { name = "litellm" },
+]
 sglang = [
     { name = "flashinfer-python" },
     { name = "sglang", extra = ["openai", "srt", "torch-memory-saver"], marker = "extra == 'extra-11-skyrl-train-sglang'" },
@@ -2781,6 +2809,7 @@ requires-dist = [
     { name = "hf-transfer" },
     { name = "hydra-core", specifier = "==1.3.2" },
     { name = "jaxtyping" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.67.5" },
     { name = "loguru" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0.0" },
     { name = "omegaconf" },
@@ -2810,7 +2839,7 @@ requires-dist = [
     { name = "vllm", marker = "extra == 'vllm'", specifier = "==0.9.2" },
     { name = "wandb" },
 ]
-provides-extras = ["deepspeed", "dev", "docs", "vllm", "sglang"]
+provides-extras = ["deepspeed", "dev", "docs", "litellm", "vllm", "sglang"]
 
 [[package]]
 name = "smmap"


### PR DESCRIPTION
This is a first stab for https://github.com/NovaSky-AI/SkyRL/issues/96

We merge this PR to a separate branch `http-inf_engine-openai` for now for users to build on top of.

The intended use case is when users have their existing agent harness and want to do rollout with the existing code while using SkyRL.

After setting the following configs:
```
generator:
  use_http_server_inference_engine_client: true
  http_server_inference_engine_client_host: "127.0.0.1"
  http_server_inference_engine_client_port: 8000
```
user can post OpenAI requests to `127.0.0.1:8000` in tools like `openai.OpenAI` or `litellm`. You can refer to `skyrl-train/examples/rollout_with_http_server_litellm.py` on how to use this feature.

Underlying-ly, when these configs are set, we launch a FastAPI server when calling `InferenceEngineClient.__init__()`, and only return when the server is ready.

We support OpenAI API, including features like `response_format`, but not features like `stream` or `tools` yet. You can see the supported / unsupported fields in `openai_api_protocol.py`.

### This PR is verified with:
- Running `run_gsm8k.sh` with `skyrl_gym_generator.py` but with `generate_with_http_server()` rather than `inference_engine_client.generate()`. Note this `generate_with_http_server()` is only intended for testing
- Unit tests `tests/gpu/test_http_inference_engine_client.py` and `skyrl-train/tests/cpu/http/test_openai_request_utils.py`
- `rollout_with_http_server_litellm.py` to check compatibility with tools like LiteLLM

However, how to balance such ease of use with token-in-token-out (https://github.com/NovaSky-AI/SkyRL/issues/123) is still under discussion. 

### TODOs:
- [x] Clean up `openai_api_protocol.py` -- be clear about the fields we do not support right now
- [x] CPU unit tests for `convert_inference_output_to_openai()` and `convert_openai_to_inference_input()`
- [x] Add a config flag that will spin up this server; test with `skyrl_gym_generator.py` E2E on `run_gsm8k.sh`
- [x] Address `trajectory_id`
- [x] Be more pragmatic about translating ChatCompletionRequest' sampling-related params to our `sampling_params` in `launch_inference_engine_http_server.py`
- [x] Check error handling
- [x] Test E2E with SkyRLGymGenerator with HTTP server, make sure performance not affected
  - Before 0.5B run_gsm8k takes 100sec for each step's generate, now it takes 130sec. It should be the performance difference between adding each request to the vLLM engine (with HTTP server) vs. batched generate with an offline engine.

### Quick note:
- If we use `OpenAI.chat.completions.create()` in `skyrl_gym_generator.py` without setting a maximum limit on the number of HTTP requests, it will hang. Using `aiohttp.ClientSession().post` does not have this issue. Revisit once this issue is encountered again.