### PR TITLE
[CI][Fix] Fix sglang import error by correcting pytest -m condition

### DIFF
--- a/skyrl-train/ci/gpu_ci_run.sh
+++ b/skyrl-train/ci/gpu_ci_run.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -xeuo pipefail
 
 export CI=true
 # Prepare datasets used in tests.
 uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 uv run examples/search/searchr1_dataset.py --local_dir $HOME/data/searchR1 --split test
 # Run all non-SGLang tests
-uv run --directory . --isolated --extra dev --extra vllm --with deepspeed pytest -s tests/gpu/gpu_ci -m "not sglang" -m "not integrations"
+uv run --directory . --isolated --extra dev --extra vllm --with deepspeed pytest -s tests/gpu/gpu_ci -m "not (sglang or integrations)"
 
 # Run tests for "integrations" folder
 uv add --active wordle --index https://hub.primeintellect.ai/will/simple/


### PR DESCRIPTION
`-m "not sglang" -m "not integrations"` will end up running sglang test, and with `--extra vllm` instead of `--extra sglang`, CI runs into sglang module not found error. To fix, we change the condition. We also add `-x` so we can see the commands running.

Tested the same change at a separate branch to trigger GPU CI, which passes: https://github.com/NovaSky-AI/SkyRL/actions/runs/17558786462