### PR TITLE
Enable/disable training on thinking tokens by configuration

### DIFF
--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -39,7 +39,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         self.use_conversation_multi_turn = generator_cfg.use_conversation_multi_turn
 
         # optionally use custom chat template to get loss masks (i.e. for Qwen3)
-        self.custom_chat_template = get_custom_chat_template(model_name)
+        self.custom_chat_template = get_custom_chat_template(model_name, generator_cfg.get("train_on_thinking_tokens", False))
         # get generation prompt ids for the tokenizer if needed
         self.generation_prompt_ids = get_generation_prompt_ids(tokenizer) if self.use_conversation_multi_turn else None
         if self.skyrl_gym_cfg.max_env_workers > 0:

--- a/skyrl-train/skyrl_train/generators/utils.py
+++ b/skyrl-train/skyrl_train/generators/utils.py
@@ -28,8 +28,8 @@ CUSTOM_CHAT_TEMPLATES = {
 }
 
 
-def get_custom_chat_template(model_name: str) -> str:
-    if "Qwen3" in model_name:
+def get_custom_chat_template(model_name: str, train_on_thinking_tokens: bool = False) -> Optional[str]:
+    if "Qwen3" in model_name and not train_on_thinking_tokens:
         return CUSTOM_CHAT_TEMPLATES["qwen3_thinking"]
     else:
         return None


### PR DESCRIPTION
## Summary

This PR introduces a configuration option to enable or disable training on "thinking tokens" for Qwen3 models in the generator. Works on issue #104.

## Changes

- Modified `get_custom_chat_template` to accept a `train_on_thinking_tokens` flag.
- Passed the `train_on_thinking_tokens` config from `generator_cfg` to `get_custom_chat_template`.