### PR TITLE
[trainer] add more robust generation output validation

### DIFF
--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -49,6 +49,7 @@ from skyrl_train.utils.trainer_utils import (
     validate_consistency_for_latest_checkpoint,
     calculate_per_dataset_metrics,
     dump_per_dataset_eval_results,
+    validate_generator_output,
     GLOBAL_STEP_PREFIX,
 )
 
@@ -663,12 +664,7 @@ class RayPPOTrainer:
         if generator_output["rollout_metrics"] is not None:
             self.all_metrics.update(generator_output["rollout_metrics"])
 
-        if len(generator_output["response_ids"]) <= 0:
-            raise RuntimeError("No outputs generated")
-
-        assert len(input_batch["prompts"]) == len(
-            generator_output["response_ids"]
-        ), f"generate objects number must be equal to all inputs number, got {len(input_batch['prompts'])} and {len(generator_output['response_ids'])}"
+        validate_generator_output(input_batch, generator_output)
 
         return generator_output
 

--- a/skyrl-train/skyrl_train/utils/trainer_utils.py
+++ b/skyrl-train/skyrl_train/utils/trainer_utils.py
@@ -240,10 +240,11 @@ def validate_generator_output(input_batch: GeneratorInput, generator_output: Gen
     if len(generator_output["response_ids"]) <= 0:
         raise RuntimeError("No outputs generated")
 
-    assert len(input_batch["prompts"]) == len(
+    assert len(input_batch["prompts"]) == len(generator_output["response_ids"]) and len(
+        generator_output["prompt_token_ids"]
+    ) == len(
         generator_output["response_ids"]
     ), f"generate objects number must be equal to all inputs number, got {len(input_batch['prompts'])} and {len(generator_output['response_ids'])}"
-
     if np.concatenate(generator_output["loss_masks"]).sum() == 0:
         logger.info(
             "WARNING: All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!"

--- a/skyrl-train/skyrl_train/utils/trainer_utils.py
+++ b/skyrl-train/skyrl_train/utils/trainer_utils.py
@@ -240,11 +240,14 @@ def validate_generator_output(input_batch: GeneratorInput, generator_output: Gen
     if len(generator_output["response_ids"]) <= 0:
         raise RuntimeError("No outputs generated")
 
+    # check that input prompts, response ids, and prompt token ids are all the same length
     assert len(input_batch["prompts"]) == len(generator_output["response_ids"]) and len(
         generator_output["prompt_token_ids"]
     ) == len(
         generator_output["response_ids"]
     ), f"generate objects number must be equal to all inputs number, got {len(input_batch['prompts'])} and {len(generator_output['response_ids'])}"
+
+    # loss masks should be non-zero for at least one element for trainer
     if np.concatenate(generator_output["loss_masks"]).sum() == 0:
         logger.info(
             "WARNING: All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!"

--- a/skyrl-train/skyrl_train/utils/trainer_utils.py
+++ b/skyrl-train/skyrl_train/utils/trainer_utils.py
@@ -257,14 +257,16 @@ def validate_generator_output(input_batch: GeneratorInput, generator_output: Gen
             ), f"Generator output {key} length must be equal to response_ids length, got {len(generator_output[key])} and {len(generator_output['response_ids'])}"
 
     # make sure that each element of response ids and loss masks are all the same length (and token level rewards if used)
-    for i in range(len(generator_output["response_ids"])):
-        assert len(generator_output["response_ids"][i]) == len(
-            generator_output["loss_masks"][i]
-        ), f"Response ids and loss masks must have the same length, for sample {i} got {len(generator_output['response_ids'][i])} and {len(generator_output['loss_masks'][i])}"
-        if isinstance(generator_output["rewards"][i], list):
-            assert len(generator_output["rewards"][i]) == len(
-                generator_output["response_ids"][i]
-            ), f"Token rewards and response ids must have the same length, for sample {i} got {len(generator_output['rewards'][i])} and {len(generator_output['response_ids'][i])}"
+    for i, (response_ids, loss_masks, rewards) in enumerate(
+        zip(generator_output["response_ids"], generator_output["loss_masks"], generator_output["rewards"])
+    ):
+        assert len(response_ids) == len(
+            loss_masks
+        ), f"Response ids and loss masks must have the same length, for sample {i} got {len(response_ids)} and {len(loss_masks)}"
+        if isinstance(rewards, list):
+            assert len(rewards) == len(
+                response_ids
+            ), f"Token rewards and response ids must have the same length, for sample {i} got {len(rewards)} and {len(response_ids)}"
 
     # loss masks should be non-zero for at least one element for trainer
     if np.concatenate(generator_output["loss_masks"]).sum() == 0:

--- a/skyrl-train/tests/cpu/test_trainer_utils.py
+++ b/skyrl-train/tests/cpu/test_trainer_utils.py
@@ -1,3 +1,7 @@
+"""
+uv run --isolated --extra dev pytest tests/cpu/test_trainer_utils.py
+"""
+
 from skyrl_train.utils.trainer_utils import (
     run_on_each_node,
     cleanup_old_checkpoints,
@@ -5,7 +9,9 @@ from skyrl_train.utils.trainer_utils import (
     sanitize_data_source,
     calculate_per_dataset_metrics,
     dump_per_dataset_eval_results,
+    validate_generator_output,
 )
+from skyrl_train.generators.base import GeneratorInput, GeneratorOutput
 from typing import Union
 import ray
 import os
@@ -312,3 +318,129 @@ def test_dump_per_dataset_eval_results_comprehensive(mock_file):
                 break
         except json.JSONDecodeError:
             continue
+
+
+def test_validate_generator_output_valid_case():
+    """Test validate_generator_output with valid case."""
+    input_batch = GeneratorInput(
+        prompts=["prompt1", "prompt2", "prompt3"],
+        env_classes=["env1", "env2", "env3"],
+        env_extras=[{"extra": 1}, {"extra": 2}, {"extra": 3}],
+        sampling_params={"temperature": 0.7},
+    )
+
+    generator_output = GeneratorOutput(
+        prompt_token_ids=[[1, 2, 3, 4], [5, 6], [7, 8, 9]],
+        response_ids=[[10, 11, 12], [13, 14], [15]],
+        rewards=[[0.5, 0.6, 0.7], [0.8, 0.9], [1.0]],  # Nested list structure
+        loss_masks=[[1, 1, 0], [1, 1], [0]],
+        stop_reasons=["stop", "length", "stop"],
+        rollout_metrics={"metric1": 0.5, "metric2": 0.6},
+    )
+
+    # Should not raise any exceptions
+    validate_generator_output(input_batch, generator_output)
+
+    # per trajectory rewards should work too
+    generator_output["rewards"] = [0.5, 0.6, 0.7]
+    validate_generator_output(input_batch, generator_output)
+
+
+def test_validate_generator_output_empty_response_ids():
+    """Test validate_generator_output raises RuntimeError when response_ids is empty."""
+    input_batch = GeneratorInput(prompts=["prompt1"], env_classes=["env1"], env_extras=None, sampling_params=None)
+
+    generator_output = GeneratorOutput(
+        prompt_token_ids=[[1, 2, 3]], response_ids=[], rewards=[], loss_masks=[], stop_reasons=[]  # Empty response_ids
+    )
+
+    with pytest.raises(RuntimeError, match="No outputs generated"):
+        validate_generator_output(input_batch, generator_output)
+
+
+def test_validate_generator_output_mismatched_prompts_responses():
+    """Test validate_generator_output raises AssertionError when prompts and response_ids lengths don't match."""
+    input_batch = GeneratorInput(
+        prompts=["prompt1", "prompt2", "prompt3"],  # 3 prompts
+        env_classes=["env1", "env2", "env3"],
+        env_extras=None,
+        sampling_params=None,
+    )
+
+    generator_output = GeneratorOutput(
+        prompt_token_ids=[[1, 2], [3, 4]],
+        response_ids=[[7, 8], [9, 10]],  # Only 2 responses
+        rewards=[0.5, 0.7],
+        loss_masks=[[1, 1], [1, 0]],
+        stop_reasons=["eos", "eos"],
+    )
+
+    with pytest.raises(AssertionError, match="generate objects number must be equal to all inputs number"):
+        validate_generator_output(input_batch, generator_output)
+
+
+def test_validate_generator_output_all_loss_masked():
+    """Test validate_generator_output logs warning when all outputs are loss masked."""
+    input_batch = GeneratorInput(
+        prompts=["prompt1", "prompt2"], env_classes=["env1", "env2"], env_extras=None, sampling_params=None
+    )
+
+    generator_output = GeneratorOutput(
+        prompt_token_ids=[[1, 2, 3], [4, 5, 6]],
+        response_ids=[[7, 8], [9, 10]],
+        rewards=[0.5, 0.7],
+        loss_masks=[[0, 0], [0, 0]],  # All zeros - completely loss masked
+        stop_reasons=["eos", "eos"],
+    )
+
+    # Capture log output to verify warning is issued
+    with patch("skyrl_train.utils.trainer_utils.logger") as mock_logger:
+        validate_generator_output(input_batch, generator_output)
+        mock_logger.info.assert_called_once_with(
+            "WARNING: All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!"
+        )
+
+
+def test_validate_generator_output_mismatched_list_lengths():
+    """Test validate_generator_output raises AssertionError when generator output lists have mismatched lengths."""
+    input_batch = GeneratorInput(
+        prompts=["prompt1", "prompt2"], env_classes=["env1", "env2"], env_extras=None, sampling_params=None
+    )
+
+    generator_output = GeneratorOutput(
+        prompt_token_ids=[[1, 2, 3], [4, 5, 6]],
+        response_ids=[[7, 8], [9, 10]],  # Length 2
+        rewards=[0.5, 0.7, 0.9],  # Length 3 - mismatch!
+        loss_masks=[[1, 1], [1, 0]],
+        stop_reasons=["eos", "eos"],
+    )
+
+    with pytest.raises(AssertionError, match="Generator output rewards length must be equal to response_ids length"):
+        validate_generator_output(input_batch, generator_output)
+
+
+def test_validate_generator_output_element_length_mismatch():
+    """Test validate_generator_output with element length mismatch."""
+    input_batch = GeneratorInput(
+        prompts=["prompt1", "prompt2", "prompt3"],
+        env_classes=["env1", "env2", "env3"],
+        env_extras=[{"extra": 1}, {"extra": 2}, {"extra": 3}],
+        sampling_params={"temperature": 0.7},
+    )
+
+    generator_output = GeneratorOutput(
+        prompt_token_ids=[[1, 2, 3, 4], [5, 6], [7, 8, 9]],
+        response_ids=[[10, 11, 12], [13, 14], [15]],
+        rewards=[[0.5, 0.6, 0.7], [0.8, 0.9], [1.0]],
+        loss_masks=[[1, 1], [1], [1, 1]],  # loss masks are not the same length as response ids
+        stop_reasons=["stop", "length", "stop"],
+        rollout_metrics={"metric1": 0.5, "metric2": 0.6},
+    )
+
+    with pytest.raises(AssertionError, match="Response ids and loss masks must have the same length"):
+        validate_generator_output(input_batch, generator_output)
+
+    generator_output["loss_masks"] = [[1, 1, 1], [1, 1], [1]]  # add correct loss masks
+    generator_output["rewards"] = [[0.5, 0.6], [0.8], [1.0, 2.0]]  # add incorrect rewards
+    with pytest.raises(AssertionError, match="Token rewards and response ids must have the same length"):
+        validate_generator_output(input_batch, generator_output)

--- a/skyrl-train/tests/cpu/test_trainer_utils.py
+++ b/skyrl-train/tests/cpu/test_trainer_utils.py
@@ -439,13 +439,13 @@ def test_validate_generator_output_element_length_mismatch():
     )
 
     with pytest.raises(
-        AssertionError, match="Response ids and loss masks must have the same length, for sample 0 got 3 and 2"
+        AssertionError, match="Response ids and loss masks must have the same length"
     ):
         validate_generator_output(input_batch, generator_output)
 
     generator_output["loss_masks"] = [[1, 1, 1], [1, 1], [1]]  # add correct loss masks
     generator_output["rewards"] = [[0.5, 0.6], [0.8], [1.0, 2.0]]  # add incorrect rewards
     with pytest.raises(
-        AssertionError, match="Token rewards and response ids must have the same length, for sample 0 got 2 and 3"
+        AssertionError, match="Token rewards and response ids must have the same length"
     ):
         validate_generator_output(input_batch, generator_output)

--- a/skyrl-train/tests/cpu/test_trainer_utils.py
+++ b/skyrl-train/tests/cpu/test_trainer_utils.py
@@ -438,14 +438,10 @@ def test_validate_generator_output_element_length_mismatch():
         rollout_metrics={"metric1": 0.5, "metric2": 0.6},
     )
 
-    with pytest.raises(
-        AssertionError, match="Response ids and loss masks must have the same length"
-    ):
+    with pytest.raises(AssertionError, match="Response ids and loss masks must have the same length"):
         validate_generator_output(input_batch, generator_output)
 
     generator_output["loss_masks"] = [[1, 1, 1], [1, 1], [1]]  # add correct loss masks
     generator_output["rewards"] = [[0.5, 0.6], [0.8], [1.0, 2.0]]  # add incorrect rewards
-    with pytest.raises(
-        AssertionError, match="Token rewards and response ids must have the same length"
-    ):
+    with pytest.raises(AssertionError, match="Token rewards and response ids must have the same length"):
         validate_generator_output(input_batch, generator_output)


### PR DESCRIPTION
# Overview
Adds a `validate_generation_output` function in `trainer_utils.py` with more robust validation of generation output format. Specifically, given 
```
class GeneratorOutput(TypedDict):
    prompt_token_ids: List[List[int]]
    response_ids: List[List[int]]
    rewards: Union[List[float], List[List[float]]]
    loss_masks: List[List[int]]
    stop_reasons: Optional[List[str]]
    rollout_metrics: Optional[Dict[str, Any]]
```

We expect
- all list attributes should have the same length  and be the same length as the input batch of prompts at dim=0
- non zero length lists
- response_ids, loss masks, and rewards (if token level rewards) should be the same length
- the sum of loss masks should be non-zero (logging a warning if it is not)

verified gsm8k run still works:
<img width="563" height="330" alt="image" src="https://github.com/user-attachments/assets/eeefebcb-d5fc-486d-b906-f4344b1e2779" />
