### PR TITLE
[Fix][Generator] Correct chat history length for retoknenize codepath with env.init

### DIFF
--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -145,6 +145,7 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         # init() returns the first prompt to be given to the model, and optional metadata dict
         chat_history, _ = env.init(chat_history)
+        initial_chat_history_length = len(chat_history)
         chat_end_index = len(chat_history)
         input_ids = self.tokenizer.apply_chat_template(
             chat_history,
@@ -221,7 +222,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         prompt_ids = input_ids[:initial_prompt_length]
         if retokenize_chat_history:
             response_encodings = self.tokenizer.apply_chat_template(
-                chat_history[len(prompt) :],
+                chat_history[initial_chat_history_length :],
                 chat_template=self.custom_chat_template,
                 add_generation_prompt=False,
                 return_dict=True,

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -222,7 +222,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         prompt_ids = input_ids[:initial_prompt_length]
         if retokenize_chat_history:
             response_encodings = self.tokenizer.apply_chat_template(
-                chat_history[initial_chat_history_length :],
+                chat_history[initial_chat_history_length:],
                 chat_template=self.custom_chat_template,
                 add_generation_prompt=False,
                 return_dict=True,


### PR DESCRIPTION
This pull request addresses a bug in the `retokenize_chat_history` codepath within SkyRLGymGenerator. The issue arose when env.init() altered the length of the chat_history, as the original length was incorrectly assumed. The fix introduces initial_chat_history_length to correctly capture the length of the chat history after the env.init() call. This new variable is then used to accurately slice the chat history, separating the initial prompt from the generated turns.

This PR fixes this issue and closes https://github.com/NovaSky-AI/SkyRL/issues/213