### PR TITLE
[Trainer] GSPO support

### DIFF
--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -291,7 +291,7 @@ Algorithm Configuration
       advantage_batch_normalize: false
       value_head_prefix: "value_head"
       policy_loss_type: "regular" # "regular", "dual_clip", "gspo", or customizable with PolicyLossRegistry
-      loss_reduction: "token_mean" # "token_mean", "sequence_mean" (ignored for GSPO)
+      loss_reduction: "token_mean" # "token_mean", "sequence_mean"
 
       # GAE parameters
       lambd: 1.0
@@ -319,7 +319,7 @@ Algorithm Configuration
 
   - ``regular``: Vanilla PPO loss with token-level importance sampling
   - ``dual_clip``: Dual clip PPO loss proposed in `this paper <https://arxiv.org/pdf/1912.09729>`_
-  - ``gspo``: Group Sequence Policy Optimization with sequence-level importance sampling for improved training stability (`arXiv:2507.18071 <https://arxiv.org/abs/2507.18071>`_)
+  - ``gspo``: `Group Sequence Policy Optimization <https://arxiv.org/abs/2507.18071>`_ with sequence-level importance sampling for improved training stability. Implements "GSPO-token" variant from the paper.
   - Custom policy losses can be registered with the ``PolicyLossRegistry``
 
 - ``algorithm.loss_reduction``: Type of loss reduction to use. Options are ``token_mean`` and ``sequence_mean``. ``token_mean`` matches token-level loss introduced by `DAPO <https://dapo-sia.github.io/>`_. ``sequence_mean`` computes per-sequence avg token loss, then averages over the batch.

--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -322,7 +322,7 @@ Algorithm Configuration
   - ``gspo``: Group Sequence Policy Optimization with sequence-level importance sampling for improved training stability (`arXiv:2507.18071 <https://arxiv.org/abs/2507.18071>`_)
   - Custom policy losses can be registered with the ``PolicyLossRegistry``
 
-- ``algorithm.loss_reduction``: Type of loss reduction to use. Options are ``token_mean`` and ``sequence_mean``. ``token_mean`` matches token-level loss introduced by `DAPO <https://dapo-sia.github.io/>`_. ``sequence_mean`` computes per-sequence avg token loss, then averages over the batch. Note: GSPO automatically uses ``sequence_mean`` regardless of this setting.
+- ``algorithm.loss_reduction``: Type of loss reduction to use. Options are ``token_mean`` and ``sequence_mean``. ``token_mean`` matches token-level loss introduced by `DAPO <https://dapo-sia.github.io/>`_. ``sequence_mean`` computes per-sequence avg token loss, then averages over the batch.
 - ``algorithm.lambd``: Lambda parameter for GAE.
 - ``algorithm.gamma``: Gamma parameter for GAE.
 - ``algorithm.eps_clip_low``: Lower bound for PPO clipping.

--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -317,6 +317,7 @@ Algorithm Configuration
 - ``algorithm.value_head_prefix``: The name used to identify the value head in the critic model.
 - ``algorithm.policy_loss_type``: Type of PPO loss to use. Currently, we implement ``regular`` and ``dual_clip``, where ``regular`` is the vanilla PPO loss, while ``dual_clip`` is the dual clip PPO loss proposed in `this paper <https://arxiv.org/pdf/1912.09729>`_. Custom policy losses can be registered with the ``PolicyLossRegistry``.
 - ``algorithm.loss_reduction``: Type of PPO loss reduction to use. Currently, we support ``token_mean`` and ``sequence_mean``. ``token_mean`` matches token-level loss introduced by `DAPO <https://dapo-sia.github.io/>`_. ``sequence_mean`` computes per-sequence avg token loss, then averages over the batch.
+- ``algorithm.importance_sampling_level``: Level at which importance sampling is aggregated. Currently, we support ``token`` and ``sequence``. ``token`` is the default and matches the original PPO/GRPO loss. ``sequence`` computes importance sampling at the sequence level, as proposed in `GSPO <https://www.arxiv.org/pdf/2507.18071>`_.
 - ``algorithm.lambd``: Lambda parameter for GAE.
 - ``algorithm.gamma``: Gamma parameter for GAE.
 - ``algorithm.eps_clip_low``: Lower bound for PPO clipping.

--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -290,8 +290,8 @@ Algorithm Configuration
       # this adds training batch level normalization to advantages 
       advantage_batch_normalize: false
       value_head_prefix: "value_head"
-      policy_loss_type: "regular" # "regular", "dual_clip", or customizable with PolicyLossRegistry
-      loss_reduction: "token_mean" # "token_mean", "sequence_mean"
+      policy_loss_type: "regular" # "regular", "dual_clip", "gspo", or customizable with PolicyLossRegistry
+      loss_reduction: "token_mean" # "token_mean", "sequence_mean" (ignored for GSPO)
 
       # GAE parameters
       lambd: 1.0
@@ -315,9 +315,14 @@ Algorithm Configuration
 - ``algorithm.kl_loss_coef``: Coefficient for the KL divergence loss.
 - ``algorithm.advantage_batch_normalize``: Whether to normalize advantages by the (global) batch mean and standard deviation.
 - ``algorithm.value_head_prefix``: The name used to identify the value head in the critic model.
-- ``algorithm.policy_loss_type``: Type of PPO loss to use. Currently, we implement ``regular`` and ``dual_clip``, where ``regular`` is the vanilla PPO loss, while ``dual_clip`` is the dual clip PPO loss proposed in `this paper <https://arxiv.org/pdf/1912.09729>`_. Custom policy losses can be registered with the ``PolicyLossRegistry``.
-- ``algorithm.loss_reduction``: Type of PPO loss reduction to use. Currently, we support ``token_mean`` and ``sequence_mean``. ``token_mean`` matches token-level loss introduced by `DAPO <https://dapo-sia.github.io/>`_. ``sequence_mean`` computes per-sequence avg token loss, then averages over the batch.
-- ``algorithm.importance_sampling_level``: Level at which importance sampling is aggregated. Currently, we support ``token`` and ``sequence``. ``token`` is the default and matches the original PPO/GRPO loss. ``sequence`` computes importance sampling at the sequence level, as proposed in `GSPO <https://www.arxiv.org/pdf/2507.18071>`_.
+- ``algorithm.policy_loss_type``: Type of policy loss to use. Options include:
+
+  - ``regular``: Vanilla PPO loss with token-level importance sampling
+  - ``dual_clip``: Dual clip PPO loss proposed in `this paper <https://arxiv.org/pdf/1912.09729>`_
+  - ``gspo``: Group Sequence Policy Optimization with sequence-level importance sampling for improved training stability (`arXiv:2507.18071 <https://arxiv.org/abs/2507.18071>`_)
+  - Custom policy losses can be registered with the ``PolicyLossRegistry``
+
+- ``algorithm.loss_reduction``: Type of loss reduction to use. Options are ``token_mean`` and ``sequence_mean``. ``token_mean`` matches token-level loss introduced by `DAPO <https://dapo-sia.github.io/>`_. ``sequence_mean`` computes per-sequence avg token loss, then averages over the batch. Note: GSPO automatically uses ``sequence_mean`` regardless of this setting.
 - ``algorithm.lambd``: Lambda parameter for GAE.
 - ``algorithm.gamma``: Gamma parameter for GAE.
 - ``algorithm.eps_clip_low``: Lower bound for PPO clipping.

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -88,9 +88,8 @@ trainer:
     # this adds training batch level normalization to advantages 
     advantage_batch_normalize: false
     value_head_prefix: "value_head"
-    policy_loss_type: "regular" # "regular", "dual_clip", or customizable with PolicyLossRegistry
-    loss_reduction: "token_mean" # "token_mean", "sequence_mean"
-    importance_sampling_level: "token" # "token", "sequence"
+    policy_loss_type: "regular" # "regular", "dual_clip", "gspo", or customizable with PolicyLossRegistry
+    loss_reduction: "token_mean" # "token_mean", "sequence_mean" (ignored for GSPO, which uses sequence_mean)
     # GAE parameters
     lambd: 1.0
     gamma: 1.0

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -89,7 +89,7 @@ trainer:
     advantage_batch_normalize: false
     value_head_prefix: "value_head"
     policy_loss_type: "regular" # "regular", "dual_clip", "gspo", or customizable with PolicyLossRegistry
-    loss_reduction: "token_mean" # "token_mean", "sequence_mean" (ignored for GSPO, which uses sequence_mean)
+    loss_reduction: "token_mean" # "token_mean", "sequence_mean"
     # GAE parameters
     lambd: 1.0
     gamma: 1.0

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -90,6 +90,7 @@ trainer:
     value_head_prefix: "value_head"
     policy_loss_type: "regular" # "regular", "dual_clip", or customizable with PolicyLossRegistry
     loss_reduction: "token_mean" # "token_mean", "sequence_mean"
+    importance_sampling_level: "token" # "token", "sequence"
     # GAE parameters
     lambd: 1.0
     gamma: 1.0

--- a/skyrl-train/skyrl_train/utils/ppo_utils.py
+++ b/skyrl-train/skyrl_train/utils/ppo_utils.py
@@ -483,6 +483,63 @@ def ppo_policy_loss(
     return loss, clip_ratio
 
 
+@register_policy_loss("gspo")
+def gspo_policy_loss(
+    log_probs: torch.Tensor,
+    old_log_probs: torch.Tensor,
+    advantages: torch.Tensor,
+    config: DictConfig,
+    loss_mask: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, float]:
+    """
+    GSPO (Group-wise Surrogate Policy Optimization) policy loss function.
+    
+    This implements sequence-level importance sampling instead of token-level importance sampling.
+    The key difference is that importance weights are computed at the sequence level and then
+    applied uniformly across all tokens in the sequence. This leads to more stable training
+    dynamics by reducing the variance in clipping behavior within sequences.
+    
+    GSPO enforces sequence_mean reduction to be consistent with its sequence-level approach.
+    
+    Reference: arXiv:2402.14740
+    """
+    # GSPO must use sequence_mean reduction
+    loss_reduction = "sequence_mean"
+
+    # Compute log ratios
+    log_ratio = log_probs - old_log_probs
+    
+    # Key GSPO innovation: sequence-level importance sampling
+    # Instead of using per-token ratios, compute sequence-averaged ratios
+    log_importance_weights = masked_mean(log_ratio, loss_mask, dim=-1)
+    
+    # Expand sequence-level importance weights to match token dimensions
+    log_importance_weights = log_importance_weights.unsqueeze(-1).expand_as(log_ratio)
+    
+    # Convert to importance ratios
+    ratio = log_importance_weights.exp()
+    
+    # Standard PPO surrogate objective with sequence-level importance weights
+    surr1 = ratio * advantages
+    surr2 = ratio.clamp(1 - config.eps_clip_low, 1 + config.eps_clip_high) * advantages
+    loss = -torch.min(surr1, surr2)
+    
+    # Compute clipping ratio for monitoring
+    clip_ratio = masked_mean((-surr2 > -surr1).float(), loss_mask).mean().detach().item()
+    
+    # Apply dual clipping if configured
+    clip_pg_losses1 = loss
+    if hasattr(config, 'dual_clip') and config.dual_clip:
+        pg_losses3 = -advantages * config.clip_ratio_c
+        clip_pg_losses2 = torch.min(pg_losses3, clip_pg_losses1)
+        loss = torch.where(advantages < 0, clip_pg_losses2, clip_pg_losses1)
+    
+    # Apply sequence_mean reduction (enforced for GSPO)
+    loss = reduce_loss(loss, loss_mask, loss_reduction)
+    
+    return loss, clip_ratio
+
+
 def reduce_loss(
     loss: torch.Tensor, loss_mask: Optional[torch.Tensor], loss_reduction: Literal["token_mean", "sequence_mean"]
 ) -> torch.Tensor:

--- a/skyrl-train/tests/cpu/algorithms/test_losses.py
+++ b/skyrl-train/tests/cpu/algorithms/test_losses.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from omegaconf import DictConfig
 from skyrl_train.utils.ppo_utils import PolicyLossRegistry
+from skyrl_train.utils import masked_mean
 
 
 # Adapted a good test from NeMO-RL
@@ -217,52 +218,71 @@ def test_policy_loss_reduction_edge_cases():
 
 
 def test_gspo_importance_sampling_levels():
-    """Tests different importance_sampling_level modes in PolicyLoss function (GSPO implementation)."""
+    """Tests GSPO policy loss function with sequence-level importance sampling.
+    
+    This test focuses on GSPO's key benefit: stabilizing clipping behavior through sequence-level
+    importance sampling, which should lead to more consistent training dynamics compared to 
+    token-level importance sampling in standard PPO.
+    """
 
     device = "cpu"
 
     clip_eps_low = 0.2
     clip_eps_high = 0.2
 
-    # Create test data where sequence-level importance sampling should differ from token-level
+    # Create test data with varied sequence lengths and extreme ratios to test clipping stability
+    # GSPO's benefit is most apparent with sequences of different lengths and high variance
     advantages = torch.tensor(
         [
-            [1.0, 2.0, 1.5],  # sequence 1: 3 tokens
-            [2.0, 1.0, 0.0],  # sequence 2: only 2 valid tokens (last masked)
+            [1.5, 2.0, 1.0, 0.8, 0.5, 0.0, 0.0, 0.0],  # long sequence: 5 valid tokens
+            [3.0, 1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # short sequence: 2 valid tokens
+            [0.5, 0.8, 1.2, 2.5, 0.0, 0.0, 0.0, 0.0],  # medium sequence: 4 valid tokens
         ],
         device=device,
     )
 
-    old_log_probs = torch.tensor([[-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]], device=device)
+    old_log_probs = torch.tensor([
+        [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
+        [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
+        [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
+    ], device=device)
 
-    # Set log_probs to create different ratios per sequence
-    log_probs = torch.tensor(
-        [[-0.5, -1.5, -0.8], [-0.7, -1.2, -2.0]],  # ratios ≈ [[1.65, 0.61, 1.22], [1.35, 0.82, 0.37]]
-        device=device,
-    )
+    # Create extreme log probability ratios to trigger significant clipping
+    # This tests GSPO's stability benefits under conditions that would cause unstable clipping
+    log_probs = torch.tensor([
+        [0.2, -2.5, -0.3, 0.1, -1.8, -1.0, -1.0, -1.0],  # high variance within sequence
+        [0.8, -0.2, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],  # extreme ratios (exp(1.8)≈6.0, exp(0.8)≈2.2)
+        [-0.5, 0.3, -1.7, 0.4, -1.0, -1.0, -1.0, -1.0],   # mixed extreme values
+    ], device=device)
 
-    # Create mask to make sequences have different effective lengths
-    loss_mask = torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 0.0]], device=device)
+    # Create masks for different sequence lengths (key for testing length normalization)
+    loss_mask = torch.tensor([
+        [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0],  # 5 tokens
+        [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # 2 tokens
+        [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0],  # 4 tokens
+    ], device=device)
 
-    # Test token-level importance sampling (standard PPO)
-    loss_fn_token = PolicyLoss(
-        loss_type="regular",
-        loss_reduction="token_mean",
-        clip_eps_low=clip_eps_low,
-        clip_eps_high=clip_eps_high,
-        importance_sampling_level="token",
-    )
-    loss_token, _ = loss_fn_token(log_probs, old_log_probs, advantages, loss_mask)
+    # Test standard PPO (token-level importance sampling)
+    ppo_config = DictConfig({
+        "eps_clip_low": clip_eps_low,
+        "eps_clip_high": clip_eps_high,
+        "clip_ratio_c": 3.0,
+        "policy_loss_type": "regular",
+        "loss_reduction": "token_mean",
+    })
+    ppo_loss_fn = PolicyLossRegistry.get("regular")
+    loss_token, _ = ppo_loss_fn(log_probs, old_log_probs, advantages, ppo_config, loss_mask)
 
-    # Test sequence-level importance sampling (GSPO)
-    loss_fn_sequence = PolicyLoss(
-        loss_type="regular",
-        loss_reduction="token_mean",
-        clip_eps_low=clip_eps_low,
-        clip_eps_high=clip_eps_high,
-        importance_sampling_level="sequence",
-    )
-    loss_sequence, _ = loss_fn_sequence(log_probs, old_log_probs, advantages, loss_mask)
+    # Test GSPO (sequence-level importance sampling)
+    gspo_config = DictConfig({
+        "eps_clip_low": clip_eps_low,
+        "eps_clip_high": clip_eps_high,
+        "clip_ratio_c": 3.0,
+        "policy_loss_type": "gspo",
+        "loss_reduction": "token_mean",  # GSPO will override this to sequence_mean
+    })
+    gspo_loss_fn = PolicyLossRegistry.get("gspo")
+    loss_sequence, _ = gspo_loss_fn(log_probs, old_log_probs, advantages, gspo_config, loss_mask)
 
     # Manual calculation for token-level (standard PPO)
     log_ratio = log_probs - old_log_probs
@@ -272,10 +292,12 @@ def test_gspo_importance_sampling_levels():
     loss_per_token_token = -torch.min(surr1_token, surr2_token)
     expected_token = (loss_per_token_token * loss_mask).sum() / (loss_mask.sum() + 1e-8)
 
+    # Calculate token-level clipping ratio
+    is_clipped_token = (-surr2_token > -surr1_token) & (loss_mask.bool())
+    clip_ratio_token = is_clipped_token.float().sum() / loss_mask.sum()
+
     # Manual calculation for sequence-level (GSPO)
-    # First compute sequence-level importance weights
-    from skyrl_train.utils import masked_mean
-    
+    # First compute sequence-level importance weights (key GSPO innovation)
     log_importance_weights_seq = masked_mean(log_ratio, loss_mask, dim=-1)
     # Expand to match the shape of log_ratio
     log_importance_weights_seq = log_importance_weights_seq.unsqueeze(-1).expand_as(log_ratio)
@@ -283,13 +305,50 @@ def test_gspo_importance_sampling_levels():
     surr1_sequence = ratio_sequence * advantages
     surr2_sequence = ratio_sequence.clamp(1 - clip_eps_low, 1 + clip_eps_high) * advantages
     loss_per_token_sequence = -torch.min(surr1_sequence, surr2_sequence)
-    expected_sequence = (loss_per_token_sequence * loss_mask).sum() / (loss_mask.sum() + 1e-8)
+    # GSPO uses sequence_mean reduction
+    expected_sequence = masked_mean(loss_per_token_sequence, loss_mask, dim=-1).mean()
 
-    # Verify results
+    # Calculate sequence-level clipping ratio
+    is_clipped_sequence = (-surr2_sequence > -surr1_sequence) & (loss_mask.bool())
+    clip_ratio_sequence = is_clipped_sequence.float().sum() / loss_mask.sum()
+
+    # Verify loss calculations
     torch.testing.assert_close(loss_token, expected_token, rtol=1e-5, atol=1e-8)
     torch.testing.assert_close(loss_sequence, expected_sequence, rtol=1e-5, atol=1e-8)
 
-    # Token-level and sequence-level should give different results when sequences have different patterns
+    # Core GSPO benefit test: Different clipping behavior
+    # GSPO should produce different clipping patterns due to sequence-level importance sampling
+    assert not torch.allclose(
+        clip_ratio_token, clip_ratio_sequence, rtol=1e-2
+    ), f"Clipping ratios should differ: token={clip_ratio_token:.4f} vs sequence={clip_ratio_sequence:.4f}"
+
+    # Test stability: sequence-level should smooth out extreme per-token variations
+    # Check that sequence-level ratios have lower variance within each sequence
+    token_ratio_variance = torch.var(ratio_token * loss_mask, dim=-1).mean()
+    sequence_ratio_variance = torch.var(ratio_sequence * loss_mask, dim=-1).mean()
+    
+    # The key insight: GSPO should reduce within-sequence variance by using sequence-averaged ratios
+    assert sequence_ratio_variance < token_ratio_variance, (
+        f"GSPO should reduce ratio variance: sequence={sequence_ratio_variance:.4f} < "
+        f"token={token_ratio_variance:.4f}"
+    )
+
+    # Token-level and sequence-level should give different results due to different importance weighting
     assert not torch.allclose(
         loss_token, loss_sequence, rtol=1e-3
-    ), "Token-level and sequence-level importance sampling should give different results"
+    ), f"Loss values should differ: token={loss_token:.6f} vs sequence={loss_sequence:.6f}"
+
+    # Test length normalization effect: sequences with different lengths should be handled more uniformly
+    # This is a key stability benefit of GSPO mentioned in the paper
+    seq_lengths = loss_mask.sum(dim=-1)  # [5, 2, 4]
+    
+    # In GSPO, the sequence-level importance weights should be the same across all tokens in a sequence
+    # This should make the treatment more uniform across different sequence lengths
+    for seq_idx in range(log_importance_weights_seq.shape[0]):
+        seq_len = int(seq_lengths[seq_idx])
+        if seq_len > 1:
+            # All importance weights within a sequence should be identical (GSPO property)
+            seq_weights = log_importance_weights_seq[seq_idx, :seq_len]
+            assert torch.allclose(seq_weights, seq_weights[0], rtol=1e-6), (
+                f"GSPO should have uniform importance weights within sequence {seq_idx}"
+            )

--- a/skyrl-train/tests/cpu/algorithms/test_losses.py
+++ b/skyrl-train/tests/cpu/algorithms/test_losses.py
@@ -219,9 +219,9 @@ def test_policy_loss_reduction_edge_cases():
 
 def test_gspo_importance_sampling_levels():
     """Tests GSPO policy loss function with sequence-level importance sampling.
-    
+
     This test focuses on GSPO's key benefit: stabilizing clipping behavior through sequence-level
-    importance sampling, which should lead to more consistent training dynamics compared to 
+    importance sampling, which should lead to more consistent training dynamics compared to
     token-level importance sampling in standard PPO.
     """
 
@@ -241,46 +241,59 @@ def test_gspo_importance_sampling_levels():
         device=device,
     )
 
-    old_log_probs = torch.tensor([
-        [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
-        [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
-        [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
-    ], device=device)
+    old_log_probs = torch.tensor(
+        [
+            [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
+            [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
+            [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
+        ],
+        device=device,
+    )
 
     # Create extreme log probability ratios to trigger significant clipping
     # This tests GSPO's stability benefits under conditions that would cause unstable clipping
-    log_probs = torch.tensor([
-        [0.2, -2.5, -0.3, 0.1, -1.8, -1.0, -1.0, -1.0],  # high variance within sequence
-        [0.8, -0.2, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],  # extreme ratios (exp(1.8)≈6.0, exp(0.8)≈2.2)
-        [-0.5, 0.3, -1.7, 0.4, -1.0, -1.0, -1.0, -1.0],   # mixed extreme values
-    ], device=device)
+    log_probs = torch.tensor(
+        [
+            [0.2, -2.5, -0.3, 0.1, -1.8, -1.0, -1.0, -1.0],  # high variance within sequence
+            [0.8, -0.2, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],  # extreme ratios (exp(1.8)≈6.0, exp(0.8)≈2.2)
+            [-0.5, 0.3, -1.7, 0.4, -1.0, -1.0, -1.0, -1.0],  # mixed extreme values
+        ],
+        device=device,
+    )
 
     # Create masks for different sequence lengths (key for testing length normalization)
-    loss_mask = torch.tensor([
-        [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0],  # 5 tokens
-        [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # 2 tokens
-        [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0],  # 4 tokens
-    ], device=device)
+    loss_mask = torch.tensor(
+        [
+            [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0],  # 5 tokens
+            [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # 2 tokens
+            [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0],  # 4 tokens
+        ],
+        device=device,
+    )
 
     # Test standard PPO (token-level importance sampling)
-    ppo_config = DictConfig({
-        "eps_clip_low": clip_eps_low,
-        "eps_clip_high": clip_eps_high,
-        "clip_ratio_c": 3.0,
-        "policy_loss_type": "regular",
-        "loss_reduction": "token_mean",
-    })
+    ppo_config = DictConfig(
+        {
+            "eps_clip_low": clip_eps_low,
+            "eps_clip_high": clip_eps_high,
+            "clip_ratio_c": 3.0,
+            "policy_loss_type": "regular",
+            "loss_reduction": "token_mean",
+        }
+    )
     ppo_loss_fn = PolicyLossRegistry.get("regular")
     loss_token, _ = ppo_loss_fn(log_probs, old_log_probs, advantages, ppo_config, loss_mask)
 
     # Test GSPO (sequence-level importance sampling)
-    gspo_config = DictConfig({
-        "eps_clip_low": clip_eps_low,
-        "eps_clip_high": clip_eps_high,
-        "clip_ratio_c": 3.0,
-        "policy_loss_type": "gspo",
-        "loss_reduction": "sequence_mean",  # GSPO recommended reduction
-    })
+    gspo_config = DictConfig(
+        {
+            "eps_clip_low": clip_eps_low,
+            "eps_clip_high": clip_eps_high,
+            "clip_ratio_c": 3.0,
+            "policy_loss_type": "gspo",
+            "loss_reduction": "sequence_mean",  # GSPO recommended reduction
+        }
+    )
     gspo_loss_fn = PolicyLossRegistry.get("gspo")
     loss_sequence, _ = gspo_loss_fn(log_probs, old_log_probs, advantages, gspo_config, loss_mask)
 
@@ -299,7 +312,7 @@ def test_gspo_importance_sampling_levels():
     # Manual calculation for sequence-level (GSPO)
     # First compute sequence-level importance weights (key GSPO innovation)
     log_importance_weights_seq = masked_mean(log_ratio, loss_mask, dim=-1).unsqueeze(-1)
-    
+
     # GSPO uses stop gradients: s_i,t(θ) = sg[s_i(θ)] · π_θ(y_i,t|x, y_i,<t) / sg[π_θ(y_i,t|x, y_i,<t)]
     # In log space: log(s_i,t(θ)) = sg[log(s_i(θ))] + log_probs - sg[log_probs]
     ratio_sequence = torch.exp(log_importance_weights_seq.detach() + log_probs - log_probs.detach())
@@ -327,7 +340,7 @@ def test_gspo_importance_sampling_levels():
     # Check that sequence-level ratios have lower variance within each sequence
     token_ratio_variance = torch.var(ratio_token * loss_mask, dim=-1).mean()
     sequence_ratio_variance = torch.var(ratio_sequence * loss_mask, dim=-1).mean()
-    
+
     # The key insight: GSPO should reduce within-sequence variance by using sequence-averaged ratios
     assert sequence_ratio_variance < token_ratio_variance, (
         f"GSPO should reduce ratio variance: sequence={sequence_ratio_variance:.4f} < "
@@ -342,7 +355,7 @@ def test_gspo_importance_sampling_levels():
     # Test length normalization effect: sequences with different lengths should be handled more uniformly
     # This is a key stability benefit of GSPO mentioned in the paper
     seq_lengths = loss_mask.sum(dim=-1)  # [5, 2, 4]
-    
+
     # In GSPO, the sequence-level importance weights should be the same across all tokens in a sequence
     # This should make the treatment more uniform across different sequence lengths
     for seq_idx in range(log_importance_weights_seq.shape[0]):
@@ -350,6 +363,6 @@ def test_gspo_importance_sampling_levels():
         if seq_len > 1:
             # All importance weights within a sequence should be identical (GSPO property)
             seq_weights = log_importance_weights_seq[seq_idx, :seq_len]
-            assert torch.allclose(seq_weights, seq_weights[0], rtol=1e-6), (
-                f"GSPO should have uniform importance weights within sequence {seq_idx}"
-            )
+            assert torch.allclose(
+                seq_weights, seq_weights[0], rtol=1e-6
+            ), f"GSPO should have uniform importance weights within sequence {seq_idx}"


### PR DESCRIPTION
This PR adds support for [Group Sequence Policy Optimization (GSPO)](https://arxiv.org/abs/2507.18071), the hotness du jour from Alibaba Qwen. The implementation in this PR is loosely based on [this one](https://github.com/huggingface/trl/pull/3775) from TRL. It adds an `importance_sampling_level` config option which can be `token` (PPO/GRPO) or `sequence` (GSPO).

I ran a short/small GSM8k run with Qwen2.5-0.5B and the loss curves look okay:
<img width="314" height="240" alt="image" src="https://github.com/user-attachments/assets/f52d7c64-416c-4419-aa96-4a03c9048007" />

However, I had to hack a few things to get this to run on Datadog's cloud infra (including changing some dependency versions) so I'd encourage one of the maintainers to reproduce these results locally before merging.