### PR TITLE
[GPU CI] Only trigger workflow for relevant changes in `skyrl-train`

### DIFF
--- a/.github/workflows/gpu_ci.yaml
+++ b/.github/workflows/gpu_ci.yaml
@@ -8,6 +8,7 @@ on:
       - 'skyrl-train/**'
       - '!skyrl-train/docs/**'
       - '!skyrl-train/examples/**'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 

--- a/.github/workflows/gpu_ci.yaml
+++ b/.github/workflows/gpu_ci.yaml
@@ -5,10 +5,10 @@ on:
     branches: 
       - main
     paths:
-      - skyrl-train/**
+      - 'skyrl-train/**'
     paths-ignore:
-      - skyrl-train/docs/
-      - skyrl-train/examples/
+      - 'skyrl-train/docs/**'
+      - 'skyrl-train/examples/**'
   workflow_dispatch:
 
 

--- a/.github/workflows/gpu_ci.yaml
+++ b/.github/workflows/gpu_ci.yaml
@@ -6,9 +6,8 @@ on:
       - main
     paths:
       - 'skyrl-train/**'
-    paths-ignore:
-      - 'skyrl-train/docs/**'
-      - 'skyrl-train/examples/**'
+      - '!skyrl-train/docs/**'
+      - '!skyrl-train/examples/**'
   workflow_dispatch:
 
 

--- a/.github/workflows/gpu_ci.yaml
+++ b/.github/workflows/gpu_ci.yaml
@@ -3,7 +3,12 @@ name: SkyRL-GPU
 on: 
   push: 
     branches: 
-      - main 
+      - main
+    paths:
+      - skyrl-train/**
+    paths-ignore:
+      - skyrl-train/docs/
+      - skyrl-train/examples/
   workflow_dispatch:
 
 


### PR DESCRIPTION
# What does this PR do?

Adds filters with `paths`  for the GPU CI workflow so that it's only triggered for relevant changes in skyrl-train. 

Note that technically we have some dependencies with `skyrl-gym` at the moment, but for the GPU CI workflow, we will focus on unit and integration tests for `skyrl-train` and thus we should be okay ignoring changes in `skyrl-gym`. 