### PR TITLE
[GPU CI] Skip integration tests if uv add fails

### DIFF
--- a/skyrl-train/ci/gpu_ci_run.sh
+++ b/skyrl-train/ci/gpu_ci_run.sh
@@ -9,9 +9,14 @@ uv run examples/search/searchr1_dataset.py --local_dir $HOME/data/searchR1 --spl
 uv run --directory . --isolated --extra dev --extra vllm --with deepspeed pytest -s tests/gpu/gpu_ci -m "not (sglang or integrations)"
 
 # Run tests for "integrations" folder
-uv add --active wordle --index https://hub.primeintellect.ai/will/simple/
-uv run --isolated --with verifiers -- python integrations/verifiers/prepare_dataset.py --env_id will/wordle
-uv run --directory . --isolated --extra dev --extra vllm --with verifiers pytest -s tests/gpu/gpu_ci/ -m "integrations"
+if add_integrations=$(uv add --active wordle --index https://hub.primeintellect.ai/will/simple/ 2>&1); then
+    echo "Running integration tests"
+    uv run --isolated --with verifiers -- python integrations/verifiers/prepare_dataset.py --env_id will/wordle
+    uv run --directory . --isolated --extra dev --extra vllm --with verifiers pytest -s tests/gpu/gpu_ci/ -m "integrations"
+else 
+    echo "Skipping integrations tests. Failed to execute uv add command"
+    echo "$add_integrations"
+fi
 
 # Run all SGLang tests
 uv run --directory . --isolated --extra dev --extra sglang --with deepspeed pytest -s tests/gpu/gpu_ci -m "sglang"


### PR DESCRIPTION
# What does this PR do?

Skips integration tests if the `uv add` command fails. 

We had a job [fail](https://github.com/NovaSky-AI/SkyRL/actions/runs/17564168798/job/49887410767) with the following reason: 

```bash
+ uv add --active wordle --index https://hub.primeintellect.ai/will/simple/
   Updating https://github.com/NVIDIA/Megatron-LM.git (core_r0.13.0)
    Updated https://github.com/NVIDIA/Megatron-LM.git (73a28a1078a8da8e6062199f7f1079a52173ab77)
error: Request failed after 1 retries
  Caused by: Failed to fetch: `https://hub.primeintellect.ai/will/simple/fastapi/`
  Caused by: HTTP status client error (404 Not Found) for url (https://hub.primeintellect.ai/will/simple/fastapi/)
```

Unreliability in Prime-Intellect Hub shouldn't fail CI. 


Tests will still continue now:

```bash
========= 25 passed, 5 deselected, 189 warnings in 2090.87s (0:34:50) ==========
++ uv add --active wordle --index https://hub.primeintellect.ai/will/simple/
+ add_integrations='   Updating https://github.com/NVIDIA/Megatron-LM.git (core_r0.13.0)
    Updated https://github.com/NVIDIA/Megatron-LM.git (73a28a1078a8da8e6062199f7f1079a52173ab77)
error: Request failed after 1 retries
  Caused by: Failed to fetch: `https://hub.primeintellect.ai/will/simple/compressed-tensors/`
  Caused by: HTTP status client error (404 Not Found) for url (https://hub.primeintellect.ai/will/simple/compressed-tensors/)'
+ echo 'Skipping integrations tests. Failed to execute uv add command'
Skipping integrations tests. Failed to execute uv add command
+ echo '   Updating https://github.com/NVIDIA/Megatron-LM.git (core_r0.13.0)
    Updated https://github.com/NVIDIA/Megatron-LM.git (73a28a1078a8da8e6062199f7f1079a52173ab77)
error: Request failed after 1 retries
  Caused by: Failed to fetch: `https://hub.primeintellect.ai/will/simple/compressed-tensors/`
  Caused by: HTTP status client error (404 Not Found) for url (https://hub.primeintellect.ai/will/simple/compressed-tensors/)'
   Updating https://github.com/NVIDIA/Megatron-LM.git (core_r0.13.0)
    Updated https://github.com/NVIDIA/Megatron-LM.git (73a28a1078a8da8e6062199f7f1079a52173ab77)
error: Request failed after 1 retries
  Caused by: Failed to fetch: `https://hub.primeintellect.ai/will/simple/compressed-tensors/`
  Caused by: HTTP status client error (404 Not Found) for url (https://hub.primeintellect.ai/will/simple/compressed-tensors/)
+ uv run --directory . --isolated --extra dev --extra sglang --with deepspeed pytest -s tests/gpu/gpu_ci -m sglang
   Building skyrl-train @ file:///home/ray/default/SkyRL/skyrl-train
Downloading lxml (5.0MiB)
Downloading xgrammar (5.6MiB)
Downloading pycryptodomex (2.2MiB)
```