### PR TITLE
[fix] Broken call to `io.exists`

### DIFF
--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -1292,7 +1292,7 @@ class RayPPOTrainer:
                 )
 
         # Validate that the path exists
-        if not io.exists(checkpoint_path):
+        if not io.exists(str(checkpoint_path)):
             raise FileNotFoundError(f"Checkpoint path not found: {checkpoint_path}")
 
         logger.info(f"Loading checkpoint from: {checkpoint_path}")


### PR DESCRIPTION
The `io` library only accepts `str`s currently, not `Path` types.

Resolves the CI failure:

<img width="73" height="45" alt="Screenshot 2025-09-07 at 10 02 46 PM" src="https://github.com/user-attachments/assets/c3c53973-9f4a-4226-bffb-45213b7d1a03" />
