### PR TITLE
get chat_end_index after env init

### DIFF
--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -88,10 +88,10 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         # need copy here since the prompt is a list of messages and we are going to modify it
         chat_history = copy.deepcopy(prompt)
-        chat_end_index = len(chat_history)
 
         # Init() returns the first prompt to be given to the model, and optional metadata dict
         chat_history, _ = env.init(chat_history)
+        chat_end_index = len(chat_history)
         input_ids = self.tokenizer.apply_chat_template(
             chat_history,
             # if we are keeping the chat history in token ids, we have to add the generation prompt to the original prompt


### PR DESCRIPTION
This PR moves the `chat_end_index` to after the `chat_history` has been modified by the `env.init` function, to get the right number.

In our use case, we are injecting the system prompt in addition to the user message in the `env.init`, so the length changes before and after.
In this case the `chat_end_index` is 1 instead of 2. We think it might be causing some bugs down the line, leading to this assertion error:
```
AssertionError: Response ids and loss masks must have the same length, for sample 0 got 27 and 50
```

Resolves #183