### PR TITLE
Make ray dependency lower-bounded

### DIFF
--- a/skyrl-train/pyproject.toml
+++ b/skyrl-train/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "accelerate",
     "torchdata",
     "omegaconf",
-    "ray==2.44.0",
+    "ray>=2.44.0",
     "peft",
     "debugpy==1.8.0",
     "hf_transfer",
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [tool.uv]
-override-dependencies = ["ray==2.44.0"]
+override-dependencies = ["ray>=2.44.0"]
 conflicts = [
     [
         { extra = "vllm" },


### PR DESCRIPTION
We are trying to run SkyRL on a managed ray cluster running version 2.46.0. Making this dependency a lower bound should allow for this.