### PR TITLE
[bug] Always backload policy model before training loop

### DIFF
--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -245,12 +245,12 @@ class RayPPOTrainer:
         # create rank0 policy model and inference_engines groups
         with Timer("setup_policy_and_generator"):
             self.setup_policy_and_generator()
+            if self.cfg.trainer.placement.colocate_all:
+                self.policy_model.backload_to_gpu()
 
         # Eval before training
         inference_engine_is_active = False
         if self.cfg.trainer.eval_interval > 0 and self.cfg.trainer.eval_before_train:
-            if self.cfg.trainer.placement.colocate_all:
-                self.policy_model.backload_to_gpu()
             with self.eval_weights_manager:
                 with Timer("eval", self.all_timings):
                     eval_metrics = asyncio.run(self.eval())


### PR DESCRIPTION
Fixes bug introduced #297 where we weren't backloading the policy model to GPU if `eval_before_train` is false. This wasn't an issue for the FSDP backend, where weight syncing still works if the model is on CPU. But got an illegal memory access error for the Megatron backend.