### PR TITLE
[GPU CI][E2E] Increase timeout for E2E CI tests

### DIFF
--- a/.github/workflows/gpu_e2e_ci.yaml
+++ b/.github/workflows/gpu_e2e_ci.yaml
@@ -42,6 +42,6 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
           envsubst < ci/anyscale_gpu_e2e_test.yaml > ci/anyscale_gpu_e2e_test_envsubst.yaml
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_envsubst.yaml --timeout 4000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test --timeout 4000
+          anyscale job submit -f ci/anyscale_gpu_e2e_test_envsubst.yaml --timeout 4500
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test --timeout 4500
           rm -f ci/anyscale_gpu_e2e_test_envsubst.yaml


### PR DESCRIPTION
# What does this PR do?

The E2E CI workflow: https://github.com/NovaSky-AI/SkyRL/actions/workflows/gpu_e2e_ci.yaml has been failing because of the default CLI timeout of 1800s for `--wait`. 

This PR uses a timeout of 4500s since the underlying job finishes successfully in 1h 10 mins (4200 s). Leaving a 300s buffer in case of wait times for grabbing an instance. 