### PR TITLE
[cleanup] Remove redundant sampling params code path

### DIFF
--- a/skyrl-train/examples/flash_rl/main_dapo_flashrl.py
+++ b/skyrl-train/examples/flash_rl/main_dapo_flashrl.py
@@ -42,7 +42,6 @@ def create_ray_wrapped_inference_engines_from_config_flashrl(cfg: DictConfig, co
         async_engine=cfg.generator.async_engine,
         max_num_batched_tokens=cfg.generator.max_num_batched_tokens,
         max_num_seqs=cfg.generator.max_num_seqs,
-        sampling_params=get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params),
         tokenizer=tokenizer,
         backend=cfg.generator.backend,
     )

--- a/skyrl-train/examples/flash_rl/main_dapo_flashrl.py
+++ b/skyrl-train/examples/flash_rl/main_dapo_flashrl.py
@@ -17,7 +17,6 @@ from skyrl_train.entrypoints.main_base import (
     create_remote_inference_engines_from_config,
 )
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
-from skyrl_train.inference_engines.utils import get_sampling_params_for_backend
 from skyrl_train.generators.base import GeneratorInterface
 from loguru import logger
 from skyrl_train.generators.base import GeneratorOutput

--- a/skyrl-train/examples/gsm8k/run_gsm8k.sh
+++ b/skyrl-train/examples/gsm8k/run_gsm8k.sh
@@ -10,7 +10,7 @@ set -x
 
 DATA_DIR="$HOME/data/gsm8k"
 NUM_GPUS=4
-LOGGER="console"  # change to "console" to print to stdout
+LOGGER="wandb"  # change to "console" to print to stdout
 
 INFERENCE_BACKEND="vllm"
 # INFERENCE_BACKEND="sglang"
@@ -19,7 +19,7 @@ uv run --isolated --extra $INFERENCE_BACKEND -m skyrl_train.entrypoints.main_bas
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \
-  trainer.policy.model.path="Qwen/Qwen2.5-0.5B-Instruct" \
+  trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \
   trainer.placement.colocate_all=true \
   trainer.strategy=fsdp2 \
   trainer.placement.policy_num_gpus_per_node=$NUM_GPUS \
@@ -28,14 +28,14 @@ uv run --isolated --extra $INFERENCE_BACKEND -m skyrl_train.entrypoints.main_bas
   generator.inference_engine_tensor_parallel_size=1 \
   trainer.epochs=20 \
   trainer.eval_batch_size=1024 \
-  trainer.eval_before_train=false \
+  trainer.eval_before_train=true \
   trainer.eval_interval=5 \
   trainer.update_epochs_per_batch=1 \
   trainer.train_batch_size=1024 \
   trainer.policy_mini_batch_size=256 \
   trainer.micro_forward_batch_size_per_gpu=64 \
   trainer.micro_train_batch_size_per_gpu=64 \
-  trainer.ckpt_interval=-1 \
+  trainer.ckpt_interval=10 \
   trainer.max_prompt_length=512 \
   generator.sampling_params.max_generate_length=1024 \
   trainer.policy.optimizer_config.lr=1.0e-6 \

--- a/skyrl-train/examples/gsm8k/run_gsm8k.sh
+++ b/skyrl-train/examples/gsm8k/run_gsm8k.sh
@@ -10,7 +10,7 @@ set -x
 
 DATA_DIR="$HOME/data/gsm8k"
 NUM_GPUS=4
-LOGGER="wandb"  # change to "console" to print to stdout
+LOGGER="console"  # change to "console" to print to stdout
 
 INFERENCE_BACKEND="vllm"
 # INFERENCE_BACKEND="sglang"
@@ -19,7 +19,7 @@ uv run --isolated --extra $INFERENCE_BACKEND -m skyrl_train.entrypoints.main_bas
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \
-  trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \
+  trainer.policy.model.path="Qwen/Qwen2.5-0.5B-Instruct" \
   trainer.placement.colocate_all=true \
   trainer.strategy=fsdp2 \
   trainer.placement.policy_num_gpus_per_node=$NUM_GPUS \
@@ -28,14 +28,14 @@ uv run --isolated --extra $INFERENCE_BACKEND -m skyrl_train.entrypoints.main_bas
   generator.inference_engine_tensor_parallel_size=1 \
   trainer.epochs=20 \
   trainer.eval_batch_size=1024 \
-  trainer.eval_before_train=true \
+  trainer.eval_before_train=false \
   trainer.eval_interval=5 \
   trainer.update_epochs_per_batch=1 \
   trainer.train_batch_size=1024 \
   trainer.policy_mini_batch_size=256 \
   trainer.micro_forward_batch_size_per_gpu=64 \
   trainer.micro_train_batch_size_per_gpu=64 \
-  trainer.ckpt_interval=10 \
+  trainer.ckpt_interval=-1 \
   trainer.max_prompt_length=512 \
   generator.sampling_params.max_generate_length=1024 \
   trainer.policy.optimizer_config.lr=1.0e-6 \

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -181,10 +181,10 @@ generator:
   # sampling params for generation phase
   sampling_params:
     max_generate_length: 1024
-    temperature: 1.1
-    top_p: 0.1
-    min_p: 0.1
-    top_k: 100
+    temperature: 1.0
+    top_p: 1.0
+    min_p: 0.0
+    top_k: -1
     logprobs: null
     stop: null
 

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -181,10 +181,10 @@ generator:
   # sampling params for generation phase
   sampling_params:
     max_generate_length: 1024
-    temperature: 1.0
-    top_p: 1.0
-    min_p: 0.0
-    top_k: -1
+    temperature: 1.1
+    top_p: 0.1
+    min_p: 0.1
+    top_k: 100
     logprobs: null
     stop: null
 

--- a/skyrl-train/skyrl_train/entrypoints/main_base.py
+++ b/skyrl-train/skyrl_train/entrypoints/main_base.py
@@ -55,7 +55,7 @@ def create_ray_wrapped_inference_engines_from_config(cfg: DictConfig, colocate_p
         async_engine=cfg.generator.async_engine,
         max_num_batched_tokens=cfg.generator.max_num_batched_tokens,
         max_num_seqs=cfg.generator.max_num_seqs,
-        sampling_params=get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params),
+        # sampling_params=get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params),
         tokenizer=tokenizer,
         backend=cfg.generator.backend,
     )
@@ -69,7 +69,7 @@ def create_remote_inference_engines_from_config(cfg: DictConfig, tokenizer: PreT
         engine_backend=cfg.generator.backend,
         tokenizer=tokenizer,
         tensor_parallel_size=cfg.generator.inference_engine_tensor_parallel_size,
-        sampling_params=get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params),
+        # sampling_params=get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params),
     )
 
 

--- a/skyrl-train/skyrl_train/entrypoints/main_base.py
+++ b/skyrl-train/skyrl_train/entrypoints/main_base.py
@@ -14,7 +14,6 @@ from skyrl_train.trainer import RayPPOTrainer
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
 from skyrl_train.inference_engines.remote_inference_engine import create_remote_inference_engines
 from skyrl_train.utils.utils import initialize_ray, get_ray_pg_ready_with_timeout
-from skyrl_train.inference_engines.utils import get_sampling_params_for_backend
 from skyrl_train.generators.base import GeneratorInterface
 from omegaconf import OmegaConf, DictConfig
 from pathlib import Path
@@ -55,7 +54,6 @@ def create_ray_wrapped_inference_engines_from_config(cfg: DictConfig, colocate_p
         async_engine=cfg.generator.async_engine,
         max_num_batched_tokens=cfg.generator.max_num_batched_tokens,
         max_num_seqs=cfg.generator.max_num_seqs,
-        # sampling_params=get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params),
         tokenizer=tokenizer,
         backend=cfg.generator.backend,
     )
@@ -69,7 +67,6 @@ def create_remote_inference_engines_from_config(cfg: DictConfig, tokenizer: PreT
         engine_backend=cfg.generator.backend,
         tokenizer=tokenizer,
         tensor_parallel_size=cfg.generator.inference_engine_tensor_parallel_size,
-        # sampling_params=get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params),
     )
 
 

--- a/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -1,7 +1,7 @@
 import ray
 from packaging import version
 from ray.actor import ActorHandle
-from typing import Dict, Any, Optional, List
+from typing import Any, List
 from ray.util.placement_group import PlacementGroupSchedulingStrategy, placement_group
 
 from skyrl_train.inference_engines.base import (
@@ -67,7 +67,6 @@ def create_ray_wrapped_inference_engines(
     async_engine=False,
     max_num_batched_tokens=8192,
     max_num_seqs=1024,
-    # sampling_params: Optional[Dict[str, Any]] = None,
     tokenizer=None,
     backend="vllm",
 ) -> List[InferenceEngineInterface]:
@@ -145,7 +144,6 @@ def create_ray_wrapped_inference_engines(
                 noset_visible_devices=noset_visible_devices,
                 max_num_batched_tokens=max_num_batched_tokens,
                 max_num_seqs=max_num_seqs,
-                # sampling_params=sampling_params,
                 # only need the logprobs for the chosen token if any
                 max_logprobs=1,
             )
@@ -191,7 +189,6 @@ def create_ray_wrapped_inference_engines(
                     noset_visible_devices=noset_visible_devices,
                     bundle_indices=bundle_indices,
                     num_gpus=0.2 if use_hybrid_engine else 1,
-                    # sampling_params=sampling_params,
                     tokenizer=tokenizer,
                 )
                 return engine

--- a/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -67,7 +67,7 @@ def create_ray_wrapped_inference_engines(
     async_engine=False,
     max_num_batched_tokens=8192,
     max_num_seqs=1024,
-    sampling_params: Optional[Dict[str, Any]] = None,
+    # sampling_params: Optional[Dict[str, Any]] = None,
     tokenizer=None,
     backend="vllm",
 ) -> List[InferenceEngineInterface]:
@@ -145,7 +145,7 @@ def create_ray_wrapped_inference_engines(
                 noset_visible_devices=noset_visible_devices,
                 max_num_batched_tokens=max_num_batched_tokens,
                 max_num_seqs=max_num_seqs,
-                sampling_params=sampling_params,
+                # sampling_params=sampling_params,
                 # only need the logprobs for the chosen token if any
                 max_logprobs=1,
             )
@@ -191,7 +191,7 @@ def create_ray_wrapped_inference_engines(
                     noset_visible_devices=noset_visible_devices,
                     bundle_indices=bundle_indices,
                     num_gpus=0.2 if use_hybrid_engine else 1,
-                    sampling_params=sampling_params,
+                    # sampling_params=sampling_params,
                     tokenizer=tokenizer,
                 )
                 return engine

--- a/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
@@ -5,7 +5,7 @@ from skyrl_train.inference_engines.base import (
     InferenceEngineOutput,
     NamedWeightsUpdateRequest,
 )
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Any
 import json
 from transformers import PreTrainedTokenizerBase
 
@@ -22,15 +22,12 @@ class RemoteInferenceEngine(InferenceEngineInterface):
         engine_backend: str,
         tokenizer: PreTrainedTokenizerBase,
         tp_size: Optional[int] = None,
-        # sampling_params: Optional[Dict[str, Any]] = None,
     ):
         """Initialize the InferenceEngine."""
         self.url = f"http://{url}"
         self.model_name = model_name
         self.engine_backend = engine_backend
         self.tp_size = tp_size
-        # self.sampling_params = sampling_params if sampling_params is not None else {}
-        # TODO: maybe
         self.sampling_params = {}
         self.tokenizer = tokenizer
 
@@ -213,7 +210,6 @@ def create_remote_inference_engines(
     engine_backend: str,
     tokenizer: PreTrainedTokenizerBase,
     tensor_parallel_size: Optional[int] = None,
-    # sampling_params: Optional[Dict[str, Any]] = None,
 ):
     return [
         RemoteInferenceEngine(
@@ -222,7 +218,6 @@ def create_remote_inference_engines(
             tokenizer=tokenizer,
             engine_backend=engine_backend,
             tp_size=tensor_parallel_size,
-            # sampling_params=sampling_params,
         )
         for url in urls
     ]

--- a/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/remote_inference_engine.py
@@ -22,14 +22,16 @@ class RemoteInferenceEngine(InferenceEngineInterface):
         engine_backend: str,
         tokenizer: PreTrainedTokenizerBase,
         tp_size: Optional[int] = None,
-        sampling_params: Optional[Dict[str, Any]] = None,
+        # sampling_params: Optional[Dict[str, Any]] = None,
     ):
         """Initialize the InferenceEngine."""
         self.url = f"http://{url}"
         self.model_name = model_name
         self.engine_backend = engine_backend
         self.tp_size = tp_size
-        self.sampling_params = sampling_params if sampling_params is not None else {}
+        # self.sampling_params = sampling_params if sampling_params is not None else {}
+        # TODO: maybe
+        self.sampling_params = {}
         self.tokenizer = tokenizer
 
     async def generate(self, input_batch: InferenceEngineInput) -> InferenceEngineOutput:
@@ -211,7 +213,7 @@ def create_remote_inference_engines(
     engine_backend: str,
     tokenizer: PreTrainedTokenizerBase,
     tensor_parallel_size: Optional[int] = None,
-    sampling_params: Optional[Dict[str, Any]] = None,
+    # sampling_params: Optional[Dict[str, Any]] = None,
 ):
     return [
         RemoteInferenceEngine(
@@ -220,7 +222,7 @@ def create_remote_inference_engines(
             tokenizer=tokenizer,
             engine_backend=engine_backend,
             tp_size=tensor_parallel_size,
-            sampling_params=sampling_params,
+            # sampling_params=sampling_params,
         )
         for url in urls
     ]

--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -159,10 +159,11 @@ class BaseVLLMInferenceEngine(InferenceEngineInterface):
 
         # Store common attributes
         self._tp_size = kwargs.get("tensor_parallel_size", 1)
-        sampling_params_dict = kwargs.pop("sampling_params", None)
-        self.sampling_params = (
-            SamplingParams(**sampling_params_dict) if sampling_params_dict is not None else SamplingParams()
-        )
+        # sampling_params_dict = kwargs.pop("sampling_params", None)
+        self.sampling_params = SamplingParams()
+        # self.sampling_params = (
+        #     SamplingParams(**sampling_params_dict) if sampling_params_dict is not None else SamplingParams()
+        # )
 
         # Let subclass create the appropriate engine
         self.llm = self._create_engine(*args, **kwargs)
@@ -188,6 +189,8 @@ class BaseVLLMInferenceEngine(InferenceEngineInterface):
         sampling_params = (
             SamplingParams(**request_sampling_params) if request_sampling_params is not None else self.sampling_params
         )
+        
+        print(f"sampling_params: {sampling_params}")
 
         return prompt_token_ids, sampling_params
 

--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -159,11 +159,7 @@ class BaseVLLMInferenceEngine(InferenceEngineInterface):
 
         # Store common attributes
         self._tp_size = kwargs.get("tensor_parallel_size", 1)
-        # sampling_params_dict = kwargs.pop("sampling_params", None)
         self.sampling_params = SamplingParams()
-        # self.sampling_params = (
-        #     SamplingParams(**sampling_params_dict) if sampling_params_dict is not None else SamplingParams()
-        # )
 
         # Let subclass create the appropriate engine
         self.llm = self._create_engine(*args, **kwargs)
@@ -189,8 +185,6 @@ class BaseVLLMInferenceEngine(InferenceEngineInterface):
         sampling_params = (
             SamplingParams(**request_sampling_params) if request_sampling_params is not None else self.sampling_params
         )
-        
-        print(f"sampling_params: {sampling_params}")
 
         return prompt_token_ids, sampling_params
 

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -263,7 +263,7 @@ class RayPPOTrainer:
                     # 0. truncate data to have even shards
                     rand_prompts = self._remove_tail_data(rand_prompts)
                     generator_input, uids = self._prepare_generator_input(
-                        self.cfg.generator.n_samples_per_prompt, rand_prompts
+                        self.cfg.generator.n_samples_per_prompt, rand_prompts, self.cfg.generator.sampling_params
                     )
 
                     # if we are continuing sampling, we don't want to trigger weight management

--- a/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py
@@ -33,6 +33,13 @@ def get_test_actor_config() -> DictConfig:
         cfg = hydra.compose(config_name="ppo_base_config")
 
         cfg.trainer.policy.model.path = MODEL
+        
+        cfg.generator.sampling_params.temperature = 0.0
+        cfg.generator.sampling_params.top_p = 1
+        cfg.generator.sampling_params.top_k = -1
+        cfg.generator.sampling_params.max_generate_length = 1024
+        cfg.generator.sampling_params.min_p = 0.0
+        cfg.generator.sampling_params.logprobs = None
 
         return cfg
 
@@ -133,22 +140,10 @@ def init_remote_inference_servers(
         tokenizer=tokenizer,
         engine_backend=backend,
         tensor_parallel_size=tp_size,
-        sampling_params=get_sampling_params_for_backend(
-            backend,
-            DictConfig(
-                {
-                    "temperature": 0.0,
-                    "top_p": 1,
-                    "top_k": -1,
-                    "max_generate_length": 1024,
-                    "min_p": 0.0,
-                    "logprobs": None,
-                }
-            ),
-        ),
     )
 
-    return InferenceEngineClient(engines, tokenizer), server_process
+    client = InferenceEngineClient(engines, tokenizer)
+    return client, server_process
 
 
 def init_ray_inference_engines(backend: str, tp_size: int) -> InferenceEngineClient:
@@ -170,19 +165,6 @@ def init_ray_inference_engines(backend: str, tp_size: int) -> InferenceEngineCli
         async_engine=True,
         max_num_batched_tokens=8192,
         max_num_seqs=1024,
-        sampling_params=get_sampling_params_for_backend(
-            backend,
-            DictConfig(
-                {
-                    "temperature": 0.0,
-                    "top_p": 1,
-                    "top_k": -1,
-                    "max_generate_length": 1024,
-                    "min_p": 0.0,
-                    "logprobs": None,
-                }
-            ),
-        ),
         tokenizer=tokenizer,
         backend=backend,
     )
@@ -190,16 +172,16 @@ def init_ray_inference_engines(backend: str, tp_size: int) -> InferenceEngineCli
     return client
 
 
-async def run_batch_generation(client, prompts):
-    engine_input = InferenceEngineInput(prompts=prompts)
+async def run_batch_generation(client, prompts, sampling_params):
+    engine_input = InferenceEngineInput(prompts=prompts, sampling_params=sampling_params)
     engine_output = await client.generate(engine_input)
     return engine_output["responses"], engine_output["stop_reasons"]
 
 
-async def run_single_generation(client, prompts):
+async def run_single_generation(client, prompts, sampling_params):
     tasks = []
     for prompt in prompts:
-        engine_input = InferenceEngineInput(prompts=[prompt])
+        engine_input = InferenceEngineInput(prompts=[prompt], sampling_params=sampling_params)
         task = client.generate(engine_input)
         tasks.append(task)
 
@@ -214,16 +196,16 @@ async def run_single_generation(client, prompts):
     return responses, finish_reasons
 
 
-async def run_batch_generation_with_tokens(client, prompt_token_ids):
-    engine_input = InferenceEngineInput(prompt_token_ids=prompt_token_ids)
+async def run_batch_generation_with_tokens(client, prompt_token_ids, sampling_params):
+    engine_input = InferenceEngineInput(prompt_token_ids=prompt_token_ids, sampling_params=sampling_params)
     engine_output = await client.generate(engine_input)
     return engine_output["responses"], engine_output["stop_reasons"]
 
 
-async def run_single_generation_with_tokens(client, prompt_token_ids):
+async def run_single_generation_with_tokens(client, prompt_token_ids, sampling_params):
     tasks = []
     for tokens in prompt_token_ids:
-        engine_input = InferenceEngineInput(prompt_token_ids=[tokens])
+        engine_input = InferenceEngineInput(prompt_token_ids=[tokens], sampling_params=sampling_params)
         task = client.generate(engine_input)
         tasks.append(task)
 
@@ -293,9 +275,10 @@ def test_inference_engines_generation(backend: str, tp_size: int):
 
         # Get responses from Ray engine
         llm_client = init_ray_inference_engines(backend, tp_size)
+        sampling_params = get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params)
 
         # Batched generation
-        local_batch_responses, batch_finish_reasons = asyncio.run(run_batch_generation(llm_client, prompts))
+        local_batch_responses, batch_finish_reasons = asyncio.run(run_batch_generation(llm_client, prompts, sampling_params))
         assert len(local_batch_responses) == len(
             prompts
         ), f"Number of responses should match number of prompts, got {len(local_batch_responses)} responses but {len(prompts)} prompts"
@@ -304,7 +287,7 @@ def test_inference_engines_generation(backend: str, tp_size: int):
         ), f"Number of finish reasons should match number of prompts, got {len(batch_finish_reasons)} finish reasons but {len(prompts)} prompts"
 
         # Single generation (ie, submit individual requests)
-        local_single_responses, single_finish_reasons = asyncio.run(run_single_generation(llm_client, prompts))
+        local_single_responses, single_finish_reasons = asyncio.run(run_single_generation(llm_client, prompts, sampling_params))
         assert len(local_single_responses) == len(
             prompts
         ), f"Number of responses should match number of prompts, got {len(local_single_responses)} responses but {len(prompts)} prompts"
@@ -354,17 +337,18 @@ def test_token_based_generation(backend: str, tp_size: int):
         )["input_ids"]
 
         llm_client = init_ray_inference_engines(backend, tp_size)
+        sampling_params = get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params)
 
         # Test batch generation with tokens
-        token_batch_responses, _ = asyncio.run(run_batch_generation_with_tokens(llm_client, prompt_token_ids))
+        token_batch_responses, _ = asyncio.run(run_batch_generation_with_tokens(llm_client, prompt_token_ids, sampling_params))
         assert len(token_batch_responses) == len(prompts)
 
         # Test single generation with tokens
-        token_single_responses, _ = asyncio.run(run_single_generation_with_tokens(llm_client, prompt_token_ids))
+        token_single_responses, _ = asyncio.run(run_single_generation_with_tokens(llm_client, prompt_token_ids, sampling_params))
         assert len(token_single_responses) == len(prompts)
 
         # Compare with prompt-based generation
-        prompt_responses, _ = asyncio.run(run_batch_generation(llm_client, prompts))
+        prompt_responses, _ = asyncio.run(run_batch_generation(llm_client, prompts, sampling_params))
 
         # Outputs should be similar since we're using the same inputs
         for i in range(len(prompts)):

--- a/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py
@@ -33,7 +33,7 @@ def get_test_actor_config() -> DictConfig:
         cfg = hydra.compose(config_name="ppo_base_config")
 
         cfg.trainer.policy.model.path = MODEL
-        
+
         cfg.generator.sampling_params.temperature = 0.0
         cfg.generator.sampling_params.top_p = 1
         cfg.generator.sampling_params.top_k = -1
@@ -278,7 +278,9 @@ def test_inference_engines_generation(backend: str, tp_size: int):
         sampling_params = get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params)
 
         # Batched generation
-        local_batch_responses, batch_finish_reasons = asyncio.run(run_batch_generation(llm_client, prompts, sampling_params))
+        local_batch_responses, batch_finish_reasons = asyncio.run(
+            run_batch_generation(llm_client, prompts, sampling_params)
+        )
         assert len(local_batch_responses) == len(
             prompts
         ), f"Number of responses should match number of prompts, got {len(local_batch_responses)} responses but {len(prompts)} prompts"
@@ -287,7 +289,9 @@ def test_inference_engines_generation(backend: str, tp_size: int):
         ), f"Number of finish reasons should match number of prompts, got {len(batch_finish_reasons)} finish reasons but {len(prompts)} prompts"
 
         # Single generation (ie, submit individual requests)
-        local_single_responses, single_finish_reasons = asyncio.run(run_single_generation(llm_client, prompts, sampling_params))
+        local_single_responses, single_finish_reasons = asyncio.run(
+            run_single_generation(llm_client, prompts, sampling_params)
+        )
         assert len(local_single_responses) == len(
             prompts
         ), f"Number of responses should match number of prompts, got {len(local_single_responses)} responses but {len(prompts)} prompts"
@@ -340,11 +344,15 @@ def test_token_based_generation(backend: str, tp_size: int):
         sampling_params = get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params)
 
         # Test batch generation with tokens
-        token_batch_responses, _ = asyncio.run(run_batch_generation_with_tokens(llm_client, prompt_token_ids, sampling_params))
+        token_batch_responses, _ = asyncio.run(
+            run_batch_generation_with_tokens(llm_client, prompt_token_ids, sampling_params)
+        )
         assert len(token_batch_responses) == len(prompts)
 
         # Test single generation with tokens
-        token_single_responses, _ = asyncio.run(run_single_generation_with_tokens(llm_client, prompt_token_ids, sampling_params))
+        token_single_responses, _ = asyncio.run(
+            run_single_generation_with_tokens(llm_client, prompt_token_ids, sampling_params)
+        )
         assert len(token_single_responses) == len(prompts)
 
         # Compare with prompt-based generation

--- a/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
@@ -101,20 +101,6 @@ async def run_generator_end_to_end(
         max_num_batched_tokens=8192,
         max_num_seqs=1024,
         tokenizer=tokenizer,
-        sampling_params=get_sampling_params_for_backend(
-            "vllm",
-            DictConfig(
-                {
-                    "temperature": 1.0,
-                    "top_p": 1.0,
-                    "top_k": -1,
-                    "max_generate_length": max_generate_length,
-                    "min_p": 0.0,
-                    "logprobs": None,
-                    "stop": ["</search>", "</answer>"] if env_class == "search" else None,
-                }
-            ),
-        ),
     )
 
     inference_engine_client = InferenceEngineClient(
@@ -168,6 +154,21 @@ async def run_generator_end_to_end(
         max_prompt_length=max_prompt_length,
         data_path=data_path,
         env_class=env_class,
+    )
+    # Attach request-time sampling params into the generator input
+    input_batch["sampling_params"] = get_sampling_params_for_backend(
+        "vllm",
+        DictConfig(
+            {
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "top_k": -1,
+                "max_generate_length": max_generate_length,
+                "min_p": 0.0,
+                "logprobs": None,
+                "stop": ["</search>", "</answer>"] if env_class == "search" else None,
+            }
+        ),
     )
 
     with Timer(f"generate_responses_async_engine_{use_async_engine}"):


### PR DESCRIPTION
## What does this PR do?
Currently, the code base has two paths for plumbing the sampling params in the training config to the inference engine requests.

Path 1) At inference engine initialization time, e.g. in `main_base.py`, the sampling params are passed into the constructor and saved as a member variable of the engine class.

Path 2) Each call to `Generator.generate()` pass in the sampling params from the `generator` config, which are then passed to the inference engines as part of `InferenceEngineInput`. 

This PR removes Path 1. Path 1 is less visible and more surprising. Further, users are used to each inference request carrying sampling params (rather than having a saved default in the engine itself), so it is more natural.