### PR TITLE
[fix] Skip special tokens for sglang when decoding token ids

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/base.py
+++ b/skyrl-train/skyrl_train/inference_engines/base.py
@@ -16,10 +16,11 @@ class InferenceEngineInput(TypedDict):
 class InferenceEngineOutput(TypedDict):
     # We always return both tokens and text outputs. The tokens are the outputs
     # of inference engine, and the text is the decoded text output. Therefore,
-    # it is guaranteed that tokenizer.decode(response_token_ids) == responses,
+    # it is guaranteed that tokenizer.decode(response_token_ids, skip_special_tokens=True) == responses,
     # but the reverse is not guaranteed, since there are multiple ways to
     # represent the same text with tokens. Therefore, for multi-turn generation,
     # please use token-in-token-out to ensure correctness.
+    # `skip_special_tokens=True` is needed because string responses do not include EOS tokens like `<|im_end|>`
     responses: List[str]
     response_ids: List[List[int]]
     stop_reasons: List[str]

--- a/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
@@ -105,7 +105,7 @@ class RemoteInferenceEngine(InferenceEngineInterface):
                 output_ids.append(cur_output_ids)
                 # SGLang only returns tokens not text when skip_tokenizer_init is True, so
                 # we manually decode it.
-                outputs.append(self.tokenizer.decode(cur_output_ids))
+                outputs.append(self.tokenizer.decode(cur_output_ids, skip_special_tokens=True))
                 finish_reasons.append(output["meta_info"]["finish_reason"]["type"])
         else:
             raise ValueError(f"Invalid engine backend: {self.engine_backend}")

--- a/skyrl-train/skyrl_train/inference_engines/sglang/sglang_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/sglang/sglang_engine.py
@@ -233,7 +233,7 @@ class SGLangInferenceEngine(InferenceEngineInterface):
 
         for output in outputs:
             response_ids.append(output["output_ids"])
-            responses.append(self.tokenizer.decode(output["output_ids"]))
+            responses.append(self.tokenizer.decode(output["output_ids"], skip_special_tokens=True))
             stop_reasons.append(output["meta_info"]["finish_reason"]["type"])
 
         return InferenceEngineOutput(


### PR DESCRIPTION
### Background
Prior PR https://github.com/NovaSky-AI/SkyRL/pull/192 changed `skip_special_token` to True in sampling params for vLLM and SGLang.

Take Qwen as an example, the implication is that:
- For string output, i.e. `InferenceEngineOutput.response`, `<|im_end|>` will be excluded 
- For token IDs output, i.e. `InferenceEngineOutput.response_ids`, the corresponding token **will NOT be excluded**, which is what we want for token-in-token-out

The goal is two folds:
- In SkyRLGymGenerator, `env.step(action)`'s `action` is `InferenceEngineOutput.response`, in which we do not want EOS tokens. This is more consistent with most inference engine output convention
- If users re-tokenize with chat template (e.g. current Qwen3 codepath), the Jinja template applies `<|im_end|>` after `message.content`, meaning that the string content does not expect to include `<|im_end|>`
  - Qwen has Jinja template: `'<|im_start|>' + message.role + '\\n' + message.content + '<|im_end|>' + '\\n'`
  - i.e. without #192, we had `<|im_end|><|im_end|>` since `message.content` includes stop token

### This PR's fix
This PR further fixes for SGLang. We use token-in-token-out for SGLang by passing in `skip_tokenizer_init=True`, which means SGLang does not return string output at all (different from vLLM, which returns both token IDs and string output). Thus, `sampling_params.skip_special_token` has no effect on SGLang. We fix this by adding `skip_special_token=True` when we convert SGLang's output token IDs to string output so its behavior is the same as vLLM backend.

Verified with `test_policy_local_engines_e2e.py`.