### PR TITLE
[Fix][CI] Fix GPU CI where search needs stop param

### DIFF
--- a/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
@@ -111,6 +111,7 @@ async def run_generator_end_to_end(
                     "max_generate_length": max_generate_length,
                     "min_p": 0.0,
                     "logprobs": None,
+                    "stop": ["</search>", "</answer>"] if env_class == "search" else None,
                 }
             ),
         ),
@@ -130,6 +131,7 @@ async def run_generator_end_to_end(
                 "max_generate_length": max_generate_length,
                 "logprobs": None,
             },
+            "append_eos_token_after_stop_str_in_multi_turn": True,  # for search
             "max_input_length": max_input_length,
             "batched": batched,
             "max_turns": max_turns,


### PR DESCRIPTION
After https://github.com/NovaSky-AI/SkyRL/pull/190, we need to pass `stop` as sampling params for multiturn search / text2sql. Without it, the GPU CI will likely fail