### PR TITLE
Fix `torch.autocast` incompatibility with DeepSpeed

### DIFF
--- a/skyrl-train/pyproject.toml
+++ b/skyrl-train/pyproject.toml
@@ -69,7 +69,7 @@ flashinfer-python = [
 
 [project.optional-dependencies]
 deepspeed = [
-    "deepspeed==0.16.5"
+    "deepspeed==0.17.5"
 ]
 dev = [
     "ruff==0.11.9",

--- a/skyrl-train/skyrl_train/config/deepspeed_config/eval.yaml
+++ b/skyrl-train/skyrl_train/config/deepspeed_config/eval.yaml
@@ -5,6 +5,9 @@ zero_optimization:
   offload_param:
     device: cpu # set to cpu for offload, else none
     pin_memory: true
+# set true to use torch.autocast. If false, deepspeed uses its own mixed precision handling
+torch_autocast:
+  enabled: false
 gradient_clipping: 1.0
 prescale_gradient: false
 wall_clock_breakdown: false

--- a/skyrl-train/skyrl_train/config/deepspeed_config/train.yaml
+++ b/skyrl-train/skyrl_train/config/deepspeed_config/train.yaml
@@ -20,6 +20,9 @@ zero_optimization:
   zero_hpz_partition_size: 1
   zero_quantized_weights: false
   zero_quantized_gradients: false
+# set true to use torch.autocast. If false, deepspeed uses its own mixed precision handling
+torch_autocast:
+  enabled: true
 # set true to save memory
 # disables stage3_prefetch_bucket_size, stage3_max_live_parameters, stage3_max_reuse_distance
 disable_trace_cache: false

--- a/skyrl-train/skyrl_train/distributed/deepspeed_strategy.py
+++ b/skyrl-train/skyrl_train/distributed/deepspeed_strategy.py
@@ -374,12 +374,11 @@ class DeepspeedStrategy(DistributedStrategy):
 
         dist.barrier()
 
-    def _set_autocast_config(self, ds_config):
-        ds_config["torch_autocast"] = {
-            "enabled": self.bf16,
-            "dtype": "bfloat16",
-            "lower_precision_safe_modules": ["torch.nn.Linear", "torch.nn.Conv2d"],
-        }
+    def _set_bf16_config(self, ds_config):
+        # torch_autocast.enabled should be set in the config file
+        # So we set the ds_config only if torch_autocast.enabled is not set
+        if not ds_config["torch_autocast"]["enabled"]:
+            ds_config["bf16"] = {"enabled": self.bf16}
 
     def get_ds_train_config(self):
         ds_config = OmegaConf.to_container(self.deepspeed_config)
@@ -389,7 +388,7 @@ class DeepspeedStrategy(DistributedStrategy):
             ds_config["zero_optimization"]["stage3_max_live_parameters"] = 0
             ds_config["zero_optimization"]["stage3_max_reuse_distance"] = 0
         ds_config["steps_per_print"] = 100
-        self._set_autocast_config(ds_config)
+        self._set_bf16_config(ds_config)
 
         # these need to be specified for deepspeed setup, but we manually handle
         # gradient accumulation in the training loop
@@ -401,7 +400,7 @@ class DeepspeedStrategy(DistributedStrategy):
     def get_ds_eval_config(self):
         ds_config = OmegaConf.to_container(self.deepspeed_config)
         ds_config["steps_per_print"] = 100
-        self._set_autocast_config(ds_config)
+        self._set_bf16_config(ds_config)
         ds_config["train_micro_batch_size_per_gpu"] = self.micro_train_batch_size_per_gpu
         ds_config["gradient_accumulation_steps"] = 1
 

--- a/skyrl-train/skyrl_train/distributed/strategy.py
+++ b/skyrl-train/skyrl_train/distributed/strategy.py
@@ -1,6 +1,7 @@
 import random
 import os
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 
 import numpy as np
 import torch
@@ -101,6 +102,15 @@ class DistributedStrategy(ABC):
         model_config.save_pretrained(hf_config_tokenizer_path)
         if tokenizer is not None:
             tokenizer.save_pretrained(hf_config_tokenizer_path)
+
+    @contextmanager
+    def autocast(self, *args, **kwargs):
+        """
+        Context manager for automatic mixed precision using torch.autocast.
+        Passes all arguments directly to torch.autocast.
+        """
+        with torch.autocast(*args, **kwargs):
+            yield
 
     @staticmethod
     def get_rng_state():

--- a/skyrl-train/skyrl_train/workers/worker.py
+++ b/skyrl-train/skyrl_train/workers/worker.py
@@ -688,7 +688,7 @@ class PolicyWorkerBase(Worker):
         rollout_action_logprobs = experience.rollout_logprobs
 
         # TODO (sumanthrh): don't think this does anything for deepspeed or fsdp rn because autocast happens internally
-        with torch.autocast(dtype=torch.bfloat16, device_type="cuda"):
+        with self.strategy.autocast(dtype=torch.bfloat16, device_type="cuda"):
             # actor loss
             action_log_probs, output = self.model(
                 sequences,
@@ -805,7 +805,7 @@ class PolicyWorkerBase(Worker):
         sequences = micro_batch["sequences"]
         response_length = micro_batch.metadata["response_length"]
         attention_mask = micro_batch["attention_mask"]
-        with torch.no_grad(), torch.autocast(dtype=torch.bfloat16, device_type="cuda"):
+        with torch.no_grad(), self.strategy.autocast(dtype=torch.bfloat16, device_type="cuda"):
             policy_logprob = self.model(
                 sequences,
                 response_length,
@@ -859,7 +859,7 @@ class CriticWorkerBase(Worker):
         response_length = micro_batch.metadata["response_length"]
         attention_mask = micro_batch["attention_mask"]
         self.model.eval()
-        with torch.no_grad(), torch.autocast(dtype=torch.bfloat16, device_type="cuda"):
+        with torch.no_grad(), self.strategy.autocast(dtype=torch.bfloat16, device_type="cuda"):
             value = self.model(
                 sequences,
                 response_length,
@@ -940,7 +940,7 @@ class CriticWorkerBase(Worker):
         attention_mask = experience.attention_mask
         loss_mask = experience.loss_mask
 
-        with torch.autocast(dtype=torch.bfloat16, device_type="cuda"):
+        with self.strategy.autocast(dtype=torch.bfloat16, device_type="cuda"):
             # critic loss
             values, output = self.model(
                 sequences,
@@ -1012,7 +1012,7 @@ class RewardWorkerBase(Worker):
         sequences = micro_batch["sequences"]
         attention_mask = micro_batch["attention_mask"]
         self.model.eval()
-        with torch.no_grad(), torch.autocast(dtype=torch.bfloat16, device_type="cuda"):
+        with torch.no_grad(), self.strategy.autocast(dtype=torch.bfloat16, device_type="cuda"):
             reward = self.model(sequences, attention_mask)
         reward = reward.to("cpu")
         output = TrainingOutputBatch(
@@ -1033,7 +1033,7 @@ class RefWorkerBase(Worker):
         sequences = micro_batch["sequences"]
         response_length = micro_batch.metadata["response_length"]
         attention_mask = micro_batch["attention_mask"]
-        with torch.no_grad(), torch.autocast(dtype=torch.bfloat16, device_type="cuda"):
+        with torch.no_grad(), self.strategy.autocast(dtype=torch.bfloat16, device_type="cuda"):
             log_probs = self.model(sequences, response_length, attention_mask, return_output=False)
         log_probs = log_probs.to("cpu")
         output = TrainingOutputBatch(


### PR DESCRIPTION
The current usage of `torch.autocast` has two issues when combined with DeepSpeed:
- `torch.autocast` is not compatible with DeepSpeed's bf16 training. `torch.autocast` expects FP32 parameters, but DeepSpeed converts all parameters to BF16.
- Starting from v0.17.2, DeepSpeed supports `torch.autocast` with ZeRO and uses it internally. If `torch.autocast` is already enabled outside the DeepSpeed engine, it raises an error.

TThis PR updates the behavior as follows:
- Replace `torch.autocast` with `strategy.autocast`, which is nop when DeepSpeed is enabled
  - `strategy.autocast` becomes a no-op when DeepSpeed is enabled.
  - This allows compatibility with newer DeepSpeed versions.
- Add a config item `torch_autocast` in yaml. 
  - If true: DeepSpeed integrates `torch.autocast` with ZeRO, as described [here](https://deepspeed.readthedocs.io/en/latest/training.html#pytorch-automatic-mixed-precision-amp).
  - If false, DeepSpeed uses its own BF16 mixed precision.
  