### PR TITLE
[logs] Change print warnings to logger.warning

### DIFF
--- a/skyrl-train/skyrl_train/distributed/strategy.py
+++ b/skyrl-train/skyrl_train/distributed/strategy.py
@@ -97,7 +97,7 @@ class DistributedStrategy(ABC):
             except Exception as e:
                 # if the generation config isn't available, we don't save it
                 logger.warning(
-                    f"Warning: Could not save generation config for '{model_config.name_or_path}'. Error: {e}"
+                    f"Could not save generation config for '{model_config.name_or_path}'. Error: {e}"
                 )
                 pass
 

--- a/skyrl-train/skyrl_train/distributed/strategy.py
+++ b/skyrl-train/skyrl_train/distributed/strategy.py
@@ -96,9 +96,7 @@ class DistributedStrategy(ABC):
                 generation_config.save_pretrained(hf_config_tokenizer_path)
             except Exception as e:
                 # if the generation config isn't available, we don't save it
-                logger.warning(
-                    f"Could not save generation config for '{model_config.name_or_path}'. Error: {e}"
-                )
+                logger.warning(f"Could not save generation config for '{model_config.name_or_path}'. Error: {e}")
                 pass
 
         model_config.save_pretrained(hf_config_tokenizer_path)

--- a/skyrl-train/skyrl_train/distributed/strategy.py
+++ b/skyrl-train/skyrl_train/distributed/strategy.py
@@ -2,6 +2,7 @@ import random
 import os
 from abc import ABC, abstractmethod
 
+from loguru import logger
 import numpy as np
 import torch
 from torch import distributed as dist
@@ -95,7 +96,9 @@ class DistributedStrategy(ABC):
                 generation_config.save_pretrained(hf_config_tokenizer_path)
             except Exception as e:
                 # if the generation config isn't available, we don't save it
-                print(f"Warning: Could not save generation config for '{model_config.name_or_path}'. Error: {e}")
+                logger.warning(
+                    f"Warning: Could not save generation config for '{model_config.name_or_path}'. Error: {e}"
+                )
                 pass
 
         model_config.save_pretrained(hf_config_tokenizer_path)

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -14,6 +14,7 @@ import numpy as np
 from concurrent.futures import ThreadPoolExecutor
 from tqdm.asyncio import tqdm
 from dataclasses import dataclass
+from loguru import logger
 
 from skyrl_train.generators.base import GeneratorInterface, GeneratorInput, GeneratorOutput
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
@@ -201,7 +202,7 @@ class SkyRLGymGenerator(GeneratorInterface):
 
             if env_step_output.get("postprocessed_action", None) is not None:
                 # TODO(Charlie): come back to this, we should deprecate postprocessed action
-                print(
+                logger.warning(
                     "WARNING: postprocessed action may violate token-in-token-out. Ideally you "
                     "post-process it in the token space rather than string space. "
                     "A better solution coming soon."

--- a/skyrl-train/skyrl_train/utils/tracking.py
+++ b/skyrl-train/skyrl_train/utils/tracking.py
@@ -126,7 +126,7 @@ class Tracking:
             if "tensorboard" in self.logger:
                 self.logger["tensorboard"].finish()
         except Exception as e:
-            print(f"WARNING: Attempted to finish tracking but got error {e}")
+            logger.warning(f"WARNING: Attempted to finish tracking but got error {e}")
 
 
 class ConsoleLogger:
@@ -300,4 +300,4 @@ class ValidationGenerationsLogger:
                     json.dump(row_data, file)
                 mlflow.log_artifact(validation_gen_step_file)
         except Exception as e:
-            print(f"WARNING: save validation generation file to mlflow failed with error {e}")
+            logger.warning(f"WARNING: save validation generation file to mlflow failed with error {e}")

--- a/skyrl-train/skyrl_train/utils/tracking.py
+++ b/skyrl-train/skyrl_train/utils/tracking.py
@@ -126,7 +126,7 @@ class Tracking:
             if "tensorboard" in self.logger:
                 self.logger["tensorboard"].finish()
         except Exception as e:
-            logger.warning(f"WARNING: Attempted to finish tracking but got error {e}")
+            logger.warning(f"Attempted to finish tracking but got error {e}")
 
 
 class ConsoleLogger:

--- a/skyrl-train/skyrl_train/utils/tracking.py
+++ b/skyrl-train/skyrl_train/utils/tracking.py
@@ -300,4 +300,4 @@ class ValidationGenerationsLogger:
                     json.dump(row_data, file)
                 mlflow.log_artifact(validation_gen_step_file)
         except Exception as e:
-            logger.warning(f"WARNING: save validation generation file to mlflow failed with error {e}")
+            logger.warning(f"save validation generation file to mlflow failed with error {e}")

--- a/skyrl-train/skyrl_train/utils/trainer_utils.py
+++ b/skyrl-train/skyrl_train/utils/trainer_utils.py
@@ -561,6 +561,4 @@ def validate_generator_output(input_batch: GeneratorInput, generator_output: Gen
 
     # loss masks should be non-zero for at least one element for trainer
     if np.concatenate(generator_output["loss_masks"]).sum() == 0:
-        logger.warning(
-            "All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!"
-        )
+        logger.warning("All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!")

--- a/skyrl-train/skyrl_train/utils/trainer_utils.py
+++ b/skyrl-train/skyrl_train/utils/trainer_utils.py
@@ -562,5 +562,5 @@ def validate_generator_output(input_batch: GeneratorInput, generator_output: Gen
     # loss masks should be non-zero for at least one element for trainer
     if np.concatenate(generator_output["loss_masks"]).sum() == 0:
         logger.warning(
-            "WARNING: All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!"
+            "All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!"
         )

--- a/skyrl-train/skyrl_train/utils/trainer_utils.py
+++ b/skyrl-train/skyrl_train/utils/trainer_utils.py
@@ -561,6 +561,6 @@ def validate_generator_output(input_batch: GeneratorInput, generator_output: Gen
 
     # loss masks should be non-zero for at least one element for trainer
     if np.concatenate(generator_output["loss_masks"]).sum() == 0:
-        logger.info(
+        logger.warning(
             "WARNING: All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!"
         )

--- a/skyrl-train/tests/cpu/test_trainer_utils.py
+++ b/skyrl-train/tests/cpu/test_trainer_utils.py
@@ -735,7 +735,7 @@ def test_validate_generator_output_all_loss_masked():
     with patch("skyrl_train.utils.trainer_utils.logger") as mock_logger:
         validate_generator_output(input_batch, generator_output)
         mock_logger.warning.assert_called_once_with(
-            "WARNING: All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!"
+            "All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!"
         )
 
 

--- a/skyrl-train/tests/cpu/test_trainer_utils.py
+++ b/skyrl-train/tests/cpu/test_trainer_utils.py
@@ -734,7 +734,7 @@ def test_validate_generator_output_all_loss_masked():
     # Capture log output to verify warning is issued
     with patch("skyrl_train.utils.trainer_utils.logger") as mock_logger:
         validate_generator_output(input_batch, generator_output)
-        mock_logger.info.assert_called_once_with(
+        mock_logger.warning.assert_called_once_with(
             "WARNING: All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!"
         )
 


### PR DESCRIPTION
There are various places in the repo where we do `print("WARNING:...")` which can be annoying. This PR changes them to `logger.warning()`.

There are still various print statements throughout the repo, but I will fix the warnings one first.

Related to https://github.com/NovaSky-AI/SkyRL/issues/168