### PR TITLE
[Fix] Fix failing sglang test after #234 

### DIFF
--- a/skyrl-train/ci/gpu_ci_run.sh
+++ b/skyrl-train/ci/gpu_ci_run.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 export CI=true
 # Prepare datasets used in tests.
 uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k

--- a/skyrl-train/ci/gpu_e2e_test_run.sh
+++ b/skyrl-train/ci/gpu_e2e_test_run.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 bash tests/gpu/gpu_e2e_test/gsm8k_colocate.sh


### PR DESCRIPTION
# What does this PR do?

Fixes failing sglang test after #234 


The failure:

```bash
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/gpu/gpu_ci/test_engine_generation.py::test_inference_engines_generation[sglang] - TypeError: run_batch_generation() missing 1 required positional argument: 'sampling_params'
====== 1 failed, 2 passed, 25 deselected, 32 warnings in 94.94s (0:01:34) ======
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```


After fixes in this PR: 


```bash
...

=========================================================================================== warnings summary ============================================================================================
tests/gpu/gpu_ci/test_engine_generation.py:226
  /home/ray/default/SkyRL/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py:226: PytestUnknownMarkWarning: Unknown pytest.mark.vllm - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytest.param("vllm", 2, marks=pytest.mark.vllm),

tests/gpu/gpu_ci/test_engine_generation.py:228
  /home/ray/default/SkyRL/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py:228: PytestUnknownMarkWarning: Unknown pytest.mark.sglang - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytest.param("sglang", 1, marks=pytest.mark.sglang),

tests/gpu/gpu_ci/test_engine_generation.py:325
  /home/ray/default/SkyRL/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py:325: PytestUnknownMarkWarning: Unknown pytest.mark.vllm - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytest.param("vllm", 2, marks=pytest.mark.vllm),

tests/gpu/gpu_ci/test_engine_generation.py:327
  /home/ray/default/SkyRL/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py:327: PytestUnknownMarkWarning: Unknown pytest.mark.sglang - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytest.param("sglang", 1, marks=pytest.mark.sglang),

tests/gpu/gpu_ci/test_engine_generation.py::test_inference_engines_generation[sglang]
tests/gpu/gpu_ci/test_engine_generation.py::test_token_based_generation[sglang]
  /home/ray/default/SkyRL/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py:32: UserWarning: 
  The version_base parameter is not specified.
  Please specify a compatability version level, or None.
  Will assume defaults for version 1.1
    with hydra.initialize_config_dir(config_dir=config_dir):

tests/gpu/gpu_ci/test_engine_generation.py: 18 warnings
  /home/ray/.cache/uv/builds-v0/.tmpJvEBqw/lib/python3.12/site-packages/multiprocess/popen_fork.py:66: DeprecationWarning: This process (pid=613265) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

tests/gpu/gpu_ci/test_engine_generation.py::test_inference_engines_generation[sglang]
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

tests/gpu/gpu_ci/test_engine_generation.py::test_inference_engines_generation[sglang]
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================= 2 passed, 2 deselected, 26 warnings in 162.71s (0:02:42) ========================================================================
```

