### PR TITLE
Clarify ObsType and the observation number

### DIFF
--- a/skyrl-gym/skyrl_gym/core.py
+++ b/skyrl-gym/skyrl_gym/core.py
@@ -23,10 +23,10 @@ class Env(Generic[ObsType, ActType]):
     The main API methods that users of this class need to know are:
 
     - `step` - Perform actions (e.g. tool calls) in the environment.
-        Return the observation, the reward for taking that actions, and a boolean value `done`.
+        Return the observations, the reward for taking that actions, and a boolean value `done`.
 
     - `init` - Initializes the environment to an initial state, required before calling step.
-        Returns the first observation for a turn and information, i.e. metrics, debug info.
+        Returns the first observations for a turn and information, i.e. metrics, debug info.
 
     - `close` - Closes the environment.
         Important when external software is used, i.e. pygame for rendering, databases
@@ -42,9 +42,9 @@ class Env(Generic[ObsType, ActType]):
                 which must be parsed and executed accordingly.
 
         Returns:
-            observation (ObsType): The resulting observation after executing the action.
+            observations (ObsType): The resulting observations after executing the action.
                 For example, this could involve executing a SQL query derived from the LLM response
-                and observing {'role': 'user', 'content': 'str(observation)'} output or any error messages from database.
+                and observing {'role': 'user', 'content': 'str(observations)'} output or any error messages from database.
 
             reward (SupportsFloat): The reward obtained by taking the action.
 
@@ -62,7 +62,7 @@ class Env(Generic[ObsType, ActType]):
         Initialize the environment, returning initial observation and optional metadata.
 
         Returns:
-            observation (ObsType): Observation of the initial state. This is analogous to the observation returned by `step`.
+            observations (ObsType): Observations of the initial state. This is analogous to the observations returned by `step`.
             info (Dict:  This dictionary contains auxiliary information complementing ``observation``. It should be analogous to
                 the ``info`` returned by `step`.
         """

--- a/skyrl-gym/skyrl_gym/envs/base_text_env.py
+++ b/skyrl-gym/skyrl_gym/envs/base_text_env.py
@@ -7,14 +7,14 @@ ConversationType = List[MessageType]
 
 
 class BaseTextEnvStepOutput(TypedDict):
-    observations: List[Dict[str, str]]  # OpenAI API Messages Format
+    observations: ConversationType  # OpenAI API Messages Format
     reward: float
     done: bool
     metadata: Dict[str, Any]
     postprocessed_action: Optional[str] = None
 
 
-class BaseTextEnv(Env[str, str]):
+class BaseTextEnv(Env[ConversationType, str]):
     """
     Base environment class for all text-in / text-out environments.
     Supports tool-calling and multi-turn trajectories.
@@ -22,7 +22,7 @@ class BaseTextEnv(Env[str, str]):
     Exposes only `step`, `init` and `close`.
 
     Input Types:
-        - ObsType: str (tool output, LLM input)
+        - ObsType: ConversationType (tool output, LLM input)
         - ActType: str (LLM output)
     """
 
@@ -62,11 +62,11 @@ class BaseTextEnv(Env[str, str]):
         Runs one environment step.
 
         Return:
-        - new_obs: [{"role": "user", "content": observation}]
+        - observations: [{"role": "user", "content": observation}]
         - reward: float
         - done: bool
         - postprocessed_action: Optional[str]
-        - Dict[str, Any]: any metadata
+        - metadata: Dict[str, Any] any metadata
         """
         pass
 


### PR DESCRIPTION
This PR clarify the difference between `observation` and `observations`, and that `ObsType` holds the latter in the `Env` class.

resolves #198