### PR TITLE
Increase GPU CI timeout to 1hr

### DIFF
--- a/.github/workflows/gpu_ci.yaml
+++ b/.github/workflows/gpu_ci.yaml
@@ -46,5 +46,5 @@ jobs:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
           ANYSCALE_HOST: https://console.anyscale.com
         run: |
-          anyscale job submit -f ci/anyscale_gpu_ci.yaml --wait --timeout 3600
+          anyscale job submit -f ci/anyscale_gpu_ci.yaml --timeout 3600
           anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-ci --timeout 3600


### PR DESCRIPTION
GPU CI is failing after 30min due to timeout, this PR increases it to 1hr. #199 tracks GPU CI migration and shortening test run times. 