### PR TITLE
Add configurable timeout for placement groups

### DIFF
--- a/skyrl-train/examples/flash_rl/flash_rl_engine.py
+++ b/skyrl-train/examples/flash_rl/flash_rl_engine.py
@@ -48,6 +48,7 @@ def create_ray_wrapped_inference_engines_flashrl(
     Create a list of RayWrappedInferenceEngine instances wrapping Ray actor handles to InferenceEngineInterface instances.
     """
     from skyrl_train.utils import ray_noset_visible_devices, get_all_env_variables, get_ray_pg_ready_with_timeout
+    from skyrl_train.utils.constants import SKYRL_RAY_PG_TIMEOUT
 
     assert not async_engine, "`async_engine` is not supported for FlashRL"
 
@@ -70,7 +71,7 @@ def create_ray_wrapped_inference_engines_flashrl(
         # Create a big placement group to ensure that all inference engines are packed
         bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_inference_engines * tensor_parallel_size)]
         shared_pg = placement_group(bundles, strategy="PACK")
-        get_ray_pg_ready_with_timeout(shared_pg, timeout=30)
+        get_ray_pg_ready_with_timeout(shared_pg, timeout=SKYRL_RAY_PG_TIMEOUT)
 
     for i in range(num_inference_engines):
         bundle_indices = None

--- a/skyrl-train/skyrl_train/entrypoints/main_base.py
+++ b/skyrl-train/skyrl_train/entrypoints/main_base.py
@@ -14,6 +14,7 @@ from skyrl_train.trainer import RayPPOTrainer
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
 from skyrl_train.inference_engines.remote_inference_engine import create_remote_inference_engines
 from skyrl_train.utils.utils import initialize_ray, get_ray_pg_ready_with_timeout
+from skyrl_train.utils.constants import SKYRL_RAY_PG_TIMEOUT
 from skyrl_train.generators.base import GeneratorInterface
 from omegaconf import OmegaConf, DictConfig
 from pathlib import Path
@@ -134,7 +135,7 @@ class BasePPOExp:
             return prompts_dataset
         return None
 
-    def get_colocate_pg(self, timeout: int = 180) -> PlacementGroup:
+    def get_colocate_pg(self, timeout: int = SKYRL_RAY_PG_TIMEOUT) -> PlacementGroup:
         """Initializes a placement group for colocated training.
 
         A single placement group that packs all the inference engines together is created.

--- a/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -77,6 +77,7 @@ def create_ray_wrapped_inference_engines(
     Create a list of RayWrappedInferenceEngine instances wrapping Ray actor handles to InferenceEngineInterface instances.
     """
     from skyrl_train.utils import ray_noset_visible_devices, get_all_env_variables, get_ray_pg_ready_with_timeout
+    from skyrl_train.utils.constants import SKYRL_RAY_PG_TIMEOUT
 
     if backend == "vllm":
         import vllm
@@ -105,7 +106,7 @@ def create_ray_wrapped_inference_engines(
         # Create a big placement group to ensure that all inference engines are packed
         bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_inference_engines * tensor_parallel_size)]
         shared_pg = placement_group(bundles, strategy="PACK")
-        get_ray_pg_ready_with_timeout(shared_pg, timeout=30)
+        get_ray_pg_ready_with_timeout(shared_pg, timeout=SKYRL_RAY_PG_TIMEOUT)
 
     for i in range(num_inference_engines):
         bundle_indices = None

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -30,6 +30,7 @@ from skyrl_train.dataset.preprocess import (
 from skyrl_train.utils import ppo_utils
 from skyrl_train.utils import trainer_utils, io
 from skyrl_train.utils import Timer, get_ray_pg_ready_with_timeout
+from skyrl_train.utils.constants import SKYRL_RAY_PG_TIMEOUT
 from skyrl_train.utils.ppo_utils import (
     compute_approx_kl,
     masked_mean,
@@ -524,7 +525,7 @@ class RayPPOTrainer:
                     for _ in range(cfg.trainer.placement.policy_num_nodes)
                 ]
                 pg = placement_group(bundles, strategy="PACK")
-                get_ray_pg_ready_with_timeout(pg, timeout=30)
+                get_ray_pg_ready_with_timeout(pg, timeout=SKYRL_RAY_PG_TIMEOUT)
 
             policy_model = PPORayActorGroup(
                 cfg,
@@ -566,7 +567,7 @@ class RayPPOTrainer:
                     for _ in range(cfg.trainer.placement.critic_num_nodes)
                 ]
                 pg = placement_group(bundles, strategy="PACK")
-                get_ray_pg_ready_with_timeout(pg, timeout=30)
+                get_ray_pg_ready_with_timeout(pg, timeout=SKYRL_RAY_PG_TIMEOUT)
 
             if cfg.trainer.critic.model.path:
                 critic_model = PPORayActorGroup(

--- a/skyrl-train/skyrl_train/utils/constants.py
+++ b/skyrl-train/skyrl_train/utils/constants.py
@@ -1,0 +1,8 @@
+import os
+
+# Timeout for allocating the placement group for different actors in SkyRL
+SKYRL_RAY_PG_TIMEOUT = int(os.environ.get("SKYRL_RAY_PG_TIMEOUT", 30))
+
+# export `LD_LIBRARY_PATH` to ray runtime env.
+# For some reason the `LD_LIBRARY_PATH` is not exported to the worker with .env file.
+SKYRL_LD_LIBRARY_PATH_EXPORT = bool(os.environ.get("SKYRL_LD_LIBRARY_PATH_EXPORT", False))

--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -7,6 +7,8 @@ from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 from ray.util.placement_group import placement_group, PlacementGroupSchedulingStrategy, PlacementGroup
 
+from .constants import SKYRL_LD_LIBRARY_PATH_EXPORT
+
 
 class Timer:
     def __init__(self, message, update_dict=None):
@@ -454,7 +456,7 @@ def prepare_runtime_environment(cfg: DictConfig) -> dict[str, str]:
         logger.info("Exporting mlflow tracking token to ray runtime env")
         env_vars["MLFLOW_TRACKING_TOKEN"] = os.environ["MLFLOW_TRACKING_TOKEN"]
 
-    if os.environ.get("SKYRL_LD_LIBRARY_PATH_EXPORT"):
+    if SKYRL_LD_LIBRARY_PATH_EXPORT:
         # export `LD_LIBRARY_PATH` to ray runtime env.
         # For some reason the `LD_LIBRARY_PATH` is not exported to the worker with .env file.
         logger.info(f"Exporting `LD_LIBRARY_PATH` to ray runtime env: {os.environ['LD_LIBRARY_PATH']}")

--- a/skyrl-train/skyrl_train/workers/worker.py
+++ b/skyrl-train/skyrl_train/workers/worker.py
@@ -17,6 +17,7 @@ from ray import ObjectRef
 from ray.util.placement_group import PlacementGroup, PlacementGroupSchedulingStrategy, placement_group
 
 from skyrl_train.utils import ray_noset_visible_devices, get_ray_pg_ready_with_timeout
+from skyrl_train.utils.constants import SKYRL_RAY_PG_TIMEOUT
 from skyrl_train.utils import io
 from skyrl_train.utils.ppo_utils import masked_mean
 from skyrl_train.distributed.dispatch import MeshRank, ActorInfo, DispatchRegistry, Dispatch
@@ -381,7 +382,7 @@ class PPORayActorGroup:
                     bundles[i][resources_name] = self._num_resources_per_node
 
             pg = placement_group(bundles, strategy="PACK")
-            get_ray_pg_ready_with_timeout(pg, timeout=30)
+            get_ray_pg_ready_with_timeout(pg, timeout=SKYRL_RAY_PG_TIMEOUT)
         if pg:
             master_actor = self.ray_actor_type.options(
                 num_cpus=num_gpus_per_actor,


### PR DESCRIPTION
# What does this PR do?


Adds a configurable timeout variable `SKYRL_RAY_PG_TIMEOUT` so that users can specify a custom timeout for allocating different placement groups in SkyRL. 

