### PR TITLE
[Config] Fix `cpu_offload` default for Ref model

### DIFF
--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -263,7 +263,7 @@ Reference Model Configuration
     ref:
       deepspeed_config: ${deepspeed_config.eval}
       fsdp_config:
-        cpu_offload: true
+        cpu_offload: false
         reshard_after_forward: true
         fsdp_size: -1
       sequence_parallel_size: 1

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -51,7 +51,7 @@ trainer:
     sequence_parallel_size: 1
     deepspeed_config: ${deepspeed_config.eval}
     fsdp_config:
-      cpu_offload: true
+      cpu_offload: false
       reshard_after_forward: true
       fsdp_size: -1
   critic:


### PR DESCRIPTION
# What does this PR do?

We've set the default for the Ref model to be `cpu_offload: true`. However, this is pretty non-intuitive and can lead to a subtle performance drop. We should use default `false`

