### PR TITLE
[fix] finish mlflow run

### DIFF
--- a/skyrl-train/skyrl_train/utils/tracking.py
+++ b/skyrl-train/skyrl_train/utils/tracking.py
@@ -184,6 +184,7 @@ class _MlflowLoggingAdapter:
 
     def finish(self):
         import mlflow
+
         mlflow.end_run()
 
 


### PR DESCRIPTION
This PR calls the `end_run` MLflow method to finish the run at the end.