### PR TITLE
fix issue with #108 that broke gpu ci

### DIFF
--- a/skyrl-train/ci/gpu_ci_run.sh
+++ b/skyrl-train/ci/gpu_ci_run.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+export CI=true
 uv run --directory . --isolated --extra dev --extra vllm pytest -s tests/gpu/gpu_ci

--- a/skyrl-train/ci/gpu_ci_run.sh
+++ b/skyrl-train/ci/gpu_ci_run.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
-export CI=true
 uv run --directory . --isolated --extra dev --extra vllm pytest -s tests/gpu/gpu_ci

--- a/skyrl-train/tests/gpu/gpu_ci/conftest.py
+++ b/skyrl-train/tests/gpu/gpu_ci/conftest.py
@@ -16,8 +16,7 @@ def ray_init_fixture():
     if ray.is_initialized():
         ray.shutdown()
     env_vars = {}
-    # hard code to 4 gpus for CI environment for now
-    if not peer_access_supported(max_num_gpus_per_node=4):
+    if not peer_access_supported(max_num_gpus_per_node=2):
         log_once("Disabling NCCL P2P for CI environment")
         env_vars = {"NCCL_P2P_DISABLE": "1", "NCCL_SHM_DISABLE": "1"}
     ray.init(runtime_env={"env_vars": env_vars})

--- a/skyrl-train/tests/gpu/gpu_ci/conftest.py
+++ b/skyrl-train/tests/gpu/gpu_ci/conftest.py
@@ -16,7 +16,8 @@ def ray_init_fixture():
     if ray.is_initialized():
         ray.shutdown()
     env_vars = {}
-    if not peer_access_supported():
+    # hard code to 4 gpus for CI environment for now
+    if not peer_access_supported(max_num_gpus_per_node=4):
         log_once("Disabling NCCL P2P for CI environment")
         env_vars = {"NCCL_P2P_DISABLE": "1", "NCCL_SHM_DISABLE": "1"}
     ray.init(runtime_env={"env_vars": env_vars})


### PR DESCRIPTION
missed an argument in `gpu_ci/conftest.py` for `peer_access_supported()` - fix for gpu ci to run 

Passing now with update:
<img width="1811" height="861" alt="image" src="https://github.com/user-attachments/assets/70011c54-1e33-44b5-83a0-616029f891d2" />


And main runs (and disables p2p access) correctly:
<img width="2067" height="203" alt="image" src="https://github.com/user-attachments/assets/399aff67-cc51-4588-a632-47698073593c" />

