### PR TITLE
[DAPO] Add support for overlong filtering

### DIFF
--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -405,6 +405,8 @@ Generator Configuration
 
     zero_reward_on_non_stop: false 
 
+    apply_overlong_filtering: false
+
 
 Inference Engine Placement Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -458,3 +460,4 @@ Misc Configuration
 ~~~~~~~~~~~~~~~~~~
 
 - ``generator.zero_reward_on_non_stop``: Whether to set the reward to 0 if the `stop_reason` is not `stop`. Cases where this is useful: Often, we have format rewards for the LLM to follow, but in cases where the LLM didn't finish the response, we typically don't want to reward it. This is a general setting for all environments.
+- ``generator.apply_overlong_filtering``: Whether to apply DAPO Overlong Filtering to the loss masks. For each trajectory that exceeds the max length (i.e., truncated and does not end with an EOS token), this masks out every token in the loss mask.

--- a/skyrl-train/examples/gsm8k/run_gsm8k.sh
+++ b/skyrl-train/examples/gsm8k/run_gsm8k.sh
@@ -9,14 +9,14 @@ set -x
 # NOTE (sumanthrh): `micro_train_batch_size_per_gpu` and `micro_forward_batch_size_per_gpu` can be tuned
 
 DATA_DIR="$HOME/data/gsm8k"
-NUM_GPUS=4
+NUM_GPUS=1
 LOGGER="wandb"  # change to "console" to print to stdout
 
 uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base \
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \
-  trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \
+  trainer.policy.model.path="Qwen/Qwen2.5-0.5B-Instruct" \
   trainer.placement.colocate_all=true \
   trainer.strategy=fsdp2 \
   trainer.placement.policy_num_gpus_per_node=$NUM_GPUS \
@@ -25,13 +25,13 @@ uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base \
   generator.inference_engine_tensor_parallel_size=1 \
   trainer.epochs=20 \
   trainer.eval_batch_size=1024 \
-  trainer.eval_before_train=true \
+  trainer.eval_before_train=false \
   trainer.eval_interval=5 \
   trainer.update_epochs_per_batch=1 \
-  trainer.train_batch_size=1024 \
-  trainer.policy_mini_batch_size=256 \
-  trainer.micro_forward_batch_size_per_gpu=64 \
-  trainer.micro_train_batch_size_per_gpu=64 \
+  trainer.train_batch_size=16 \
+  trainer.policy_mini_batch_size=16 \
+  trainer.micro_forward_batch_size_per_gpu=16 \
+  trainer.micro_train_batch_size_per_gpu=16 \
   trainer.ckpt_interval=10 \
   trainer.max_prompt_length=512 \
   generator.sampling_params.max_generate_length=1024 \
@@ -41,7 +41,7 @@ uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base \
   generator.run_engines_locally=true \
   generator.weight_sync_backend=nccl \
   generator.async_engine=true \
-  generator.batched=true \
+  generator.batched=false \
   environment.env_class=gsm8k \
   generator.n_samples_per_prompt=5 \
   generator.gpu_memory_utilization=0.8 \

--- a/skyrl-train/examples/gsm8k/run_gsm8k.sh
+++ b/skyrl-train/examples/gsm8k/run_gsm8k.sh
@@ -9,14 +9,14 @@ set -x
 # NOTE (sumanthrh): `micro_train_batch_size_per_gpu` and `micro_forward_batch_size_per_gpu` can be tuned
 
 DATA_DIR="$HOME/data/gsm8k"
-NUM_GPUS=1
+NUM_GPUS=4
 LOGGER="wandb"  # change to "console" to print to stdout
 
 uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base \
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \
-  trainer.policy.model.path="Qwen/Qwen2.5-0.5B-Instruct" \
+  trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \
   trainer.placement.colocate_all=true \
   trainer.strategy=fsdp2 \
   trainer.placement.policy_num_gpus_per_node=$NUM_GPUS \
@@ -25,13 +25,13 @@ uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base \
   generator.inference_engine_tensor_parallel_size=1 \
   trainer.epochs=20 \
   trainer.eval_batch_size=1024 \
-  trainer.eval_before_train=false \
+  trainer.eval_before_train=true \
   trainer.eval_interval=5 \
   trainer.update_epochs_per_batch=1 \
-  trainer.train_batch_size=16 \
-  trainer.policy_mini_batch_size=16 \
-  trainer.micro_forward_batch_size_per_gpu=16 \
-  trainer.micro_train_batch_size_per_gpu=16 \
+  trainer.train_batch_size=1024 \
+  trainer.policy_mini_batch_size=256 \
+  trainer.micro_forward_batch_size_per_gpu=64 \
+  trainer.micro_train_batch_size_per_gpu=64 \
   trainer.ckpt_interval=10 \
   trainer.max_prompt_length=512 \
   generator.sampling_params.max_generate_length=1024 \
@@ -41,7 +41,7 @@ uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base \
   generator.run_engines_locally=true \
   generator.weight_sync_backend=nccl \
   generator.async_engine=true \
-  generator.batched=false \
+  generator.batched=true \
   environment.env_class=gsm8k \
   generator.n_samples_per_prompt=5 \
   generator.gpu_memory_utilization=0.8 \

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -195,7 +195,8 @@ generator:
   zero_reward_on_non_stop: false 
 
   # Whether to apply DAPO Overlong Filtering to the loss masks.
-  # For each trajectory that exceeds the max length, this masks out every token in the loss mask.
+  # For each trajectory that exceeds the max length (i.e., truncated and does not end with an 
+  # EOS token), this masks out every token in the loss mask.
   apply_overlong_filtering: false
 
 environment:

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -194,6 +194,10 @@ generator:
   # TODO (erictang000): Show clear ablations for benefits of this on GSM8K or SQL.
   zero_reward_on_non_stop: false 
 
+  # Whether to apply DAPO Overlong Filtering to the loss masks.
+  # For each trajectory that exceeds the max length, this masks out every token in the loss mask.
+  apply_overlong_filtering: false
+
 environment:
   env_class: "gsm8k"
   # NOTE: environment specific defaults for environment.skyrl_gym are set at the following path:

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -135,7 +135,7 @@ class SkyRLGymGenerator(GeneratorInterface):
                 break
 
         env.close()  # does nothing for now
-        
+
         prompt_ids = input_ids[:initial_prompt_length]
         if self.custom_chat_template and self.use_conversation_multi_turn:
             response_encodings = self.tokenizer.apply_chat_template(
@@ -231,7 +231,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         rollout_metrics = self._rollout_metrics(responses, rewards)
 
         if self.generator_cfg.apply_overlong_filtering:
-            loss_masks = apply_overlong_filtering(loss_masks, stop_reasons)
+            loss_masks = apply_overlong_filtering(loss_masks, responses, self.tokenizer.eos_token_id)
 
         generator_output: GeneratorOutput = {
             "prompt_token_ids": prompt_token_ids,
@@ -302,7 +302,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             rewards = self._zero_reward_if_not_stop(rewards, stop_reasons)
 
         if self.generator_cfg.apply_overlong_filtering:
-            loss_masks = apply_overlong_filtering(loss_masks, stop_reasons)
+            loss_masks = apply_overlong_filtering(loss_masks, responses, self.tokenizer.eos_token_id)
 
         generator_output: GeneratorOutput = {
             "prompt_token_ids": prompt_token_ids,

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -12,7 +12,7 @@ from skyrl_train.inference_engines.inference_engine_client import InferenceEngin
 from skyrl_train.inference_engines.base import InferenceEngineInput, ConversationType
 from omegaconf import DictConfig
 from skyrl_gym.envs.base_text_env import BaseTextEnvStepOutput
-from skyrl_train.generators.utils import get_custom_chat_template, get_generation_prompt_ids
+from skyrl_train.generators.utils import get_custom_chat_template, get_generation_prompt_ids, apply_overlong_filtering
 
 
 class SkyRLGymGenerator(GeneratorInterface):
@@ -238,6 +238,9 @@ class SkyRLGymGenerator(GeneratorInterface):
         responses = truncated_responses
         rollout_metrics = self._rollout_metrics(responses, rewards)
 
+        if self.generator_cfg.apply_overlong_filtering:
+            loss_masks = apply_overlong_filtering(loss_masks, stop_reasons)
+
         generator_output: GeneratorOutput = {
             "prompt_token_ids": prompt_token_ids,
             "response_ids": responses,
@@ -307,6 +310,9 @@ class SkyRLGymGenerator(GeneratorInterface):
         if self.generator_cfg.zero_reward_on_non_stop:
             # set reward to 0 if the stop reason is not "stop"
             rewards = self._zero_reward_if_not_stop(rewards, stop_reasons)
+
+        if self.generator_cfg.apply_overlong_filtering:
+            loss_masks = apply_overlong_filtering(loss_masks, stop_reasons)
 
         generator_output: GeneratorOutput = {
             "prompt_token_ids": prompt_token_ids,

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -57,7 +57,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         max_tokens: int,
         max_input_length: int,
         sampling_params: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[List[int], float, str, List[int], List[int], Dict[str, Any]]:
+    ) -> Tuple[List[int], float, str, List[int], List[int]]:
         """
         Multi-turn generation loop that executes a single trajectory.
 
@@ -73,7 +73,6 @@ class SkyRLGymGenerator(GeneratorInterface):
             stop_reason: str
             loss_mask: List[int]
             prompt_token_ids: List[int]
-            rollout_metrics: Dict[str, Any]
         """
 
         # Create a new environment instance
@@ -137,13 +136,6 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         env.close()  # does nothing for now
         
-        rollout_metrics = {}
-        if self.use_conversation_multi_turn:
-            prompt_text = "".join(m["content"] for m in prompt if m["role"] == "user")
-            response_text = "".join(m["content"] for m in chat_history[len(prompt):] if m["role"] == "assistant")
-            rollout_metrics["trajectories"] = [(prompt_text), (response_text), reward]
-            print(f"Rollout metrics: {rollout_metrics}")
-
         prompt_ids = input_ids[:initial_prompt_length]
         if self.custom_chat_template and self.use_conversation_multi_turn:
             response_encodings = self.tokenizer.apply_chat_template(
@@ -177,7 +169,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         response_ids = response_ids[:max_response_tokens]
         loss_mask = loss_mask[:max_response_tokens]
 
-        return response_ids, reward, stop_reason, loss_mask, prompt_ids, rollout_metrics
+        return response_ids, reward, stop_reason, loss_mask, prompt_ids
 
     async def generate_batched(
         self,
@@ -302,10 +294,8 @@ class SkyRLGymGenerator(GeneratorInterface):
         stop_reasons = sum([[output[2]] for output in all_outputs], [])
         loss_masks = sum([[output[3]] for output in all_outputs], [])
         prompt_token_ids = sum([[output[4]] for output in all_outputs], [])
-        individual_rollout_metrics = [output[5] for output in all_outputs]
 
-        # Combine all rollout metrics
-        rollout_metrics = self._rollout_metrics(responses, rewards, individual_rollout_metrics)
+        rollout_metrics = self._rollout_metrics(responses, rewards)
         
         if self.generator_cfg.zero_reward_on_non_stop:
             # set reward to 0 if the stop reason is not "stop"
@@ -325,7 +315,7 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         return generator_output
 
-    def _rollout_metrics(self, responses: List[List[int]], rewards: List[float], individual_rollout_metrics: List[Dict[str, Any]] = None):
+    def _rollout_metrics(self, responses: List[List[int]], rewards: List[float]):
         num_tokens_arr = np.array([len(response) for response in responses])
         non_zero_rewards_arr = np.array([reward > 0.0 for reward in rewards])
         zero_rewards_arr = np.array([reward == 0.0 for reward in rewards])
@@ -338,7 +328,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             np.mean(num_tokens_arr[zero_rewards_arr]) if zero_rewards_arr.sum() > 0 else np.zeros(1)
         )
 
-        rollout_metrics = {
+        return {
             "generate/min_num_tokens": np.min(num_tokens_arr).item(),
             "generate/max_num_tokens": np.max(num_tokens_arr).item(),
             "generate/avg_num_tokens": np.mean(num_tokens_arr).item(),
@@ -346,19 +336,6 @@ class SkyRLGymGenerator(GeneratorInterface):
             "generate/avg_tokens_non_zero_rewards": avg_tokens_non_zero_rewards.item(),
             "generate/avg_tokens_zero_rewards": avg_tokens_zero_rewards.item(),
         }
-        
-        if individual_rollout_metrics:
-            # Create wandb table from trajectory data
-            trajectory_data = [metrics.get("trajectories") for metrics in individual_rollout_metrics if metrics.get("trajectories")]
-            if trajectory_data:
-                import wandb
-                # TODO(tgriggs): Add step to this
-                table = wandb.Table(columns=["prompt", "response", "reward"])
-                for prompt_text, response_text, reward in trajectory_data:
-                    table.add_data(prompt_text, response_text, reward)
-                rollout_metrics["trajectories/traces"] = table
-            
-        return rollout_metrics
 
     def _zero_reward_if_not_stop(self, rewards: List[float], stop_reasons: List[str]):
         """Sets the reward to 0 if the stop reason is not "stop".

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -296,7 +296,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         prompt_token_ids = sum([[output[4]] for output in all_outputs], [])
 
         rollout_metrics = self._rollout_metrics(responses, rewards)
-        
+
         if self.generator_cfg.zero_reward_on_non_stop:
             # set reward to 0 if the stop reason is not "stop"
             rewards = self._zero_reward_if_not_stop(rewards, stop_reasons)

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -304,8 +304,6 @@ class SkyRLGymGenerator(GeneratorInterface):
         # Combine all rollout metrics
         rollout_metrics = self._rollout_metrics(responses, rewards, individual_rollout_metrics)
         
-        # print(f"All rollout metrics: {rollout_metrics}")
-
         if self.generator_cfg.zero_reward_on_non_stop:
             # set reward to 0 if the stop reason is not "stop"
             rewards = self._zero_reward_if_not_stop(rewards, stop_reasons)

--- a/skyrl-train/skyrl_train/generators/utils.py
+++ b/skyrl-train/skyrl_train/generators/utils.py
@@ -104,7 +104,7 @@ def apply_overlong_filtering(
     """
     Implements DAPO Overlong Filtering: zero-out every token's mask whenever
     the response does not end with the eos token id (i.e. truncated).
-    
+
     Returns:
         - filtered_masks: The loss masks with tokens zeroed out for truncated responses
     """

--- a/skyrl-train/skyrl_train/generators/utils.py
+++ b/skyrl-train/skyrl_train/generators/utils.py
@@ -98,19 +98,20 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput]) -> G
 
 def apply_overlong_filtering(
     loss_masks: List[List[int]],
-    stop_reasons: List[str],
+    response_ids: List[List[int]],
+    eos_token_id: int,
 ) -> List[List[int]]:
     """
     Implements DAPO Overlong Filtering: zero-out every token's mask whenever
-    the stop_reason was 'length' (i.e. truncated).
+    the response does not end with the eos token id (i.e. truncated).
     
     Returns:
         - filtered_masks: The loss masks with tokens zeroed out for truncated responses
     """
-    assert len(loss_masks) == len(stop_reasons), "loss_masks and stop_reasons must have the same length"
+    assert len(loss_masks) == len(response_ids), "loss_masks and response_ids must have the same length"
     filtered_masks = []
-    for mask, reason in zip(loss_masks, stop_reasons):
-        if reason == "length":
+    for mask, response in zip(loss_masks, response_ids):
+        if len(response) == 0 or response[-1] != eos_token_id:
             filtered_masks.append([0] * len(mask))
         else:
             filtered_masks.append(mask)

--- a/skyrl-train/skyrl_train/generators/utils.py
+++ b/skyrl-train/skyrl_train/generators/utils.py
@@ -94,3 +94,24 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput]) -> G
         result["stop_reasons"] = sum([output["stop_reasons"] for output in generator_outputs], [])
 
     return result
+
+
+def apply_overlong_filtering(
+    loss_masks: List[List[int]],
+    stop_reasons: List[str],
+) -> List[List[int]]:
+    """
+    Implements DAPO Overlong Filtering: zero-out every token's mask whenever
+    the stop_reason was 'length' (i.e. truncated).
+    
+    Returns:
+        - filtered_masks: The loss masks with tokens zeroed out for truncated responses
+    """
+    assert len(loss_masks) == len(stop_reasons), "loss_masks and stop_reasons must have the same length"
+    filtered_masks = []
+    for mask, reason in zip(loss_masks, stop_reasons):
+        if reason == "length":
+            filtered_masks.append([0] * len(mask))
+        else:
+            filtered_masks.append(mask)
+    return filtered_masks

--- a/skyrl-train/skyrl_train/generators/utils.py
+++ b/skyrl-train/skyrl_train/generators/utils.py
@@ -106,13 +106,10 @@ def apply_overlong_filtering(
     the response does not end with the eos token id (i.e. truncated).
 
     Returns:
-        - filtered_masks: The loss masks with tokens zeroed out for truncated responses
+        - The loss masks with tokens zeroed out for truncated responses
     """
     assert len(loss_masks) == len(response_ids), "loss_masks and response_ids must have the same length"
-    filtered_masks = []
-    for mask, response in zip(loss_masks, response_ids):
-        if len(response) == 0 or response[-1] != eos_token_id:
-            filtered_masks.append([0] * len(mask))
-        else:
-            filtered_masks.append(mask)
-    return filtered_masks
+    return [
+        [0] * len(mask) if not response or response[-1] != eos_token_id else mask
+        for mask, response in zip(loss_masks, response_ids)
+    ]

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py
@@ -70,6 +70,7 @@ async def test_skyrl_gym_generator_chat_templating_exact(model_name):
             "batched": False,
             "max_turns": 3,
             "zero_reward_on_non_stop": False,
+            "apply_overlong_filtering": False,
             "use_conversation_multi_turn": True,
         }
     )

--- a/skyrl-train/tests/cpu/generators/test_utils.py
+++ b/skyrl-train/tests/cpu/generators/test_utils.py
@@ -51,17 +51,17 @@ from skyrl_train.generators.utils import apply_overlong_filtering
 def test_apply_overlong_filtering(loss_masks, response_ids, eos_token_id, expected_masks):
     """
     Test the apply_overlong_filtering function which implements DAPO Overlong Filtering.
-    
+
     This function should zero-out every token's mask whenever the response does not end
     with the eos token id (i.e. truncated), while leaving other masks unchanged.
     """
     result = apply_overlong_filtering(loss_masks, response_ids, eos_token_id)
-    
+
     assert result == expected_masks, f"Expected {expected_masks}, but got {result}"
-    
+
     # Verify that the original inputs are not modified (immutability check)
     assert len(result) == len(loss_masks), "Result should have same length as input"
-    
+
     # Check that each individual mask is processed correctly
     for i, (original_mask, response, expected_mask) in enumerate(zip(loss_masks, response_ids, expected_masks)):
         if len(response) == 0 or response[-1] != eos_token_id:
@@ -79,17 +79,17 @@ def test_apply_overlong_filtering_immutability():
     original_loss_masks = [[1, 1, 0, 1], [0, 1, 1]]
     original_response_ids = [[1, 2, 3, 4], [5, 6, 7]]  # First ends with eos=4, second doesn't
     eos_token_id = 4
-    
+
     # Create copies to compare against later
     loss_masks_copy = [mask[:] for mask in original_loss_masks]  # Deep copy of lists
     response_ids_copy = [response[:] for response in original_response_ids]  # Deep copy of lists
-    
+
     result = apply_overlong_filtering(original_loss_masks, original_response_ids, eos_token_id)
-    
+
     # Verify original inputs are unchanged
     assert original_loss_masks == loss_masks_copy, "Original loss_masks should not be modified"
     assert original_response_ids == response_ids_copy, "Original response_ids should not be modified"
-    
+
     # Verify result is correct
     expected = [[1, 1, 0, 1], [0, 0, 0]]  # Second mask zeroed due to not ending with eos
     assert result == expected, f"Expected {expected}, got {result}"
@@ -100,7 +100,7 @@ def test_apply_overlong_filtering_immutability():
     [
         # Test case 1: More loss_masks than response_ids
         ([[1, 1], [0, 1]], [[1, 2]]),
-        # Test case 2: More response_ids than loss_masks  
+        # Test case 2: More response_ids than loss_masks
         ([[1, 1]], [[1, 2], [3, 4]]),
         # Test case 3: Empty loss_masks but non-empty response_ids
         ([], [[1, 2]]),
@@ -110,9 +110,9 @@ def test_apply_overlong_filtering_immutability():
 )
 def test_apply_overlong_filtering_length_mismatch_assertion(loss_masks, response_ids):
     """
-    Test that apply_overlong_filtering raises AssertionError when loss_masks and response_ids 
+    Test that apply_overlong_filtering raises AssertionError when loss_masks and response_ids
     have different lengths.
     """
     eos_token_id = 4
     with pytest.raises(AssertionError, match="loss_masks and response_ids must have the same length"):
-        apply_overlong_filtering(loss_masks, response_ids, eos_token_id) 
+        apply_overlong_filtering(loss_masks, response_ids, eos_token_id)

--- a/skyrl-train/tests/cpu/generators/test_utils.py
+++ b/skyrl-train/tests/cpu/generators/test_utils.py
@@ -83,23 +83,23 @@ def test_apply_overlong_filtering_immutability():
     assert result == expected, f"Expected {expected}, got {result}"
 
 
-# @pytest.mark.parametrize(
-#     "loss_masks,stop_reasons",
-#     [
-#         # Test case 1: More loss_masks than stop_reasons
-#         ([[1, 1], [0, 1]], ["stop"]),
-#         # Test case 2: More stop_reasons than loss_masks  
-#         ([[1, 1]], ["stop", "length"]),
-#         # Test case 3: Empty loss_masks but non-empty stop_reasons
-#         ([], ["stop"]),
-#         # Test case 4: Non-empty loss_masks but empty stop_reasons
-#         ([[1, 0]], []),
-#     ],
-# )
-# def test_apply_overlong_filtering_length_mismatch_assertion(loss_masks, stop_reasons):
-#     """
-#     Test that apply_overlong_filtering raises AssertionError when loss_masks and stop_reasons 
-#     have different lengths.
-#     """
-#     with pytest.raises(AssertionError, match="loss_masks and stop_reasons must have the same length"):
-#         apply_overlong_filtering(loss_masks, stop_reasons) 
+@pytest.mark.parametrize(
+    "loss_masks,stop_reasons",
+    [
+        # Test case 1: More loss_masks than stop_reasons
+        ([[1, 1], [0, 1]], ["stop"]),
+        # Test case 2: More stop_reasons than loss_masks  
+        ([[1, 1]], ["stop", "length"]),
+        # Test case 3: Empty loss_masks but non-empty stop_reasons
+        ([], ["stop"]),
+        # Test case 4: Non-empty loss_masks but empty stop_reasons
+        ([[1, 0]], []),
+    ],
+)
+def test_apply_overlong_filtering_length_mismatch_assertion(loss_masks, stop_reasons):
+    """
+    Test that apply_overlong_filtering raises AssertionError when loss_masks and stop_reasons 
+    have different lengths.
+    """
+    with pytest.raises(AssertionError, match="loss_masks and stop_reasons must have the same length"):
+        apply_overlong_filtering(loss_masks, stop_reasons) 

--- a/skyrl-train/tests/cpu/generators/test_utils.py
+++ b/skyrl-train/tests/cpu/generators/test_utils.py
@@ -1,0 +1,105 @@
+"""
+uv run --extra dev --isolated pytest tests/cpu/generators/test_utils.py
+"""
+
+import pytest
+from skyrl_train.generators.utils import apply_overlong_filtering
+
+
+@pytest.mark.parametrize(
+    "loss_masks,stop_reasons,expected_masks",
+    [
+        # Test case 1: No length stop reasons - masks should remain unchanged
+        (
+            [[1, 1, 0, 1], [0, 1, 1, 1], [1, 0, 1]],
+            ["stop", "stop", "stop"],
+            [[1, 1, 0, 1], [0, 1, 1, 1], [1, 0, 1]],
+        ),
+        # Test case 2: All length stop reasons - all masks should be zeroed
+        (
+            [[1, 1, 0, 1], [0, 1, 1, 1], [1, 0, 1]],
+            ["length", "length", "length"],
+            [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0]],
+        ),
+        # Test case 3: Mixed stop reasons - only length masks should be zeroed
+        (
+            [[1, 1, 0, 1], [0, 1, 1, 1], [1, 0, 1, 0, 1]],
+            ["stop", "length", "stop"],
+            [[1, 1, 0, 1], [0, 0, 0, 0], [1, 0, 1, 0, 1]],
+        ),
+        # Test case 4: Different stop reasons including length
+        (
+            [[1, 1], [1, 0, 1], [0, 1, 1, 1]],
+            ["eos", "length", "abort"],
+            [[1, 1], [0, 0, 0], [0, 1, 1, 1]],
+        ),
+        # Test case 5: Empty lists
+        ([], [], []),
+    ],
+)
+def test_apply_overlong_filtering(loss_masks, stop_reasons, expected_masks):
+    """
+    Test the apply_overlong_filtering function which implements DAPO Overlong Filtering.
+    
+    This function should zero-out every token's mask whenever the stop_reason was 'length'
+    (i.e. truncated), while leaving other masks unchanged.
+    """
+    result = apply_overlong_filtering(loss_masks, stop_reasons)
+    
+    assert result == expected_masks, f"Expected {expected_masks}, but got {result}"
+    
+    # Verify that the original inputs are not modified (immutability check)
+    assert len(result) == len(loss_masks), "Result should have same length as input"
+    
+    # Check that each individual mask is processed correctly
+    for i, (original_mask, stop_reason, expected_mask) in enumerate(zip(loss_masks, stop_reasons, expected_masks)):
+        if stop_reason == "length":
+            # Should be all zeros with same length as original
+            assert result[i] == [0] * len(original_mask), f"Mask {i} should be all zeros for length stop reason"
+        else:
+            # Should be unchanged
+            assert result[i] == original_mask, f"Mask {i} should be unchanged for non-length stop reason"
+
+
+def test_apply_overlong_filtering_immutability():
+    """
+    Test that apply_overlong_filtering doesn't modify the original input lists.
+    """
+    original_loss_masks = [[1, 1, 0, 1], [0, 1, 1]]
+    original_stop_reasons = ["stop", "length"]
+    
+    # Create copies to compare against later
+    loss_masks_copy = [mask[:] for mask in original_loss_masks]  # Deep copy of lists
+    stop_reasons_copy = original_stop_reasons[:]  # Shallow copy is fine for strings
+    
+    result = apply_overlong_filtering(original_loss_masks, original_stop_reasons)
+    
+    # Verify original inputs are unchanged
+    assert original_loss_masks == loss_masks_copy, "Original loss_masks should not be modified"
+    assert original_stop_reasons == stop_reasons_copy, "Original stop_reasons should not be modified"
+    
+    # Verify result is correct
+    expected = [[1, 1, 0, 1], [0, 0, 0]]  # Second mask zeroed due to "length"
+    assert result == expected, f"Expected {expected}, got {result}"
+
+
+# @pytest.mark.parametrize(
+#     "loss_masks,stop_reasons",
+#     [
+#         # Test case 1: More loss_masks than stop_reasons
+#         ([[1, 1], [0, 1]], ["stop"]),
+#         # Test case 2: More stop_reasons than loss_masks  
+#         ([[1, 1]], ["stop", "length"]),
+#         # Test case 3: Empty loss_masks but non-empty stop_reasons
+#         ([], ["stop"]),
+#         # Test case 4: Non-empty loss_masks but empty stop_reasons
+#         ([[1, 0]], []),
+#     ],
+# )
+# def test_apply_overlong_filtering_length_mismatch_assertion(loss_masks, stop_reasons):
+#     """
+#     Test that apply_overlong_filtering raises AssertionError when loss_masks and stop_reasons 
+#     have different lengths.
+#     """
+#     with pytest.raises(AssertionError, match="loss_masks and stop_reasons must have the same length"):
+#         apply_overlong_filtering(loss_masks, stop_reasons) 


### PR DESCRIPTION
## What does this PR do? 

Adds `apply_overlong_filtering` to the generator config, and provides a generator utility method `apply_overlong_filtering()` for post-processing the loss mask.

I originally implemented this using the `stop_reasons` to determine whether the sequence was truncated, but instead switched to looking for `eos_token` in the response IDs for a more general approach.

## Tests
Added CPU tests for the utility method and for SkyRL Gym Generator's use of the utility method.