### PR TITLE
[Fix] Reset registries in BaseFunctionRegistry.sync_with_actor() when needed and fix registry reset

### DIFF
--- a/skyrl-train/skyrl_train/utils/ppo_utils.py
+++ b/skyrl-train/skyrl_train/utils/ppo_utils.py
@@ -387,7 +387,7 @@ class BaseFunctionRegistry:
             try:
                 actor = ray.get_actor(cls._actor_name)  # this raises exception if the actor is stale
                 ray.kill(actor)
-            except Exception:
+            except ValueError:
                 pass  # Actor may already be gone
         cls._functions.clear()
         cls._ray_actor = None

--- a/skyrl-train/skyrl_train/utils/ppo_utils.py
+++ b/skyrl-train/skyrl_train/utils/ppo_utils.py
@@ -256,6 +256,16 @@ class BaseFunctionRegistry:
         if not ray.is_initialized():
             raise Exception("Ray is not initialized, cannot sync with actor")
 
+        # First check if the actor is still alive
+        # NOTE(Charlie): This is mainly for unit tests, where we run multiple unit tests in the
+        # same Python process, and each unit test has ray init/shutdown. This makes cls's attributes
+        # outdated (e.g. the _ray_actor points to a stale actor in the previous ray session).
+        try:
+            _ = ray.get_actor(cls._actor_name)  # this raises exception if the actor is stale
+        except ValueError:
+            cls._ray_actor = None
+            cls._synced_to_actor = False
+
         # First, sync our local functions to the actor
         cls._sync_local_to_actor()
 
@@ -465,12 +475,6 @@ def register_policy_loss(name: Union[str, PolicyLossType]):
         return wrapper
 
     return decorator
-
-
-def reset_registries():
-    """Reset the registries."""
-    PolicyLossRegistry.reset()
-    AdvantageEstimatorRegistry.reset()
 
 
 def sync_registries():

--- a/skyrl-train/skyrl_train/utils/ppo_utils.py
+++ b/skyrl-train/skyrl_train/utils/ppo_utils.py
@@ -385,7 +385,8 @@ class BaseFunctionRegistry:
         """Resets the registry (useful for testing purposes)."""
         if ray.is_initialized() and cls._ray_actor is not None:
             try:
-                ray.kill(cls._ray_actor)
+                actor = ray.get_actor(cls._actor_name)  # this raises exception if the actor is stale
+                ray.kill(actor)
             except Exception:
                 pass  # Actor may already be gone
         cls._functions.clear()
@@ -464,6 +465,12 @@ def register_policy_loss(name: Union[str, PolicyLossType]):
         return wrapper
 
     return decorator
+
+
+def reset_registries():
+    """Reset the registries."""
+    PolicyLossRegistry.reset()
+    AdvantageEstimatorRegistry.reset()
 
 
 def sync_registries():

--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -9,7 +9,6 @@ from ray.util.placement_group import placement_group, PlacementGroupSchedulingSt
 from skyrl_train.utils.ppo_utils import (
     AdvantageEstimatorRegistry,
     PolicyLossRegistry,
-    reset_registries,
     sync_registries,
 )
 
@@ -331,7 +330,6 @@ def initialize_ray(cfg: DictConfig):
     ray.init(runtime_env={"env_vars": env_vars})
 
     # create the named ray actors for the registries to make available to all workers
-    reset_registries()
     sync_registries()
 
 

--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -6,7 +6,12 @@ import torch
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 from ray.util.placement_group import placement_group, PlacementGroupSchedulingStrategy, PlacementGroup
-from skyrl_train.utils.ppo_utils import AdvantageEstimatorRegistry, PolicyLossRegistry, sync_registries
+from skyrl_train.utils.ppo_utils import (
+    AdvantageEstimatorRegistry,
+    PolicyLossRegistry,
+    reset_registries,
+    sync_registries,
+)
 
 
 class Timer:
@@ -326,6 +331,7 @@ def initialize_ray(cfg: DictConfig):
     ray.init(runtime_env={"env_vars": env_vars})
 
     # create the named ray actors for the registries to make available to all workers
+    reset_registries()
     sync_registries()
 
 

--- a/skyrl-train/tests/cpu/utils/test_ppo_utils.py
+++ b/skyrl-train/tests/cpu/utils/test_ppo_utils.py
@@ -438,3 +438,43 @@ def test_registry_named_actor_creation():
 
     finally:
         AdvantageEstimatorRegistry.reset()
+
+
+def test_registry_reset_after_ray_shutdown():
+    """
+    Test that the registry resets properly after ray is shutdown.
+
+    This mimics when we run multiple unit tests in a row with ray inits and shutdowns.
+    """
+
+    def _register_func_and_verify():
+        """Register a function and verify it works."""
+
+        def test_func(**kwargs):
+            rewards = kwargs["token_level_rewards"]
+            return rewards * 2, rewards * 3
+
+        AdvantageEstimatorRegistry.register("named_actor_test", test_func)
+        retrieved = AdvantageEstimatorRegistry.get("named_actor_test")
+        assert retrieved == test_func
+        actor = ray.get_actor("advantage_estimator_registry")
+        assert actor is not None
+
+    try:
+        import ray
+
+        # 1. Initialize ray and register function
+        if not ray.is_initialized():
+            ray.init()
+        _register_func_and_verify()
+
+        # 2. Shutdown ray
+        ray.shutdown()
+
+        # 3. Initialize ray, reset registry, and register function
+        ray.init()
+        AdvantageEstimatorRegistry.reset()
+        _register_func_and_verify()
+
+    finally:
+        ray.shutdown()


### PR DESCRIPTION
This PR does two things.

### Change 1
Currently, when we run unit tests like `test_policy_vllm_e2e.py`, in the same Python process, we do `ray.init()` and `ray.shutdown()` for each unit test. However, the states of `BaseFunctionRegistry` persist across each init/shutdown. This makes attributes like `BaseFunctionRegistry._actor_handle` outdated -- as  the actor is killed by `ray.shutdown()`.

This leads to the Registry mistakenly thinking the actor is still alive, leading to error in `BaseFunctionRegistry` for subsequent unit tests.

To fix this, we check whether the actor is still alive with `ray.get_actor(cls._actor_name)` in `BaseFunctionRegistry.sync_with_actor()`. If dead, we reset the attributes accordingly.

An alternative fix is to call `BaseFunctionRegistry.reset()` before each `ray.shutdown()` in unit tests -- this seems less robust in my opinion.

### Change 2
While fixing this, realized that `BaseFunctionRegistry.reset()` has a small issue (this method is not used in non-test code anyway). For a stale actor, `ray.kill(cls._ray_actor)` would directly crash on a C++ level, which cannot be caught by `except Exception`. This can be observed with the newly added `test_registry_reset_after_ray_shutdown()`. Before this PR, this unit test runs into: 

```bash
2025-08-12 02:48:38,218 INFO worker.py:1927 -- Started a local Ray instance.
2025-08-12 02:48:38,264 INFO packaging.py:588 -- Creating a file package for local module '/home/ubuntu/SkyRL/skyrl-train'.
2025-08-12 02:48:38,327 INFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_51aa048fab463db9.zip' (3.07MiB) to Ray cluster...
2025-08-12 02:48:38,339 INFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_51aa048fab463db9.zip'.
[2025-08-12 02:48:39,449 C 1324650 1324650] actor_manager.cc:55:  Check failed: it != actor_handles_.end() Cannot find an actor handle of id, fdbd48b711397d054bcf399101000000. This method should be called only when you ensure actor handles exists.
*** StackTrace Information ***
/home/ubuntu/.cache/uv/builds-v0/.tmpQDkgsz/lib/python3.12/site-packages/ray/_raylet.so(+0x151a6ea) [0x718cf071a6ea] ray::operator<<()
```

To fix this, we use `actor = ray.get_actor(cls._actor_name)` before killing it.