### PR TITLE
[Fix][CI] Address generator CI test fails when model stop reason is length

### DIFF
--- a/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
@@ -46,7 +46,7 @@ class TestEnv(BaseTextEnv):
         self.turns += 1
         done = self.turns >= self.max_turns
         return BaseTextEnvStepOutput(
-            observations=[{"role": "user", "content": f" {self.turns}"}] if not done else [],
+            observations=[{"role": "user", "content": f"{OBSERVATION_PROMPT} {self.turns}"}] if not done else [],
             reward=0,
             done=done,
             metadata={},

--- a/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
@@ -57,9 +57,9 @@ register(
 )
 
 MODEL_TO_GENERATION_PROMPT = {
-    "Qwen/Qwen2.5-3B-Instruct": "<|im_start|>assistant\n",
-    "unsloth/Llama-3.2-3B-Instruct": "<|start_header_id|>assistant<|end_header_id|>\n\n",
-    "Qwen/Qwen3-1.7B": "<|im_start|>assistant\n",
+    "Qwen/Qwen2.5-1.5B-Instruct": "<|im_start|>assistant\n",
+    "unsloth/Llama-3.2-1B-Instruct": "<|start_header_id|>assistant<|end_header_id|>\n\n",
+    "Qwen/Qwen3-0.6B": "<|im_start|>assistant\n",
 }
 
 
@@ -69,7 +69,7 @@ async def run_generator_end_to_end(
     n_samples_per_prompt,
     num_inference_engines,
     tensor_parallel_size,
-    model="Qwen/Qwen2.5-3B-Instruct",
+    model="Qwen/Qwen2.5-1.5B-Instruct",
     max_prompt_length=512,
     max_input_length=2048,
     max_generate_length=1024,
@@ -258,7 +258,7 @@ async def test_generator_multi_turn_search():
             n_samples_per_prompt=5,
             num_inference_engines=2,
             tensor_parallel_size=2,
-            model="Qwen/Qwen2.5-3B-Instruct",
+            model="Qwen/Qwen2.5-1.5B-Instruct",
             max_prompt_length=2048,
             max_input_length=4096,
             max_generate_length=1000,
@@ -274,7 +274,9 @@ async def test_generator_multi_turn_search():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("model_name", ["unsloth/Llama-3.2-3B-Instruct", "Qwen/Qwen2.5-3B-Instruct", "Qwen/Qwen3-1.7B"])
+@pytest.mark.parametrize(
+    "model_name", ["unsloth/Llama-3.2-1B-Instruct", "Qwen/Qwen2.5-1.5B-Instruct", "Qwen/Qwen3-0.6B"]
+)
 async def test_generator_formatting_use_conversation_multi_turn(model_name):
     """
     Test generator formatting when using conversation formatting for multi-turn
@@ -329,7 +331,7 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
                 # On length stops, the model may not produce EOS at the end of each assistant turn.
                 # Only check that generation prompts are masked out.
                 logger.warning(f"Got stop reason {stop_reason}, so we did not fully checked the response")
-            if model_name == "Qwen/Qwen3-1.7B":
+            if model_name == "Qwen/Qwen3-0.6B":
                 assert (
                     sum(1 for _ in prompt_token_ids if _ == tokenizer.eos_token_id) == 1
                 )  # 1 user eos (no system for Qwen3)
@@ -340,7 +342,9 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("model_name", ["unsloth/Llama-3.2-3B-Instruct", "Qwen/Qwen2.5-3B-Instruct", "Qwen/Qwen3-1.7B"])
+@pytest.mark.parametrize(
+    "model_name", ["unsloth/Llama-3.2-1B-Instruct", "Qwen/Qwen2.5-1.5B-Instruct", "Qwen/Qwen3-0.6B"]
+)
 async def test_generator_formatting_no_use_conversation_multi_turn(model_name):
     """
     Test generator formatting when not using conversation formatting for multi-turn
@@ -395,7 +399,7 @@ async def test_generator_formatting_no_use_conversation_multi_turn(model_name):
             assert (
                 sum(1 for _ in masked_in_resp_ids if _ == tokenizer.eos_token_id) == 1
             )  # 1 eos for each assistant response
-            if model_name == "Qwen/Qwen3-1.7B":
+            if model_name == "Qwen/Qwen3-0.6B":
                 assert (
                     sum(1 for _ in prompt_token_ids if _ == tokenizer.eos_token_id) == 1
                 )  # 1 user eos (no system for Qwen3)

--- a/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
@@ -274,9 +274,7 @@ async def test_generator_multi_turn_search():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "model_name", ["unsloth/Llama-3.2-3B-Instruct", "Qwen/Qwen2.5-3B-Instruct", "Qwen/Qwen3-1.7B"]
-)
+@pytest.mark.parametrize("model_name", ["unsloth/Llama-3.2-3B-Instruct", "Qwen/Qwen2.5-3B-Instruct", "Qwen/Qwen3-1.7B"])
 async def test_generator_formatting_use_conversation_multi_turn(model_name):
     """
     Test generator formatting when using conversation formatting for multi-turn
@@ -312,17 +310,19 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
 
             # Observations and EOS expectations only strictly apply when the model finished turns
             if stop_reason == "stop":
-                assert "give me another solution 1" in masked_out_resp_str, '"give me another solution 1" observation should be loss masked out'
-                assert "give me another solution 2" in masked_out_resp_str, '"give me another solution 2" observation should be loss masked out'
+                assert (
+                    "give me another solution 1" in masked_out_resp_str
+                ), '"give me another solution 1" observation should be loss masked out'
+                assert (
+                    "give me another solution 2" in masked_out_resp_str
+                ), '"give me another solution 2" observation should be loss masked out'
                 assert (
                     MODEL_TO_GENERATION_PROMPT[model_name] in masked_out_resp_str
                     and MODEL_TO_GENERATION_PROMPT[model_name] not in masked_in_resp_str
                 ), "generation prompts should be loss masked out"
 
                 # count number of eos tokens in masked_in_resp_ids: 1 eos per assistant response (3 turns)
-                assert (
-                    sum(1 for _ in masked_in_resp_ids if _ == tokenizer.eos_token_id) == 3
-                )
+                assert sum(1 for _ in masked_in_resp_ids if _ == tokenizer.eos_token_id) == 3
                 # total eos in full response: 2 user eos + 3 assistant eos
                 assert sum(1 for _ in resp_ids if _ == tokenizer.eos_token_id) == 5
             else:
@@ -344,9 +344,7 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "model_name", ["unsloth/Llama-3.2-3B-Instruct", "Qwen/Qwen2.5-3B-Instruct", "Qwen/Qwen3-1.7B"]
-)
+@pytest.mark.parametrize("model_name", ["unsloth/Llama-3.2-3B-Instruct", "Qwen/Qwen2.5-3B-Instruct", "Qwen/Qwen3-1.7B"])
 async def test_generator_formatting_no_use_conversation_multi_turn(model_name):
     """
     Test generator formatting when not using conversation formatting for multi-turn
@@ -381,8 +379,12 @@ async def test_generator_formatting_no_use_conversation_multi_turn(model_name):
             masked_out_resp_str = tokenizer.decode(masked_out_resp_ids)
             masked_in_resp_str = tokenizer.decode(masked_in_resp_ids)
 
-            assert "give me another solution 1" in masked_out_resp_str, '"give me another solution 1" observation should be loss masked out'
-            assert "give me another solution 2" in masked_out_resp_str, '"give me another solution 2" observation should be loss masked out'
+            assert (
+                "give me another solution 1" in masked_out_resp_str
+            ), '"give me another solution 1" observation should be loss masked out'
+            assert (
+                "give me another solution 2" in masked_out_resp_str
+            ), '"give me another solution 2" observation should be loss masked out'
             assert (
                 prompt_str.count(MODEL_TO_GENERATION_PROMPT[model_name])
                 + resp_str.count(MODEL_TO_GENERATION_PROMPT[model_name])

--- a/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_skyrl_gym_generator.py
@@ -308,6 +308,11 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
             masked_out_resp_str = tokenizer.decode(masked_out_resp_ids)
             masked_in_resp_str = tokenizer.decode(masked_in_resp_ids)
 
+            assert (
+                MODEL_TO_GENERATION_PROMPT[model_name] in masked_out_resp_str
+                and MODEL_TO_GENERATION_PROMPT[model_name] not in masked_in_resp_str
+            ), "generation prompts should be loss masked out"
+
             # Observations and EOS expectations only strictly apply when the model finished turns
             if stop_reason == "stop":
                 assert (
@@ -316,11 +321,6 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
                 assert (
                     "give me another solution 2" in masked_out_resp_str
                 ), '"give me another solution 2" observation should be loss masked out'
-                assert (
-                    MODEL_TO_GENERATION_PROMPT[model_name] in masked_out_resp_str
-                    and MODEL_TO_GENERATION_PROMPT[model_name] not in masked_in_resp_str
-                ), "generation prompts should be loss masked out"
-
                 # count number of eos tokens in masked_in_resp_ids: 1 eos per assistant response (3 turns)
                 assert sum(1 for _ in masked_in_resp_ids if _ == tokenizer.eos_token_id) == 3
                 # total eos in full response: 2 user eos + 3 assistant eos
@@ -328,10 +328,6 @@ async def test_generator_formatting_use_conversation_multi_turn(model_name):
             else:
                 # On length stops, the model may not produce EOS at the end of each assistant turn.
                 # Only check that generation prompts are masked out.
-                assert (
-                    MODEL_TO_GENERATION_PROMPT[model_name] in masked_out_resp_str
-                    and MODEL_TO_GENERATION_PROMPT[model_name] not in masked_in_resp_str
-                ), "generation prompts should be loss masked out"
                 logger.warning(f"Got stop reason {stop_reason}, so we did not fully checked the response")
             if model_name == "Qwen/Qwen3-1.7B":
                 assert (


### PR DESCRIPTION
Our unit test checks whether, for turns=3, the final conversation generates 3 EOS token. This will not be the case when the model's generation stop due to length. To address, we do the following:
- In the dummy environment, change observation `"turn {i}"` to `"give me another solution {i}"`, which might make more sense for the model
- Increase max generate length from 1000 to 3000
- Final guard is to check when the stop reason is not `"stop"`, we don't check the number of EOS token IDs