### PR TITLE
[Trainer] Support per-token rewards in trainer

### DIFF
--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -679,19 +679,25 @@ class RayPPOTrainer:
 
         In the future algorithm specific reward or loss mask post processing should be done here.
         """
-        # TODO (tgriggs): This assumes response-level rewards. Should support per-token rewards from generator
         mean_raw_reward, pass_at_n = get_metrics_from_generator_output(
             generator_output,
             uids,
         )
 
-        rewards: List[float] = generator_output["rewards"]
+        rewards = generator_output["rewards"]
         responses: List[List[int]] = generator_output["response_ids"]
         per_token_rewards: List[List[float]] = []
-        for reward, response in zip(rewards, responses):
-            per_token_reward = [0] * len(response)
-            per_token_reward[-1] = float(reward)
-            per_token_rewards.append(per_token_reward)
+        
+        # Check if rewards are already token-level (List[List[float]]) or response-level (List[float])
+        if rewards and isinstance(rewards[0], list):
+            # Token-level rewards: rewards is List[List[float]]
+            per_token_rewards = rewards
+        else:
+            # Response-level rewards: rewards is List[float], convert to per-token rewards
+            for reward, response in zip(rewards, responses):
+                per_token_reward = [0.0] * len(response)
+                per_token_reward[-1] = float(reward)
+                per_token_rewards.append(per_token_reward)
 
         n_samples_per_prompt = self.cfg.generator.n_samples_per_prompt
 

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -2,7 +2,7 @@ import asyncio
 import math
 import os
 import shutil
-from typing import Any, List, Optional, Dict, Tuple
+from typing import Any, List, Optional, Dict, Tuple, Union
 from jaxtyping import Float
 from pathlib import Path
 import ray
@@ -684,10 +684,10 @@ class RayPPOTrainer:
             uids,
         )
 
-        rewards = generator_output["rewards"]
+        rewards: Union[List[float], List[List[float]]] = generator_output["rewards"]
         responses: List[List[int]] = generator_output["response_ids"]
         per_token_rewards: List[List[float]] = []
-        
+
         # Check if rewards are already token-level (List[List[float]]) or response-level (List[float])
         if rewards and isinstance(rewards[0], list):
             # Token-level rewards: rewards is List[List[float]]

--- a/skyrl-train/tests/cpu/test_generator_postprocess.py
+++ b/skyrl-train/tests/cpu/test_generator_postprocess.py
@@ -1,0 +1,167 @@
+"""
+Test for token-level rewards support in RayPPOTrainer.postprocess_generator_output method.
+
+Run with:
+uv run --isolated --extra dev pytest tests/cpu/test_generator_postprocess.py
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from omegaconf import OmegaConf
+
+from skyrl_train.trainer import RayPPOTrainer
+from skyrl_train.generators.base import GeneratorOutput
+
+
+class DummyDataset:
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, idx):
+        return "dummy"
+
+    def collate_fn(self, batch):
+        return batch
+
+
+def create_config(batch_size):
+    return OmegaConf.create(
+        {
+            "trainer": {
+                "train_batch_size": batch_size,
+                "eval_batch_size": batch_size,
+                "resume_mode": "none",
+                "seed": 42,
+                "epochs": 1,
+            },
+            "generator": {
+                "n_samples_per_prompt": 1,
+            },
+        }
+    )
+
+
+def test_response_level_rewards():
+    """Test postprocess_generator_output with response-level rewards (List[float])."""
+    
+    # Test length=1
+    config = create_config(1)
+    trainer = RayPPOTrainer(
+        cfg=config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=None,
+        inference_engine_client=None,
+        generator=MagicMock(),
+    )
+    
+    with patch('skyrl_train.trainer.get_metrics_from_generator_output') as mock_get_metrics:
+        mock_get_metrics.return_value = (1.0, 1.0)
+        
+        generator_output: GeneratorOutput = {
+            "prompt_token_ids": [[1, 2]],
+            "response_ids": [[3, 4, 5]],
+            "rewards": [1.0],  # Response-level reward
+            "loss_masks": [[1, 1, 1]],
+            "stop_reasons": ["stop"],
+            "rollout_metrics": None,
+        }
+        
+        result = trainer.postprocess_generator_output(generator_output, ["uid1"])
+        
+        # Verify conversion to per-token rewards
+        assert result["rewards"] == [[0.0, 0.0, 1.0]]
+    
+    # Test length=2
+    config = create_config(2)
+    trainer = RayPPOTrainer(
+        cfg=config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=None,
+        inference_engine_client=None,
+        generator=MagicMock(),
+    )
+    
+    with patch('skyrl_train.trainer.get_metrics_from_generator_output') as mock_get_metrics:
+        mock_get_metrics.return_value = (0.75, 0.5)
+        
+        generator_output: GeneratorOutput = {
+            "prompt_token_ids": [[1, 2], [3, 4]],
+            "response_ids": [[5, 6], [7, 8, 9]],
+            "rewards": [1.0, 0.5],  # Response-level rewards
+            "loss_masks": [[1, 1], [1, 1, 1]],
+            "stop_reasons": ["stop", "stop"],
+            "rollout_metrics": None,
+        }
+        
+        result = trainer.postprocess_generator_output(generator_output, ["uid1", "uid2"])
+        
+        # Verify conversion to per-token rewards
+        assert result["rewards"] == [[0.0, 1.0], [0.0, 0.0, 0.5]]
+
+
+def test_token_level_rewards():
+    """Test postprocess_generator_output with token-level rewards (List[List[float]])."""
+    
+    # Test length=1
+    config = create_config(1)
+    trainer = RayPPOTrainer(
+        cfg=config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=None,
+        inference_engine_client=None,
+        generator=MagicMock(),
+    )
+    
+    with patch('skyrl_train.trainer.get_metrics_from_generator_output') as mock_get_metrics:
+        mock_get_metrics.return_value = (0.6, 1.0)
+        
+        per_token_rewards = [[0.1, 0.2, 0.3]]
+        generator_output: GeneratorOutput = {
+            "prompt_token_ids": [[1, 2]],
+            "response_ids": [[3, 4, 5]],
+            "rewards": per_token_rewards,  # Token-level rewards
+            "loss_masks": [[1, 1, 1]],
+            "stop_reasons": ["stop"],
+            "rollout_metrics": None,
+        }
+        
+        result = trainer.postprocess_generator_output(generator_output, ["uid1"])
+        
+        # Verify token-level rewards are unchanged
+        assert result["rewards"] == per_token_rewards
+    
+    # Test length=2
+    config = create_config(2)
+    trainer = RayPPOTrainer(
+        cfg=config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=None,
+        inference_engine_client=None,
+        generator=MagicMock(),
+    )
+    
+    with patch('skyrl_train.trainer.get_metrics_from_generator_output') as mock_get_metrics:
+        mock_get_metrics.return_value = (0.4, 0.5)
+        
+        per_token_rewards = [[0.1, 0.3], [0.2, 0.1, 0.1]]
+        generator_output: GeneratorOutput = {
+            "prompt_token_ids": [[1, 2], [3, 4]],
+            "response_ids": [[5, 6], [7, 8, 9]],
+            "rewards": per_token_rewards,  # Token-level rewards
+            "loss_masks": [[1, 1], [1, 1, 1]],
+            "stop_reasons": ["stop", "stop"],
+            "rollout_metrics": None,
+        }
+        
+        result = trainer.postprocess_generator_output(generator_output, ["uid1", "uid2"])
+        
+        # Verify token-level rewards are unchanged
+        assert result["rewards"] == per_token_rewards

--- a/skyrl-train/tests/cpu/test_generator_postprocess.py
+++ b/skyrl-train/tests/cpu/test_generator_postprocess.py
@@ -5,8 +5,7 @@ Run with:
 uv run --isolated --extra dev pytest tests/cpu/test_generator_postprocess.py
 """
 
-import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from omegaconf import OmegaConf
 
 from skyrl_train.trainer import RayPPOTrainer
@@ -43,7 +42,7 @@ def create_config(batch_size):
 
 def test_response_level_rewards():
     """Test postprocess_generator_output with response-level rewards (List[float])."""
-    
+
     # Test length=1
     config = create_config(1)
     trainer = RayPPOTrainer(
@@ -55,24 +54,21 @@ def test_response_level_rewards():
         inference_engine_client=None,
         generator=MagicMock(),
     )
-    
-    with patch('skyrl_train.trainer.get_metrics_from_generator_output') as mock_get_metrics:
-        mock_get_metrics.return_value = (1.0, 1.0)
-        
-        generator_output: GeneratorOutput = {
-            "prompt_token_ids": [[1, 2]],
-            "response_ids": [[3, 4, 5]],
-            "rewards": [1.0],  # Response-level reward
-            "loss_masks": [[1, 1, 1]],
-            "stop_reasons": ["stop"],
-            "rollout_metrics": None,
-        }
-        
-        result = trainer.postprocess_generator_output(generator_output, ["uid1"])
-        
-        # Verify conversion to per-token rewards
-        assert result["rewards"] == [[0.0, 0.0, 1.0]]
-    
+
+    generator_output: GeneratorOutput = {
+        "prompt_token_ids": [[1, 2]],
+        "response_ids": [[3, 4, 5]],
+        "rewards": [1.0],  # Response-level reward
+        "loss_masks": [[1, 1, 1]],
+        "stop_reasons": ["stop"],
+        "rollout_metrics": None,
+    }
+
+    result = trainer.postprocess_generator_output(generator_output, ["uid1"])
+
+    # Verify conversion to per-token rewards
+    assert result["rewards"] == [[0.0, 0.0, 1.0]]
+
     # Test length=2
     config = create_config(2)
     trainer = RayPPOTrainer(
@@ -84,28 +80,25 @@ def test_response_level_rewards():
         inference_engine_client=None,
         generator=MagicMock(),
     )
-    
-    with patch('skyrl_train.trainer.get_metrics_from_generator_output') as mock_get_metrics:
-        mock_get_metrics.return_value = (0.75, 0.5)
-        
-        generator_output: GeneratorOutput = {
-            "prompt_token_ids": [[1, 2], [3, 4]],
-            "response_ids": [[5, 6], [7, 8, 9]],
-            "rewards": [1.0, 0.5],  # Response-level rewards
-            "loss_masks": [[1, 1], [1, 1, 1]],
-            "stop_reasons": ["stop", "stop"],
-            "rollout_metrics": None,
-        }
-        
-        result = trainer.postprocess_generator_output(generator_output, ["uid1", "uid2"])
-        
-        # Verify conversion to per-token rewards
-        assert result["rewards"] == [[0.0, 1.0], [0.0, 0.0, 0.5]]
+
+    generator_output: GeneratorOutput = {
+        "prompt_token_ids": [[1, 2], [3, 4]],
+        "response_ids": [[5, 6], [7, 8, 9]],
+        "rewards": [1.0, 0.5],  # Response-level rewards
+        "loss_masks": [[1, 1], [1, 1, 1]],
+        "stop_reasons": ["stop", "stop"],
+        "rollout_metrics": None,
+    }
+
+    result = trainer.postprocess_generator_output(generator_output, ["uid1", "uid2"])
+
+    # Verify conversion to per-token rewards
+    assert result["rewards"] == [[0.0, 1.0], [0.0, 0.0, 0.5]]
 
 
 def test_token_level_rewards():
     """Test postprocess_generator_output with token-level rewards (List[List[float]])."""
-    
+
     # Test length=1
     config = create_config(1)
     trainer = RayPPOTrainer(
@@ -117,25 +110,22 @@ def test_token_level_rewards():
         inference_engine_client=None,
         generator=MagicMock(),
     )
-    
-    with patch('skyrl_train.trainer.get_metrics_from_generator_output') as mock_get_metrics:
-        mock_get_metrics.return_value = (0.6, 1.0)
-        
-        per_token_rewards = [[0.1, 0.2, 0.3]]
-        generator_output: GeneratorOutput = {
-            "prompt_token_ids": [[1, 2]],
-            "response_ids": [[3, 4, 5]],
-            "rewards": per_token_rewards,  # Token-level rewards
-            "loss_masks": [[1, 1, 1]],
-            "stop_reasons": ["stop"],
-            "rollout_metrics": None,
-        }
-        
-        result = trainer.postprocess_generator_output(generator_output, ["uid1"])
-        
-        # Verify token-level rewards are unchanged
-        assert result["rewards"] == per_token_rewards
-    
+
+    per_token_rewards = [[0.1, 0.2, 0.3]]
+    generator_output: GeneratorOutput = {
+        "prompt_token_ids": [[1, 2]],
+        "response_ids": [[3, 4, 5]],
+        "rewards": per_token_rewards,  # Token-level rewards
+        "loss_masks": [[1, 1, 1]],
+        "stop_reasons": ["stop"],
+        "rollout_metrics": None,
+    }
+
+    result = trainer.postprocess_generator_output(generator_output, ["uid1"])
+
+    # Verify token-level rewards are unchanged
+    assert result["rewards"] == per_token_rewards
+
     # Test length=2
     config = create_config(2)
     trainer = RayPPOTrainer(
@@ -147,21 +137,18 @@ def test_token_level_rewards():
         inference_engine_client=None,
         generator=MagicMock(),
     )
-    
-    with patch('skyrl_train.trainer.get_metrics_from_generator_output') as mock_get_metrics:
-        mock_get_metrics.return_value = (0.4, 0.5)
-        
-        per_token_rewards = [[0.1, 0.3], [0.2, 0.1, 0.1]]
-        generator_output: GeneratorOutput = {
-            "prompt_token_ids": [[1, 2], [3, 4]],
-            "response_ids": [[5, 6], [7, 8, 9]],
-            "rewards": per_token_rewards,  # Token-level rewards
-            "loss_masks": [[1, 1], [1, 1, 1]],
-            "stop_reasons": ["stop", "stop"],
-            "rollout_metrics": None,
-        }
-        
-        result = trainer.postprocess_generator_output(generator_output, ["uid1", "uid2"])
-        
-        # Verify token-level rewards are unchanged
-        assert result["rewards"] == per_token_rewards
+
+    per_token_rewards = [[0.1, 0.3], [0.2, 0.1, 0.1]]
+    generator_output: GeneratorOutput = {
+        "prompt_token_ids": [[1, 2], [3, 4]],
+        "response_ids": [[5, 6], [7, 8, 9]],
+        "rewards": per_token_rewards,  # Token-level rewards
+        "loss_masks": [[1, 1], [1, 1, 1]],
+        "stop_reasons": ["stop", "stop"],
+        "rollout_metrics": None,
+    }
+
+    result = trainer.postprocess_generator_output(generator_output, ["uid1", "uid2"])
+
+    # Verify token-level rewards are unchanged
+    assert result["rewards"] == per_token_rewards


### PR DESCRIPTION
# What does this PR do?

Supports per-token rewards from the generator. Currently, the postprocess_generator_output function is hardcoded to only support per-sequence rewards, but we should be able to easily support per-token rewards. 

I've also added a test to make sure that the postprocessing function is tested. This is placed in a new file for ease of use. 