### PR TITLE
[Fix][Generator] Add chat_template in each step retokenization

### DIFF
--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -511,7 +511,10 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         # re-apply whole chat template so length check is correct
         input_ids = self.tokenizer.apply_chat_template(
-            chat_history[:chat_end_index], add_generation_prompt=False, tokenize=True
+            chat_history[:chat_end_index],
+            chat_template=self.custom_chat_template,
+            add_generation_prompt=False,
+            tokenize=True,
         )
         return chat_history, chat_end_index, input_ids
 


### PR DESCRIPTION
Prior to this PR, in the re-tokenize chat history codepath, we did not use `self.custom_chat_template`. Though currently only Qwen3 enters this codepath, which would not be affected. Besides, this `input_ids` is only used for length checking, but it is still good to apply the `custom_chat_template` for consistency.