### PR TITLE
[fix] Add missing required argument to OpenAIServingChat

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -336,6 +336,7 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
             model_config=model_config,
             models=models,
             response_role="assistant",
+            request_logger=None,
             chat_template=None,
             chat_template_content_format="auto",
         )


### PR DESCRIPTION
`request_logger` is a required argument.