### PR TITLE
Add warning for certain uv versions due to `uv run --with` regression

### DIFF
--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -8,7 +8,7 @@ Requirements
 
 We use `uv <https://docs.astral.sh/uv/>`_ to manage dependencies. We also make use of the `uv` and `ray` integration to manage dependencies for ray workers. 
 
-If you're :ref:`running on an existing Ray cluster <running-on-existing-ray-cluster>`, we suggest using Ray 2.48.0 and Python 3.12.
+If you're :ref:`running on an existing Ray cluster <running-on-existing-ray-cluster>`, we suggest using Ray 2.48.0 and Python 3.12. However, we support Ray versions >= 2.44.0. 
 
 
 Docker (recommended)
@@ -42,6 +42,7 @@ For installation without the Dockerfile, make sure you meet the pre-requisities:
 - CUDA 12.8
 - `uv <https://docs.astral.sh/uv/>`_
 - `ray <https://docs.ray.io/en/latest/>`_ 2.48.0
+
 
 System Dependencies
 ~~~~~~~~~~~~~~~~~~~
@@ -154,6 +155,10 @@ We include these dependencies in the legacy Dockerfile: `Dockerfile.ray244 <http
 
     pip install vllm==0.9.2 --extra-index-url https://download.pytorch.org/whl/cu128
     pip install ray==2.46.0 omegaconf==2.3.0 loguru==0.7.3 jaxtyping==0.3.2 pyarrow==20.0.0
+
+
+.. note::
+    We recommend using uv version 0.8.3 or above. uv versions 0.8.0, 0.8.1, or 0.8.2 have a `bug <https://github.com/astral-sh/uv/issues/14860>`_ in the ``--with`` flag.
 
 Development 
 -----------

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -10,6 +10,9 @@ We use `uv <https://docs.astral.sh/uv/>`_ to manage dependencies. We also make u
 
 If you're :ref:`running on an existing Ray cluster <running-on-existing-ray-cluster>`, we suggest using Ray 2.48.0 and Python 3.12. However, we support Ray versions >= 2.44.0. 
 
+.. warning::
+
+    ⚠️ We do not recommend using Ray 2.47.0 and 2.47.1 for SkyRL due to known issues in the uv+ray integration.
 
 Docker (recommended)
 ---------------------
@@ -32,7 +35,7 @@ We provide a docker image with the base dependencies ``erictang000/skyrl-train-r
     cd SkyRL/skyrl-train
 
 
-That is it! You should now be to able to run our :doc:`quick start example <quickstart>`.
+That is it! You should now be able to run our :doc:`quick start example <quickstart>`.
 
 Install without Dockerfile
 --------------------------
@@ -120,7 +123,7 @@ Finally, you can initialize a Ray cluster using the following command (for singl
 .. note::
     For multi-node clusters, please follow the `Ray documentation <https://docs.ray.io/en/latest/cluster/getting-started.html>`_.
 
-You should now be to able to run our :doc:`quick start example <quickstart>`.
+You should now be able to run our :doc:`quick start example <quickstart>`.
 
 .. _running-on-existing-ray-cluster:
 
@@ -157,8 +160,9 @@ We include these dependencies in the legacy Dockerfile: `Dockerfile.ray244 <http
     pip install ray==2.46.0 omegaconf==2.3.0 loguru==0.7.3 jaxtyping==0.3.2 pyarrow==20.0.0
 
 
-.. note::
-    We recommend using uv version 0.8.3 or above. uv versions 0.8.0, 0.8.1, or 0.8.2 have a `bug <https://github.com/astral-sh/uv/issues/14860>`_ in the ``--with`` flag.
+.. warning::
+    
+    ⚠️ We do not recommend using uv versions 0.8.0, 0.8.1, or 0.8.2 due to a `bug <https://github.com/astral-sh/uv/issues/14860>`_ in the ``--with`` flag behaviour.
 
 Development 
 -----------


### PR DESCRIPTION
# What does this PR do?

Adds a warning for uv versions 0.8.0, 0.8.1 and 0.8.2 due to a bug in the uv run --with flag for "Running in ray cluster" section. These are relatively new versions and thus it's better to have this detail in the documentation for users. 


<img width="692" height="458" alt="Screenshot 2025-07-25 at 6 09 15 PM" src="https://github.com/user-attachments/assets/f1997eac-2867-4552-8ef7-eea8741e32b6" />
<img width="779" height="568" alt="Screenshot 2025-07-25 at 6 09 19 PM" src="https://github.com/user-attachments/assets/5080d328-c934-4864-91a8-932902dea934" />
