### PR TITLE
[FlashRL 2/N] Support list of weights during weight sync for colocated training

### DIFF
--- a/skyrl-train/examples/async/async_trainer.py
+++ b/skyrl-train/examples/async/async_trainer.py
@@ -4,7 +4,8 @@ import sys
 from loguru import logger
 from skyrl_train.trainer import RayPPOTrainer
 from tqdm import tqdm
-from skyrl_train.utils import Timer, normalize_advantages_dict
+from skyrl_train.utils import Timer
+from skyrl_train.utils.ppo_utils import normalize_advantages_dict
 from skyrl_train.training_batch import TrainingInputBatch
 from skyrl_train.generators.base import GeneratorOutput
 from skyrl_train.utils.trainer_utils import ResumeMode

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -160,7 +160,7 @@ generator:
   backend: "vllm"
   weight_sync_backend: "nccl"
   # if using cuda_ipc, we send in batches of this size in GB
-  weight_transfer_threshold_cuda_ipc_in_GB: 1.0
+  weight_transfer_threshold_cuda_ipc_GB: 1.0
   inference_engine_tensor_parallel_size: 4
   n_samples_per_prompt: 5
   async_engine: true

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -113,6 +113,7 @@ trainer:
       type: null # filter, replace, or null
       max_sample_batches: 30 # sample at most this many batches before stopping, -1 to sample forever
       min_replace_ratio: 0.3 # minimum proportion of good samples with which to replace bad samples (for replace strategy only)
+    
 
   gradient_checkpointing: true
   gradient_checkpointing_use_reentrant: false
@@ -156,6 +157,8 @@ generator:
   num_inference_engines: 1
   backend: "vllm"
   weight_sync_backend: "nccl"
+  # if using cuda_ipc, we send in batches of this size in GB
+  weight_transfer_threshold_cuda_ipc_in_GB: 0.5
   inference_engine_tensor_parallel_size: 4
   n_samples_per_prompt: 5
   async_engine: true

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -158,7 +158,7 @@ generator:
   backend: "vllm"
   weight_sync_backend: "nccl"
   # if using cuda_ipc, we send in batches of this size in GB
-  weight_transfer_threshold_cuda_ipc_in_GB: 0.5
+  weight_transfer_threshold_cuda_ipc_in_GB: 1.0
   inference_engine_tensor_parallel_size: 4
   n_samples_per_prompt: 5
   async_engine: true

--- a/skyrl-train/skyrl_train/inference_engines/base.py
+++ b/skyrl-train/skyrl_train/inference_engines/base.py
@@ -20,11 +20,11 @@ class InferenceEngineOutput(TypedDict):
     response_logprobs: Optional[List[List[float]]]
 
 
-class NamedWeightUpdateRequest(TypedDict):
-    name: str
-    dtype: str
-    shape: List[int]
-    extras: Optional[Dict[str, Any]]
+class NamedWeightsUpdateRequest(TypedDict):
+    names: List[str]
+    dtypes: List[str]
+    shapes: List[List[int]]
+    extras: Optional[List[Dict[str, Any]]]
 
 
 class InferenceEngineInterface(ABC):
@@ -48,7 +48,7 @@ class InferenceEngineInterface(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def update_named_weight(self, request: NamedWeightUpdateRequest):
+    async def update_named_weights(self, request: NamedWeightsUpdateRequest):
         raise NotImplementedError()
 
     @abstractmethod

--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -96,9 +96,8 @@ class InferenceEngineClient(InferenceEngineInterface):
                     add_resp_logprobs = True
                     response_logprobs[original_idx] = result["response_logprobs"][local_idx]
 
-        # something went wrong
-        if any([len(response) == 0 for response in responses]) or not all(
-            [isinstance(sample_ids, list) for sample_ids in response_ids]
+        if any([len(response) == 0 for response in responses]) or (
+            add_resp_ids and not all([isinstance(sample_ids, list) for sample_ids in response_ids])
         ):
             raise RuntimeError(
                 "Did not receive responses / response ids for some prompts. This should never happen. There is likely something wrong with the inference engine"

--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -2,7 +2,7 @@ from skyrl_train.inference_engines.base import (
     InferenceEngineInterface,
     InferenceEngineInput,
     InferenceEngineOutput,
-    NamedWeightUpdateRequest,
+    NamedWeightsUpdateRequest,
 )
 import asyncio
 from typing import List, Any, Optional
@@ -192,8 +192,8 @@ class InferenceEngineClient(InferenceEngineInterface):
             rank_offset_count += engine.tp_size
         await asyncio.gather(*tasks)
 
-    async def update_named_weight(self, request: NamedWeightUpdateRequest):
-        return await self._run_on_all_engines("update_named_weight", request=request)
+    async def update_named_weights(self, request: NamedWeightsUpdateRequest):
+        return await self._run_on_all_engines("update_named_weights", request=request)
 
     async def reset_prefix_cache(self):
         return await self._run_on_all_engines("reset_prefix_cache")

--- a/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -8,7 +8,7 @@ from skyrl_train.inference_engines.base import (
     InferenceEngineInterface,
     InferenceEngineInput,
     InferenceEngineOutput,
-    NamedWeightUpdateRequest,
+    NamedWeightsUpdateRequest,
 )
 
 
@@ -41,8 +41,8 @@ class RayWrappedInferenceEngine(InferenceEngineInterface):
             master_addr, master_port, rank_offset, world_size, group_name, backend, override_existing
         )
 
-    async def update_named_weight(self, request: NamedWeightUpdateRequest):
-        return await self.inference_engine_actor.update_named_weight.remote(request)
+    async def update_named_weights(self, request: NamedWeightsUpdateRequest):
+        return await self.inference_engine_actor.update_named_weights.remote(request)
 
     async def teardown(self):
         return await self.inference_engine_actor.teardown.remote()

--- a/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
@@ -3,7 +3,7 @@ from skyrl_train.inference_engines.base import (
     InferenceEngineInterface,
     InferenceEngineInput,
     InferenceEngineOutput,
-    NamedWeightUpdateRequest,
+    NamedWeightsUpdateRequest,
 )
 from typing import List, Optional, Dict, Any
 import json
@@ -103,25 +103,36 @@ class RemoteInferenceEngine(InferenceEngineInterface):
             ) as response:
                 return await response.json()
 
-    async def update_named_weight(self, request: NamedWeightUpdateRequest):
-        if request.get("extras") and "ipc_handles" in request["extras"]:
+    async def update_named_weights(self, request: NamedWeightsUpdateRequest):
+        if "names" not in request:
+            raise ValueError(f"Expected update weight request with 'names' entry, got keys: {request.keys()}")
+
+        assert (
+            len(request["names"]) == 1
+        ), f"Remote inference engines support only requests with a single named weight at a time , got request with {len(request['names'])} entries"
+
+        if request.get("extras") and "ipc_handles" in request["extras"][0]:
             raise ValueError(
                 "Remote inference engines do not support CUDA IPC weight updates. Only local engines support IPC."
             )
         if self.engine_backend == "vllm":
-            weight_update_method = "update_weight"
+            weight_update_method = "update_weights"
         elif self.engine_backend == "sglang":
             weight_update_method = "update_weights_from_distributed"
         else:
             raise ValueError(f"Invalid engine backend: {self.engine_backend}")
 
         async with aiohttp.ClientSession() as session:
+            name = request[0]["name"]
+            dtype = request[0]["dtypes"]
+            shape = request[0]["shape"]
+
             resp = await session.post(
                 f"{self.url}/{weight_update_method}",
                 json={
-                    "name": request["name"],
-                    "dtype": request["dtype"],
-                    "shape": request["shape"],
+                    "name": name,
+                    "dtype": dtype,
+                    "shape": shape,
                 },
             )
             return await resp.json()

--- a/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
@@ -123,9 +123,9 @@ class RemoteInferenceEngine(InferenceEngineInterface):
             raise ValueError(f"Invalid engine backend: {self.engine_backend}")
 
         async with aiohttp.ClientSession() as session:
-            name = request[0]["name"]
-            dtype = request[0]["dtypes"]
-            shape = request[0]["shape"]
+            name = request["names"][0]
+            dtype = request["dtypes"][0]
+            shape = request["shapes"][0]
 
             resp = await session.post(
                 f"{self.url}/{weight_update_method}",

--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -103,7 +103,7 @@ class WorkerWrap:
             assert dtype == self.model_config.dtype, f"mismatch dtype: src {dtype}, dst {self.model_config.dtype}"
             weight = torch.empty(shape, dtype=dtype, device="cuda")
             torch.distributed.broadcast(weight, 0, group=self._model_update_group)
-            weight_list.append(((name, weight)))
+            weight_list.append((name, weight))
 
         self.model_runner.model.load_weights(weights=weight_list)
         for weight in weight_list:

--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -15,7 +15,7 @@ from skyrl_train.inference_engines.base import (
     InferenceEngineInterface,
     InferenceEngineInput,
     InferenceEngineOutput,
-    NamedWeightUpdateRequest,
+    NamedWeightsUpdateRequest,
 )
 from skyrl_train.utils import str_to_torch_dtype
 
@@ -95,37 +95,49 @@ class WorkerWrap:
             f"rank={rank}, world_size={world_size}, group_name={group_name}",
         )
 
-    def update_weight(self, name: str, dtype: str, shape: List[int]):
+    def update_weights(self, names: List[str], dtypes: List[str], shapes: List[List[int]]):
         """Broadcast weight to all vllm workers from source rank 0 (actor model)"""
-        dtype = str_to_torch_dtype(dtype)
-        assert dtype == self.model_config.dtype, f"mismatch dtype: src {dtype}, dst {self.model_config.dtype}"
-        weight = torch.empty(shape, dtype=dtype, device="cuda")
-        torch.distributed.broadcast(weight, 0, group=self._model_update_group)
+        weight_list = []
+        for name, dtype, shape in zip(names, dtypes, shapes):
+            dtype = str_to_torch_dtype(dtype)
+            assert dtype == self.model_config.dtype, f"mismatch dtype: src {dtype}, dst {self.model_config.dtype}"
+            weight = torch.empty(shape, dtype=dtype, device="cuda")
+            torch.distributed.broadcast(weight, 0, group=self._model_update_group)
+            weight_list.append(((name, weight)))
 
-        self.model_runner.model.load_weights(weights=[(name, weight)])
+        self.model_runner.model.load_weights(weights=weight_list)
+        for weight in weight_list:
+            del weight
 
-        del weight
+    def update_weights_cuda_ipc(
+        self, names: List[str], dtypes: List[str], shapes: List[int], ipc_handles: List[Dict[str, Any]]
+    ):
 
-    def update_weight_cuda_ipc(self, name: str, dtype: str, shape: List[int], ipc_handles: Dict[str, Any]):
+        weight_list = []
+        for name, dtype, shape, ipc_handle in zip(names, dtypes, shapes, ipc_handles):
 
-        dtype = str_to_torch_dtype(dtype)
-        device = torch.cuda.current_device()
-        props = torch.cuda.get_device_properties(device)
-        physical_gpu_id = str(props.uuid)
+            dtype = str_to_torch_dtype(dtype)
+            device = torch.cuda.current_device()
+            props = torch.cuda.get_device_properties(device)
+            physical_gpu_id = str(props.uuid)
 
-        assert dtype == self.model_config.dtype, f"mismatch dtype: src {dtype}, dst {self.model_config.dtype}"
+            assert dtype == self.model_config.dtype, f"mismatch dtype: src {dtype}, dst {self.model_config.dtype}"
 
-        handle = ipc_handles[physical_gpu_id]
+            handle = ipc_handle[physical_gpu_id]
 
-        device_id = self.device.index
-        func, args = handle
-        list_args = list(args)
-        # the key is to change device id to the current device id
-        # in case two processes have different CUDA_VISIBLE_DEVICES
-        list_args[6] = device_id
-        weight = func(*list_args)
-        self.model_runner.model.load_weights(weights=[(name, weight)])
-        torch.cuda.synchronize()
+            device_id = self.device.index
+            func, args = handle
+            list_args = list(args)
+            # the key is to change device id to the current device id
+            # in case two processes have different CUDA_VISIBLE_DEVICES
+            list_args[6] = device_id
+            weight = func(*list_args)
+            weight_list.append((name, weight))
+
+        self.model_runner.model.load_weights(weights=weight_list)
+
+        for weight in weight_list:
+            del weight
 
     # TODO (sumanthrh): Add destroy process group RPC as a atexit handler to Trainer code.
     def destroy_weights_update_group(self):
@@ -267,23 +279,29 @@ class VLLMInferenceEngine(BaseVLLMInferenceEngine):
             args=(master_addr, master_port, rank_offset, world_size, group_name, backend, override_existing),
         )
 
-    async def update_named_weight(self, request: NamedWeightUpdateRequest):
+    async def update_named_weights(self, request: NamedWeightsUpdateRequest):
+        if "names" not in request:
+            raise ValueError(f"Expected update weight request with 'names' entry, got keys: {request.keys()}")
+
         engine = self._get_engine()
         # Use IPC if handles are provided
-        if request.get("extras") and "ipc_handles" in request["extras"]:
+        if request.get("extras") and "ipc_handles" in request["extras"][0]:
             return await asyncio.to_thread(
                 engine.collective_rpc,
-                "update_weight_cuda_ipc",
+                "update_weights_cuda_ipc",
                 args=(
-                    request["name"],
-                    request["dtype"],
-                    request["shape"],
-                    request["extras"]["ipc_handles"],
+                    request["names"],
+                    request["dtypes"],
+                    request["shapes"],
+                    [extra["ipc_handles"] for extra in request["extras"]],
                 ),
             )
         else:
+            assert (
+                len(request["names"]) == 1
+            ), f"Update weights without cuda IPC only supports a single named weight at a time , got request with {len(request['names'])} entries"
             return await asyncio.to_thread(
-                engine.collective_rpc, "update_weight", args=(request["name"], request["dtype"], request["shape"])
+                engine.collective_rpc, "update_weights", args=(request["names"], request["dtypes"], request["shapes"])
             )
 
     async def teardown(self):
@@ -350,22 +368,39 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
             args=(master_addr, master_port, rank_offset, world_size, group_name, backend, override_existing),
         )
 
-    async def update_named_weight(self, request: NamedWeightUpdateRequest):
+    async def update_named_weights(self, request: NamedWeightsUpdateRequest):
+        if "names" not in request:
+            raise ValueError(f"Expected update weight request with 'names' entry, got keys: {request.keys()}")
+
+        if not len(request["names"]):
+            raise ValueError("Update weight request should have atleast one entry in 'names'")
+
         engine = self._get_engine()
         # Use IPC if handles are provided
-        if request.get("extras") and "ipc_handles" in request["extras"]:
+
+        is_ipc = request.get("extras") and "ipc_handles" in request["extras"][0]
+
+        if is_ipc:
             return await engine.collective_rpc(
-                "update_weight_cuda_ipc",
+                "update_weights_cuda_ipc",
                 args=(
-                    request["name"],
-                    request["dtype"],
-                    request["shape"],
-                    request["extras"]["ipc_handles"],
+                    request["names"],
+                    request["dtypes"],
+                    request["shapes"],
+                    [extra["ipc_handles"] for extra in request["extras"]],
                 ),
             )
         else:
+            assert (
+                len(request["names"]) == 1
+            ), f"Update weights without cuda IPC only supports a single named weight at a time , got request with {len(request['names'])} entries"
             return await engine.collective_rpc(
-                "update_weight", args=(request["name"], request["dtype"], request["shape"])
+                "update_weights",
+                args=(
+                    request["names"],
+                    request["dtypes"],
+                    request["shapes"],
+                ),
             )
 
     async def teardown(self):

--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -283,6 +283,9 @@ class VLLMInferenceEngine(BaseVLLMInferenceEngine):
         if "names" not in request:
             raise ValueError(f"Expected update weight request with 'names' entry, got keys: {request.keys()}")
 
+        if not len(request["names"]):
+            raise ValueError("Update weight request should have atleast one entry in 'names'")
+
         engine = self._get_engine()
         # Use IPC if handles are provided
         if request.get("extras") and "ipc_handles" in request["extras"][0]:

--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_server.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_server.py
@@ -98,15 +98,15 @@ class VllmServer:
             await engine.reset_prefix_cache()
             return {"status": "ok"}
 
-        @app.post("/update_weight")
-        async def _update_weight(request: Request):
+        @app.post("/update_weights")
+        async def _update_weights(request: Request):
             data = await request.json()
-            name = data.get("name")
-            dtype = data.get("dtype")
-            shape = data.get("shape")
+            names = data.get("name")
+            dtypes = data.get("dtype")
+            shapes = data.get("shape")
             await engine.collective_rpc(
-                "update_weight",
-                args=(name, dtype, shape),
+                "update_weights",
+                args=(names, dtypes, shapes),
             )
             return {"status": "ok"}
 

--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_server.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_server.py
@@ -101,9 +101,10 @@ class VllmServer:
         @app.post("/update_weights")
         async def _update_weights(request: Request):
             data = await request.json()
-            names = data.get("name")
-            dtypes = data.get("dtype")
-            shapes = data.get("shape")
+            # engine expects a list of objects
+            names = [data.get("name")]
+            dtypes = [data.get("dtype")]
+            shapes = [data.get("shape")]
             await engine.collective_rpc(
                 "update_weights",
                 args=(names, dtypes, shapes),

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -29,15 +29,14 @@ from skyrl_train.dataset.preprocess import (
 )
 from skyrl_train import utils
 from skyrl_train.utils import trainer_utils
-from skyrl_train.utils import (
-    Timer,
+from skyrl_train.utils import Timer, get_ray_pg_ready_with_timeout
+from skyrl_train.utils.ppo_utils import (
     compute_approx_kl,
     masked_mean,
-    normalize_advantages_dict,
-    get_ray_pg_ready_with_timeout,
     get_kl_controller,
     FixedKLController,
     AdaptiveKLController,
+    normalize_advantages_dict,
 )
 from skyrl_train.distributed.dispatch import MeshRank, concatenate_outputs_after_mesh_dispatch, ActorInfo
 from skyrl_train.workers.worker import PPORayActorGroup

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -27,7 +27,7 @@ from skyrl_train.generators.utils import concatenate_generator_outputs, get_metr
 from skyrl_train.dataset.preprocess import (
     convert_prompts_responses_to_batch_tensors,
 )
-from skyrl_train import utils
+from skyrl_train.utils import ppo_utils
 from skyrl_train.utils import trainer_utils
 from skyrl_train.utils import Timer, get_ray_pg_ready_with_timeout
 from skyrl_train.utils.ppo_utils import (
@@ -775,7 +775,7 @@ class RayPPOTrainer:
         # TODO (erictang000): we are just supporting custom rewards for now
         token_level_rewards = data["custom_rewards"]
 
-        advantages, returns = utils.compute_advantages_and_returns(
+        advantages, returns = ppo_utils.compute_advantages_and_returns(
             token_level_rewards=token_level_rewards,
             response_mask=data["response_mask"],
             index=data.metadata["uids"],

--- a/skyrl-train/skyrl_train/utils/__init__.py
+++ b/skyrl-train/skyrl_train/utils/__init__.py
@@ -1,2 +1,1 @@
 from .utils import *  # noqa: F401, F403
-from .ppo_utils import *  # noqa: F401, F403

--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -6,11 +6,6 @@ import torch
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 from ray.util.placement_group import placement_group, PlacementGroupSchedulingStrategy, PlacementGroup
-from skyrl_train.utils.ppo_utils import (
-    AdvantageEstimatorRegistry,
-    PolicyLossRegistry,
-    sync_registries,
-)
 
 
 class Timer:
@@ -120,6 +115,8 @@ def validate_batch_sizes(cfg: DictConfig):
 
 
 def validate_cfg(cfg: DictConfig):
+    from .ppo_utils import AdvantageEstimatorRegistry, PolicyLossRegistry
+
     if cfg.generator.max_turns == 1:
         assert (
             cfg.generator.max_input_length == cfg.trainer.max_prompt_length
@@ -311,6 +308,10 @@ def get_physical_gpu_id():
 
 
 def initialize_ray(cfg: DictConfig):
+    from .ppo_utils import (
+        sync_registries,
+    )
+
     # TODO(sumanthrh): introduce a debug mode and add debugging flags like `CUDA_LAUNCH_BLOCKING` here
     env_vars = {}
 

--- a/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
+++ b/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
@@ -128,7 +128,7 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
                     shape = param.shape if self.zero_stage != 3 else param.ds_shape
 
                     update_weight_task = asyncio.create_task(
-                        inference_engine_client.update_named_weight(
+                        inference_engine_client.update_named_weights(
                             {
                                 "names": [name],
                                 "dtypes": [self.cfg.generator.model_dtype],

--- a/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
+++ b/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
@@ -122,22 +122,22 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
 
         torch.cuda.empty_cache()
         model = self.model.model.module
-        for name, param in model.named_parameters():
-            # broadcast
-            if not self.use_cuda_ipc:
+        if not self.use_cuda_ipc:
+            for name, param in model.named_parameters():
                 if torch.distributed.get_rank() == 0:
                     shape = param.shape if self.zero_stage != 3 else param.ds_shape
 
                     update_weight_task = asyncio.create_task(
                         inference_engine_client.update_named_weight(
                             {
-                                "name": name,
-                                "dtype": self.cfg.generator.model_dtype,
-                                "shape": shape,
+                                "names": [name],
+                                "dtypes": [self.cfg.generator.model_dtype],
+                                "shapes": [shape],
                             }
                         )
                     )
 
+                # broadcast
                 def gather_and_broadcast(param):
                     # For ZeRO-3, allgather sharded parameter and broadcast to all InferenceEngines by rank 0
                     with deepspeed.zero.GatheredParameters([param], enabled=self.zero_stage == 3):
@@ -148,11 +148,16 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
                 await asyncio.to_thread(gather_and_broadcast, param)
                 if torch.distributed.get_rank() == 0:
                     await update_weight_task
+            torch.distributed.barrier()
+        # CUDA IPC
+        else:
+            from torch.multiprocessing.reductions import reduce_tensor
 
-            # CUDA IPC
-            else:
-                from torch.multiprocessing.reductions import reduce_tensor
+            # we sent in batches of 1GB as an optimization
+            weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
+            current_size = 0
 
+            for name, param in model.named_parameters():
                 # For ZeRO-3, allgather sharded parameter and broadcast to all InferenceEngines by rank 0
                 with deepspeed.zero.GatheredParameters([param], enabled=self.zero_stage == 3):
                     weight = param.data.clone()
@@ -170,21 +175,30 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
 
                         shape = param.shape if self.zero_stage != 3 else param.ds_shape
 
-                        await asyncio.create_task(
-                            inference_engine_client.update_named_weight(
-                                {
-                                    "name": name,
-                                    "dtype": self.cfg.generator.model_dtype,
-                                    "shape": shape,
-                                    "extras": {
-                                        "ipc_handles": ipc_handles,
-                                    },
-                                }
-                            )
+                        weights_update_request["names"].append(name)
+                        weights_update_request["dtypes"].append(self.cfg.generator.model_dtype)
+                        weights_update_request["shapes"].append(shape)
+                        weights_update_request["extras"].append(
+                            {
+                                "ipc_handles": ipc_handles,
+                            }
                         )
+                        if current_size > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
+                            await asyncio.create_task(
+                                inference_engine_client.update_named_weights(weights_update_request)
+                            )
+                            current_size = 0
+                            weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
 
                     torch.distributed.barrier()
                     torch.cuda.synchronize()
+
+            # sync any remaining weights
+            if torch.distributed.get_rank() == 0 and len(weights_update_request["names"]) > 0:
+                await asyncio.create_task(inference_engine_client.update_named_weights(weights_update_request))
+                current_size = 0
+                weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
+            torch.distributed.barrier()
 
         if cache_reset_task is not None:
             await cache_reset_task

--- a/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
+++ b/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
@@ -186,7 +186,7 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
                         current_size += weight.nbytes
                         # We send in batches as an optimization
                         # sync if threshold is reached
-                        if current_size / (1024**3) > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
+                        if current_size / (1024**3) > self.cfg.generator.weight_transfer_threshold_cuda_ipc_GB:
                             await inference_engine_client.update_named_weights(weights_update_request)
                             current_size = 0
                             weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}

--- a/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
+++ b/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
@@ -154,7 +154,6 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
         else:
             from torch.multiprocessing.reductions import reduce_tensor
 
-            # we sent in batches of 1GB as an optimization
             weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
             current_size = 0
 
@@ -185,6 +184,8 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
                             }
                         )
                         current_size += weight.nbytes
+                        # We send in batches as an optimization
+                        # sync if threshold is reached
                         if current_size / (1024**3) > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
                             await inference_engine_client.update_named_weights(weights_update_request)
                             current_size = 0

--- a/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
+++ b/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
@@ -184,9 +184,7 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
                             }
                         )
                         if current_size / (1024**3) > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
-                            await asyncio.create_task(
-                                inference_engine_client.update_named_weights(weights_update_request)
-                            )
+                            await inference_engine_client.update_named_weights(weights_update_request)
                             current_size = 0
                             weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
                             # force collect any sent tensors if possible to be memory efficient

--- a/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
+++ b/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
@@ -184,6 +184,7 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
                                 "ipc_handles": ipc_handles,
                             }
                         )
+                        current_size += weight.nbytes
                         if current_size / (1024**3) > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
                             await inference_engine_client.update_named_weights(weights_update_request)
                             current_size = 0

--- a/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -106,22 +106,22 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
             )
         params = self.model.model.state_dict()
 
-        for name, param in params.items():
-            # broadcast
-            if not self.use_cuda_ipc:
+        if not self.use_cuda_ipc:
+            for name, param in params.items():
                 if torch.distributed.get_rank() == 0:
                     shape = param.shape
 
                     update_weight_task = asyncio.create_task(
                         inference_engine_client.update_named_weight(
                             {
-                                "name": name,
-                                "dtype": self.cfg.generator.model_dtype,
-                                "shape": shape,
+                                "names": [name],
+                                "dtypes": [self.cfg.generator.model_dtype],
+                                "shapes": [shape],
                             }
                         )
                     )
 
+                # broadcast
                 def gather_and_broadcast(param):
                     # For FSDP, gather parameter and broadcast to all InferenceEngines by rank 0
                     device = torch.cuda.current_device()
@@ -134,19 +134,23 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
                 await asyncio.to_thread(gather_and_broadcast, param)
                 if torch.distributed.get_rank() == 0:
                     await update_weight_task
+                torch.distributed.barrier()
+        # CUDA IPC
+        else:
+            # we sent in batches of 1GB as an optimization
+            weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
+            current_size = 0
 
-            # CUDA IPC
-            else:
+            for name, param in params.items():
                 from torch.multiprocessing.reductions import reduce_tensor
 
                 device = torch.cuda.current_device()
                 param = param.to(device, non_blocking=True).full_tensor() if isinstance(param, DTensor) else param
                 param = param.to(generator_dtype)
-                weight = param.data.clone()
+                weight = param.detach().contiguous()
                 ipc_handle = reduce_tensor(weight)
 
                 ipc_handle = {get_physical_gpu_id(): ipc_handle}
-
                 ipc_handle_list = [None] * torch.distributed.get_world_size()
                 torch.distributed.all_gather_object(ipc_handle_list, ipc_handle)
 
@@ -155,23 +159,27 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
                     for d in ipc_handle_list:
                         ipc_handles.update(d)
 
-                    shape = param.shape
+                    current_size += weight.nbytes
+                    weights_update_request["names"].append(name)
+                    weights_update_request["dtypes"].append(self.cfg.generator.model_dtype)
+                    weights_update_request["shapes"].append(param.shape)
+                    weights_update_request["extras"].append({"ipc_handles": ipc_handles})
+                    # sync if threshold is reached
+                    if current_size > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
+                        await asyncio.create_task(inference_engine_client.update_named_weights(weights_update_request))
 
-                    await asyncio.create_task(
-                        inference_engine_client.update_named_weight(
-                            {
-                                "name": name,
-                                "dtype": self.cfg.generator.model_dtype,
-                                "shape": shape,
-                                "extras": {
-                                    "ipc_handles": ipc_handles,
-                                },
-                            }
-                        )
-                    )
-
+                        current_size = 0
+                        weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
                 torch.distributed.barrier()
                 torch.cuda.synchronize()
+
+            # sync any remaining weights
+            if len(weights_update_request["names"]) > 0 and torch.distributed.get_rank() == 0:
+                await asyncio.create_task(inference_engine_client.update_named_weights(weights_update_request))
+                current_size = 0
+                weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
+            torch.distributed.barrier()
+            torch.cuda.synchronize()
 
         if cache_reset_task is not None:
             await cache_reset_task

--- a/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -166,7 +166,7 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
                     weights_update_request["extras"].append({"ipc_handles": ipc_handles})
                     # We send in batches as an optimization
                     # sync if threshold is reached
-                    if current_size / (1024**3) > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
+                    if current_size / (1024**3) > self.cfg.generator.weight_transfer_threshold_cuda_ipc_GB:
                         await inference_engine_client.update_named_weights(weights_update_request)
 
                         current_size = 0

--- a/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -112,7 +112,7 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
                     shape = param.shape
 
                     update_weight_task = asyncio.create_task(
-                        inference_engine_client.update_named_weight(
+                        inference_engine_client.update_named_weights(
                             {
                                 "names": [name],
                                 "dtypes": [self.cfg.generator.model_dtype],

--- a/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -166,7 +166,7 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
                     weights_update_request["extras"].append({"ipc_handles": ipc_handles})
                     # sync if threshold is reached
                     if current_size / (1024**3) > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
-                        await asyncio.create_task(inference_engine_client.update_named_weights(weights_update_request))
+                        await inference_engine_client.update_named_weights(weights_update_request)
 
                         current_size = 0
                         weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}

--- a/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -138,7 +138,6 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
                 torch.distributed.barrier()
         # CUDA IPC
         else:
-            # we sent in batches of 1GB as an optimization
             weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
             current_size = 0
 
@@ -165,6 +164,7 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
                     weights_update_request["dtypes"].append(self.cfg.generator.model_dtype)
                     weights_update_request["shapes"].append(param.shape)
                     weights_update_request["extras"].append({"ipc_handles": ipc_handles})
+                    # We send in batches as an optimization
                     # sync if threshold is reached
                     if current_size / (1024**3) > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
                         await inference_engine_client.update_named_weights(weights_update_request)

--- a/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -170,6 +170,8 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
 
                         current_size = 0
                         weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
+                        # force collect any sent tensors if possible to be memory efficient
+                        torch.cuda.ipc_collect()
                 torch.distributed.barrier()
                 torch.cuda.synchronize()
 
@@ -178,8 +180,6 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
                 await asyncio.create_task(inference_engine_client.update_named_weights(weights_update_request))
                 current_size = 0
                 weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
-                # force collect any sent tensors if possible to be memory efficient
-                torch.cuda.ipc_collect()
             torch.distributed.barrier()
             torch.cuda.synchronize()
 

--- a/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -165,7 +165,7 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
                     weights_update_request["shapes"].append(param.shape)
                     weights_update_request["extras"].append({"ipc_handles": ipc_handles})
                     # sync if threshold is reached
-                    if current_size > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
+                    if current_size / (1024**3) > self.cfg.generator.weight_transfer_threshold_cuda_ipc_in_GB:
                         await asyncio.create_task(inference_engine_client.update_named_weights(weights_update_request))
 
                         current_size = 0
@@ -178,6 +178,8 @@ class FSDPPolicyRayActorBase(PolicyWorkerBase):
                 await asyncio.create_task(inference_engine_client.update_named_weights(weights_update_request))
                 current_size = 0
                 weights_update_request = {"names": [], "dtypes": [], "shapes": [], "extras": []}
+                # force collect any sent tensors if possible to be memory efficient
+                torch.cuda.ipc_collect()
             torch.distributed.barrier()
             torch.cuda.synchronize()
 

--- a/skyrl-train/skyrl_train/workers/worker.py
+++ b/skyrl-train/skyrl_train/workers/worker.py
@@ -16,7 +16,8 @@ import torch.distributed
 from ray import ObjectRef
 from ray.util.placement_group import PlacementGroup, PlacementGroupSchedulingStrategy, placement_group
 
-from skyrl_train.utils import masked_mean, ray_noset_visible_devices, get_ray_pg_ready_with_timeout
+from skyrl_train.utils import ray_noset_visible_devices, get_ray_pg_ready_with_timeout
+from skyrl_train.utils.ppo_utils import masked_mean
 from skyrl_train.distributed.dispatch import MeshRank, ActorInfo, DispatchRegistry, Dispatch
 from skyrl_train.distributed.strategy import DistributedStrategy
 from transformers import PreTrainedModel

--- a/skyrl-train/tests/cpu/algorithms/test_losses.py
+++ b/skyrl-train/tests/cpu/algorithms/test_losses.py
@@ -7,8 +7,7 @@ uv run --isolated --extra dev -- pytest tests/cpu/algorithms/test_losses.py
 import pytest
 import torch
 from omegaconf import DictConfig
-from skyrl_train.utils.ppo_utils import PolicyLossRegistry
-from skyrl_train.utils import masked_mean
+from skyrl_train.utils.ppo_utils import PolicyLossRegistry, masked_mean
 
 
 # Adapted a good test from NeMO-RL

--- a/skyrl-train/tests/cpu/test_trainer.py
+++ b/skyrl-train/tests/cpu/test_trainer.py
@@ -179,7 +179,7 @@ def test_calculate_kl_create_experience_batched(dummy_config):
     assert metrics["avg_kl"] == approx(0.1249, abs=1e-4)
 
 
-@patch("skyrl_train.utils.compute_advantages_and_returns", new_callable=MagicMock)
+@patch("skyrl_train.utils.ppo_utils.compute_advantages_and_returns", new_callable=MagicMock)
 def test_calc_advantages_and_returns(mock_compute_adv_and_ret, dummy_config):
     trainer = RayPPOTrainer(
         cfg=dummy_config,

--- a/skyrl-train/tests/gpu/test_grpo_sp_sanity.py
+++ b/skyrl-train/tests/gpu/test_grpo_sp_sanity.py
@@ -12,7 +12,8 @@ from skyrl_train.entrypoints.main_base import BasePPOExp, config_dir
 from skyrl_train.trainer import RayPPOTrainer
 import ray
 from tqdm import tqdm
-from skyrl_train.utils import Timer, normalize_advantages_dict
+from skyrl_train.utils import Timer
+from skyrl_train.utils.ppo_utils import normalize_advantages_dict
 
 
 import asyncio


### PR DESCRIPTION
# What does this PR do?

Supports a list of weights during weight sync for colocated training. During colocated training, we use CUDA IPC for weight syncing. The current impl is syncing weights param by param, which can be pretty inefficient. In this PR, we sycn tensors in batches of a configurable parameter (default 1GB). That is, we collect ipc metadata until the total size of underlying tensors is 1GB and forward to the inference engine. Each TP rank will materialize all tensors in this list  (i.e additional memory usage of 1GB here) and issue a single load_weights call. 

**How much faster is it?**

Even for a 14B model on a 8xH100 node (TP2), the weight sync time can reduce from around 4.4s to 1.6s (60% reduction). This will matter much more for larger models. 

This PR is needed for the FlashRL integration to work well, because we have a custom load weights impl that - long story short - allcoates new storage in each call and also issues some `empty_cache` calls. Without batching, the load weights call will be too slow in such cases. This PR reduces time for weight sync for a 1.5B model with flashrl from 5 mins to < 5s. 

I've tested the PR with our E2E tests for colocated and non-colocated and also tested the remote engine codepath. 

This PR also makes the following changes:
- Fixes bug introduced in #145 for the codepath with trajectory based routing when `response_ids` is not returned by the engine. 
- Fixes bug introduced in #126   for starting remote servers. import of `skyrl_train.utils.ppo_utils` will trigger registering. IN some cases, like with the vllm server init, we will not call `sync_registries` and there will be an error. The solution is to import guard `skyrl_train.utils.ppo_utils` unless the user themselves import it (for custom functions) or they go through the main entrypoint ( main -> `initialize_ray`-> sync)


TODO:
- [x] Verify non-colocated training works
- [x]  Run e2e test