### PR TITLE
[Generator] Support token-in-token-out rollout

### DIFF
--- a/skyrl-train/skyrl_train/entrypoints/main_base.py
+++ b/skyrl-train/skyrl_train/entrypoints/main_base.py
@@ -61,12 +61,13 @@ def create_ray_wrapped_inference_engines_from_config(cfg: DictConfig, colocate_p
     )
 
 
-def create_remote_inference_engines_from_config(cfg: DictConfig):
+def create_remote_inference_engines_from_config(cfg: DictConfig, tokenizer):
     # TODO(tgriggs): We may want a separate config for the model name in case it's different from the name used in the OpenAI API
     return create_remote_inference_engines(
         urls=cfg.generator.remote_inference_engine_urls,
         model_name=cfg.trainer.policy.model.path,
         engine_backend=cfg.generator.backend,
+        tokenizer=tokenizer,
         tensor_parallel_size=cfg.generator.inference_engine_tensor_parallel_size,
         sampling_params=get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params),
     )
@@ -247,7 +248,7 @@ class BasePPOExp:
         if self.cfg.generator.run_engines_locally:
             inference_engines = create_ray_wrapped_inference_engines_from_config(self.cfg, self.colocate_pg, tokenizer)
         else:
-            inference_engines = create_remote_inference_engines_from_config(self.cfg)
+            inference_engines = create_remote_inference_engines_from_config(self.cfg, tokenizer)
 
         inference_engine_client = InferenceEngineClient(inference_engines)
 

--- a/skyrl-train/skyrl_train/entrypoints/main_base.py
+++ b/skyrl-train/skyrl_train/entrypoints/main_base.py
@@ -6,7 +6,7 @@ uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base
 
 from ray.util.placement_group import placement_group, PlacementGroup
 
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from skyrl_train.dataset import PromptDataset
 from skyrl_train.utils import validate_cfg
 
@@ -36,7 +36,7 @@ config_dir = str(Path(__file__).parent.parent / "config")
 __all__ = ["BasePPOExp", "config_dir"]
 
 
-def create_ray_wrapped_inference_engines_from_config(cfg: DictConfig, colocate_pg, tokenizer):
+def create_ray_wrapped_inference_engines_from_config(cfg: DictConfig, colocate_pg, tokenizer: PreTrainedTokenizerBase):
     from skyrl_train.inference_engines.ray_wrapped_inference_engine import create_ray_wrapped_inference_engines
 
     return create_ray_wrapped_inference_engines(
@@ -61,7 +61,7 @@ def create_ray_wrapped_inference_engines_from_config(cfg: DictConfig, colocate_p
     )
 
 
-def create_remote_inference_engines_from_config(cfg: DictConfig, tokenizer):
+def create_remote_inference_engines_from_config(cfg: DictConfig, tokenizer: PreTrainedTokenizerBase):
     # TODO(tgriggs): We may want a separate config for the model name in case it's different from the name used in the OpenAI API
     return create_remote_inference_engines(
         urls=cfg.generator.remote_inference_engine_urls,

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -231,8 +231,6 @@ class SkyRLGymGenerator(GeneratorInterface):
                 response_ids.append(self.tokenizer.eos_token_id)
                 loss_mask.append(1)
 
-        # TODO(Charlie): do we need to truncate generation_prompt_ids of the last round?
-
         # need to truncate loss mask correctly for responses that go to max length
         if self.max_turns > 1:
             # max total resp length = max tokens (max length of final turn generation) + max_input_length (max input for any generation turn) - len(original prompt)
@@ -293,8 +291,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         truncated_logprobs: Optional[List[List[float]]] = [] if logprobs is not None else None
 
         for i, (response, response_ids, env) in enumerate(zip(responses, all_response_ids, envs)):
-            # step on function and compute reward
-            # assert self.tokenizer.decode(response_ids) == response  # TODO(Charlie): remove this
+            # step on environment and compute reward
             env_step_output: BaseTextEnvStepOutput = env.step(response)
             reward = env_step_output["reward"]
             rewards.append(reward)

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -138,8 +138,8 @@ class SkyRLGymGenerator(GeneratorInterface):
         chat_history, _ = env.init(chat_history)
         input_ids = self.tokenizer.apply_chat_template(
             chat_history,
-            # If add_generation_prompt when retokenize_chat_history==True, both the prompt_ids and
-            # response_ids will include the generation prompt due to how `response_encodings["input_ids"]` works.
+            # If retokenize_chat_history==True, avoid including the generation prompt in both the
+            # prompt_ids and response_ids due to how `response_encodings["input_ids"]` works.
             add_generation_prompt=not retokenize_chat_history,
             tokenize=True,
         )

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -460,6 +460,12 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         loss_mask is not maintained because we get it at the end of the trajectory with
         `response_encodings["assistant_masks"]`.
+
+        Returns:
+            chat_history: The updated chat history.
+            chat_end_index: The updated chat end index.
+            input_ids: The new input IDs after tokenizing the chat history, mainly used to check if
+              the input length is too long for next turn.
         """
         assert self.use_conversation_multi_turn and self.custom_chat_template
         # remove eos token from end of output if it exists, since it will be reapplied by the chat template
@@ -594,7 +600,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         Returns:
             loss_mask: List[int]
             input_ids: List[int]
-            logprobs: Optional[List[int]]
+            logprobs: Optional[List[float]]
         """
         # just update raw tokens and loss mask
         new_resp_tokens = output_ids.copy()

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -53,7 +53,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             raise ValueError("`sampling_params.logprobs` should be `None` if `batched` is `False`")
 
         # base_conversation is used when `use_conversation_multi_turn==True and custom_chat_template==None` to
-        # correctly format and tokenize observations. Using both user and assistant messages as most observations are user messages.
+        # correctly format and tokenize observations.
         # Follows https://jybsuper.github.io/posts/multiturn_tokenization/#the-breakthrough-fixed-base-approach
         self.base_conversation = [
             {"role": "system", "content": "You are a helpful assistant."},
@@ -178,8 +178,8 @@ class SkyRLGymGenerator(GeneratorInterface):
                 # TODO(Charlie): come back to this, we should deprecate postprocessed action
                 print(
                     "WARNING: postprocessed action may violate token-in-token-out. Ideally you "
-                    "post-process it in the token space rather than string space, and you can do "
-                    "it in SkyRLGymGenerator."
+                    "post-process it in the token space rather than string space. "
+                    "A better solution coming soon."
                 )
                 output = env_step_output["postprocessed_action"]
                 output_ids = self.tokenizer.encode(output, add_special_tokens=False)
@@ -208,7 +208,6 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         env.close()  # does nothing for now
 
-        # TODO(Charlie): this makes the prompt_ids include the generation prompt, is this what we want?
         prompt_ids = input_ids[:initial_prompt_length]
         if retokenize_chat_history:
             response_encodings = self.tokenizer.apply_chat_template(
@@ -550,7 +549,6 @@ class SkyRLGymGenerator(GeneratorInterface):
             input_ids += observation_ids
             loss_mask += [0] * len(observation_ids)
         else:
-            # TODO(Charlie): or assert done? i.e. can we still prompt another turn if no observation?
             if not done:
                 input_ids += self.generation_prompt_ids
                 loss_mask += [0] * len(self.generation_prompt_ids)

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -499,9 +499,7 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         # 2. apply chat template for observations, also generate generation prompt for next turn
         if len(new_obs) > 0:
-            observation_ids = self.tokenizer.apply_chat_template(
-                new_obs, add_generation_prompt=True, tokenize=True
-            )
+            observation_ids = self.tokenizer.apply_chat_template(new_obs, add_generation_prompt=True, tokenize=True)
             observation_ids = observation_ids[len(self.system_prompt_ids) :]
             input_ids += observation_ids
             loss_mask += [0] * len(observation_ids)

--- a/skyrl-train/skyrl_train/inference_engines/base.py
+++ b/skyrl-train/skyrl_train/inference_engines/base.py
@@ -14,9 +14,15 @@ class InferenceEngineInput(TypedDict):
 
 
 class InferenceEngineOutput(TypedDict):
+    # We always return both tokens and text outputs. The tokens are the outputs
+    # of inference engine, and the text is the decoded text output. Therefore,
+    # it is guaranteed that tokenizer.decode(response_token_ids) == responses,
+    # but the reverse is not guaranteed, since there are multiple ways to
+    # represent the same text with tokens. Therefore, for multi-turn generation,
+    # please use token-in-token-out to ensure correctness.
     responses: List[str]
+    response_ids: List[List[int]]
     stop_reasons: List[str]
-    response_ids: Optional[List[List[int]]]
     response_logprobs: Optional[List[List[float]]]
 
 

--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -95,13 +95,6 @@ class InferenceEngineClient(InferenceEngineInterface):
                     add_resp_logprobs = True
                     response_logprobs[original_idx] = result["response_logprobs"][local_idx]
 
-        if any([len(response) == 0 for response in responses]) or (
-            add_resp_ids and not all([isinstance(sample_ids, list) for sample_ids in response_ids])
-        ):
-            raise RuntimeError(
-                "Did not receive responses / response ids for some prompts. This should never happen. There is likely something wrong with the inference engine"
-            )
-
         return InferenceEngineOutput(
             responses=responses,
             stop_reasons=stop_reasons,

--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -47,7 +47,9 @@ class InferenceEngineClient(InferenceEngineInterface):
             # Split evenly across engines
             return await self._generate_batched(prompts, prompt_token_ids, sampling_params)
 
-    async def _generate_with_trajectory_routing(self, prompts, prompt_token_ids, trajectory_ids, sampling_params):
+    async def _generate_with_trajectory_routing(
+        self, prompts, prompt_token_ids, trajectory_ids, sampling_params
+    ) -> InferenceEngineOutput:
         """
         Route prompts to engines based on trajectory_ids and return results in the original order of the prompts.
         """
@@ -80,18 +82,15 @@ class InferenceEngineClient(InferenceEngineInterface):
         responses: list[str] = [""] * n
         stop_reasons: list[str] = [""] * n
         response_logprobs: List[Optional[List[float]]] = [None for _ in range(n)]
-        response_ids: List[Optional[List[float]]] = [None for _ in range(n)]
+        response_ids: List[List[int]] = [[] for _ in range(n)]
         # a bit hacky for now
-        add_resp_ids = False
         add_resp_logprobs = False
 
         for indices, result in zip(indices_list, results):
             for local_idx, original_idx in enumerate(indices):
                 responses[original_idx] = result["responses"][local_idx]
                 stop_reasons[original_idx] = result["stop_reasons"][local_idx]
-                if result.get("response_ids", None):
-                    add_resp_ids = True
-                    response_ids[original_idx] = result["response_ids"][local_idx]
+                response_ids[original_idx] = result["response_ids"][local_idx]
                 if result.get("response_logprobs", None):
                     add_resp_logprobs = True
                     response_logprobs[original_idx] = result["response_logprobs"][local_idx]
@@ -106,11 +105,11 @@ class InferenceEngineClient(InferenceEngineInterface):
         return InferenceEngineOutput(
             responses=responses,
             stop_reasons=stop_reasons,
-            response_ids=response_ids if add_resp_ids else None,
+            response_ids=response_ids,
             response_logprobs=response_logprobs if add_resp_logprobs else None,
         )
 
-    async def _generate_batched(self, prompts, prompt_token_ids, sampling_params):
+    async def _generate_batched(self, prompts, prompt_token_ids, sampling_params) -> InferenceEngineOutput:
         """
         Split prompts evenly across engines and return results in the original order of the prompts.
         """
@@ -144,15 +143,14 @@ class InferenceEngineClient(InferenceEngineInterface):
         for output in all_outputs:
             responses.extend(output["responses"])
             stop_reasons.extend(output["stop_reasons"])
-            if output.get("response_ids", None):
-                response_ids.extend(output["response_ids"])
+            response_ids.extend(output["response_ids"])
             if output.get("response_logprobs", None):
                 response_logprobs.extend(output["response_logprobs"])
 
         return InferenceEngineOutput(
             responses=responses,
             stop_reasons=stop_reasons,
-            response_ids=response_ids if len(response_ids) else None,
+            response_ids=response_ids,
             response_logprobs=response_logprobs if len(response_logprobs) else None,
         )
 

--- a/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
@@ -89,7 +89,7 @@ class RemoteInferenceEngine(InferenceEngineInterface):
 
         if self.engine_backend == "vllm":
             for i, choice in enumerate(response.get("choices", [])):
-                # Since n=1, so choice of index i represents the output of `pompt[i]`
+                # Since n=1, index i represents the output for `prompt[i]`
                 assert choice["index"] == i, "Expect the choices to be ordered by index."
                 text = choice["text"]
                 outputs.append(text)

--- a/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
@@ -7,7 +7,6 @@ from skyrl_train.inference_engines.base import (
 )
 from typing import List, Optional, Dict, Any
 import json
-import asyncio
 from transformers import PreTrainedTokenizerBase
 
 
@@ -52,19 +51,24 @@ class RemoteInferenceEngine(InferenceEngineInterface):
             )["input_ids"]
 
         sampling_params = request_sampling_params if request_sampling_params is not None else self.sampling_params
+        if "n" in sampling_params and sampling_params["n"] > 1:
+            raise ValueError(
+                "n is not supported yet for remote inference engines. "
+                "You can set `config.generator.n_samples_per_prompt` instead."
+            )
 
-        # 2. Send requests to servers
-        output_tasks = []
+        # 2. Send a batched request to the server
+        response = None
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=None)) as session:
             headers = {"Content-Type": "application/json"}
-
+            payload = {}
+            request_url = ""
             if self.engine_backend == "vllm":
-                # vLLM does not support /generate, use /completions instead
+                # vLLM does not support /generate, use /completions instead. It supports batch generation.
                 payload = sampling_params.copy()
                 payload["model"] = self.model_name
-                for p_ids in prompt_token_ids:
-                    payload["prompt"] = p_ids
-                    output_tasks.append(session.post(f"{self.url}/v1/completions", json=payload, headers=headers))
+                payload["prompt"] = prompt_token_ids
+                request_url = f"{self.url}/v1/completions"
             elif self.engine_backend == "sglang":
                 # SGLang supports /generate, works exactly like its Python `async_generate()` method
                 # and can do batch generation.
@@ -72,43 +76,39 @@ class RemoteInferenceEngine(InferenceEngineInterface):
                     "input_ids": prompt_token_ids,
                     "sampling_params": sampling_params,
                 }
-                output_tasks.append(session.post(f"{self.url}/generate", json=payload, headers=headers))
+                request_url = f"{self.url}/generate"
             else:
                 raise ValueError(f"Invalid engine backend: {self.engine_backend}")
+            async with session.post(request_url, json=payload, headers=headers) as resp:
+                response = await resp.json()
 
-            request_outputs = await asyncio.gather(*output_tasks)
+        # 3. Parse outputs
+        outputs = []
+        output_ids = []
+        finish_reasons = []
 
-            # 3. Parse outputs
-            outputs = []
-            output_ids = []
-            finish_reasons = []
-
-            if self.engine_backend == "vllm":
-                # TODO (sumanthrh): This is creating a flattened list of outputs. If sampling n > 1, we should fix this.
-                for request_output in request_outputs:
-                    response = await request_output.json()
-                    for choice in response.get("choices", []):
-                        text = choice["text"]
-                        outputs.append(text)
-                        finish_reasons.append(choice["finish_reason"])
-                        # TODO(Charlie): this is not token-in-token-out because vLLM does not support
-                        # returning token IDs via HTTP requests. Fix after this vLLM PR is merged:
-                        # https://github.com/vllm-project/vllm/pull/22587
-                        output_ids.append(self.tokenizer.encode(text, add_special_tokens=False))
-            elif self.engine_backend == "sglang":
-                assert len(request_outputs) == 1, "Expect a single asyncio task for SGLang"
-                request_output = request_outputs[0]
-                response = await request_output.json()
-                # since prompt_token_ids is a list of lists, response is a list of dicts
-                for output in response:
-                    cur_output_ids = output["output_ids"]
-                    output_ids.append(cur_output_ids)
-                    # SGLang only returns tokens not text when skip_tokenizer_init is True, so
-                    # we manually decode it.
-                    outputs.append(self.tokenizer.decode(cur_output_ids))
-                    finish_reasons.append(output["meta_info"]["finish_reason"]["type"])
-            else:
-                raise ValueError(f"Invalid engine backend: {self.engine_backend}")
+        if self.engine_backend == "vllm":
+            for i, choice in enumerate(response.get("choices", [])):
+                # Since n=1, so choice of index i represents the output of `pompt[i]`
+                assert choice["index"] == i, "Expect the choices to be ordered by index."
+                text = choice["text"]
+                outputs.append(text)
+                finish_reasons.append(choice["finish_reason"])
+                # TODO(Charlie): this is not token-in-token-out because vLLM does not support
+                # returning token IDs via HTTP requests. Fix after this vLLM PR is merged:
+                # https://github.com/vllm-project/vllm/pull/22587
+                output_ids.append(self.tokenizer.encode(text, add_special_tokens=False))
+        elif self.engine_backend == "sglang":
+            # since prompt_token_ids is a list of lists, response is a list of dicts
+            for output in response:
+                cur_output_ids = output["output_ids"]
+                output_ids.append(cur_output_ids)
+                # SGLang only returns tokens not text when skip_tokenizer_init is True, so
+                # we manually decode it.
+                outputs.append(self.tokenizer.decode(cur_output_ids))
+                finish_reasons.append(output["meta_info"]["finish_reason"]["type"])
+        else:
+            raise ValueError(f"Invalid engine backend: {self.engine_backend}")
 
         return InferenceEngineOutput(
             responses=outputs, stop_reasons=finish_reasons, response_ids=output_ids, response_logprobs=None

--- a/skyrl-train/skyrl_train/inference_engines/sglang/sglang_server.py
+++ b/skyrl-train/skyrl_train/inference_engines/sglang/sglang_server.py
@@ -18,6 +18,10 @@ class SGLangServer:
 
 
 if __name__ == "__main__":
-    server_args = prepare_server_args(sys.argv[1:])
+    args = sys.argv[1:]
+    # SGLang requires `skip-tokenizer-init` to do token-in-token-out with `/generate` endpoint
+    if "--skip-tokenizer-init" not in args:
+        args.append("--skip-tokenizer-init")
+    server_args = prepare_server_args(args)
     sglang_server = SGLangServer(server_args)
     sglang_server.run_server()

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -20,9 +20,9 @@ MOCK_TOKENIZER_ENCODED_IDS = [1, 2, 3, 4]
 @pytest.fixture
 def mock_tokenizer():
     """
-    A mock tokenizer that encodes any non-empty string to `[1,2,3,4]`.
+    A mock tokenizer that encodes any non-empty string to `MOCK_TOKENIZER_ENCODED_IDS`.
     For chat template, if `tokenize=False`, concatenate the content of each message.
-    If `tokenize=True`, return `[1,2,3,4]` for each message.
+    If `tokenize=True`, return `MOCK_TOKENIZER_ENCODED_IDS` for each message.
     """
     tokenizer = MagicMock()
 
@@ -461,7 +461,7 @@ async def test_length_limit_exceeded_during_conversation(
         )
 
     # We start with initial prompt len 4 due to mock_apply_chat_template
-    # Each turn, obesrvation is 4 tokens due to mock_encode
+    # Each turn, observation is 4 tokens due to mock_encode
     mock_env.step.side_effect = mock_step_never_done
     max_input_length = 20  # Low limit to trigger length exceeded
 

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -245,7 +245,7 @@ async def test_agent_loop_single_turn(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
-    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
+    generator.base_conversation_token_ids = []  # to make sure observation_ids are encoded correctly
 
     prompt = [{"role": "user", "content": "What is 2 + 2?"}]
     extras = {"answer": "4"}
@@ -272,7 +272,7 @@ async def test_generate_batched(mock_make, mock_tokenizer, mock_llm, mock_env, m
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
-    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
+    generator.base_conversation_token_ids = []  # to make sure observation_ids are encoded correctly
 
     prompts = [[{"role": "user", "content": "What is 3 + 5?"}]]
     env_extras = [{"answer": "8"}]
@@ -376,7 +376,7 @@ async def test_generate_interface_compliance(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
-    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
+    generator.base_conversation_token_ids = []  # to make sure observation_ids are encoded correctly
 
     # Create test data based on batched mode
     if batched:
@@ -498,7 +498,7 @@ async def test_length_limit_exceeded_during_conversation(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
-    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
+    generator.base_conversation_token_ids = []  # to make sure observation_ids are encoded correctly
 
     prompt = [{"role": "user", "content": "Start conversation"}]
     extras = {"test": "value"}
@@ -588,7 +588,7 @@ async def test_multi_turn_response_truncation(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
-    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
+    generator.base_conversation_token_ids = []  # to make sure observation_ids are encoded correctly
 
     prompt = [{"role": "user", "content": "Initial prompt"}]
     extras = {}
@@ -670,7 +670,7 @@ async def test_postprocessed_action_used(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
-    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
+    generator.base_conversation_token_ids = []  # to make sure observation_ids are encoded correctly
 
     prompt = [{"role": "user", "content": "Initial input"}]
     env_extras = {}
@@ -729,7 +729,7 @@ async def test_apply_overlong_filtering_non_batched(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
-    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
+    generator.base_conversation_token_ids = []  # to make sure observation_ids are encoded correctly
 
     # First test: response that doesn't end with eos token (should be filtered)
     mock_llm.generate = AsyncMock(
@@ -841,7 +841,7 @@ async def test_apply_overlong_filtering_batched(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
-    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
+    generator.base_conversation_token_ids = []  # to make sure observation_ids are encoded correctly
 
     # Test batched mode with response that doesn't end with eos token
     prompts = [[{"role": "user", "content": "Test prompt"}]]

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -11,9 +11,18 @@ from skyrl_train.generators.utils import concatenate_generator_outputs, get_metr
 from skyrl_gym.envs.base_text_env import BaseTextEnvStepOutput
 
 
+# Mock constants, where 4 is the eos token id
+MOCK_LLM_OUTPUT_IDS = [1, 10, 12, 4]
+MOCK_TOKENIZER_ENCODED_IDS = [1, 2, 3, 4]
+
 # TODO (erictang000): clean up the mocking for tests in this file
 @pytest.fixture
 def mock_tokenizer():
+    """
+    A mock tokenizer that encodes any non-empty string to `[1,2,3,4]`.
+    For chat template, if `tokenize=False`, concatenate the content of each message.
+    If `tokenize=True`, return `[1,2,3,4]` for each message.
+    """
     tokenizer = MagicMock()
 
     def mock_apply_chat_template(x, **kwargs):
@@ -23,14 +32,14 @@ def mock_tokenizer():
             # Non-dict return
             if isinstance(x, list) and len(x) > 0 and isinstance(x[0], list):
                 # Multiple prompts
-                return [[1, 2, 3, 4] for _ in x]
+                return [MOCK_TOKENIZER_ENCODED_IDS.copy() for _ in x]
             else:
                 # Single prompt or conversation
-                return [1, 2, 3, 4]
+                return MOCK_TOKENIZER_ENCODED_IDS.copy()
 
     def mock_encode(x, **kwargs):
         if x != "":
-            return [1, 2, 3, 4]
+            return MOCK_TOKENIZER_ENCODED_IDS.copy()
         else:
             return []
 
@@ -39,12 +48,16 @@ def mock_tokenizer():
     tokenizer.encode.side_effect = mock_encode
     tokenizer.eos_token_id = 4
     tokenizer.eos_token = "<|end_of_turn|>"
-    tokenizer.return_value = {"input_ids": [1, 2, 3, 4]}  # simulate tokenized response
+    tokenizer.return_value = {"input_ids": MOCK_TOKENIZER_ENCODED_IDS.copy()}  # simulate tokenized response
     return tokenizer
 
 
 @pytest.fixture
 def mock_llm():
+    """
+    This replaces InferenceEngineClient, where `.generate()` always returns MOCK_LLM_OUTPUT_IDS
+    for each prompt, with corresponding string output "mocked output".
+    """
     mock = MagicMock()
 
     # Mock the new generate method
@@ -54,8 +67,8 @@ def mock_llm():
             "responses": ["mocked output"] * num_prompts,
             "stop_reasons": ["stop"] * num_prompts,
             # say response gets tokenized to 3 tokens
-            "response_logprobs": [[0.1, 0.2, 0.3]] * num_prompts,
-            "response_ids": [[1, 10, 12]] * num_prompts,
+            "response_logprobs": [[0.1] * len(MOCK_LLM_OUTPUT_IDS)] * num_prompts,
+            "response_ids": [MOCK_LLM_OUTPUT_IDS.copy()] * num_prompts,
         }
 
     mock.generate = AsyncMock(side_effect=mock_generate)
@@ -213,6 +226,10 @@ def validate_generator_output(output: GeneratorOutput) -> bool:
 async def test_agent_loop_single_turn(
     mock_make, mock_tokenizer, mock_llm, mock_env, mock_generator_cfg, use_conversation_multi_turn, mock_env_cfg
 ):
+    """
+    This test mocks when we call SkyRLGymGenerator.agent_loop() despite being a single-turn generation.
+    This is when `batched=False`. Here the environment does nothing.
+    """
     mock_generator_cfg.use_conversation_multi_turn = use_conversation_multi_turn
     mock_env.step.side_effect = lambda x: BaseTextEnvStepOutput(observations=[], reward=1.0, done=True, metadata={})
     mock_tokenizer.eos_token_id = 4  # bypass check for eos token id for this test
@@ -227,17 +244,18 @@ async def test_agent_loop_single_turn(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
+    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
 
     prompt = [{"role": "user", "content": "What is 2 + 2?"}]
     extras = {"answer": "4"}
-    response_text, reward, stop_reason, loss_mask, input_prompt, rollout_logprobs = await generator.agent_loop(
+    response_ids, reward, stop_reason, loss_mask, prompt_ids, rollout_logprobs = await generator.agent_loop(
         prompt, mock_env_cfg.env_class, extras, max_tokens=8, max_input_length=512
     )
 
-    assert response_text == [1, 2, 3, 4]
+    assert response_ids == MOCK_LLM_OUTPUT_IDS
     assert reward == 1.0
     assert stop_reason == "stop"
-    assert loss_mask == [1, 1, 1, 1]
+    assert loss_mask == [1] * len(MOCK_LLM_OUTPUT_IDS)
 
 
 @pytest.mark.asyncio
@@ -253,6 +271,7 @@ async def test_generate_batched(mock_make, mock_tokenizer, mock_llm, mock_env, m
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
+    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
 
     prompts = [[{"role": "user", "content": "What is 3 + 5?"}]]
     env_extras = [{"answer": "8"}]
@@ -266,11 +285,11 @@ async def test_generate_batched(mock_make, mock_tokenizer, mock_llm, mock_env, m
     generator_output: GeneratorOutput = await generator.generate(input_batch)
 
     # uses output from llm directly
-    assert generator_output["response_ids"][0] == [1, 10, 12]
+    assert generator_output["response_ids"][0] == MOCK_LLM_OUTPUT_IDS
 
     assert generator_output["rewards"][0] == 1.0
     assert generator_output["stop_reasons"][0] == "stop"
-    assert generator_output["loss_masks"][0] == [1, 1, 1]
+    assert generator_output["loss_masks"][0] == [1] * len(MOCK_LLM_OUTPUT_IDS)
 
 
 def test_generator_output_concatenation():
@@ -356,6 +375,7 @@ async def test_generate_interface_compliance(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
+    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
 
     # Create test data based on batched mode
     if batched:
@@ -427,6 +447,7 @@ async def test_length_limit_exceeded_during_conversation(
     mock_make.return_value = mock_env
     mock_generator_cfg.batched = False  # Use agent_loop mode
     mock_generator_cfg.max_turns = 5  # Allow multiple turns
+    mock_generator_cfg.use_conversation_multi_turn = True
     mock_env.init.return_value = ([{"role": "user", "content": "Initial input"}], {})
 
     # Configure environment to never set done=True naturally (we want to hit length limit)
@@ -438,38 +459,29 @@ async def test_length_limit_exceeded_during_conversation(
             metadata={},
         )
 
+    # We start with initial prompt len 4 due to mock_apply_chat_template
+    # Each turn, obesrvation is 4 tokens due to mock_encode
     mock_env.step.side_effect = mock_step_never_done
+    max_input_length = 20  # Low limit to trigger length exceeded
 
-    # Configure tokenizer for use_conversation_multi_turn=True
-    def mock_apply_chat_template(messages, **kwargs):
-        if kwargs.get("tokenize", True):
-            # Initial prompt: 10 tokens
-            return [1] * 10
+    # Mock the new generate method
+    def mock_generate(input_batch):
+        num_prompts = len(input_batch["prompts"]) if "prompts" in input_batch else len(input_batch["prompt_token_ids"])
+        if turns_to_exceed == 1:
+            mock_llm_output_ids = [1] * 20  # Enough to exceed limit immediately (4 + 20 + 4 = 28 > 20)
+            assert len(MOCK_TOKENIZER_ENCODED_IDS) + len(mock_llm_output_ids) + len(MOCK_TOKENIZER_ENCODED_IDS) > max_input_length
         else:
-            # Return string representations for template differences
-            # This simulates the chat template string output
-            return "template_" + "_".join([msg.get("content", "") for msg in messages])
+            assert turns_to_exceed == 3
+            mock_llm_output_ids = [1] * 2  # Enough to exceed limit after 3 turns (4 + (2 + 4) * 3 = 22 > 20)
+            assert len(MOCK_TOKENIZER_ENCODED_IDS) + (len(mock_llm_output_ids) + len(MOCK_TOKENIZER_ENCODED_IDS)) * turns_to_exceed > max_input_length
+        return {
+            "responses": ["mocked output"] * num_prompts,
+            "stop_reasons": ["stop"] * num_prompts,
+            "response_logprobs": [[0.1] * len(mock_llm_output_ids)] * num_prompts,
+            "response_ids": [mock_llm_output_ids.copy()] * num_prompts,
+        }
 
-    def mock_encode(text, **kwargs):
-        # Simulate token encoding based on content
-        if "mocked output" in str(text):
-            # Assistant responses
-            if turns_to_exceed == 1:
-                return [1] * 15  # Enough to exceed limit immediately (10 + 15 = 25 > 20)
-            else:
-                return [1] * 4  # 4 tokens per assistant response
-        elif "next" in str(text):
-            # User observations - 1 token each
-            return [1] * 1
-        elif "template_" in str(text):
-            # For template string differences - simulate incremental content
-            content_parts = str(text).split("_")[1:]  # Remove "template_" prefix
-            return [1] * len(content_parts)  # 1 token per content part
-        else:
-            return [1] * 1  # Default
-
-    mock_tokenizer.apply_chat_template.side_effect = mock_apply_chat_template
-    mock_tokenizer.encode.side_effect = mock_encode
+    mock_llm.generate = AsyncMock(side_effect=mock_generate)
 
     generator = SkyRLGymGenerator(
         generator_cfg=mock_generator_cfg,
@@ -478,10 +490,10 @@ async def test_length_limit_exceeded_during_conversation(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
+    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
 
     prompt = [{"role": "user", "content": "Start conversation"}]
     extras = {"test": "value"}
-    max_input_length = 20  # Low limit to trigger length exceeded
 
     response_ids, reward, stop_reason, loss_mask, prompt_token_ids, rollout_logprobs = await generator.agent_loop(
         prompt, "test_env", extras, max_tokens=100, max_input_length=max_input_length
@@ -514,6 +526,7 @@ async def test_multi_turn_response_truncation(
     mock_make.return_value = mock_env
     mock_generator_cfg.max_turns = 3  # Ensure multi-turn logic is triggered
     mock_generator_cfg.batched = False  # Test is for agent_loop
+    mock_generator_cfg.use_conversation_multi_turn = True
     mock_env.init.return_value = ([{"role": "user", "content": "Initial input"}], {})
 
     # Configure environment to run for multiple turns to generate enough tokens for truncation
@@ -530,12 +543,12 @@ async def test_multi_turn_response_truncation(
     mock_env.step.side_effect = mock_step_multi_turn
 
     # Define token lengths to control the test
-    initial_prompt_len = 10
+    initial_prompt_len = 13
     max_tokens_from_llm = 20
     max_input_len = 50
 
     # Expected max response tokens = max_tokens + max_input_length - initial_prompt_length
-    expected_max_response_tokens = max_tokens_from_llm + max_input_len - initial_prompt_len  # 20 + 50 - 10 = 60
+    expected_max_response_tokens = max_tokens_from_llm + max_input_len - initial_prompt_len  # 20 + 50 - 13 = 57
 
     def mock_apply_chat_template(messages, **kwargs):
         if kwargs.get("tokenize", True):
@@ -546,10 +559,19 @@ async def test_multi_turn_response_truncation(
             return "".join([msg.get("content", "") for msg in messages])
 
     def mock_encode(text, **kwargs):
-        return [1] * 10
+        # This makes observation_ids to always be 13 tokens
+        return [1] * 13
 
     mock_tokenizer.apply_chat_template.side_effect = mock_apply_chat_template
     mock_tokenizer.encode.side_effect = mock_encode
+
+    # The intitial prompt is 13 tokens due to mock_apply_chat_template
+    # Each turn, observation is 13 tokens due to mock_encode and empty system_prompt_ids
+    # And the LLM response is 4 tokens due to MOCK_LLM_OUTPUT_IDS
+    # So input_ids are 13, 30, 47, 64. And 64 would cause a break in the loop due to exceeding max_input_len.
+    # Then with 64, we get the `input_ids[initial_prompt_length:]`, which makes our final
+    # response_ids to be 64 - 13 = 51 tokens. So in this case, we are not truncated by expected_max_response_tokens.
+    expected_final_response_tokens = 51
 
     generator = SkyRLGymGenerator(
         generator_cfg=mock_generator_cfg,
@@ -558,6 +580,7 @@ async def test_multi_turn_response_truncation(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
+    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
 
     prompt = [{"role": "user", "content": "Initial prompt"}]
     extras = {}
@@ -567,12 +590,13 @@ async def test_multi_turn_response_truncation(
     )
 
     # Verify truncation occurred
+    assert len(response_ids) <= expected_max_response_tokens
     assert (
-        len(response_ids) == expected_max_response_tokens
-    ), f"Expected {expected_max_response_tokens} response tokens, got {len(response_ids)}"
+        len(response_ids) == expected_final_response_tokens
+    ), f"Expected {expected_final_response_tokens} response tokens, got {len(response_ids)}"
     assert (
-        len(loss_mask) == expected_max_response_tokens
-    ), f"Expected {expected_max_response_tokens} loss mask entries, got {len(loss_mask)}"
+        len(loss_mask) == expected_final_response_tokens
+    ), f"Expected {expected_final_response_tokens} loss mask entries, got {len(loss_mask)}"
 
     # Verify stop reason is "length" due to truncation
     assert stop_reason == "length", f"Expected stop_reason='length', got '{stop_reason}'"
@@ -638,6 +662,7 @@ async def test_postprocessed_action_used(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
+    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
 
     prompt = [{"role": "user", "content": "Initial input"}]
     env_extras = {}
@@ -686,16 +711,7 @@ async def test_apply_overlong_filtering_non_batched(
         else:
             return "".join([msg.get("content", "") for msg in messages])
 
-    def mock_encode_or_tokenize(text, **kwargs):
-        # Return different token patterns for different responses
-        if "truncated" in str(text):
-            # Simulate a long response that will get truncated by max_response_tokens
-            return [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]  # 10 tokens, will be truncated
-        else:
-            return [20, 21, 4]  # 3 tokens, ends with eos_token_id=4
-
     mock_tokenizer.apply_chat_template.side_effect = mock_apply_chat_template
-    mock_tokenizer.encode.side_effect = mock_encode_or_tokenize
     mock_tokenizer.eos_token_id = 4  # Set EOS token ID
 
     generator = SkyRLGymGenerator(
@@ -705,9 +721,14 @@ async def test_apply_overlong_filtering_non_batched(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
+    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
 
     # First test: response that doesn't end with eos token (should be filtered)
-    mock_llm.generate = AsyncMock(return_value={"responses": ["truncated response"], "stop_reasons": ["length"]})
+    mock_llm.generate = AsyncMock(return_value={
+        "responses": ["truncated response"],
+        "stop_reasons": ["length"],
+        "response_ids": [[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]],  # 10 tokens, will be truncated
+    })
 
     input_batch_truncated: GeneratorInput = {
         "prompts": [[{"role": "user", "content": "Test prompt"}]],
@@ -732,7 +753,11 @@ async def test_apply_overlong_filtering_non_batched(
     # Second test: response that ends with eos token (should not be filtered)
     # Reset the environment init to ensure clean state
     mock_env.init.return_value = ([{"role": "user", "content": "Fresh input"}], {})
-    mock_llm.generate = AsyncMock(return_value={"responses": ["normal response"], "stop_reasons": ["stop"]})
+    mock_llm.generate = AsyncMock(return_value={
+        "responses": ["truncated response"],
+        "stop_reasons": ["length"],
+        "response_ids": [[20, 21, 4]],  # 3 tokens, ends with eos token 4
+    })
 
     input_batch_normal: GeneratorInput = {
         "prompts": [[{"role": "user", "content": "Another test prompt"}]],
@@ -804,6 +829,7 @@ async def test_apply_overlong_filtering_batched(
         tokenizer=mock_tokenizer,
         model_name="test_model",
     )
+    generator.system_prompt_ids = []  # to make sure observation_ids are encoded correctly
 
     # Test batched mode with response that doesn't end with eos token
     prompts = [[{"role": "user", "content": "Test prompt"}]]

--- a/skyrl-train/tests/gpu/test_engine_generation.py
+++ b/skyrl-train/tests/gpu/test_engine_generation.py
@@ -17,7 +17,7 @@ import asyncio
 import subprocess
 import os
 from tests.gpu.utils import get_available_gpus, wait_for_server, are_responses_similar, get_test_prompts
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from omegaconf import DictConfig
 from skyrl_train.inference_engines.base import InferenceEngineInput
 from skyrl_train.utils import initialize_ray
@@ -37,7 +37,9 @@ def get_test_actor_config() -> DictConfig:
         return cfg
 
 
-def init_remote_inference_servers(tp_size: int, backend: str) -> Tuple[InferenceEngineClient, subprocess.Popen]:
+def init_remote_inference_servers(
+    tp_size: int, backend: str, tokenizer: PreTrainedTokenizerBase
+) -> Tuple[InferenceEngineClient, subprocess.Popen]:
     available_gpus = get_available_gpus()
     assert (
         len(available_gpus) >= tp_size
@@ -71,10 +73,14 @@ def init_remote_inference_servers(tp_size: int, backend: str) -> Tuple[Inference
             "--model",
             MODEL,
             "--enforce-eager",
+            "--gpu-memory-utilization",
+            "0.8",
             "--tensor-parallel-size",
             str(tp_size),
+            # NOTE (sumanthrh): Currently, there's an issue with distributed executor backend ray for vllm 0.9.2.
+            # For standalone server, we use mp for now.
             "--distributed-executor-backend",
-            "ray",
+            "mp",
             "--dtype",
             "bfloat16",
             "--host",
@@ -124,11 +130,21 @@ def init_remote_inference_servers(tp_size: int, backend: str) -> Tuple[Inference
     engines = create_remote_inference_engines(
         urls=[f"localhost:{engine_port}"],
         model_name=MODEL,
+        tokenizer=tokenizer,
         engine_backend=backend,
         tensor_parallel_size=tp_size,
         sampling_params=get_sampling_params_for_backend(
             backend,
-            DictConfig({"temperature": 0.0, "top_p": 1, "top_k": -1, "max_generate_length": 1024, "min_p": 0.0}),
+            DictConfig(
+                {
+                    "temperature": 0.0,
+                    "top_p": 1,
+                    "top_k": -1,
+                    "max_generate_length": 1024,
+                    "min_p": 0.0,
+                    "logprobs": None,
+                }
+            ),
         ),
     )
 
@@ -155,7 +171,16 @@ def init_ray_inference_engines(backend: str, tp_size: int) -> InferenceEngineCli
         max_num_seqs=1024,
         sampling_params=get_sampling_params_for_backend(
             backend,
-            DictConfig({"temperature": 0.0, "top_p": 1, "top_k": -1, "max_generate_length": 1024, "min_p": 0.0}),
+            DictConfig(
+                {
+                    "temperature": 0.0,
+                    "top_p": 1,
+                    "top_k": -1,
+                    "max_generate_length": 1024,
+                    "min_p": 0.0,
+                    "logprobs": None,
+                }
+            ),
         ),
         tokenizer=AutoTokenizer.from_pretrained(MODEL),
         backend=backend,
@@ -231,9 +256,10 @@ def test_inference_engines_generation(backend: str, tp_size: int):
         initialize_ray(cfg)
 
         prompts = get_test_prompts(MODEL)
+        tokenizer = AutoTokenizer.from_pretrained(MODEL)
 
         try:
-            llm_client, remote_server_process = init_remote_inference_servers(tp_size, backend)
+            llm_client, remote_server_process = init_remote_inference_servers(tp_size, backend, tokenizer)
 
             # Batched generation
             remote_batch_responses, batch_finish_reasons = asyncio.run(run_batch_generation(llm_client, prompts))

--- a/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
@@ -209,8 +209,8 @@ async def run_generator_end_to_end(
 @pytest.mark.parametrize(
     ("use_async_engine", "batched", "n_samples_per_prompt", "num_inference_engines", "tensor_parallel_size"),
     [
-        (False, True, 5, 1, 1),  # tests SkyRLGymGenerator.generate_batched for single-turn
-        (True, False, 5, 1, 1),  # tests SkyRLGymGenerator.agent_loop for single-turn
+        (False, True, 5, 2, 1),  # tests SkyRLGymGenerator.generate_batched for single-turn
+        (True, False, 5, 1, 2),  # tests SkyRLGymGenerator.agent_loop for single-turn
         # Add more combinations as needed
     ],
 )

--- a/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
@@ -110,6 +110,7 @@ async def run_generator_end_to_end(
                         "top_k": -1,
                         "max_generate_length": max_generate_length,
                         "min_p": 0.0,
+                        "logprobs": None,
                     }
                 ),
             ),
@@ -122,7 +123,10 @@ async def run_generator_end_to_end(
     # Create a mock generator config
     generator_cfg = DictConfig(
         {
-            "sampling_params": {"max_generate_length": max_generate_length},
+            "sampling_params": {
+                "max_generate_length": max_generate_length,
+                "logprobs": None,
+            },
             "max_input_length": max_input_length,
             "batched": batched,
             "max_turns": max_turns,
@@ -205,8 +209,8 @@ async def run_generator_end_to_end(
 @pytest.mark.parametrize(
     ("use_async_engine", "batched", "n_samples_per_prompt", "num_inference_engines", "tensor_parallel_size"),
     [
-        (False, True, 5, 2, 1),
-        (True, False, 5, 1, 2),
+        (False, True, 5, 1, 1),  # tests SkyRLGymGenerator.generate_batched for single-turn
+        (True, False, 5, 1, 1),  # tests SkyRLGymGenerator.agent_loop for single-turn
         # Add more combinations as needed
     ],
 )

--- a/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/test_skyrl_gym_generator.py
@@ -56,7 +56,7 @@ register(
 )
 
 MODEL_TO_GENERATION_PROMPT = {
-    "Qwen/Qwen2.5-0.5B-Instruct": "<|im_start|>assistant\n",
+    "Qwen/Qwen2.5-1.5B-Instruct": "<|im_start|>assistant\n",
     "unsloth/Llama-3.2-1B-Instruct": "<|start_header_id|>assistant<|end_header_id|>\n\n",
     "Qwen/Qwen3-0.6B": "<|im_start|>assistant\n",
 }
@@ -290,7 +290,7 @@ async def test_generator_multi_turn_search():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "model_name", ["unsloth/Llama-3.2-1B-Instruct", "Qwen/Qwen2.5-0.5B-Instruct", "Qwen/Qwen3-0.6B"]
+    "model_name", ["unsloth/Llama-3.2-1B-Instruct", "Qwen/Qwen2.5-1.5B-Instruct", "Qwen/Qwen3-0.6B"]
 )
 async def test_generator_formatting_use_conversation_multi_turn(model_name):
     """
@@ -308,7 +308,7 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
             model=model_name,
             max_prompt_length=1000,
             max_input_length=3000,
-            max_generate_length=500,
+            max_generate_length=1000,
             env_class="test_env",
             num_prompts=2,
             max_turns=3,
@@ -332,6 +332,7 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
             ), "generation prompts should be loss masked out"
 
             # count number of eos tokens in masked_in_resp_ids
+            # NOTE: this could fail if the stop reason is "length" where model fails to generate eos
             assert (
                 sum(1 for _ in masked_in_resp_ids if _ == tokenizer.eos_token_id) == 3
             )  # 1 eos for each assistant response
@@ -348,7 +349,7 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "model_name", ["unsloth/Llama-3.2-1B-Instruct", "Qwen/Qwen2.5-0.5B-Instruct", "Qwen/Qwen3-0.6B"]
+    "model_name", ["unsloth/Llama-3.2-1B-Instruct", "Qwen/Qwen2.5-1.5B-Instruct", "Qwen/Qwen3-0.6B"]
 )
 async def test_generator_formatting_no_use_conversation_multi_turn(model_name):
     """


### PR DESCRIPTION
This PR ensures token-in-token-out rollout in most codepaths in SkyRL. The motivation of having token-in/out is described in this issue https://github.com/NovaSky-AI/SkyRL/issues/123

## Changes
### 1. Making sure the inference engines are doing token-in-token-out (returning `InferenceEngineOutput.response_ids`)
- While `response_ids` were already added for local vLLM engine in https://github.com/NovaSky-AI/SkyRL/pull/145, this PR supports this field for {vllm, sglang} x {remote engine, local engine}.
  - SGLang remote engine:
    - with `--skip-tokenizer-init` passed to SGLang engine creation, we can use `/generate` endpoint, which can take in batch input via HTTP, performing token-in-token-out (almost exactly the same as the python `.generate()`)
  - SGLang local engine: same thing
  - vLLM remote engine:
    - While `/completions` can take token-in, it does not do token-out. vLLM's `/generate` is demo-only according to its doc. So vLLM server endpoint does not support token-in-token-out yet
    - Instead, we do token-in, and prepare `response_ids` by re-encoding the text output from vLLM for a fake token-out
    - This will be fixed after this PR lands in vLLM: https://github.com/vllm-project/vllm/pull/22587
  - That is, SGLang uses `/generate` and vLLM uses `/completions` (neither use `/chat/completions`)
- We always return both `response_ids` and `responses` in `InferenceEngineOutput`, but users when writing their own generator should use `response_ids` (either to prepare next turn's input or `GeneratorOutput`) to respect token-in-token-out. `responses` should only be used to parse for tool calls (like a "read-only" thing)

### 2. Making sure SkyRLGymGenerator respects token-in-token-out
After making sure the InferenceEngineClient is token-in-token-out and returns token IDs to the generator, we need to make sure the generator itself respects token-in-token-out while conforming to (multi-turn) chat templates.
- There are 2 codepaths in SkyRLGymGenerator, `generate_batched()` for single-turn, and `agent_loop()` for both single-turn and multi-turn
  - `generate_batched()` now supports token-in-token-out by simply passing `InferenceEngineOutput.response_ids` to `GeneratorOutput`
  - `agent_loop()` is more tricky, elaborated below

`SkyRLGymGenerator` has 3 ways of managing context in `agent_loop()`, configured by `cfg.generator.use_conversation_multi_turn` and whether `get_custom_chat_template()` returns None (currently it means that the model is Qwen3).
1. Always re-tokenize chat history, when `use_conversation_multi_turn==True` and `get_custom_chat_template() is not None` 
2. `use_conversation_multi_turn == True`, but has no custom chat template
3. `use_conversation_multi_turn == False`

This PR ensures token-in-token-out for codepaths 2 and 3 (but not 1) and make the 3 codepaths more distinct and clearer in the code.

#### 2.1. Always re-tokenize chat history (does not support token-in-token-out)
- This codepath currently serves Qwen3 models, where we always re-tokenize the chat history for each turn
- There are two reasons for this:
  - Qwen3 removes non-last turn thinking tokens
  - Able to get `["assistant_masks"]` and `["input_ids"]` from the final tokenized chat history with the help of `{% generation %}` and `{% endgeneration %}` tags in the jinja template
- That is, this codepath rollouts Qwen3 by following the inference chat template, and returns only the last-turn thinking tokens to Generator for the training pipeline
- Comment:
  - It is debatable whether this is the best method to train Qwen3 -- will revisit this codepath in a future PR
  - TODO: Users should be able to train Qwen3 following 2.2 by default, and follow 2.1 by setting a config flag

#### 2.2 `use_conversation_multi_turn == True` without re-tokenizing chat history each turn
- In this codepath, the agent loop does the following
  1. Tokenize dataset's prompt to initialize `input_ids`
  2. Feed `input_ids` to LLM engine, get `output_ids` out (thanks to change 1)
  3. `input_ids += output_ids` (a.k.a. token-in-token-out) -- the next turn's input IDs are precisely what the LLM generated
  4. Tokenize observations got from SkyRL-Gym's environment output (i.e. `env.step()`), and append to `input_ids` -- this is a bit tricky, explained later below
  5. Repeat 2-4 until `env.step()` marks done

- To ensure that the observation is correctly tokenized, we follow the delta-based method proposed [here](https://jybsuper.github.io/posts/multiturn_tokenization/#the-breakthrough-fixed-base-approach)
  - We instantiate `self.base_conversation_token_ids` in `__init__()` and use that to get `observation_ids`
  - One tricky thing is how Qwen models will do: `<|assistant|>something<|im_end|>\n<|user|>something...`
  - That is, after the assistant generates the EOS token `<|im_end|>`, the chat template adds a `\n`
  - We need to manually add this `\n` by making sure `self.base_conversation_token_ids` ends with the EOS token ID
  - For more, see changes in `tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py`

#### 2.3 `use_conversation_multi_turn == False`
- This PR makes this codepath support token-in-token-out without much change (replace `self.tokenizer.encode(output)` with `output_ids` from `InferenceEngineClient`).
- See `_get_next_input_ids_with_single_turn_chat_template()` on what this codepath does

## Tests
- GPU tests
  - `tests/gpu/test_skyrl_gym_generator.py` (besides search and text2sql)
  - `test_engine_generation.py` works (both remote and local)
- CPU tests all passed
  - `tests/cpu.generator/test_skyrl_gym_generator.py`: this PR changes this test a lot because we no longer re-tokenize the LLM output (i.e. the mock tokenizer would be used much less). We should re-write this CPU test and only use a mock LLM, but use an actual tokenizer
  - `tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py`
  - We should consider testing more than Qwen and Llama3 tokenizers

## TODOs
TODOs till ready for a review
- [x] Support token-in-token-out for `SkyRLGymGenerator.generate_batched()`
- [x] Support token-in-token-out for `SkyRLGymGenerator.agent_loop()`
- [x] Make remote engines return tokens
- [x] Thoroughly test each codepath

Future PRs
Tracked by https://github.com/NovaSky-AI/SkyRL/issues/179
- CPU testing
  - [ ] Do not mock tokenizer in `skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py`, use an actual tokenizer. This should make the test cleaner. Can also parametrize tokenizer and test with different models.
  - [ ] Consider adding tokenizers beyond Qwen and Llama
  - [ ] Add single-turn code path to `tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py`
- [ ] Deprecate post-processed action for SkyRL Gym to ensure token-in-token-out
- [ ] Re-consider Qwen3 training, should it follow the "always re-tokenize chat history" codepath? Maybe by default make it follow 2.2 and only follow 2.1 with a config flag
- [ ] Add a documentation page detailing the behavior of SkyRLGymGenerator, where the content is mainly this PR description and the current chunks of comments. With the doc, we can remove those chunks of comments in the file and keep it more lightweight
- [ ] Consider maintaining string-based `chat_history` in `agent_loop()` even when token-in-token-out, with the goal of doing a sanity check of equivalence between the maintained `input_ids` and `chat_history`