### PR TITLE
[tests] Fix gpu offload test

### DIFF
--- a/skyrl-train/tests/gpu/test_worker_offload.py
+++ b/skyrl-train/tests/gpu/test_worker_offload.py
@@ -10,7 +10,7 @@ import os
 import shutil
 
 from tests.gpu.utils import init_worker_with_type, make_dummy_experience, make_dummy_tensorbatch
-from skyrl_train.utils.utils import print_mem
+from skyrl_train.utils.utils import print_mem, validate_cfg
 from skyrl_train.entrypoints.main_base import config_dir
 from skyrl_train.training_batch import TrainingOutputBatch
 
@@ -24,6 +24,7 @@ def get_test_actor_config() -> DictConfig:
     cfg.trainer.policy.model.path = MODEL_NAME
     cfg.trainer.placement.policy_num_gpus_per_node = 2
     cfg.trainer.use_sample_packing = False
+    validate_cfg(cfg)
 
     return cfg
 

--- a/skyrl-train/tests/gpu/utils.py
+++ b/skyrl-train/tests/gpu/utils.py
@@ -20,7 +20,7 @@ from skyrl_train.entrypoints.main_base import config_dir
 from skyrl_train.utils import get_ray_pg_ready_with_timeout
 from skyrl_train.distributed.dispatch import concatenate_outputs_after_mesh_dispatch
 from skyrl_train.generators.base import GeneratorInput, ConversationType
-from skyrl_train.utils.utils import peer_access_supported
+from skyrl_train.utils.utils import peer_access_supported, validate_cfg
 
 
 TEST_DATA_PATH = os.path.expanduser("~/data/gsm8k/validation.parquet")
@@ -85,6 +85,7 @@ def make_dummy_experience(seq_len=10, num_actions=4) -> Experience:
         loss_mask=torch.ones((B, num_actions), dtype=int, device="cpu"),
         action_mask=torch.ones((B, num_actions), dtype=int, device="cpu"),
         num_actions=num_actions,
+        rollout_logprobs=0.4 * torch.ones((B, num_actions), device="cpu"),
         info={},
     )
 

--- a/skyrl-train/tests/gpu/utils.py
+++ b/skyrl-train/tests/gpu/utils.py
@@ -20,7 +20,7 @@ from skyrl_train.entrypoints.main_base import config_dir
 from skyrl_train.utils import get_ray_pg_ready_with_timeout
 from skyrl_train.distributed.dispatch import concatenate_outputs_after_mesh_dispatch
 from skyrl_train.generators.base import GeneratorInput, ConversationType
-from skyrl_train.utils.utils import peer_access_supported, validate_cfg
+from skyrl_train.utils.utils import peer_access_supported
 
 
 TEST_DATA_PATH = os.path.expanduser("~/data/gsm8k/validation.parquet")


### PR DESCRIPTION
Fix small bug in worker offload test so we can check #212


```bash
uv run --extra dev --extra deepspeed --isolated pytest tests/gpu/test_worker_offload.py::test_critic_policy_offload_memory_and_correctness -k deepspeed
```

<img width="327" height="46" alt="image" src="https://github.com/user-attachments/assets/e34a80aa-c83e-4b71-a314-6aaaae60a303" />
