### PR TITLE
[docs] Update libnuma installation instructions

### DIFF
--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -57,7 +57,7 @@ The only packages required are `build-essential` and `libnuma <https://github.co
     sudo apt update && sudo apt-get install build-essential libnuma-dev
 
 .. note::
-   `libnuma-dev` will require sudo privileges. If you are running on a machine without sudo access, we recommend using the Dockerfile. However, you can install from source using:
+   Installing `libnuma-dev` will require sudo privileges. If you are running on a machine without sudo access, we recommend using the Dockerfile. However, you can install from source using:
    
    .. code-block:: bash
 

--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -56,7 +56,25 @@ The only packages required are `build-essential` and `libnuma <https://github.co
 
     sudo apt update && sudo apt-get install build-essential libnuma-dev
 
-This will require sudo privileges. If you are running on a machine without sudo access, we recommend using the Dockerfile.
+.. note::
+   `libnuma-dev` will require sudo privileges. If you are running on a machine without sudo access, we recommend using the Dockerfile. However, you can install from source using:
+   
+   .. code-block:: bash
+
+       # Get the source
+       wget https://github.com/numactl/numactl/releases/download/v2.0.16/numactl-2.0.16.tar.gz
+       tar xzf numactl-2.0.16.tar.gz
+       cd numactl-2.0.16
+       
+       # Build to a local prefix
+       ./configure --prefix=$HOME/.local
+       make
+       make install
+       
+       # Point compiler and linker to it
+       export CPATH=$HOME/.local/include:$CPATH
+       export LIBRARY_PATH=$HOME/.local/lib:$LIBRARY_PATH
+       export LD_LIBRARY_PATH=$HOME/.local/lib:$LD_LIBRARY_PATH
 
 Installing SkyRL-Train
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Add quick script for installing numactl without using docker. This is relevant for those who don't want to use docker, but don't have sudo access (e.g., RunPod VMs).

<img width="681" height="546" alt="Screenshot 2025-08-24 at 4 56 40 PM" src="https://github.com/user-attachments/assets/25941fd6-3157-4e74-afdd-db723e7f9f6d" />
