### PR TITLE
Add check for whether p2p access is supported - allows code to run on L4/L40S after #73 upgrade to cuda 12.8

### DIFF
--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -267,7 +267,7 @@ def initialize_ray(cfg: DictConfig):
             )
             env_vars["VLLM_USE_V1"] = "1"
             env_vars["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
-        
+
     if not peer_access_supported():
         logger.info("Peer access is not supported, disabling P2P and SHM")
         env_vars["NCCL_P2P_DISABLE"] = "1"
@@ -341,14 +341,15 @@ def print_mem(tag: str, mem: dict):
         f"Total: {format_gib(mem['total'])}"
     )
 
+
 def peer_access_supported():
     if not torch.cuda.is_available():
         return False
-    
+
     device_count = torch.cuda.device_count()
     if device_count < 2:
         return False
-    
+
     # Check P2P access between all GPU pairs
     for i in range(device_count):
         for j in range(device_count):
@@ -357,5 +358,5 @@ def peer_access_supported():
                 can_access = torch.cuda.can_device_access_peer(i, j)
                 if not can_access:
                     return False
-    
+
     return True

--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -269,7 +269,7 @@ def initialize_ray(cfg: DictConfig):
             env_vars["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
 
     if not peer_access_supported():
-        logger.info("Peer access is not supported, disabling P2P and SHM")
+        logger.info("Peer access is not supported on this node type, disabling P2P and SHM")
         env_vars["NCCL_P2P_DISABLE"] = "1"
         env_vars["NCCL_SHM_DISABLE"] = "1"
 

--- a/skyrl-train/tests/gpu/gpu_ci/conftest.py
+++ b/skyrl-train/tests/gpu/gpu_ci/conftest.py
@@ -3,6 +3,7 @@ import ray
 import os
 from loguru import logger
 from functools import lru_cache
+import torch
 
 
 @lru_cache(5)
@@ -10,16 +11,31 @@ def log_once(msg):
     logger.info(msg)
     return None
 
+def peer_access_supported():
+    if not torch.cuda.is_available():
+        return False
+    
+    device_count = torch.cuda.device_count()
+    if device_count < 2:
+        return False
+    
+    # Check P2P access between all GPU pairs
+    for i in range(device_count):
+        for j in range(device_count):
+            if i != j:
+                # This checks if device i can access device j's memory
+                can_access = torch.cuda.can_device_access_peer(i, j)
+                if not can_access:
+                    return False
+    
+    return True
 
 @pytest.fixture
 def ray_init_fixture():
     if ray.is_initialized():
         ray.shutdown()
-    # NOTE (sumanthrh): We disable SHM for CI environment by default - L4s don't support P2P access
-    # if `CI=false`, then this will be overriden.
     env_vars = {}
-    val = os.environ.get("CI", "").lower()
-    if val in ("1", "true", "yes"):
+    if peer_access_supported():
         log_once("Disabling NCCL P2P for CI environment")
         env_vars = {"NCCL_P2P_DISABLE": "1", "NCCL_SHM_DISABLE": "1"}
     ray.init(runtime_env={"env_vars": env_vars})

--- a/skyrl-train/tests/gpu/gpu_ci/conftest.py
+++ b/skyrl-train/tests/gpu/gpu_ci/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import ray
-import os
 from loguru import logger
 from functools import lru_cache
 import torch
@@ -11,14 +10,15 @@ def log_once(msg):
     logger.info(msg)
     return None
 
+
 def peer_access_supported():
     if not torch.cuda.is_available():
         return False
-    
+
     device_count = torch.cuda.device_count()
     if device_count < 2:
         return False
-    
+
     # Check P2P access between all GPU pairs
     for i in range(device_count):
         for j in range(device_count):
@@ -27,8 +27,9 @@ def peer_access_supported():
                 can_access = torch.cuda.can_device_access_peer(i, j)
                 if not can_access:
                     return False
-    
+
     return True
+
 
 @pytest.fixture
 def ray_init_fixture():

--- a/skyrl-train/tests/gpu/gpu_ci/conftest.py
+++ b/skyrl-train/tests/gpu/gpu_ci/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import ray
 from loguru import logger
 from functools import lru_cache
-import torch
+from skyrl_train.utils.utils import peer_access_supported
 
 
 @lru_cache(5)
@@ -11,32 +11,12 @@ def log_once(msg):
     return None
 
 
-def peer_access_supported():
-    if not torch.cuda.is_available():
-        return False
-
-    device_count = torch.cuda.device_count()
-    if device_count < 2:
-        return False
-
-    # Check P2P access between all GPU pairs
-    for i in range(device_count):
-        for j in range(device_count):
-            if i != j:
-                # This checks if device i can access device j's memory
-                can_access = torch.cuda.can_device_access_peer(i, j)
-                if not can_access:
-                    return False
-
-    return True
-
-
 @pytest.fixture
 def ray_init_fixture():
     if ray.is_initialized():
         ray.shutdown()
     env_vars = {}
-    if peer_access_supported():
+    if not peer_access_supported():
         log_once("Disabling NCCL P2P for CI environment")
         env_vars = {"NCCL_P2P_DISABLE": "1", "NCCL_SHM_DISABLE": "1"}
     ray.init(runtime_env={"env_vars": env_vars})


### PR DESCRIPTION
# Overview
After #73, the main code path no longer runs on GPUs without P2P support (potentially due to cuda 12.8 upgrade?) - an error would be thrown like

```bash
torch.distributed.DistBackendError: NCCL error in: /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:3353, unhandled cuda error (run with NCCL_DEBUG=INFO for details), NCCL version 2.26.2
ncclUnhandledCudaError: Call to CUDA function failed.
Last error:
Cuda failure 217 'peer access is not supported between these two devices'
```

This PR adds a check for whether peer access is supported (using torch/cuda) between all GPUs on a node to the ray initialization, and sets relevant NCCL env vars to allow the code to run on these machine types.

```python
if not peer_access_supported():
        logger.info("Peer access is not supported, disabling P2P and SHM")
        env_vars["NCCL_P2P_DISABLE"] = "1"
        env_vars["NCCL_SHM_DISABLE"] = "1"
```

Example running on L40S:
<img width="1854" height="227" alt="image" src="https://github.com/user-attachments/assets/1cca46b5-6e16-4ae7-9a33-df52d138bdeb" />

