### PR TITLE
[tiny fix] Remove the example launch command for main files

### DIFF
--- a/skyrl-train/examples/async/main_async.py
+++ b/skyrl-train/examples/async/main_async.py
@@ -1,5 +1,5 @@
 """
-uv run --isolated --extra vllm -m examples.async.main_async
+Main entrypoint for async training.
 """
 
 import hydra

--- a/skyrl-train/examples/flash_rl/main_dapo_flashrl.py
+++ b/skyrl-train/examples/flash_rl/main_dapo_flashrl.py
@@ -1,5 +1,5 @@
 """
-uv run --isolated --extra flashrl -m examples.flash_rl.main_dapo_flashrl
+Main entrypoint for DAPO training with FlashRL.
 """
 
 import ray

--- a/skyrl-train/examples/llm_as_a_judge/main_llm_judge.py
+++ b/skyrl-train/examples/llm_as_a_judge/main_llm_judge.py
@@ -1,3 +1,6 @@
+"""
+Main entrypoint for the LLM-as-a-judge example.
+"""
 import ray
 import hydra
 from omegaconf import DictConfig

--- a/skyrl-train/examples/llm_as_a_judge/main_llm_judge.py
+++ b/skyrl-train/examples/llm_as_a_judge/main_llm_judge.py
@@ -1,6 +1,7 @@
 """
 Main entrypoint for the LLM-as-a-judge example.
 """
+
 import ray
 import hydra
 from omegaconf import DictConfig

--- a/skyrl-train/examples/llm_as_a_judge/main_llm_judge.py
+++ b/skyrl-train/examples/llm_as_a_judge/main_llm_judge.py
@@ -1,7 +1,3 @@
-"""
-uv run --isolated --extra vllm -m examples.llm_as_a_judge.main_llm_judge
-"""
-
 import ray
 import hydra
 from omegaconf import DictConfig

--- a/skyrl-train/examples/terminal_bench/entrypoints/main_tbench.py
+++ b/skyrl-train/examples/terminal_bench/entrypoints/main_tbench.py
@@ -1,5 +1,5 @@
 """
-uv run --isolated --extra vllm --extra sandboxes -m examples.terminal_bench.main_tbench
+Main entrypoint for training on terminal bench tasks.
 """
 
 import ray

--- a/skyrl-train/examples/terminal_bench/entrypoints/main_tbench_generate.py
+++ b/skyrl-train/examples/terminal_bench/entrypoints/main_tbench_generate.py
@@ -1,5 +1,5 @@
 """
-uv run --isolated --extra vllm --extra sandboxes -m examples.terminal_bench.main_tbench_generate
+Main entrypoint for generating rollouts on terminal bench tasks.
 """
 
 import ray

--- a/skyrl-train/skyrl_train/entrypoints/main_base.py
+++ b/skyrl-train/skyrl_train/entrypoints/main_base.py
@@ -1,7 +1,5 @@
 """
-
-uv run --isolated --extra vllm -- python -m skyrl_train.entrypoints.main_base
-
+Main entrypoint for training.
 """
 
 from ray.util.placement_group import placement_group, PlacementGroup

--- a/skyrl-train/skyrl_train/entrypoints/main_base.py
+++ b/skyrl-train/skyrl_train/entrypoints/main_base.py
@@ -1,6 +1,6 @@
 """
 
-uv run --isolated --extra vllm -m skyrl_train.entrypoints.main_base
+uv run --isolated --extra vllm -- python -m skyrl_train.entrypoints.main_base
 
 """
 


### PR DESCRIPTION
This PR deletes the examples `uv run ...` launch commands added to the top of many `main` files.

A few users have hit a mysterious `uv` error, and I learned it's because they were using the default command in `main_base.py`, which is incorrect. Here was the error:

```
AssertionError: uv run command [] is not a suffix of command line ['uv', 'run', '--isolated', '--extra', 'vllm', '--extra', 'sandboxes', '-m', 'examples.terminal_bench.main_tbench_generate']
```

Users shouldn't actually run these commands directly, it's much much better to go through a `.sh` file in the examples.