### PR TITLE
Support exporting environment-specific metrics

### DIFF
--- a/skyrl-gym/skyrl_gym/envs/base_text_env.py
+++ b/skyrl-gym/skyrl_gym/envs/base_text_env.py
@@ -11,6 +11,7 @@ class BaseTextEnvStepOutput(TypedDict):
     reward: float
     done: bool
     metadata: Dict[str, Any]
+    metrics: Dict[str, Any]
     postprocessed_action: Optional[str] = None
 
 

--- a/skyrl-gym/skyrl_gym/envs/gsm8k/env.py
+++ b/skyrl-gym/skyrl_gym/envs/gsm8k/env.py
@@ -19,9 +19,29 @@ class GSM8kEnv(BaseTextEnv):
     def _get_reward(self, action: str) -> float:
         return utils.compute_score(action, self.ground_truth)
 
+    def _calculate_metrics(self, action: str, reward: float) -> Dict[str, Any]:
+        """Calculate environment-specific metrics for training insights."""
+
+        response_length = len(action)
+        word_count = len(action.split())
+        answer_accuracy = float(reward > 0)
+        
+        return {
+            "response_length": response_length,
+            "word_count": word_count,
+            "answer_accuracy": answer_accuracy,
+        }
+
     def step(self, action: str) -> BaseTextEnvStepOutput:
         done = True  # always done after one step
         reward = self._get_reward(action)
+        metrics = self._calculate_metrics(action, reward)
 
         # No observation in gsm8k, and no tool call
-        return BaseTextEnvStepOutput(observations=[], reward=reward, done=done, metadata={})
+        return BaseTextEnvStepOutput(
+            observations=[], 
+            reward=reward, 
+            done=done, 
+            metadata={}, 
+            metrics=metrics
+        )

--- a/skyrl-train/skyrl_train/generators/base.py
+++ b/skyrl-train/skyrl_train/generators/base.py
@@ -18,6 +18,7 @@ class GeneratorOutput(TypedDict):
     stop_reasons: Optional[List[str]]
     rollout_metrics: Optional[Dict[str, Any]]
     rollout_logprobs: Optional[List[List[float]]]
+    env_metrics: Optional[List[Dict[str, Any]]]
 
 
 class GeneratorInterface(ABC):

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -60,7 +60,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         max_tokens: int,
         max_input_length: int,
         sampling_params: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[List[int], float, str, List[int], List[int], Optional[List[float]]]:
+    ) -> Tuple[List[int], float, str, List[int], List[int], Optional[List[float]], Optional[Dict[str, Any]]]:
         """
         Multi-turn generation loop that executes a single trajectory.
 
@@ -77,6 +77,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             loss_mask: List[int]
             prompt_token_ids: List[int]
             rollout_logprobs: Optional[List[float]]
+            env_metrics: Optional[Dict[str, Any]]
         """
         # Create a new environment instance
         env_extras["max_turns"] = self.max_turns  # TODO(shu): move this to config

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -288,10 +288,10 @@ class SkyRLGymGenerator(GeneratorInterface):
         if self.batched:
             return await self.generate_batched(
                 prompts, env_classes, env_extras, max_tokens, max_input_length, sampling_params
-            )  # Calls for single-turn parallel generation
+            )
 
         # Async agent loop to generate trajectories in parallel.
-        tasks = []  # Use agent_loop() for multi-turn sequential generation
+        tasks = []
         for i in range(len(prompts)):
             tasks.append(
                 self.agent_loop(

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -124,6 +124,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             new_obs = env_step_output["observations"]
             reward = env_step_output["reward"]
             done = env_step_output["done"]
+            env_metrics = env_step_output.get("metrics", {})
 
             if env_step_output.get("postprocessed_action", None) is not None:
                 output = env_step_output["postprocessed_action"]
@@ -176,7 +177,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         response_ids = response_ids[:max_response_tokens]
         loss_mask = loss_mask[:max_response_tokens]
 
-        return response_ids, reward, stop_reason, loss_mask, prompt_ids, rollout_logprobs
+        return response_ids, reward, stop_reason, loss_mask, prompt_ids, rollout_logprobs, env_metrics
 
     async def generate_batched(
         self,
@@ -220,6 +221,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         truncated_responses = []
         rewards = []
         loss_masks = []
+        env_metrics = []
         truncated_logprobs: Optional[List[List[float]]] = [] if logprobs is not None else None
 
         for i, (response, env) in enumerate(zip(responses, envs)):
@@ -227,6 +229,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             env_step_output: BaseTextEnvStepOutput = env.step(response)
             reward = env_step_output["reward"]
             rewards.append(reward)
+            env_metrics.append(env_step_output.get("metrics", {}))
 
             # NOTE (sumanthrh): We add a guard since response_ids is `None` with remote inference engine
             if all_response_ids is not None:
@@ -259,6 +262,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             "stop_reasons": stop_reasons,
             "rollout_metrics": rollout_metrics,
             "rollout_logprobs": truncated_logprobs,
+            "env_metrics": env_metrics,
         }
 
         return generator_output
@@ -283,10 +287,10 @@ class SkyRLGymGenerator(GeneratorInterface):
         if self.batched:
             return await self.generate_batched(
                 prompts, env_classes, env_extras, max_tokens, max_input_length, sampling_params
-            )
+            )  # Calls for single-turn parallel generation
 
         # Async agent loop to generate trajectories in parallel.
-        tasks = []
+        tasks = []  # Use agent_loop() for multi-turn sequential generation
         for i in range(len(prompts)):
             tasks.append(
                 self.agent_loop(
@@ -311,6 +315,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         stop_reasons = [output[2] for output in all_outputs]
         loss_masks = [output[3] for output in all_outputs]
         prompt_token_ids = [output[4] for output in all_outputs]
+        env_metrics = [output[6] for output in all_outputs]
 
         if sampling_params is not None:
             # sampling params will be a dict in the format of the inference engine backend
@@ -341,11 +346,12 @@ class SkyRLGymGenerator(GeneratorInterface):
             "stop_reasons": stop_reasons,
             "rollout_metrics": rollout_metrics,
             "rollout_logprobs": rollout_logprobs,
+            "env_metrics": env_metrics,
         }
 
         return generator_output
 
-    def _rollout_metrics(self, responses: List[List[int]], rewards: List[float]):
+    def _rollout_metrics(self, responses: List[List[int]], rewards: List[float]) -> Dict[str, float]:
         num_tokens_arr = np.array([len(response) for response in responses])
         non_zero_rewards_arr = np.array([reward > 0.0 for reward in rewards])
         zero_rewards_arr = np.array([reward == 0.0 for reward in rewards])

--- a/skyrl-train/skyrl_train/generators/utils.py
+++ b/skyrl-train/skyrl_train/generators/utils.py
@@ -99,6 +99,7 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput]) -> G
             if generator_outputs[0]["rollout_logprobs"]
             else None
         ),
+        "env_metrics": sum([output.get("env_metrics", []) for output in generator_outputs], []),
     }
     if "stop_reasons" in generator_outputs[0]:
         result["stop_reasons"] = sum([output["stop_reasons"] for output in generator_outputs], [])

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -14,6 +14,7 @@ from ray.util.placement_group import PlacementGroup, placement_group
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 from transformers import AutoTokenizer
+from collections import defaultdict
 
 from skyrl_train.dataset import PromptDataset
 from skyrl_train.utils.tracking import Tracking
@@ -183,8 +184,6 @@ class RayPPOTrainer:
         # 4. Aggregate environment metrics for logging
         env_aggregated_metrics = {}
         if concat_all_env_metrics:
-            from collections import defaultdict
-
             metric_sums = defaultdict(float)
             metric_counts = defaultdict(int)
 

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -197,7 +197,6 @@ class RayPPOTrainer:
                     except (ValueError, TypeError):
                         logger.warning(f"Skipping non-numeric environment metric '{key}' with value '{value}'"
                                        f" - only numeric metrics are aggregated for logging")
-                        pass
             
             for key in metric_sums:
                 if metric_counts[key] > 0:

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -2,6 +2,7 @@ import asyncio
 import math
 import os
 import shutil
+from collections import defaultdict
 from typing import Any, List, Optional, Dict, Tuple, Union
 from jaxtyping import Float
 from pathlib import Path
@@ -14,7 +15,6 @@ from ray.util.placement_group import PlacementGroup, placement_group
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 from transformers import AutoTokenizer
-from collections import defaultdict
 
 from skyrl_train.dataset import PromptDataset
 from skyrl_train.utils.tracking import Tracking
@@ -195,8 +195,8 @@ class RayPPOTrainer:
                         metric_sums[key] += float(value)
                         metric_counts[key] += 1
                     except (ValueError, TypeError):
-                        # Non-numeric metric values are ignored.
-                        # Consider adding a log warning if this is unexpected.
+                        logger.warning(f"Skipping non-numeric environment metric '{key}' with value '{value}'"
+                                       f" - only numeric metrics are aggregated for logging")
                         pass
             
             for key in metric_sums:

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -159,7 +159,7 @@ class RayPPOTrainer:
             generator_input, uids = self._prepare_generator_input(
                 self.cfg.generator.eval_n_samples_per_prompt, prompts, sampling_params
             )
-            generator_output: GeneratorOutput = await self.generate(generator_input)  # {"env/metrics": ____}
+            generator_output: GeneratorOutput = await self.generate(generator_input)
             generator_outputs.append(generator_output)
             concat_all_envs.extend(generator_input["env_classes"])
             concat_env_extras.extend(generator_input["env_extras"])

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -183,21 +183,26 @@ class RayPPOTrainer:
         # 4. Aggregate environment metrics for logging
         env_aggregated_metrics = {}
         if concat_all_env_metrics:
-            # Get all unique metric keys across all environments
-            all_metric_keys = set()
+            from collections import defaultdict
+
+            metric_sums = defaultdict(float)
+            metric_counts = defaultdict(int)
+
             for metrics_dict in concat_all_env_metrics:
-                if metrics_dict:
-                    all_metric_keys.update(metrics_dict.keys())
+                if not metrics_dict:
+                    continue
+                for key, value in metrics_dict.items():
+                    try:
+                        metric_sums[key] += float(value)
+                        metric_counts[key] += 1
+                    except (ValueError, TypeError):
+                        # Non-numeric metric values are ignored.
+                        # Consider adding a log warning if this is unexpected.
+                        pass
             
-            # Calculate mean for each metric across all samples
-            for metric_key in all_metric_keys:
-                values = []
-                for metrics_dict in concat_all_env_metrics:
-                    if metrics_dict and metric_key in metrics_dict:
-                        values.append(float(metrics_dict[metric_key]))
-                
-                if values:  # Only add if we have values
-                    env_aggregated_metrics[f"env/{metric_key}"] = sum(values) / len(values)
+            for key in metric_sums:
+                if metric_counts[key] > 0:
+                    env_aggregated_metrics[f"env/{key}"] = metric_sums[key] / metric_counts[key]
 
         eval_metrics.update(
             {

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -1101,10 +1101,7 @@ def test_env_metrics_in_generator_output_schema():
         {"metric1": 10.0, "metric2": "test2"}
     ]
     
-    assert "env_metrics" in concatenated_output, "env_metrics should be in concatenated output"
-
-    for key, value in concatenated_output.items(): 
-        print(f"Key: {key}, Value: {value}")
+    assert "env_metrics" in concatenated_output, f"env_metrics should be in concatenated output, instead got {concatenated_output["env_metrics"]}"
     
     assert concatenated_output["env_metrics"] == expected_env_metrics, (
         f"env_metrics concatenation failed. Expected {expected_env_metrics}, "

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -839,19 +839,14 @@ async def test_env_metrics_collection_and_aggregation(
     """
     Test that environment metrics are properly collected from environments
     and included in GeneratorOutput for both batched and non-batched modes.
-    
-    This tests the env_metrics functionality added in the PR:
-    1. Environment returns metrics in step output
-    2. Generator collects and includes them in GeneratorOutput
-    3. Metrics have correct structure and values
     """
     mock_make.return_value = mock_env
     mock_generator_cfg.batched = False  # Test non-batched mode first
     mock_generator_cfg.max_turns = 1
     mock_env.init.return_value = ([{"role": "user", "content": "Initial input"}], {})
 
-    # Mock environment to return metrics in step output
     def mock_step_with_metrics(action):
+        print(f"DEBUG: action received = '{action}', length = {len(action)}")  # Debug line
         return BaseTextEnvStepOutput(
             observations=[{"role": "user", "content": "next"}],
             reward=1.0,
@@ -1101,7 +1096,7 @@ def test_env_metrics_in_generator_output_schema():
         {"metric1": 10.0, "metric2": "test2"}
     ]
     
-    assert "env_metrics" in concatenated_output, f"env_metrics should be in concatenated output, instead got {concatenated_output["env_metrics"]}"
+    assert "env_metrics" in concatenated_output, "env_metrics should be in concatenated output"
     
     assert concatenated_output["env_metrics"] == expected_env_metrics, (
         f"env_metrics concatenation failed. Expected {expected_env_metrics}, "

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -230,7 +230,7 @@ async def test_agent_loop_single_turn(
 
     prompt = [{"role": "user", "content": "What is 2 + 2?"}]
     extras = {"answer": "4"}
-    response_text, reward, stop_reason, loss_mask, input_prompt, rollout_logprobs = await generator.agent_loop(
+    response_text, reward, stop_reason, loss_mask, input_prompt, rollout_logprobs, env_metrics = await generator.agent_loop(
         prompt, mock_env_cfg.env_class, extras, max_tokens=8, max_input_length=512
     )
 
@@ -238,6 +238,7 @@ async def test_agent_loop_single_turn(
     assert reward == 1.0
     assert stop_reason == "stop"
     assert loss_mask == [1, 1, 1, 1]
+    assert env_metrics == {}
 
 
 @pytest.mark.asyncio
@@ -283,6 +284,7 @@ def test_generator_output_concatenation():
         "stop_reasons",
         "rollout_metrics",
         "rollout_logprobs",
+        "env_metrics",
     ]
     assert set(GeneratorOutput.__annotations__.keys()) == set(expected_fields), (
         "GeneratorOutput fields are not what we expect. "
@@ -562,7 +564,7 @@ async def test_multi_turn_response_truncation(
     prompt = [{"role": "user", "content": "Initial prompt"}]
     extras = {}
 
-    response_ids, _, stop_reason, loss_mask, _, _ = await generator.agent_loop(
+    response_ids, _, stop_reason, loss_mask, _, _, _ = await generator.agent_loop(
         prompt, "test_env", extras, max_tokens=max_tokens_from_llm, max_input_length=max_input_len
     )
 

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -485,7 +485,7 @@ async def test_length_limit_exceeded_during_conversation(
     extras = {"test": "value"}
     max_input_length = 20  # Low limit to trigger length exceeded
 
-    response_ids, reward, stop_reason, loss_mask, prompt_token_ids, rollout_logprobs = await generator.agent_loop(
+    response_ids, reward, stop_reason, loss_mask, prompt_token_ids, rollout_logprobs, env_metrics = await generator.agent_loop(
         prompt, "test_env", extras, max_tokens=100, max_input_length=max_input_length
     )
 
@@ -644,7 +644,7 @@ async def test_postprocessed_action_used(
     prompt = [{"role": "user", "content": "Initial input"}]
     env_extras = {}
 
-    response_ids, reward, stop_reason, loss_mask, prompt_ids, _ = await generator.agent_loop(
+    response_ids, reward, stop_reason, loss_mask, prompt_ids, _, _ = await generator.agent_loop(
         prompt, "test_env", env_extras, max_tokens=20, max_input_length=50
     )
 

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -846,7 +846,6 @@ async def test_env_metrics_collection_and_aggregation(
     mock_env.init.return_value = ([{"role": "user", "content": "Initial input"}], {})
 
     def mock_step_with_metrics(action):
-        print(f"DEBUG: action received = '{action}', length = {len(action)}")  # Debug line
         return BaseTextEnvStepOutput(
             observations=[{"role": "user", "content": "next"}],
             reward=1.0,
@@ -896,7 +895,7 @@ async def test_env_metrics_collection_and_aggregation(
     assert isinstance(metrics_dict, dict), "Each env_metrics entry should be a dict"
     
     expected_metrics = {
-        "response_length": 12,  # Length of "mocked output"
+        "response_length": 13,  # Length of "mocked output"
         "word_count": 2,        # "mocked" and "output"
         "answer_accuracy": 1.0,
         "custom_metric": 42.5

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -1101,7 +1101,10 @@ def test_env_metrics_in_generator_output_schema():
         {"metric1": 10.0, "metric2": "test2"}
     ]
     
-    assert "env_metrics" in concatenated_output, f"env_metrics should be in concatenated output, instead is {concatenated_output}"
+    assert "env_metrics" in concatenated_output, "env_metrics should be in concatenated output"
+
+    for key, value in concatenated_output.items(): 
+        print(f"Key: {key}, Value: {value}")
     
     assert concatenated_output["env_metrics"] == expected_env_metrics, (
         f"env_metrics concatenation failed. Expected {expected_env_metrics}, "

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -829,3 +829,279 @@ async def test_apply_overlong_filtering_batched(
         0,
         0,
     ], "Loss mask should be all zeros for response not ending with eos token"
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_env_metrics_collection_and_aggregation(
+    mock_make, mock_tokenizer, mock_llm, mock_env, mock_generator_cfg, mock_env_cfg
+):
+    """
+    Test that environment metrics are properly collected from environments
+    and included in GeneratorOutput for both batched and non-batched modes.
+    
+    This tests the env_metrics functionality added in the PR:
+    1. Environment returns metrics in step output
+    2. Generator collects and includes them in GeneratorOutput
+    3. Metrics have correct structure and values
+    """
+    mock_make.return_value = mock_env
+    mock_generator_cfg.batched = False  # Test non-batched mode first
+    mock_generator_cfg.max_turns = 1
+    mock_env.init.return_value = ([{"role": "user", "content": "Initial input"}], {})
+
+    # Mock environment to return metrics in step output
+    def mock_step_with_metrics(action):
+        return BaseTextEnvStepOutput(
+            observations=[{"role": "user", "content": "next"}],
+            reward=1.0,
+            done=True,
+            metadata={},
+            metrics={
+                "response_length": len(action),
+                "word_count": len(action.split()),
+                "answer_accuracy": 1.0,
+                "custom_metric": 42.5
+            }
+        )
+
+    mock_env.step.side_effect = mock_step_with_metrics
+
+    generator = SkyRLGymGenerator(
+        generator_cfg=mock_generator_cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+        model_name="test_model",
+    )
+
+    # Test with single prompt
+    prompts = [[{"role": "user", "content": "What is 2 + 2?"}]]
+    env_extras = [{"answer": "4"}]
+    env_classes = [mock_env_cfg.env_class]
+
+    input_batch: GeneratorInput = {
+        "prompts": prompts,
+        "env_extras": env_extras,
+        "env_classes": env_classes,
+    }
+
+    generator_output: GeneratorOutput = await generator.generate(input_batch)
+
+    # Verify env_metrics is present in output
+    assert "env_metrics" in generator_output, "env_metrics should be present in GeneratorOutput"
+    
+    # Verify structure: List[Dict[str, Any]]
+    env_metrics = generator_output["env_metrics"]
+    assert isinstance(env_metrics, list), "env_metrics should be a list"
+    assert len(env_metrics) == 1, "Should have one metrics dict per trajectory"
+    
+    # Verify metrics content
+    metrics_dict = env_metrics[0]
+    assert isinstance(metrics_dict, dict), "Each env_metrics entry should be a dict"
+    
+    expected_metrics = {
+        "response_length": 12,  # Length of "mocked output"
+        "word_count": 2,        # "mocked" and "output"
+        "answer_accuracy": 1.0,
+        "custom_metric": 42.5
+    }
+    
+    for key, expected_value in expected_metrics.items():
+        assert key in metrics_dict, f"Metric '{key}' should be present"
+        assert metrics_dict[key] == expected_value, f"Metric '{key}' should have value {expected_value}"
+
+
+@pytest.mark.asyncio  
+@patch("skyrl_gym.make")
+async def test_env_metrics_batched_mode(
+    mock_make, mock_tokenizer, mock_llm, mock_env, mock_generator_cfg, mock_env_cfg
+):
+    """
+    Test that environment metrics work correctly in batched mode with multiple trajectories.
+    """
+    mock_make.return_value = mock_env
+    mock_generator_cfg.batched = True  # Test batched mode
+    mock_env.init.return_value = ([{"role": "user", "content": "Initial input"}], {})
+
+    # Track which response we're processing to return different metrics
+    step_call_count = 0
+    
+    def mock_step_with_varying_metrics(action):
+        nonlocal step_call_count
+        step_call_count += 1
+        
+        # Return different metrics for each trajectory
+        if step_call_count == 1:
+            metrics = {"accuracy": 1.0, "length": 10}
+        elif step_call_count == 2:
+            metrics = {"accuracy": 0.0, "length": 5}
+        else:
+            metrics = {"accuracy": 0.5, "length": 8}
+            
+        return BaseTextEnvStepOutput(
+            observations=[],
+            reward=1.0,
+            done=True,
+            metadata={},
+            metrics=metrics
+        )
+
+    mock_env.step.side_effect = mock_step_with_varying_metrics
+
+    generator = SkyRLGymGenerator(
+        generator_cfg=mock_generator_cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+        model_name="test_model",
+    )
+
+    # Test with multiple prompts
+    prompts = [
+        [{"role": "user", "content": "Problem 1"}],
+        [{"role": "user", "content": "Problem 2"}],
+        [{"role": "user", "content": "Problem 3"}]
+    ]
+    env_extras = [{"answer": "1"}, {"answer": "2"}, {"answer": "3"}]
+    env_classes = [mock_env_cfg.env_class] * 3
+
+    input_batch: GeneratorInput = {
+        "prompts": prompts,
+        "env_extras": env_extras,
+        "env_classes": env_classes,
+    }
+
+    generator_output: GeneratorOutput = await generator.generate(input_batch)
+
+    # Verify env_metrics structure for multiple trajectories
+    env_metrics = generator_output["env_metrics"]
+    assert len(env_metrics) == 3, "Should have metrics for all 3 trajectories"
+    
+    # Verify each trajectory has different metrics
+    expected_metrics = [
+        {"accuracy": 1.0, "length": 10},
+        {"accuracy": 0.0, "length": 5}, 
+        {"accuracy": 0.5, "length": 8}
+    ]
+    
+    for i, (actual, expected) in enumerate(zip(env_metrics, expected_metrics)):
+        assert actual == expected, f"Trajectory {i} metrics should match expected values"
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make") 
+async def test_env_metrics_empty_when_no_metrics(
+    mock_make, mock_tokenizer, mock_llm, mock_env, mock_generator_cfg, mock_env_cfg
+):
+    """
+    Test that env_metrics handles cases where environment doesn't return metrics.
+    Should return empty dict as default.
+    """
+    mock_make.return_value = mock_env
+    mock_generator_cfg.batched = False
+    mock_generator_cfg.max_turns = 1
+    mock_env.init.return_value = ([{"role": "user", "content": "Initial input"}], {})
+
+    # Mock environment that doesn't return metrics (old style)
+    def mock_step_no_metrics(action):
+        return BaseTextEnvStepOutput(
+            observations=[],
+            reward=1.0,
+            done=True,
+            metadata={}
+            # No metrics field
+        )
+
+    mock_env.step.side_effect = mock_step_no_metrics
+
+    generator = SkyRLGymGenerator(
+        generator_cfg=mock_generator_cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+        model_name="test_model",
+    )
+
+    prompts = [[{"role": "user", "content": "Test"}]]
+    env_extras = [{}]
+    env_classes = [mock_env_cfg.env_class]
+
+    input_batch: GeneratorInput = {
+        "prompts": prompts,
+        "env_extras": env_extras,
+        "env_classes": env_classes,
+    }
+
+    generator_output: GeneratorOutput = await generator.generate(input_batch)
+
+    # Verify env_metrics contains empty dict when no metrics provided
+    env_metrics = generator_output["env_metrics"]
+    assert len(env_metrics) == 1, "Should have one entry per trajectory"
+    assert env_metrics[0] == {}, "Should be empty dict when no metrics provided"
+
+
+def test_env_metrics_in_generator_output_schema():
+    """
+    Test that env_metrics field is properly defined in GeneratorOutput TypedDict
+    and included in concatenation operations.
+    """
+    # Verify env_metrics is in GeneratorOutput schema
+    expected_fields = [
+        "prompt_token_ids",
+        "response_ids", 
+        "rewards",
+        "loss_masks",
+        "stop_reasons",
+        "rollout_metrics",
+        "rollout_logprobs",
+        "env_metrics",  # This should be present
+    ]
+    
+    actual_fields = list(GeneratorOutput.__annotations__.keys())
+    assert set(actual_fields) == set(expected_fields), (
+        f"GeneratorOutput fields mismatch. Expected {expected_fields}, got {actual_fields}"
+    )
+    
+    # Verify env_metrics type annotation
+    env_metrics_type = GeneratorOutput.__annotations__["env_metrics"]
+    assert "Optional" in str(env_metrics_type), "env_metrics should be Optional"
+    assert "List" in str(env_metrics_type), "env_metrics should be List type"
+    assert "Dict" in str(env_metrics_type), "env_metrics should contain Dict elements"
+
+    # Test concatenation includes env_metrics
+    generator_output_1: GeneratorOutput = {
+        "prompt_token_ids": [[1, 2]],
+        "response_ids": [[3, 4]],
+        "rewards": [1.0],
+        "loss_masks": [[1, 1]],
+        "stop_reasons": ["stop"],
+        "rollout_logprobs": [[0.1, 0.2]],
+        "rollout_metrics": {"test": 1.0},
+        "env_metrics": [{"metric1": 5.0, "metric2": "test"}]
+    }
+
+    generator_output_2: GeneratorOutput = {
+        "prompt_token_ids": [[5, 6]],
+        "response_ids": [[7, 8]], 
+        "rewards": [2.0],
+        "loss_masks": [[1, 1]],
+        "stop_reasons": ["stop"],
+        "rollout_logprobs": [[0.3, 0.4]],
+        "rollout_metrics": {"test": 2.0},
+        "env_metrics": [{"metric1": 10.0, "metric2": "test2"}]
+    }
+
+    generator_outputs = [generator_output_1, generator_output_2]
+    concatenated_output = concatenate_generator_outputs(generator_outputs)
+
+    # Verify env_metrics are properly concatenated
+    expected_env_metrics = [
+        {"metric1": 5.0, "metric2": "test"},
+        {"metric1": 10.0, "metric2": "test2"}
+    ]
+    
+    assert "env_metrics" in concatenated_output, "env_metrics should be in concatenated output"
+    assert concatenated_output["env_metrics"] == expected_env_metrics, (
+        f"env_metrics concatenation failed. Expected {expected_env_metrics}, "
+        f"got {concatenated_output['env_metrics']}"
+    )

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -830,6 +830,7 @@ async def test_apply_overlong_filtering_batched(
         0,
     ], "Loss mask should be all zeros for response not ending with eos token"
 
+
 @pytest.mark.asyncio
 @patch("skyrl_gym.make")
 async def test_env_metrics_collection_and_aggregation(
@@ -908,10 +909,10 @@ async def test_env_metrics_collection_and_aggregation(
     
     for key, expected_value in expected_metrics.items():
         assert key in metrics_dict, f"Metric '{key}' should be present"
-        assert metrics_dict[key] == expected_value, f"Metric '{key}' should have value {expected_value}"
+        assert metrics_dict[key] == expected_value, f"Metric '{key}' should have value {expected_value}, got {metrics_dict[key]}"
 
 
-@pytest.mark.asyncio  
+@pytest.mark.asyncio
 @patch("skyrl_gym.make")
 async def test_env_metrics_batched_mode(
     mock_make, mock_tokenizer, mock_llm, mock_env, mock_generator_cfg, mock_env_cfg
@@ -1054,7 +1055,7 @@ def test_env_metrics_in_generator_output_schema():
         "stop_reasons",
         "rollout_metrics",
         "rollout_logprobs",
-        "env_metrics",  # This should be present
+        "env_metrics", 
     ]
     
     actual_fields = list(GeneratorOutput.__annotations__.keys())
@@ -1100,7 +1101,8 @@ def test_env_metrics_in_generator_output_schema():
         {"metric1": 10.0, "metric2": "test2"}
     ]
     
-    assert "env_metrics" in concatenated_output, "env_metrics should be in concatenated output"
+    assert "env_metrics" in concatenated_output, f"env_metrics should be in concatenated output, instead is {concatenated_output}"
+    
     assert concatenated_output["env_metrics"] == expected_env_metrics, (
         f"env_metrics concatenation failed. Expected {expected_env_metrics}, "
         f"got {concatenated_output['env_metrics']}"


### PR DESCRIPTION
Issue: #139 

## Add Environment Metrics Support to SkyRL-Gym
### Summary
This PR adds support for environment-specific metrics collection and logging in SkyRL-Gym environments. 

- Added `metrics` of type `Dict[str,Any]` to `BaseTextEnvStepOutput`
- Added `env_metrics` of type `Optional[List[Dict[str, Any]]]` to `GeneratorOutput`
- Logic added in `concatenate_generator_outputs` in `utils.py`
- Logic added in `generate()` and `generate_batched()` to collect metrics from environment steps
- `eval()` computes aggregation by **mean** across evaluation batches
- Aggregated metrics are logged to wandb under the `env/*` name
- Example environment: `GSM8k`
   - Added `_calculate_metrics()` method for the metrics: response_length, word_count, answer_accuracy
- Added 4 unit tests (non-batched and batched, compatibility with envs that don't report metrics, concatenation logic, edge cases)