### PR TITLE
[Fix] Set skip_special_tokens to True in default sampling params

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/utils.py
+++ b/skyrl-train/skyrl_train/inference_engines/utils.py
@@ -5,7 +5,7 @@ from omegaconf import DictConfig, ListConfig
 def get_vllm_sampling_params(sampling_params: DictConfig) -> Dict[str, Any]:
     vllm_sampling_params = {
         "min_tokens": 1,
-        "skip_special_tokens": False,
+        "skip_special_tokens": True,
         "include_stop_str_in_output": True,
         "max_tokens": sampling_params.max_generate_length,
         "temperature": sampling_params.temperature,
@@ -27,7 +27,7 @@ def get_vllm_sampling_params(sampling_params: DictConfig) -> Dict[str, Any]:
 def get_sglang_sampling_params(sampling_params: DictConfig) -> Dict[str, Any]:
     # min_tokens, include_stop_str_in_output are not used in sglang
     sglang_sampling_params = {
-        "skip_special_tokens": False,
+        "skip_special_tokens": True,
         "max_new_tokens": sampling_params.max_generate_length,
         "temperature": sampling_params.temperature,
         "top_p": sampling_params.top_p,


### PR DESCRIPTION
By default, SkyRL currently calls inference engines with `skip_special_tokens=False`. This causes special tokens (e.g. `<|im_end|>`) to appear in the decoded text output. This means that the decoded output passed in to environments via `env.step(output)` (in the `agent_loop`) may include stop tokens, which likely isn’t expected behavior.

This PR addresses that by setting skip_special_tokens=True when sampling from vLLM and SGLang.

I briefly validated this change functions as intended by comparing two runs w/ and w/o, and am no longer seeing the `<|im_end|>` tokens when I log `output`.