### PR TITLE
[Fix] revert "Optimize tuple unpacking in skyrl_gym_generator.generate() "

### DIFF
--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -306,10 +306,11 @@ class SkyRLGymGenerator(GeneratorInterface):
             mininterval=5,
         )
 
-        if not all_outputs:
-            responses, rewards, stop_reasons, loss_masks, prompt_token_ids = [], [], [], [], []
-        else:
-            responses, rewards, stop_reasons, loss_masks, prompt_token_ids = map(list, zip(*all_outputs))
+        responses = sum([[output[0]] for output in all_outputs], [])
+        rewards = sum([[output[1]] for output in all_outputs], [])
+        stop_reasons = sum([[output[2]] for output in all_outputs], [])
+        loss_masks = sum([[output[3]] for output in all_outputs], [])
+        prompt_token_ids = sum([[output[4]] for output in all_outputs], [])
 
         if sampling_params is not None:
             # sampling params will be a dict in the format of the inference engine backend


### PR DESCRIPTION
# What does this PR do?


Reverts #138  since it's incorrect after #145 - `rollout_logprobs` is also returned now and it's dtype is `Optional[List[float]]`.