### PR TITLE
[GPU CI] Fix deepspeed dependency in GPU CI

### DIFF
--- a/skyrl-train/ci/gpu_ci_run.sh
+++ b/skyrl-train/ci/gpu_ci_run.sh
@@ -6,7 +6,7 @@ export CI=true
 uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 uv run examples/search/searchr1_dataset.py --local_dir $HOME/data/searchR1 --split test
 # Run all non-SGLang tests
-uv run --directory . --isolated --extra dev --extra vllm --with deepspeed pytest -s tests/gpu/gpu_ci -m "not (sglang or integrations)"
+uv run --directory . --isolated --extra dev --extra vllm --extra deepspeed pytest -s tests/gpu/gpu_ci -m "not (sglang or integrations)"
 
 # Run tests for "integrations" folder
 if add_integrations=$(uv add --active wordle --index https://hub.primeintellect.ai/will/simple/ 2>&1); then
@@ -19,4 +19,4 @@ else
 fi
 
 # Run all SGLang tests
-uv run --directory . --isolated --extra dev --extra sglang --with deepspeed pytest -s tests/gpu/gpu_ci -m "sglang"
+uv run --directory . --isolated --extra dev --extra sglang --extra deepspeed pytest -s tests/gpu/gpu_ci -m "sglang"


### PR DESCRIPTION
# What does this PR do?

GPU CI is failing locally with the following error:

```bash
(base) ray@ip-10-0-145-16:~/default/gen-tracker/skyrl-train$ bash ci/gpu_ci_run.sh
......
ImportError while loading conftest '/home/ray/default/gen-tracker/skyrl-train/tests/gpu/conftest.py'.
tests/gpu/conftest.py:3: in <module>
    from tests.gpu.utils import ray_init_for_tests
tests/gpu/utils.py:18: in <module>
    from skyrl_train.workers.worker import PPORayActorGroup
skyrl_train/workers/worker.py:25: in <module>
    from transformers import PreTrainedModel
../../../.cache/uv/builds-v0/.tmp27LTUz/lib/python3.12/site-packages/transformers/utils/import_utils.py:2305: in __getattr__
    raise ModuleNotFoundError(
E   ModuleNotFoundError: Could not import module 'PreTrainedModel'. Are this object's requirements defined correctly?
```

The root cause is that we are using `--with deepspeed` instead of `--extra deepspeed`. IN the former case, we end up using a different version of dependencies and that causes some issues. 