### PR TITLE
[Trainer] Support registering custom advantage estimators

### DIFF
--- a/skyrl-train/examples/algorithm/custom_advantage_estimator/main_custom_adv_est.py
+++ b/skyrl-train/examples/algorithm/custom_advantage_estimator/main_custom_adv_est.py
@@ -1,0 +1,58 @@
+"""
+uv run --isolated --extra vllm -m examples.algorithm.custom_advantage_estimator.main_custom_adv_est
+"""
+
+import ray
+import hydra
+import torch
+import numpy as np
+from omegaconf import DictConfig
+from skyrl_train.utils import initialize_ray
+from skyrl_train.entrypoints.main_base import BasePPOExp, config_dir, validate_cfg
+
+
+# Example of custom advantage estimator: "simple_baseline"
+def compute_simple_baseline_advantage(
+    token_level_rewards: torch.Tensor, response_mask: torch.Tensor, index: np.ndarray, **kwargs
+):
+    """
+    A simple custom advantage estimator that uses response-level rewards
+    and computes advantages against a simple baseline.
+
+    This is just an example - replace with your own logic.
+    """
+    with torch.no_grad():
+        response_rewards = (token_level_rewards * response_mask).sum(dim=-1, keepdim=True)
+
+        # Simple baseline: use the mean reward across the batch
+        baseline = response_rewards.mean()
+        advantages = (response_rewards - baseline) * response_mask
+        returns = advantages.clone()
+
+        return advantages, returns
+
+
+@ray.remote(num_cpus=1)
+def skyrl_entrypoint(cfg: DictConfig):
+    # Import inside the remote function so it's available in the Ray worker
+    from skyrl_train.utils.ppo_utils import AdvantageEstimatorRegistry
+
+    # Register the custom advantage estimator
+    AdvantageEstimatorRegistry.register("simple_baseline", compute_simple_baseline_advantage)
+
+    # make sure that the training loop is not run on the head node.
+    exp = BasePPOExp(cfg)
+    exp.run()
+
+
+@hydra.main(config_path=config_dir, config_name="ppo_base_config", version_base=None)
+def main(cfg: DictConfig) -> None:
+    # validate the arguments
+    validate_cfg(cfg)
+
+    initialize_ray(cfg)
+    ray.get(skyrl_entrypoint.remote(cfg))
+
+
+if __name__ == "__main__":
+    main()

--- a/skyrl-train/examples/algorithm/custom_advantage_estimator/run_cusotm_adv_est.sh
+++ b/skyrl-train/examples/algorithm/custom_advantage_estimator/run_cusotm_adv_est.sh
@@ -1,0 +1,54 @@
+set -x
+
+# Example of custom advantage estimator: "simple_baseline"
+# Colocated GRPO training+generation for Qwen2.5-1.5B-Instruct on GSM8K.
+
+# uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
+# export WANDB_API_KEY=<your_key_here>
+# bash examples/gsm8k/run_gsm8k.sh
+
+# NOTE (sumanthrh): `micro_train_batch_size_per_gpu` and `micro_forward_batch_size_per_gpu` can be tuned
+
+DATA_DIR="$HOME/data/gsm8k"
+NUM_GPUS=4
+LOGGER="wandb"  # change to "console" to print to stdout
+
+uv run --isolated --extra vllm -m examples.algorithm.custom_advantage_estimator.main_custom_adv_est \
+  data.train_data="['$DATA_DIR/train.parquet']" \
+  data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.algorithm.advantage_estimator="simple_baseline" \
+  trainer.policy.model.path="Qwen/Qwen2.5-0.5B-Instruct" \
+  trainer.placement.colocate_all=true \
+  trainer.strategy=fsdp2 \
+  trainer.placement.policy_num_gpus_per_node=$NUM_GPUS \
+  trainer.placement.ref_num_gpus_per_node=$NUM_GPUS \
+  generator.num_inference_engines=$NUM_GPUS \
+  generator.inference_engine_tensor_parallel_size=1 \
+  trainer.epochs=20 \
+  trainer.eval_batch_size=1024 \
+  trainer.eval_before_train=true \
+  trainer.eval_interval=5 \
+  trainer.update_epochs_per_batch=1 \
+  trainer.train_batch_size=1024 \
+  trainer.policy_mini_batch_size=256 \
+  trainer.micro_forward_batch_size_per_gpu=64 \
+  trainer.micro_train_batch_size_per_gpu=64 \
+  trainer.ckpt_interval=10 \
+  trainer.max_prompt_length=512 \
+  generator.sampling_params.max_generate_length=1024 \
+  trainer.policy.optimizer_config.lr=1.0e-6 \
+  trainer.algorithm.use_kl_loss=true \
+  generator.backend=vllm \
+  generator.run_engines_locally=true \
+  generator.weight_sync_backend=nccl \
+  generator.async_engine=true \
+  generator.batched=true \
+  environment.env_class=gsm8k \
+  generator.n_samples_per_prompt=5 \
+  generator.gpu_memory_utilization=0.8 \
+  trainer.logger="$LOGGER" \
+  trainer.project_name="custom_adv_est_gsm8k" \
+  trainer.run_name="custom_adv_est_gsm8k_test" \
+  trainer.resume_mode=null \
+  trainer.ckpt_path="$HOME/ckpts/gsm8k_1.5B_ckpt" \
+  $@

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -76,7 +76,7 @@ trainer:
       fsdp_size: -1
     sequence_parallel_size: 1
   algorithm:
-    advantage_estimator: "grpo"
+    advantage_estimator: "grpo"  # Customizable with AdvantageEstimatorRegistry
     kl_target: null
     init_kl_coef: 0.0
     use_kl_estimator_k3: true

--- a/skyrl-train/skyrl_train/utils/ppo_utils.py
+++ b/skyrl-train/skyrl_train/utils/ppo_utils.py
@@ -18,10 +18,56 @@
 
 import torch
 import numpy as np
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union, List, Callable, Dict
+from enum import Enum
 from skyrl_train.training_batch import TrainingInputBatch
 from jaxtyping import Float
 from collections import defaultdict
+
+
+class AdvantageEstimator(Enum):
+    GAE = "gae"
+    GRPO = "grpo"
+    
+    def __str__(self):
+        return self.value
+
+
+class AdvantageEstimatorRegistry:
+    _estimators: Dict[str, Callable] = {}
+    
+    @classmethod
+    def register(cls, name: Union[str, AdvantageEstimator], func: Callable):
+        """Register an advantage estimator function."""
+        # Convert enum to string if needed
+        if isinstance(name, AdvantageEstimator):
+            name = name.value
+            
+        if name in cls._estimators:
+            raise ValueError(f"Estimator '{name}' already registered")
+        
+        cls._estimators[name] = func
+    
+    @classmethod
+    def get(cls, name: str) -> Callable:
+        """Get an estimator function by name."""
+        if name not in cls._estimators:
+            available = list(cls._estimators.keys())
+            raise ValueError(f"Unknown estimator '{name}'. Available: {available}")
+        return cls._estimators[name]
+    
+    @classmethod
+    def list_available(cls) -> List[str]:
+        """List all registered estimators."""
+        return list(cls._estimators.keys())
+
+
+def register_advantage_estimator(name: Union[str, AdvantageEstimator]):
+    """Decorator to register an advantage estimator function."""
+    def decorator(func: Callable):
+        AdvantageEstimatorRegistry.register(name, func)
+        return func
+    return decorator
 
 
 # TODO (erictang000): unused right now, but will be useful as we add more algorithm support
@@ -224,31 +270,58 @@ def compute_grpo_outcome_advantage(
     return scores, scores
 
 
+
+
+@register_advantage_estimator(AdvantageEstimator.GAE)
+def _compute_gae_advantage_return_wrapper(**kwargs):
+    """Wrapper for GAE that matches the registry interface."""
+    return compute_gae_advantage_return(
+        token_level_rewards=kwargs['token_level_rewards'],
+        values=kwargs['values'],
+        response_mask=kwargs['response_mask'],
+        gamma=kwargs['gamma'],
+        lambd=kwargs['lambd'],
+    )
+
+
+@register_advantage_estimator(AdvantageEstimator.GRPO)
+def _compute_grpo_outcome_advantage_wrapper(**kwargs):
+    """Wrapper for GRPO that matches the registry interface."""
+    return compute_grpo_outcome_advantage(
+        token_level_rewards=kwargs['token_level_rewards'],
+        response_mask=kwargs['response_mask'],
+        index=kwargs['index'],
+        epsilon=kwargs['epsilon'],
+        norm_adv_by_std_in_grpo=kwargs['norm_adv_by_std_in_grpo'],
+    )
+
+
 def compute_advantages_and_returns(
     token_level_rewards: torch.Tensor,
     response_mask: torch.Tensor,
     index: np.ndarray,
-    adv_estimator: str,
+    adv_estimator: Union[str, AdvantageEstimator],
     values: Optional[torch.Tensor] = None,
     norm_adv_by_std_in_grpo: bool = True,
     gamma=1.0,
     lambd=1.0,
 ):
-    if adv_estimator == "gae":
-        advantages, returns = compute_gae_advantage_return(
-            token_level_rewards=token_level_rewards,
-            values=values,
-            response_mask=response_mask,
-            gamma=gamma,
-            lambd=lambd,
-        )
-    elif adv_estimator == "grpo":
-        advantages, returns = compute_grpo_outcome_advantage(
-            token_level_rewards=token_level_rewards,
-            response_mask=response_mask,
-            index=index,
-            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
-        )
+    # Convert enum to string if needed
+    if isinstance(adv_estimator, AdvantageEstimator):
+        estimator_name = adv_estimator.value
     else:
-        raise ValueError(f"Invalid adv_estimator: {adv_estimator}")
-    return advantages, returns
+        estimator_name = adv_estimator
+    
+    # Get the estimator function from registry
+    estimator_func = AdvantageEstimatorRegistry.get(estimator_name)
+    
+    # Call with all parameters
+    return estimator_func(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+        values=values,
+        norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+        gamma=gamma,
+        lambd=lambd,
+    )

--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -140,10 +140,6 @@ def validate_cfg(cfg: DictConfig):
         cfg.trainer.sequence_parallel_backend == "ulysses"
     ), f"only ulysses is supported as of now, got {cfg.trainer.sequence_parallel_backend}"
 
-    assert cfg.trainer.algorithm.advantage_estimator in (
-        "gae",
-        "grpo",
-    ), f"invalid advantage estimator: {cfg.trainer.algorithm.advantage_estimator}"
     # if advantage estimator is GAE, then critic path should be provided
     if cfg.trainer.algorithm.advantage_estimator == "gae":
         assert (

--- a/skyrl-train/tests/cpu/utils/test_ppo_utils.py
+++ b/skyrl-train/tests/cpu/utils/test_ppo_utils.py
@@ -10,8 +10,11 @@ from skyrl_train.utils.ppo_utils import (
     compute_approx_kl,
     compute_gae_advantage_return,
     compute_grpo_outcome_advantage,
+    compute_advantages_and_returns,
     AdaptiveKLController,
     FixedKLController,
+    AdvantageEstimatorRegistry,
+    register_advantage_estimator,
 )
 import numpy as np
 
@@ -144,3 +147,79 @@ def test_fixed_kl_controller():
     controller = FixedKLController(kl_coef=0.1)
     controller.update(current=1.0, n_steps=10)
     assert controller.value == 0.1  # Should remain unchanged
+
+
+def test_advantage_estimator_registration():
+    """Test that we can register and retrieve a custom estimator."""
+
+    # Create a simple dummy estimator
+    def dummy_estimator(**kwargs):
+        return torch.zeros_like(kwargs["token_level_rewards"]), torch.zeros_like(kwargs["token_level_rewards"])
+
+    # Register it
+    AdvantageEstimatorRegistry.register("dummy", dummy_estimator)
+
+    # Check it's retrievable
+    retrieved_func = AdvantageEstimatorRegistry.get("dummy")
+    assert retrieved_func == dummy_estimator
+
+    # Check it's in the available list
+    assert "dummy" in AdvantageEstimatorRegistry.list_available()
+
+
+def test_duplicate_registration_error():
+    """Test that registering the same name twice raises an error."""
+
+    def estimator1(**kwargs):
+        return None, None
+
+    def estimator2(**kwargs):
+        return None, None
+
+    # Register first one
+    AdvantageEstimatorRegistry.register("duplicate_test", estimator1)
+
+    # Try to register second one with same name - should fail
+    with pytest.raises(ValueError, match="already registered"):
+        AdvantageEstimatorRegistry.register("duplicate_test", estimator2)
+
+
+def test_unknown_estimator_error():
+    """Test that getting an unknown estimator raises error."""
+    with pytest.raises(ValueError, match="Unknown estimator.*Available:"):
+        AdvantageEstimatorRegistry.get("nonexistent_estimator")
+
+
+def test_decorator_registration():
+    """Test that the decorator works for registration."""
+
+    @register_advantage_estimator("decorated_estimator")
+    def my_custom_estimator(**kwargs):
+        return torch.ones_like(kwargs["token_level_rewards"]), torch.ones_like(kwargs["token_level_rewards"])
+
+    # Check it was registered
+    assert "decorated_estimator" in AdvantageEstimatorRegistry.list_available()
+
+    # Check we can retrieve it
+    retrieved = AdvantageEstimatorRegistry.get("decorated_estimator")
+    assert retrieved == my_custom_estimator
+
+
+def test_custom_estimator_integration(advantage_test_data):
+    """Test that compute_advantages_and_returns works with custom estimators."""
+    rewards, values, response_mask, index = advantage_test_data
+
+    # Register a simple custom estimator
+    @register_advantage_estimator("simple_test")
+    def simple_estimator(**kwargs):
+        # Just return the rewards as both advantages and returns
+        r = kwargs["token_level_rewards"]
+        return r, r
+
+    # Use it in the main function
+    adv, ret = compute_advantages_and_returns(
+        token_level_rewards=rewards, response_mask=response_mask, index=index, adv_estimator="simple_test"
+    )
+
+    assert torch.allclose(adv, rewards)
+    assert torch.allclose(ret, rewards)


### PR DESCRIPTION
## What does this PR do? 

Adds an `AdvantageEstimatorRegistry` to support custom advantage estimation methods without modifying the skyrl-train package. 

Added `examples/algorithm/custom_advantage_estimator` folder to give quick example of how to register a custom adv est function.

## Tests
Adding cpu test to ensure registration works. 