### PR TITLE
[dependencies] Upgrade ray to 2.48.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM anyscale/ray:2.44.0-slim-py312-cu128
+FROM anyscale/ray:2.48.0-slim-py312-cu128
 
 RUN sudo apt-get update -y && sudo apt-get install -y wget kmod libxml2 build-essential libnuma-dev
 
@@ -17,8 +17,3 @@ RUN sudo apt-get update \
 RUN sudo apt update && sudo apt install --fix-broken && sudo apt install -y default-jre-headless openjdk-8-jdk \
     && sudo apt-get clean \
     && sudo rm -rf /var/lib/apt/lists/*
-
-# NOTE: vllm installation in base environment is needed for uv + vLLM to work
-RUN pip install vllm==0.9.2 --extra-index-url https://download.pytorch.org/whl/cu128 \
-    && pip install ray==2.44.0 \
-    && rm -rf ~/.cache/pip

--- a/docker/Dockerfile.ray244
+++ b/docker/Dockerfile.ray244
@@ -1,0 +1,22 @@
+FROM anyscale/ray:2.44.0-slim-py312-cu128
+
+RUN sudo apt-get update -y && sudo apt-get install -y wget kmod libxml2 build-essential libnuma-dev
+
+# the cuda compiler here is needed for deepspeed
+RUN wget https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda_12.8.0_570.86.10_linux.run \
+    && sudo sh cuda_12.8.0_570.86.10_linux.run --silent --toolkit && rm -rf cuda_12.8.0_570.86.10_linux.run
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN echo "export RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook" >> /home/ray/.bashrc
+RUN sudo apt-get update \
+    && sudo apt-get install -y openssh-server iputils-ping net-tools iproute2 traceroute netcat \
+    libopenexr-dev libxi-dev libglfw3-dev libglew-dev libomp-dev libxinerama-dev libxcursor-dev tzdata \
+    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt update && sudo apt install --fix-broken && sudo apt install -y default-jre-headless openjdk-8-jdk \
+    && sudo apt-get clean \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# NOTE: vllm installation in base environment is needed for uv + vLLM to work
+RUN pip install vllm==0.9.2 --extra-index-url https://download.pytorch.org/whl/cu128 \
+    && pip install ray==2.44.0 omegaconf==2.3.0 loguru==0.7.3 \
+    && rm -rf ~/.cache/pip
+RUN pip install pyarrow==20.0.0 jaxtyping==0.3.2 && rm -rf ~/.cache/pip

--- a/skyrl-train/README.md
+++ b/skyrl-train/README.md
@@ -45,7 +45,7 @@ The only requirements are:
 - CUDA version 12.8
 - [uv](https://docs.astral.sh/uv/)
 
-If you're running on an existing Ray cluster, make sure to use Ray 2.44.0 and Python 3.12. If not, proceed with the installation instructions below.
+If you're running on an existing Ray cluster, make sure to use Ray 2.48.0 and Python 3.12. If not, proceed with the installation instructions below.
 
 
 First, clone the repository:

--- a/skyrl-train/ci/anyscale_gpu_ci.yaml
+++ b/skyrl-train/ci/anyscale_gpu_ci.yaml
@@ -1,6 +1,6 @@
 name: skyrl-train-gpu-ci
 entrypoint: bash ci/gpu_ci_run.sh
-image_uri: sumanthrh/skyrl-train-ray-2.48.0-py3.12-cu12.8 # (Optional) Exclusive with `containerfile`.
+image_uri: erictang000/skyrl-train-ray-2.48.0-py3.12-cu12.8 # (Optional) Exclusive with `containerfile`.
 cloud: sky-anyscale-aws-us-east-1
 ray_version: "2.48.0"
 compute_config: l4_ci 

--- a/skyrl-train/ci/anyscale_gpu_ci.yaml
+++ b/skyrl-train/ci/anyscale_gpu_ci.yaml
@@ -1,8 +1,8 @@
 name: skyrl-train-gpu-ci
 entrypoint: bash ci/gpu_ci_run.sh
-image_uri: sumanthrh/skyrl-train-ray-2.44.0-py3.12-cu12.8 # (Optional) Exclusive with `containerfile`.
+image_uri: sumanthrh/skyrl-train-ray-2.48.0-py3.12-cu12.8 # (Optional) Exclusive with `containerfile`.
 cloud: sky-anyscale-aws-us-east-1
-ray_version: "2.44.0"
+ray_version: "2.48.0"
 compute_config: l4_ci 
 working_dir: . # (Optional) Use current working directory "." as the working_dir. Can be any local path or remote .zip file in cloud storage.
 env_vars:

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -128,13 +128,27 @@ Running on an existing Ray cluster
 
 For running on an existing Ray cluster, you need to first make sure that the python version used is 3.12. 
 
-We recommend using Ray version 2.48.0 and above for the best experience. However, SkyRL-Train is compatible with any Ray version 2.44.0 and above (except 2.47.0 and 2.47.1 -- which we do not recommend due to an issue in the uv + Ray integration). Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46.0) would be to override the version at runtime with the ``--with`` flag. For example, to run with Ray 2.46.0, you can do:
+Ray >= 2.48.0
+~~~~~~~~~~~~~
+
+We recommend using Ray version 2.48.0 and above for the best experience. In this case, you can simply use the ``uv run`` command to get training started.
+
+.. code-block:: bash
+
+    uv run -m skyrl_train.entrypoints.main_base ...
+
+Ray < 2.48.0
+~~~~~~~~~~~~
+SkyRL-Train is compatible with any Ray version 2.44.0 and above (except 2.47.0 and 2.47.1 -- which we do not recommend due to an issue in the uv + Ray integration). 
+Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46.0) would be to override the version at runtime with the ``--with`` flag. 
+For example, to run with Ray 2.46.0, you can do:
 
 .. code-block:: bash
 
     uv run .... --with ray==2.46.0 -m skyrl_train.entrypoints.main_base ...
 
-For ray versions >= 2.44.0 but < 2.48.0, you need to install vllm in the base pip environment, and then re-install ray to your desired version to ensure that the uv + Ray integration works as expected.
+For ray versions >= 2.44.0 but < 2.48.0, you additionally need to install vllm in the base pip environment, and then re-install ray to your desired version to ensure that the uv + Ray integration works as expected. 
+We include these dependencies in the legacy Dockerfile: `Dockerfile.ray244 <https://github.com/NovaSky-AI/SkyRL/blob/main/docker/Dockerfile.ray244>`_.
 
 .. code-block:: bash
 

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -135,7 +135,7 @@ We recommend using Ray version 2.48.0 and above for the best experience. In this
 
 .. code-block:: bash
 
-    uv run -m skyrl_train.entrypoints.main_base ...
+    uv run ... --with ray==2.xx.yy -m skyrl_train.entrypoints.main_base ...
 
 Ray < 2.48.0
 ~~~~~~~~~~~~

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -148,7 +148,7 @@ For example, to run with Ray 2.46.0, you can do:
     uv run .... --with ray==2.46.0 -m skyrl_train.entrypoints.main_base ...
 
 For ray versions >= 2.44.0 but < 2.48.0, you additionally need to install vllm in the base pip environment, and then re-install ray to your desired version to ensure that the uv + Ray integration works as expected. 
-We include these dependencies in the legacy Dockerfile: `Dockerfile.ray244 <https://github.com/NovaSky-AI/SkyRL/blob/main/docker/Dockerfile.ray244>`_.
+We include these dependencies in the legacy Dockerfile: `Dockerfile.ray244 <https://github.com/NovaSky-AI/SkyRL/blob/main/docker/Dockerfile.ray244>`_, or you can install them manually:
 
 .. code-block:: bash
 

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -14,7 +14,7 @@ If you're running on an existing Ray cluster, make sure to use Ray 2.48.0 and Py
 Docker (recommended)
 ---------------------
 
-We provide a docker image with the base dependencies ``sumanthrh/skyrl-train-ray-2.48.0-py3.12-cu12.8`` for quick setup. 
+We provide a docker image with the base dependencies ``erictang000/skyrl-train-ray-2.48.0-py3.12-cu12.8`` for quick setup. 
 
 1. Make sure to have `NVIDIA Container Runtime <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html>`_ installed.
 
@@ -22,7 +22,7 @@ We provide a docker image with the base dependencies ``sumanthrh/skyrl-train-ray
 
 .. code-block:: bash
 
-    docker run -it  --runtime=nvidia --gpus all --shm-size=8g --name skyrl-train sumanthrh/skyrl-train-ray-2.48.0-py3.12-cu12.8 /bin/bash
+    docker run -it  --runtime=nvidia --gpus all --shm-size=8g --name skyrl-train erictang000/skyrl-train-ray-2.48.0-py3.12-cu12.8 /bin/bash
 
 3. Inside the launched container, setup the latest version of the project:
 

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -8,7 +8,7 @@ Requirements
 
 We use `uv <https://docs.astral.sh/uv/>`_ to manage dependencies. We also make use of the `uv` and `ray` integration to manage dependencies for ray workers. 
 
-If you're :ref:`running on an existing Ray cluster <running-on-existing-ray-cluster>`, make sure to use Ray 2.48.0 and Python 3.12.
+If you're :ref:`running on an existing Ray cluster <running-on-existing-ray-cluster>`, we suggest using Ray 2.48.0 and Python 3.12.
 
 
 Docker (recommended)
@@ -121,15 +121,25 @@ Finally, you can initialize a Ray cluster using the following command (for singl
 
 You should now be to able to run our :doc:`quick start example <quickstart>`.
 
+.. _running-on-existing-ray-cluster:
+
 Running on an existing Ray cluster
 ----------------------------------
 
-For running on an existing Ray cluster, you need to first make sure that the python version used is 3.12. SkyRL-Train should be compatible with any Ray version 2.44 and above (except 2.47.0 and 2.47.1 -- which we do not recommend due to an issue in the uv + Ray integration). Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46) would be to override the version at runtime with the ``--with`` flag. For example, to run with Ray 2.46, you can do:
+For running on an existing Ray cluster, you need to first make sure that the python version used is 3.12. 
+
+We recommend using Ray version 2.48.0 and above for the best experience. However, SkyRL-Train is compatible with any Ray version 2.44.0 and above (except 2.47.0 and 2.47.1 -- which we do not recommend due to an issue in the uv + Ray integration). Since we use a uv lockfile to pin dependencies, the best way to run SkyRL-Train on a custom Ray version (say 2.46.0) would be to override the version at runtime with the ``--with`` flag. For example, to run with Ray 2.46.0, you can do:
 
 .. code-block:: bash
 
     uv run .... --with ray==2.46.0 -m skyrl_train.entrypoints.main_base ...
 
+For ray versions >= 2.44.0 but < 2.48.0, you need to install vllm in the base pip environment, and then re-install ray to your desired version to ensure that the uv + Ray integration works as expected.
+
+.. code-block:: bash
+
+    pip install vllm==0.9.2 --extra-index-url https://download.pytorch.org/whl/cu128
+    pip install ray==2.46.0
 
 Development 
 -----------

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -8,7 +8,7 @@ Requirements
 
 We use `uv <https://docs.astral.sh/uv/>`_ to manage dependencies. We also make use of the `uv` and `ray` integration to manage dependencies for ray workers. 
 
-If you're running on an existing Ray cluster, make sure to use Ray 2.48.0 and Python 3.12.
+If you're :ref:`running on an existing Ray cluster <running-on-existing-ray-cluster>`, make sure to use Ray 2.48.0 and Python 3.12.
 
 
 Docker (recommended)
@@ -103,7 +103,6 @@ After activating the virtual environment, make sure to configure Ray to use `uv`
     export RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook
     # or add to your .bashrc
     # echo 'export RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook' >> ~/.bashrc
-
 
 Initialize Ray cluster
 ----------------------

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -8,13 +8,13 @@ Requirements
 
 We use `uv <https://docs.astral.sh/uv/>`_ to manage dependencies. We also make use of the `uv` and `ray` integration to manage dependencies for ray workers. 
 
-If you're running on an existing Ray cluster, make sure to use Ray 2.44.0 and Python 3.12.
+If you're running on an existing Ray cluster, make sure to use Ray 2.48.0 and Python 3.12.
 
 
 Docker (recommended)
 ---------------------
 
-We provide a docker image with the base dependencies ``sumanthrh/skyrl-train-ray-2.44.0-py3.12-cu12.8`` for quick setup. 
+We provide a docker image with the base dependencies ``sumanthrh/skyrl-train-ray-2.48.0-py3.12-cu12.8`` for quick setup. 
 
 1. Make sure to have `NVIDIA Container Runtime <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html>`_ installed.
 
@@ -22,7 +22,7 @@ We provide a docker image with the base dependencies ``sumanthrh/skyrl-train-ray
 
 .. code-block:: bash
 
-    docker run -it  --runtime=nvidia --gpus all --shm-size=8g --name skyrl-train sumanthrh/skyrl-train-ray-2.44.0-py3.12-cu12.8 /bin/bash
+    docker run -it  --runtime=nvidia --gpus all --shm-size=8g --name skyrl-train sumanthrh/skyrl-train-ray-2.48.0-py3.12-cu12.8 /bin/bash
 
 3. Inside the launched container, setup the latest version of the project:
 
@@ -41,7 +41,7 @@ For installation without the Dockerfile, make sure you meet the pre-requisities:
 
 - CUDA 12.8
 - `uv <https://docs.astral.sh/uv/>`_
-- `ray <https://docs.ray.io/en/latest/>`_ 2.44.0
+- `ray <https://docs.ray.io/en/latest/>`_ 2.48.0
 
 System Dependencies
 ~~~~~~~~~~~~~~~~~~~

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -139,7 +139,7 @@ For ray versions >= 2.44.0 but < 2.48.0, you need to install vllm in the base pi
 .. code-block:: bash
 
     pip install vllm==0.9.2 --extra-index-url https://download.pytorch.org/whl/cu128
-    pip install ray==2.46.0
+    pip install ray==2.46.0 omegaconf==2.3.0 loguru==0.7.3 jaxtyping==0.3.2 pyarrow==20.0.0
 
 Development 
 -----------

--- a/skyrl-train/pyproject.toml
+++ b/skyrl-train/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "accelerate",
     "torchdata",
     "omegaconf",
-    "ray==2.44.0",
+    "ray==2.48.0",
     "peft",
     "debugpy==1.8.0",
     "hf_transfer",
@@ -41,7 +41,6 @@ dependencies = [
 ]
 
 [tool.uv]
-override-dependencies = ["ray==2.44.0"]
 conflicts = [
     [
         { extra = "vllm" },

--- a/skyrl-train/uv.lock
+++ b/skyrl-train/uv.lock
@@ -17,9 +17,6 @@ conflicts = [[
     { package = "skyrl-train", extra = "vllm" },
 ]]
 
-[manifest]
-overrides = [{ name = "ray", specifier = "==2.44.0" }]
-
 [[package]]
 name = "absl-py"
 version = "2.3.0"
@@ -383,6 +380,20 @@ wheels = [
 ]
 
 [[package]]
+name = "cupy-cuda12x"
+version = "13.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastrlock", marker = "sys_platform != 'darwin'" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/4a/1f5346f610c55e63c296fedea9cf3a7283ba057ac19f18b3b201038c2598/cupy_cuda12x-13.5.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:d841701470e7c3da63c751d1bdf5eca0cae3ff4f485923f419e21912fc8b25b1", size = 118630886, upload-time = "2025-07-11T04:38:32.735Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/01/f04662dccce0f40060b9fd2fe35eb8a42666312332c01cfe7fbae97f8e81/cupy_cuda12x-13.5.1-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:09cfccd917d9ce96c7c457b80172f939c92ad1dfc923b9135c86b519c77e81a6", size = 113069415, upload-time = "2025-07-11T04:38:38.212Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1b/107b485a0d4caed85b2792fc8353b1708789216b6d22b15c0ee8d22142b1/cupy_cuda12x-13.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:8e71d51782dc071118909872e069724479cdb0286e93a7b4ddf2acd21c892dd3", size = 89981695, upload-time = "2025-07-11T04:38:42.907Z" },
+]
+
+[[package]]
 name = "datasets"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -587,6 +598,20 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-11-skyrl-train-vllm'" },
+]
+
+[[package]]
+name = "fastrlock"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/b1/1c3d635d955f2b4bf34d45abf8f35492e04dbd7804e94ce65d9f928ef3ec/fastrlock-0.8.3.tar.gz", hash = "sha256:4af6734d92eaa3ab4373e6c9a1dd0d5ad1304e172b1521733c6c3b3d73c8fa5d", size = 79327, upload-time = "2024-12-17T11:03:39.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/df/56270f2e10c1428855c990e7a7e5baafa9e1262b8e789200bd1d047eb501/fastrlock-0.8.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8cb2cf04352ea8575d496f31b3b88c42c7976e8e58cdd7d1550dfba80ca039da", size = 55727, upload-time = "2024-12-17T11:02:17.26Z" },
+    { url = "https://files.pythonhosted.org/packages/57/21/ea1511b0ef0d5457efca3bf1823effb9c5cad4fc9dca86ce08e4d65330ce/fastrlock-0.8.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85a49a1f1e020097d087e1963e42cea6f307897d5ebe2cb6daf4af47ffdd3eed", size = 52201, upload-time = "2024-12-17T11:02:19.512Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/cdecb7aa976f34328372f1c4efd6c9dc1b039b3cc8d3f38787d640009a25/fastrlock-0.8.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f13ec08f1adb1aa916c384b05ecb7dbebb8df9ea81abd045f60941c6283a670", size = 53924, upload-time = "2024-12-17T11:02:20.85Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6d/59c497f8db9a125066dd3a7442fab6aecbe90d6fec344c54645eaf311666/fastrlock-0.8.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0ea4e53a04980d646def0f5e4b5e8bd8c7884288464acab0b37ca0c65c482bfe", size = 52140, upload-time = "2024-12-17T11:02:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/62/04/9138943c2ee803d62a48a3c17b69de2f6fa27677a6896c300369e839a550/fastrlock-0.8.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:38340f6635bd4ee2a4fb02a3a725759fe921f2ca846cb9ca44531ba739cc17b4", size = 53261, upload-time = "2024-12-17T11:02:24.418Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4b/db35a52589764c7745a613b6943bbd018f128d42177ab92ee7dde88444f6/fastrlock-0.8.3-cp312-cp312-win_amd64.whl", hash = "sha256:da06d43e1625e2ffddd303edcd6d2cd068e1c486f5fd0102b3f079c44eb13e2c", size = 31235, upload-time = "2024-12-17T11:02:25.708Z" },
 ]
 
 [[package]]
@@ -2312,13 +2337,11 @@ wheels = [
 
 [[package]]
 name = "ray"
-version = "2.44.0"
+version = "2.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiosignal" },
     { name = "click" },
     { name = "filelock" },
-    { name = "frozenlist" },
     { name = "jsonschema" },
     { name = "msgpack" },
     { name = "packaging" },
@@ -2327,11 +2350,16 @@ dependencies = [
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/2f/15ec0da8b0716b838299760b88b7ffc042ef79d40248a799364eb2ef1b13/ray-2.44.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:53dc75ea2b4fd869ea4a6cca9de5e02aa24f2f0d18e0a08b8a765ab2be65dd1c", size = 68138830, upload-time = "2025-03-21T05:23:57.54Z" },
-    { url = "https://files.pythonhosted.org/packages/30/64/77d2839d66058530ca434dd0d5fa4299480644208f1966cdd972f3ada7f6/ray-2.44.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:398e9be193c97f734af019f0eface1f45c94195b96ecc4a647ad607650df572c", size = 65431753, upload-time = "2025-03-21T05:24:04.94Z" },
-    { url = "https://files.pythonhosted.org/packages/34/5b/fa9a467d2b8b53d04be1743cd7732a5ef98f5227200bb75544cdae0c75eb/ray-2.44.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:2a911e699e483ac4879110b608b06b35e602191c0e7b97326ca497c5caafe6a8", size = 67189648, upload-time = "2025-03-21T05:24:11.206Z" },
-    { url = "https://files.pythonhosted.org/packages/70/eb/aba1de11b1dda0257599ed04260c9fec9cb3d0e77f4abcac9319db59e60d/ray-2.44.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:0d65ac523801e40a397bbf552f406867bb9469dd261046ca63cdc2ec3110db87", size = 68129021, upload-time = "2025-03-21T05:24:17.539Z" },
-    { url = "https://files.pythonhosted.org/packages/98/b9/04043b1fa05994b459eb32cd8fcebe495df5558099a705e6dd1e99b76444/ray-2.44.0-cp312-cp312-win_amd64.whl", hash = "sha256:9bb3b6df352653c4479325161a0e17e2c6b3278661c69ff842602d7440312af7", size = 25682480, upload-time = "2025-03-21T05:24:22.865Z" },
+    { url = "https://files.pythonhosted.org/packages/41/53/0d105e1baa6c8c9582f90154ba3f0ca08d58129384ea2707b2e59449b03b/ray-2.48.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:8de799f3b0896f48d306d5e4a04fc6037a08c495d45f9c79935344e5693e3cf8", size = 67302857, upload-time = "2025-07-18T22:33:06.414Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/7de1e9d92a45b1805fe828dcbd18b4c5a1f35ab3cad9134efeb20a3ab3e5/ray-2.48.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:5a6f57126eac9dd3286289e07e91e87b054792f9698b6f7ccab88b624816b542", size = 69823198, upload-time = "2025-07-18T22:33:12.494Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a6/e7c969bd371c65b7c233d86f23610489e15164ee7eadb3eb78f9d55eda4d/ray-2.48.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:f1cf33d260316f92f77558185f1c36fc35506d76ee7fdfed9f5b70f9c4bdba7f", size = 69151702, upload-time = "2025-07-18T22:33:18.655Z" },
+    { url = "https://files.pythonhosted.org/packages/61/02/1894be2ab930b599de0f1f77f785b86c78bda4873c6c2dd65d1de5b40837/ray-2.48.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:a42ed3b640f4b599a3fc8067c83ee60497c0f03d070d7a7df02a388fa17a546b", size = 70124265, upload-time = "2025-07-18T22:33:25.155Z" },
+    { url = "https://files.pythonhosted.org/packages/79/8c/d3653d17337fc787af108411d9c9a38333c9fbdf247283ee56dd096d3360/ray-2.48.0-cp312-cp312-win_amd64.whl", hash = "sha256:e15fdffa6b60d5729f6025691396b8a01dc3461ba19dc92bba354ec1813ed6b1", size = 26745570, upload-time = "2025-07-18T22:33:31.328Z" },
+]
+
+[package.optional-dependencies]
+cgraph = [
+    { name = "cupy-cuda12x", marker = "sys_platform != 'darwin'" },
 ]
 
 [[package]]
@@ -2785,7 +2813,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=6.2.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
-    { name = "ray", specifier = "==2.44.0" },
+    { name = "ray", specifier = "==2.48.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.11.9" },
     { name = "sglang", extras = ["srt", "openai", "torch-memory-saver"], marker = "extra == 'sglang'", specifier = "==0.4.8.post1" },
     { name = "skyrl-gym", editable = "skyrl-gym" },
@@ -3620,7 +3648,7 @@ dependencies = [
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "pyzmq" },
-    { name = "ray" },
+    { name = "ray", extra = ["cgraph"], marker = "extra == 'extra-11-skyrl-train-vllm'" },
     { name = "regex" },
     { name = "requests" },
     { name = "scipy" },


### PR DESCRIPTION
# What does this PR do
Upgrades ray to 2.48.0, which allows us to remove the pip install vllm in the Dockerfile as a fallback for when uv + vllm does not resolve dependencies with the vllm + ray backend correctly.

We leave the previous Dockerfile in `docker/Dockerfile.ray244` for backwards compatibility