### PR TITLE
[docs][trivial] Add libnuma error in installation page

### DIFF
--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -77,11 +77,11 @@ The only packages required are `build-essential` and `libnuma <https://github.co
        export LD_LIBRARY_PATH=$HOME/.local/lib:$LD_LIBRARY_PATH
 
 .. note::
-    If libnuma is not set up, you might run into errors such as the following when running SkyRL:
+   If libnuma is not set up, you might run into errors such as the following when running SkyRL:
 
-    .. code-block:: bash
+   .. code-block:: bash
 
-        AttributeError: ray::FSDPRefRayActorBase.offload_to_cpu: undefined symbol: numa_parse_nodestring. Did you mean: '_return_value'?
+       AttributeError: ray::FSDPRefRayActorBase.offload_to_cpu: undefined symbol: numa_parse_nodestring. Did you mean: '_return_value'?
 
 Installing SkyRL-Train
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
A small follow-up to https://github.com/NovaSky-AI/SkyRL/pull/191, we add the potential error that users might run into if libnuma is not setup, helping them triage errors better.

<img width="500" height="820" alt="image" src="https://github.com/user-attachments/assets/421fb3e2-9ca9-49db-aff7-a8fb6f4a34c8" />
