### PR TITLE
2/N Terminal Bench Integration

### DIFF
--- a/skyrl-train/examples/terminal_bench/entrypoints/main_tbench_generate.py
+++ b/skyrl-train/examples/terminal_bench/entrypoints/main_tbench_generate.py
@@ -50,10 +50,20 @@ class TerminalBenchGenerateExp(BasePPOExp):
     def run(self):
         generator = self._setup_generator()
 
-        # TODO(tgriggs): Plumb the sandboxes task list here instead of an empty prompt
-        num_prompts = 16
+        # Build input from the training dataset
+        num_prompts = len(self.train_dataset)
+        prompts = []
+        env_extras = []
+        for i in range(num_prompts):
+            prompt, _, extra = self.train_dataset[i]
+            prompts.append(prompt)
+            env_extras.append(extra)
+
         input_batch = GeneratorInput(
-            prompts=["" for _ in range(num_prompts)],
+            prompts=prompts,
+            env_classes=None,
+            env_extras=env_extras,
+            sampling_params=None,
         )
 
         # Start generation

--- a/skyrl-train/examples/terminal_bench/generator/terminal_bench_generator.py
+++ b/skyrl-train/examples/terminal_bench/generator/terminal_bench_generator.py
@@ -49,13 +49,13 @@ class TerminalBenchGenerator(GeneratorInterface):
         self.max_episodes = terminal_bench_cfg.max_episodes
 
     async def generate(self, input_batch: GeneratorInput) -> GeneratorOutput:
-        # TODO(tgriggs): Plumb the sandboxes task list here instead of using (and ignoring) empty prompts
-        prompts = input_batch["prompts"]
+        task_paths = [extra["terminal_bench"]["task_path"] for extra in input_batch["env_extras"]]
+
         tasks = []
-        for _ in range(len(prompts)):
+        for task_path in task_paths:
             tasks.append(
                 self.terminal_bench_agent_loop(
-                    prompt="",
+                    task_path=task_path,
                 )
             )
 
@@ -79,14 +79,14 @@ class TerminalBenchGenerator(GeneratorInterface):
 
     async def terminal_bench_agent_loop(
         self,
-        prompt: ConversationType,
+        task_path: str,
     ) -> TerminalBenchAgentOutput:
         """
         Run a single terminal_bench agent.
         """
         if self.agent_name == "terminus":
             trial_config = TrialConfig(
-                task=LocalTaskConfig(id=LocalTaskId(path=f"{self.sandboxes_dir}/examples/tasks/hello-world")),
+                task=LocalTaskConfig(id=LocalTaskId(path=task_path)),
                 trials_dir=Path(self.trials_dir),
                 agent=AgentConfig(
                     name=AgentName.TERMINUS_2.value,
@@ -96,7 +96,7 @@ class TerminalBenchGenerator(GeneratorInterface):
             )
         elif self.agent_name == "oracle":
             trial_config = TrialConfig(
-                task=LocalTaskConfig(id=LocalTaskId(path=f"{self.sandboxes_dir}/examples/tasks/hello-world")),
+                task=LocalTaskConfig(id=LocalTaskId(path=task_path)),
                 trials_dir=Path(self.trials_dir),
                 agent=AgentConfig(
                     name=AgentName.ORACLE,

--- a/skyrl-train/examples/terminal_bench/prepare_dataset.py
+++ b/skyrl-train/examples/terminal_bench/prepare_dataset.py
@@ -1,0 +1,50 @@
+import argparse
+import os
+from typing import Any, Dict, List
+
+from datasets import Dataset
+
+
+def build_row(task_path: str, data_source: str) -> Dict[str, Any]:
+    task_path_abs = os.path.abspath(task_path)
+    return {
+        "data_source": data_source,
+        "prompt": "dummy",
+        "terminal_bench": {
+            "task_path": task_path_abs,
+        },
+    }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate Parquet dataset from a terminal_bench directory.")
+    parser.add_argument("--task_dir", required=True, help="Directory containing task subdirectories.")
+    parser.add_argument("--output_dir", default="~/data/terminal_bench", help="Output directory for Parquet file.")
+    parser.add_argument("--output_name", default="train", help="Output name for Parquet file.")
+
+    args = parser.parse_args()
+
+    task_dir = os.path.abspath(os.path.expanduser(args.task_dir))
+    output_dir = os.path.expanduser(args.output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Enumerate task subdirectories
+    task_dirs: List[str] = []
+    try:
+        for entry in sorted(os.listdir(task_dir)):
+            if entry.startswith('.'):
+                continue
+            full_path = os.path.join(task_dir, entry)
+            if os.path.isdir(full_path):
+                task_dirs.append(full_path)
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Task directory not found: {task_dir}")
+
+    data_source = "terminal_bench"
+    rows = [build_row(task_path=task_dir, data_source=data_source) for task_dir in task_dirs]
+
+    dataset = Dataset.from_list(rows)
+
+    # Save to Parquet
+    out_path = os.path.join(output_dir, f"{args.output_name}.parquet")
+    dataset.to_parquet(out_path)

--- a/skyrl-train/examples/terminal_bench/run_tbench.sh
+++ b/skyrl-train/examples/terminal_bench/run_tbench.sh
@@ -3,11 +3,16 @@ set -x
 # WORK IN PROGRESS
 # Colocated GRPO training+generation for Qwen2.5-1.5B-Instruct on TerminalBench tasks.
 
-# uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
+# uv run examples/terminal_bench/prepare_dataset.py --task_dir $HOME/data/terminal_bench/tasks --output_dir $HOME/data/terminal_bench --output_name train
 # export WANDB_API_KEY=<your_key_here>
 # bash examples/terminal_bench/run_tbench.sh
 
-DATA_DIR="$HOME/data/gsm8k"
+# If you have a validation set, run:
+#   uv run examples/terminal_bench/prepare_dataset.py --task_dir $HOME/data/terminal_bench/validation_tasks --output_dir $HOME/data/terminal_bench --output_name validation
+# and add the following to the script below:
+#   data.val_data="['$DATA_DIR/validation.parquet']" \
+
+DATA_DIR="$HOME/data/terminal_bench"
 NUM_GPUS=1
 LOGGER="console"  # change to "console" to print to stdout
 TBENCH_CONFIG_DIR="examples/terminal_bench"
@@ -15,7 +20,6 @@ SANDBOXES_DIR="sandboxes" # TODO: For now, `sandboxes` is cloned into SkyRL/skyr
 
 uv run --isolated --extra vllm --extra sandboxes --with "sandbox@./sandboxes" -m examples.terminal_bench.entrypoints.main_tbench \
   data.train_data="['$DATA_DIR/train.parquet']" \
-  data.val_data="['$DATA_DIR/validation.parquet']" \
   hydra.searchpath=[file://$TBENCH_CONFIG_DIR] \
   +terminal_bench_config=terminal_bench \
   terminal_bench_config.max_episodes=16 \

--- a/skyrl-train/examples/terminal_bench/run_tbench_gen.sh
+++ b/skyrl-train/examples/terminal_bench/run_tbench_gen.sh
@@ -3,8 +3,9 @@ set -x
 # WORK IN PROGRESS
 # Colocated GRPO training+generation for Qwen2.5-1.5B-Instruct on TerminalBench tasks.
 
+# uv run examples/terminal_bench/prepare_dataset.py --task_dir $HOME/data/terminal_bench/tasks --output_dir $HOME/data/terminal_bench --output_name train
 # export WANDB_API_KEY=<your_key_here>
-# bash examples/terminal_bench/run_tbench.sh
+# bash examples/terminal_bench/run_tbench_gen.sh
 
 NUM_GPUS=1
 LOGGER="console"  # change to "console" to print to stdout
@@ -12,6 +13,7 @@ TBENCH_CONFIG_DIR="examples/terminal_bench"
 SANDBOXES_DIR="sandboxes" # TODO: For now, `sandboxes` is cloned into SkyRL/skyrl-train.
 
 uv run --isolated --extra vllm --extra sandboxes --with "sandbox@./sandboxes" -m examples.terminal_bench.entrypoints.main_tbench_generate \
+  data.val_data="['$DATA_DIR/train.parquet']" \
   hydra.searchpath=[file://$TBENCH_CONFIG_DIR] \
   +terminal_bench_config=terminal_bench \
   terminal_bench_config.max_episodes=16 \


### PR DESCRIPTION
Adds support for building a dataset of TBench tasks to pass to the generator.

Currently still *slightly* hacky in that we pass in dummy prompts and send the TBench task path through the `env_extras` field. It's fine, just not clean.