### PR TITLE
[vLLM] Skip the version check if an development version is being used

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -92,7 +92,9 @@ def create_ray_wrapped_inference_engines(
         import vllm
         from skyrl_train.inference_engines.vllm.vllm_engine import VLLMRayActor, AsyncVLLMRayActor
 
-        assert version.parse(vllm.__version__) >= version.parse("0.8.3"), "SkyRL-Train only supports vLLM >= 0.8.3"
+        # if a dev version is being used, skip the version check
+        if "dev" not in vllm.__version__:
+            assert version.parse(vllm.__version__) >= version.parse("0.8.3"), "SkyRL-Train only supports vLLM >= 0.8.3"
     elif backend == "sglang":
         # We import SGLang later to avoid importing vllm. See `get_sglang_engine` for more.
         pass


### PR DESCRIPTION
# What does this PR do?

Sometimes it is desirable to use a development version of vLLM by installling from source. With vLLM's version convention, the dev version looks something like: `0.1.dev8666+g0e3bb543f`.  Currently, using a dev version will fail due to a strict version check. This PR makes a minor edit to skip the version check if a dev version is being used. 