### PR TITLE
[Docs] Add docs for running on an existing ray cluster

### DIFF
--- a/.github/workflows/cpu_ci.yaml
+++ b/.github/workflows/cpu_ci.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           activate-environment: true
       - name: Install skyrl-train
-        run:  uv sync --frozen --extra dev # installs from lock file
+        run:  uv sync --frozen --extra dev --extra muon # installs from lock file
       - name: Run cpu tests
         run:  uv run --frozen pytest tests/cpu/
   

--- a/.github/workflows/cpu_ci.yaml
+++ b/.github/workflows/cpu_ci.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           activate-environment: true
       - name: Install skyrl-train
-        run:  uv sync --frozen --extra dev --extra muon # installs from lock file
+        run:  uv sync --frozen --extra dev # installs from lock file
       - name: Run cpu tests
         run:  uv run --frozen pytest tests/cpu/
   

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -123,9 +123,9 @@ Finally, you can initialize a Ray cluster using the following command (for singl
 You should now be to able to run our :doc:`quick start example <quickstart>`.
 
 Running on an existing Ray cluster
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------
 
-For running on an existing Ray cluster, you need to make sure that the python version used is 3.12. SkyRL-Train should be compatible with any ray version 2.44 and above (Except 2.47.0 and 2.47.1 - which we do not recommend due to an issue in the uv + ray integration). Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46) would be to use override at runtime: 
+For running on an existing Ray cluster, you need to first make sure that the python version used is 3.12. SkyRL-Train should be compatible with any ray version 2.44 and above (Except 2.47.0 and 2.47.1 - which we do not recommend due to an issue in the uv + ray integration). Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46) would be to override the version at runtime with the ``--with`` flag.
 
 .. code-block:: bash
     uv run .... --with ray=2.46.0 skyrl_train.entrypoints.main_base ...

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -125,10 +125,10 @@ You should now be to able to run our :doc:`quick start example <quickstart>`.
 Running on an existing Ray cluster
 ----------------------------------
 
-For running on an existing Ray cluster, you need to first make sure that the python version used is 3.12. SkyRL-Train should be compatible with any ray version 2.44 and above (Except 2.47.0 and 2.47.1 - which we do not recommend due to an issue in the uv + ray integration). Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46) would be to override the version at runtime with the ``--with`` flag.
+For running on an existing Ray cluster, you need to first make sure that the python version used is 3.12. SkyRL-Train should be compatible with any ray version 2.44 and above (Except 2.47.0 and 2.47.1 - which we do not recommend due to an issue in the uv + ray integration). Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46) would be to override the version at runtime with the ``--with`` flag. For example, to run with Ray 2.46, you can do:
 
 .. code-block:: bash
-    uv run .... --with ray=2.46.0 skyrl_train.entrypoints.main_base ...
+    uv run .... --with ray==2.46.0 -m skyrl_train.entrypoints.main_base ...
 
 
 Development 

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -122,6 +122,14 @@ Finally, you can initialize a Ray cluster using the following command (for singl
 
 You should now be to able to run our :doc:`quick start example <quickstart>`.
 
+Running on an existing Ray cluster
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For running on an existing Ray cluster, you need to make sure that the python version used is 3.12. SkyRL-Train should be compatible with any ray version 2.44 and above (Except 2.47.0 and 2.47.1 - which we do not recommend due to an issue in the uv + ray integration). Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46) would be to use override at runtime: 
+
+.. code-block:: bash
+    uv run .... --with ray=2.46.0 skyrl_train.entrypoints.main_base ...
+
 
 Development 
 -----------

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -125,9 +125,10 @@ You should now be to able to run our :doc:`quick start example <quickstart>`.
 Running on an existing Ray cluster
 ----------------------------------
 
-For running on an existing Ray cluster, you need to first make sure that the python version used is 3.12. SkyRL-Train should be compatible with any ray version 2.44 and above (Except 2.47.0 and 2.47.1 - which we do not recommend due to an issue in the uv + ray integration). Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46) would be to override the version at runtime with the ``--with`` flag. For example, to run with Ray 2.46, you can do:
+For running on an existing Ray cluster, you need to first make sure that the python version used is 3.12. SkyRL-Train should be compatible with any Ray version 2.44 and above (except 2.47.0 and 2.47.1 -- which we do not recommend due to an issue in the uv + Ray integration). Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46) would be to override the version at runtime with the ``--with`` flag. For example, to run with Ray 2.46, you can do:
 
 .. code-block:: bash
+
     uv run .... --with ray==2.46.0 -m skyrl_train.entrypoints.main_base ...
 
 


### PR DESCRIPTION
# What does this PR do?

Adds documentation for running on an existing ray cluster with a different ray version. Currently, we use a uv lockfile to pin all dependencies, so this PR adds some instructions for overriding the ray version. To make sure as many users as possible to through the same "golden path", we will have one recommended Ray version that is pinned and well-tested. In the future as we get more CI testing bandwidth, we will expand the support to more Ray versions.