### PR TITLE
[InfEngineClient] Extract out routing logic to a helper

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -7,6 +7,7 @@ from skyrl_train.inference_engines.base import (
 from transformers import PreTrainedTokenizerBase
 import asyncio
 from typing import List, Any, Optional, Dict
+from skyrl_train.inference_engines.utils import route_prompts_to_engines, hash_with_sha256
 from omegaconf import DictConfig
 import threading
 import random
@@ -50,6 +51,7 @@ class InferenceEngineClient(InferenceEngineInterface):
         return await asyncio.gather(*awaitables)
 
     async def generate(self, input_batch: InferenceEngineInput) -> InferenceEngineOutput:
+        # 0. Extract input
         prompts = input_batch.get("prompts")
         prompt_token_ids = input_batch.get("prompt_token_ids")
         trajectory_ids = input_batch.get("trajectory_ids")
@@ -66,55 +68,32 @@ class InferenceEngineClient(InferenceEngineInterface):
                 tokenize=True,
             )["input_ids"]
 
-        # TODO(tgriggs): If there are no traj ids, we'd still like to load balance instead of landing on a single engine.
-        if trajectory_ids is not None:
-            # Route based on trajectory_ids
-            return await self._generate_with_trajectory_routing(prompt_token_ids, trajectory_ids, sampling_params)
-        else:
-            # Split evenly across engines
-            return await self._generate_batched(prompt_token_ids, sampling_params)
+        num_prompts = len(prompt_token_ids)
+        num_inference_engines = len(self.engines)
 
-    async def chat_completion(self, request_payload: Dict[str, Any]) -> Dict[str, Any]:
-        trajectory_id = request_payload["json"].pop("trajectory_id", None)
-        if trajectory_id is None:
-            # if trajectory_id is not provided, we'll use a random engine
-            engine_idx = random.randint(0, len(self.engines) - 1)
-        else:
-            engine_idx = abs(hash(str(trajectory_id))) % len(self.engines)
-        return await self.engines[engine_idx].chat_completion(request_payload)
+        # 1. Route prompts to engines
+        engine_idx_to_prompt_ids: dict[int, list[int]] = route_prompts_to_engines(
+            num_prompts=num_prompts,
+            num_inference_engines=num_inference_engines,
+            trajectory_ids=trajectory_ids,
+        )
 
-    async def _generate_with_trajectory_routing(
-        self, prompt_token_ids, trajectory_ids, sampling_params
-    ) -> InferenceEngineOutput:
-        """
-        Route prompts to engines based on trajectory_ids and return results in the original order of the prompts.
-        """
-        # Group prompts by engine
-        engine_groups: dict[int, dict[str, list]] = {}
-        assert len(prompt_token_ids) == len(
-            trajectory_ids
-        ), f"Mismatch between number of prompts ({len(prompt_token_ids)}) and trajectory_ids ({len(trajectory_ids)})"
-        for i, (token_ids, traj_id) in enumerate(zip(prompt_token_ids, trajectory_ids)):
-            engine_idx = abs(hash(str(traj_id))) % len(self.engines)
-            group = engine_groups.setdefault(engine_idx, {"token_ids": [], "indices": []})
-            group["token_ids"].append(token_ids)
-            group["indices"].append(i)
-
-        # Build two parallel lists: one of tasks, one of the index‐lists
+        # 2. Generate responses concurrently
         tasks: list[asyncio.Task] = []
         indices_list: list[list[int]] = []
-        for engine_idx, group in engine_groups.items():
-            inp = InferenceEngineInput(
-                prompt_token_ids=group["token_ids"],
+        for engine_idx, prompt_ids in engine_idx_to_prompt_ids.items():
+            # index prompt_token_ids with prompt_ids
+            cur_prompt_token_ids = [prompt_token_ids[i] for i in prompt_ids]
+            engine_input = InferenceEngineInput(
+                prompt_token_ids=cur_prompt_token_ids,
                 sampling_params=sampling_params,
             )
-            coro = self.engines[engine_idx].generate(inp)
-            tasks.append(asyncio.create_task(coro))
-            indices_list.append(group["indices"])
+            tasks.append(self.engines[engine_idx].generate(engine_input))
+            indices_list.append(prompt_ids)
 
         results = await asyncio.gather(*tasks)
 
-        # Reconstruct output in original order
+        # 3. Reconstruct output in original order
         n = len(prompt_token_ids)
         responses: list[str] = [""] * n
         stop_reasons: list[str] = [""] * n
@@ -139,48 +118,14 @@ class InferenceEngineClient(InferenceEngineInterface):
             response_logprobs=response_logprobs if add_resp_logprobs else None,
         )
 
-    async def _generate_batched(self, prompt_token_ids, sampling_params) -> InferenceEngineOutput:
-        """
-        Split prompts evenly across engines and return results in the original order of the prompts.
-        """
-        num_inference_engines = len(self.engines)
-        dp_item_size = (len(prompt_token_ids) + num_inference_engines - 1) // num_inference_engines
-
-        tasks = []
-        for dp_rank in range(num_inference_engines):
-            start_idx = dp_rank * dp_item_size
-            end_idx = (dp_rank + 1) * dp_item_size
-            dp_items = prompt_token_ids[start_idx:end_idx]
-
-            if len(dp_items) <= 0:
-                continue
-
-            engine_input = InferenceEngineInput(
-                prompt_token_ids=dp_items,
-                sampling_params=sampling_params,
-            )
-            tasks.append(self.engines[dp_rank].generate(engine_input))
-
-        all_outputs = await asyncio.gather(*tasks)
-
-        # Flatten results
-        responses = []
-        stop_reasons = []
-        response_ids = []
-        response_logprobs = []
-        for output in all_outputs:
-            responses.extend(output["responses"])
-            stop_reasons.extend(output["stop_reasons"])
-            response_ids.extend(output["response_ids"])
-            if output.get("response_logprobs", None):
-                response_logprobs.extend(output["response_logprobs"])
-
-        return InferenceEngineOutput(
-            responses=responses,
-            stop_reasons=stop_reasons,
-            response_ids=response_ids,
-            response_logprobs=response_logprobs if len(response_logprobs) else None,
-        )
+    async def chat_completion(self, request_payload: Dict[str, Any]) -> Dict[str, Any]:
+        trajectory_id = request_payload["json"].pop("trajectory_id", None)
+        if trajectory_id is None:
+            # if trajectory_id is not provided, we'll use a random engine
+            engine_idx = random.randint(0, len(self.engines) - 1)
+        else:
+            engine_idx = hash_with_sha256(str(trajectory_id)) % len(self.engines)
+        return await self.engines[engine_idx].chat_completion(request_payload)
 
     async def wake_up(self, *args: Any, **kwargs: Any):
         return await self._run_on_all_engines("wake_up", *args, **kwargs)

--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -88,7 +88,7 @@ class InferenceEngineClient(InferenceEngineInterface):
                 prompt_token_ids=cur_prompt_token_ids,
                 sampling_params=sampling_params,
             )
-            tasks.append(self.engines[engine_idx].generate(engine_input))
+            tasks.append(asyncio.create_task(self.engines[engine_idx].generate(engine_input)))
             indices_list.append(prompt_ids)
 
         results = await asyncio.gather(*tasks)

--- a/skyrl-train/skyrl_train/inference_engines/utils.py
+++ b/skyrl-train/skyrl_train/inference_engines/utils.py
@@ -115,7 +115,5 @@ def route_prompts_to_engines(
     # 3. trajectory_id provided, we route by trajectory_id
     for i, cur_tid in enumerate(trajectory_ids):
         engine_idx = hash_with_sha256(str(cur_tid)) % num_inference_engines
-        if engine_idx not in engine_idx_to_prompt_ids:
-            engine_idx_to_prompt_ids[engine_idx] = []
-        engine_idx_to_prompt_ids[engine_idx].append(i)
+        engine_idx_to_prompt_ids.setdefault(engine_idx, []).append(i)
     return engine_idx_to_prompt_ids

--- a/skyrl-train/skyrl_train/inference_engines/utils.py
+++ b/skyrl-train/skyrl_train/inference_engines/utils.py
@@ -1,4 +1,6 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional, Union
+import random
+import hashlib
 from omegaconf import DictConfig, ListConfig
 
 
@@ -57,3 +59,63 @@ def get_sampling_params_for_backend(backend: str, sampling_params: DictConfig) -
         return get_sglang_sampling_params(sampling_params)
     else:
         raise ValueError(f"Unsupported generation backend: {backend}")
+
+
+def hash_with_sha256(x: Union[int, str]) -> int:
+    return int.from_bytes(hashlib.sha256(str(x).encode()).digest(), "big")
+
+
+def route_prompts_to_engines(
+    num_prompts: int, num_inference_engines: int, trajectory_ids: Optional[Union[list[int], list[str]]]
+) -> dict[int, list[int]]:
+    """
+    Given the number of prompts, number of inference engines, and the trajectory_id, return a mapping
+    from engine index to the list of prompt IDs the engine will process.
+
+    Args:
+    - num_prompts: int - The number of prompts.
+    - num_inference_engines: int - The number of inference engines.
+    - trajectory_ids: Optional[Union[list[int], list[str]]] - The trajectory IDs.
+
+    Required:
+    - num_prompts > 0
+    - num_inference_engines > 0
+    - trajectory_ids is a list of integers or strings if provided
+    - len(trajectory_ids) == num_prompts if provided
+
+    Returns:
+    - dict[int, list[int]] - A mapping from engine index to the list of prompt IDs the engine will process.
+    """
+    # 0. Validation
+    assert num_prompts > 0, "Number of prompts must be greater than 0"
+    assert num_inference_engines > 0, "Number of inference engines must be greater than 0"
+    if trajectory_ids is not None:
+        assert isinstance(trajectory_ids, list) and all(
+            isinstance(tid, (int, str)) for tid in trajectory_ids
+        ), "Trajectory ID must be a list of integers or strings"
+        assert len(trajectory_ids) == num_prompts, "Trajectory ID must have the same length as the number of prompts"
+
+    # 1. trajectory_id not provided, with a single prompt: route to a random engine for a naive load balancing.
+    if trajectory_ids is None and num_prompts == 1:
+        engine_idx = random.randint(0, num_inference_engines - 1)
+        return {engine_idx: [0]}
+
+    # 2. trajectory_id not provided, with a batched prompt: split evenly across engines.
+    engine_idx_to_prompt_ids: dict[int, list[int]] = {}
+    if trajectory_ids is None:
+        dp_item_size = (num_prompts + num_inference_engines - 1) // num_inference_engines
+        for dp_rank in range(num_inference_engines):
+            start_idx = dp_rank * dp_item_size
+            end_idx = min((dp_rank + 1) * dp_item_size, num_prompts)
+            prompt_ids = list(range(start_idx, end_idx))
+            if len(prompt_ids) > 0:
+                engine_idx_to_prompt_ids[dp_rank] = prompt_ids
+        return engine_idx_to_prompt_ids
+
+    # 3. trajectory_id provided, we route by trajectory_id
+    for i, cur_tid in enumerate(trajectory_ids):
+        engine_idx = hash_with_sha256(str(cur_tid)) % num_inference_engines
+        if engine_idx not in engine_idx_to_prompt_ids:
+            engine_idx_to_prompt_ids[engine_idx] = []
+        engine_idx_to_prompt_ids[engine_idx].append(i)
+    return engine_idx_to_prompt_ids

--- a/skyrl-train/tests/cpu/test_route_prompts_to_engines.py
+++ b/skyrl-train/tests/cpu/test_route_prompts_to_engines.py
@@ -1,0 +1,86 @@
+"""
+Test for route_prompts_to_engines function that routes prompts to inference engines in inference engine client.
+
+Run with:
+uv run --isolated --extra dev pytest tests/cpu/test_route_prompts_to_engines.py
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from skyrl_train.inference_engines.utils import route_prompts_to_engines, hash_with_sha256
+
+
+def test_single_prompt_no_trajectory_random_engine():
+    # Force deterministic random routing to engine index 1
+    with patch("random.randint", return_value=1):
+        mapping = route_prompts_to_engines(num_prompts=1, num_inference_engines=4, trajectory_ids=None)
+    assert mapping == {1: [0]}
+
+
+def test_batched_even_split_exact_multiple():
+    # 4 prompts, 2 engines => [0,1] and [2,3]
+    num_prompts = 4
+    num_engines = 2
+    mapping = route_prompts_to_engines(num_prompts=num_prompts, num_inference_engines=num_engines, trajectory_ids=None)
+    assert mapping == {0: [0, 1], 1: [2, 3]}
+
+
+def test_batched_uneven_split():
+    # 5 prompts, 2 engines => ceil(5/2)=3 => [0,1,2] and [3,4]
+    mapping = route_prompts_to_engines(num_prompts=5, num_inference_engines=2, trajectory_ids=None)
+    assert mapping == {0: [0, 1, 2], 1: [3, 4]}
+
+    # 5 prompts, 3 engines => ceil(5/3)=2 => [0,1] and [2,3] and [4]
+    mapping = route_prompts_to_engines(num_prompts=5, num_inference_engines=3, trajectory_ids=None)
+    assert mapping == {0: [0, 1], 1: [2, 3], 2: [4]}
+
+    # 5 prompts, 4 engines => ceil(5/4)=2 => [0,1] and [2,3] and [4]
+    mapping = route_prompts_to_engines(num_prompts=5, num_inference_engines=4, trajectory_ids=None)
+    assert mapping == {0: [0, 1], 1: [2, 3], 2: [4]}
+
+    # 129 prompts, 4 engines => ceil(129/4)=33 => [0,1,2,...,32] and [33,34,35,...,65] and [66,67,68,...,99] and [100,101,102,...,128]
+    mapping = route_prompts_to_engines(num_prompts=129, num_inference_engines=4, trajectory_ids=None)
+    assert mapping == {0: list(range(33)), 1: list(range(33, 66)), 2: list(range(66, 99)), 3: list(range(99, 129))}
+
+
+def test_batched_more_engines_than_prompts():
+    # 2 prompts, 4 engines => size=1 => {0:[0], 1:[1]}
+    mapping = route_prompts_to_engines(num_prompts=2, num_inference_engines=4, trajectory_ids=None)
+    assert mapping == {0: [0], 1: [1]}
+
+
+def test_with_trajectory_ids_grouping_and_partition():
+    num_engines = 4
+    # Ensure same trajectory IDs route to the same engine index
+    tids = ["A", "A", "B", "C", "B"]
+    # hash A ends in 45, B ends in 44, C ends in 69, with % 4 they become 1, 0, 1
+    engine_idx = [hash_with_sha256(tid) % num_engines for tid in tids]  # what we do in route_prompts_to_engines
+    assert engine_idx == [1, 1, 0, 1, 0]
+    mapping = route_prompts_to_engines(num_prompts=5, num_inference_engines=num_engines, trajectory_ids=tids)
+
+    assert mapping == {1: [0, 1, 3], 0: [2, 4]}
+
+
+def test_validation_errors():
+    # num_prompts must be > 0
+    with pytest.raises(AssertionError):
+        route_prompts_to_engines(num_prompts=0, num_inference_engines=1, trajectory_ids=None)
+
+    # num_inference_engines must be > 0
+    with pytest.raises(AssertionError):
+        route_prompts_to_engines(num_prompts=1, num_inference_engines=0, trajectory_ids=None)
+
+    # trajectory_ids length must match
+    with pytest.raises(AssertionError):
+        route_prompts_to_engines(num_prompts=2, num_inference_engines=1, trajectory_ids=["x"])  # len 1 != 2
+
+    # trajectory_ids type checking
+    with pytest.raises(AssertionError):
+        route_prompts_to_engines(num_prompts=2, num_inference_engines=1, trajectory_ids=[1, 2.0])  # float invalid
+
+    # No error
+    route_prompts_to_engines(num_prompts=2, num_inference_engines=1, trajectory_ids=[1, 2])
+    route_prompts_to_engines(num_prompts=2, num_inference_engines=1, trajectory_ids=None)
+    route_prompts_to_engines(num_prompts=1, num_inference_engines=1, trajectory_ids=None)


### PR DESCRIPTION
This PR removes `_generate_batched()` and `_generate_with_trajectory_routing()` in `InferenceEngineClient` by adding a helper method that:

```python
def route_prompts_to_engines(
    num_prompts: int, num_inference_engines: int, trajectory_ids: Optional[Union[list[int], list[str]]]
) -> dict[int, list[int]]:
```

returning a mapping from engine ID to the prompt IDs they work on.

This removes the duplicated code when gathering the output.

In addition, for the `/completions` PR, this will be highly beneficial. Without this PR we would need to duplicate `_generate_with_trajectory_routing()` and `_generate_batched()`, which are for `InferenceEngineInput` and make another pair for `CompletionRequest`.

We also change `hash()` to `int.from_bytes(hashlib.sha256(str(x).encode()).digest(), "big")`, since the former is seeded by a random seed that is per-python-process. The latter is deterministic.

### Testing
- Added new unit test
- GPU CI passed
- GSM8K, i.e. single-turn code path (ran both batched and non-batched). Same generation time, reward, eval. Compared against PR #238 
<img width="1209" height="610" alt="image" src="https://github.com/user-attachments/assets/974d7266-738b-4d69-9c56-28d9546d14fb" />

- search-r1 (compared against the TITO PR, with single-turn and 4turns). Reward and eval are same -- meaning keeping the original order worked as expected; timing is roughly 7% slower for some reason. Will assume it to be variance.
<img width="1414" height="627" alt="image" src="https://github.com/user-attachments/assets/958d5cfe-d384-43a4-a4ed-43ca06e3515d" />
