### PR TITLE
[fix] Resolve CI error due to import error

### DIFF
--- a/skyrl-train/tests/gpu/gpu_ci/test_verifiers_generator.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_verifiers_generator.py
@@ -88,6 +88,7 @@ async def _run_verifiers_end_to_end(
     )
 
     from integrations.verifiers.verifiers_generator import VerifiersGenerator
+
     generator = VerifiersGenerator(
         generator_cfg=generator_cfg,
         tokenizer=tokenizer,

--- a/skyrl-train/tests/gpu/gpu_ci/test_verifiers_generator.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_verifiers_generator.py
@@ -11,7 +11,6 @@ import socket
 from tests.gpu.utils import get_test_actor_config, init_inference_engines
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
 from skyrl_train.inference_engines.utils import get_sampling_params_for_backend
-from integrations.verifiers.verifiers_generator import VerifiersGenerator
 
 # Mark all tests in this file as "integrations"
 pytestmark = pytest.mark.integrations
@@ -88,6 +87,7 @@ async def _run_verifiers_end_to_end(
         }
     )
 
+    from integrations.verifiers.verifiers_generator import VerifiersGenerator
     generator = VerifiersGenerator(
         generator_cfg=generator_cfg,
         tokenizer=tokenizer,


### PR DESCRIPTION
We cannot import `VerifiersGenerator` unless `--with verifiers` is included in the `uv` command. An error is thrown when pytest is collecting all tests and tries to import `VerifiersGenerator`.

This PR moves the import of `VerifiersGenerator` in the test into the test body so that it's only imported when executed. 

Confirmed that Verifiers integration tests still pass with the commands in the CI pipeline:

<img width="77" height="20" alt="Screenshot 2025-09-07 at 10 48 53 PM" src="https://github.com/user-attachments/assets/c8272e9e-ab01-4bba-be76-42e5cc508c0c" />
