### PR TITLE
[Generator] Run env methods in threadpool executor

### DIFF
--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -145,7 +145,11 @@ class SkyRLGymGenerator(GeneratorInterface):
         chat_history = copy.deepcopy(prompt)
 
         # init() returns the first prompt to be given to the model, and optional metadata dict
-        chat_history, _ = env.init(chat_history)
+        if self.env_executor is not None:
+            loop = asyncio.get_running_loop()
+            chat_history, _ = await loop.run_in_executor(self.env_executor, env.init, chat_history)
+        else:
+            chat_history, _ = env.init(chat_history)
         initial_chat_history_length = len(chat_history)
         chat_end_index = len(chat_history)
         input_ids = self.tokenizer.apply_chat_template(

--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -96,6 +96,13 @@ class SkyRLGymGenerator(GeneratorInterface):
             )
             self.base_conversation_token_ids = self.base_conversation_token_ids[: last_eos_token_index + 1]
 
+    async def _run_in_executor_if_available(self, func, *args, **kwargs):
+        if (executor := self.env_executor) is not None:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(executor, func, *args, **kwargs)
+        else:
+            return func(*args, **kwargs)
+
     async def agent_loop(
         self,
         prompt: ConversationType,
@@ -145,11 +152,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         chat_history = copy.deepcopy(prompt)
 
         # init() returns the first prompt to be given to the model, and optional metadata dict
-        if self.env_executor is not None:
-            loop = asyncio.get_running_loop()
-            chat_history, _ = await loop.run_in_executor(self.env_executor, env.init, chat_history)
-        else:
-            chat_history, _ = env.init(chat_history)
+        chat_history, _ = await self._run_in_executor_if_available(env.init, chat_history)
         initial_chat_history_length = len(chat_history)
         chat_end_index = len(chat_history)
         input_ids = self.tokenizer.apply_chat_template(
@@ -196,11 +199,7 @@ class SkyRLGymGenerator(GeneratorInterface):
                     output_ids.append(self.tokenizer.eos_token_id)
 
             # 2. Environment step
-            if self.env_executor is not None:
-                loop = asyncio.get_running_loop()
-                env_step_output: BaseTextEnvStepOutput = await loop.run_in_executor(self.env_executor, env.step, output)
-            else:
-                env_step_output: BaseTextEnvStepOutput = env.step(output)
+            env_step_output: BaseTextEnvStepOutput = await self._run_in_executor_if_available(env.step, output)
             new_obs = env_step_output["observations"]
             reward = env_step_output["reward"]
             done = env_step_output["done"]
@@ -237,7 +236,7 @@ class SkyRLGymGenerator(GeneratorInterface):
                 stop_reason = "length"
                 break
 
-        env.close()
+        await self._run_in_executor_if_available(env.close)
 
         prompt_ids = input_ids[:initial_prompt_length]
         if retokenize_chat_history:
@@ -310,7 +309,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             env_extra["max_turns"] = self.max_turns
             env_config = self.skyrl_gym_cfg.get(env_class, DictConfig({}))
             env = skyrl_gym.make(env_class, env_config=env_config, extras=env_extra)
-            init_prompt, _ = env.init(prompt)
+            init_prompt, _ = await self._run_in_executor_if_available(env.init, prompt)
             init_prompts.append(init_prompt)
             envs.append(env)
 
@@ -329,7 +328,7 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         for i, (response, response_ids, env) in enumerate(zip(responses, all_response_ids, envs)):
             # step on environment and compute reward
-            env_step_output: BaseTextEnvStepOutput = env.step(response)
+            env_step_output: BaseTextEnvStepOutput = await self._run_in_executor_if_available(env.step, response)
             reward = env_step_output["reward"]
             rewards.append(reward)
 
@@ -341,7 +340,7 @@ class SkyRLGymGenerator(GeneratorInterface):
                 sample_logprobs = logprobs[i][: len(response_ids)]
                 truncated_logprobs.append(sample_logprobs)
 
-            env.close()
+            await self._run_in_executor_if_available(env.close)
 
         prompt_token_ids = self.tokenizer.apply_chat_template(prompts, add_generation_prompt=True, tokenize=True)
         responses = truncated_responses


### PR DESCRIPTION
# What does this PR do?

Makes all calls to environment in SkyRLGymGenerator asynchronous.

Calls to env.init/step/close may have expensive blocking operations, in which case the entire process is blocked waiting for each env method call to complete sequentially. By submitting all environment calls to a threadpool the same way we do for env.step, all blocking operations in the environment can happen concurrently.

# Tests
I didn't add tests since it looks like this code path is covered by existing e2e tests and I'm not sure it's worth adding a specific test case for.

I did run this myself with my own environment and confirmed that my blocking network operations are now executed concurrently, resulting in significant time savings (about 15% reduction in step time)