### PR TITLE
Plumb `engine_init_kwargs` from CLI to inference engine

### DIFF
--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -532,7 +532,7 @@ Generation Parameters
 - ``generator.eval_n_samples_per_prompt``: Number of samples to generate per prompt for evaluation.
 - ``generator.max_turns``: Maximum number of turns for generation with multi-turn RL.
 - ``generator.use_conversation_multi_turn``: Whether to use conversation format for multi-turn generation. If set to ``true`` then observations are appended to the chat history as a new turn. If set to ``false`` then observations are appended as-is to the assistant response in token space and generation is continued  (after removing any EOS token in the response).  We've observed some cases where model can be sensitive to chat history format (ex: in SkyRL-SQL), and thus ``false`` can be used for full control over the exact tokens added after environment interaction.
-- ``generator.engine_init_kwargs``: Inference engine arguments passed directly to the vLLM or SGLang engine. To specify an engine arg in the CLI override, use the format: +generator.engine_init_kwargs.[arg_name]=value
+- ``generator.engine_init_kwargs``: Inference engine arguments passed directly to the vLLM or SGLang engine. To specify an engine arg in the CLI override, use the format: +generator.engine_init_kwargs.[arg_name]=value. If duplicate kwargs are passed or kwargs clash with existing generator arguments (e.g., ``tensor_parallel_size``), an error is raised.
 
 Misc Configuration
 ~~~~~~~~~~~~~~~~~~

--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -451,7 +451,7 @@ Generator Configuration
     max_num_seqs: 1024
     remote_inference_engine_urls: ["127.0.0.1:8001"]
     max_turns: 1
-    vllm_engine_kwargs: {}
+    engine_init_kwargs: {}
 
     override_existing_update_group: "auto" # "auto", "enable", "disable"
     # sampling params for generation phase
@@ -532,7 +532,7 @@ Generation Parameters
 - ``generator.eval_n_samples_per_prompt``: Number of samples to generate per prompt for evaluation.
 - ``generator.max_turns``: Maximum number of turns for generation with multi-turn RL.
 - ``generator.use_conversation_multi_turn``: Whether to use conversation format for multi-turn generation. If set to ``true`` then observations are appended to the chat history as a new turn. If set to ``false`` then observations are appended as-is to the assistant response in token space and generation is continued  (after removing any EOS token in the response).  We've observed some cases where model can be sensitive to chat history format (ex: in SkyRL-SQL), and thus ``false`` can be used for full control over the exact tokens added after environment interaction.
-- ``generator.vllm_engine_kwargs``: vLLM engine arguments passed directly to the vLLM engine. To specify a vLLM engine arg in the CLI override, use the format: +generator.vllm_engine_kwargs.[arg_name]=value
+- ``generator.engine_init_kwargs``: vLLM engine arguments passed directly to the vLLM engine. To specify a vLLM engine arg in the CLI override, use the format: +generator.engine_init_kwargs.[arg_name]=value
 
 Misc Configuration
 ~~~~~~~~~~~~~~~~~~

--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -532,7 +532,7 @@ Generation Parameters
 - ``generator.eval_n_samples_per_prompt``: Number of samples to generate per prompt for evaluation.
 - ``generator.max_turns``: Maximum number of turns for generation with multi-turn RL.
 - ``generator.use_conversation_multi_turn``: Whether to use conversation format for multi-turn generation. If set to ``true`` then observations are appended to the chat history as a new turn. If set to ``false`` then observations are appended as-is to the assistant response in token space and generation is continued  (after removing any EOS token in the response).  We've observed some cases where model can be sensitive to chat history format (ex: in SkyRL-SQL), and thus ``false`` can be used for full control over the exact tokens added after environment interaction.
-- ``generator.engine_init_kwargs``: vLLM engine arguments passed directly to the vLLM engine. To specify a vLLM engine arg in the CLI override, use the format: +generator.engine_init_kwargs.[arg_name]=value
+- ``generator.engine_init_kwargs``: Inference engine arguments passed directly to the vLLM or SGLang engine. To specify an engine arg in the CLI override, use the format: +generator.engine_init_kwargs.[arg_name]=value
 
 Misc Configuration
 ~~~~~~~~~~~~~~~~~~

--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -451,6 +451,7 @@ Generator Configuration
     max_num_seqs: 1024
     remote_inference_engine_urls: ["127.0.0.1:8001"]
     max_turns: 1
+    vllm_engine_kwargs: {}
 
     override_existing_update_group: "auto" # "auto", "enable", "disable"
     # sampling params for generation phase
@@ -531,6 +532,7 @@ Generation Parameters
 - ``generator.eval_n_samples_per_prompt``: Number of samples to generate per prompt for evaluation.
 - ``generator.max_turns``: Maximum number of turns for generation with multi-turn RL.
 - ``generator.use_conversation_multi_turn``: Whether to use conversation format for multi-turn generation. If set to ``true`` then observations are appended to the chat history as a new turn. If set to ``false`` then observations are appended as-is to the assistant response in token space and generation is continued  (after removing any EOS token in the response).  We've observed some cases where model can be sensitive to chat history format (ex: in SkyRL-SQL), and thus ``false`` can be used for full control over the exact tokens added after environment interaction.
+- ``generator.vllm_engine_kwargs``: vLLM engine arguments passed directly to the vLLM engine. To specify a vLLM engine arg in the CLI override, use the format: +generator.vllm_engine_kwargs.[arg_name]=value
 
 Misc Configuration
 ~~~~~~~~~~~~~~~~~~

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -199,7 +199,6 @@ generator:
   # To specify a vLLM engine arg in the CLI override, use the format: +generator.vllm_engine_kwargs.arg_name=value
   vllm_engine_kwargs: {}
 
-
   override_existing_update_group: "auto" # "auto", "enable", "disable"
   # sampling params for generation phase
   sampling_params:

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -195,9 +195,9 @@ generator:
   http_endpoint_port: 8000
   max_turns: 1
 
-  # vLLM Engine Argumentss, which are passed directly to the vLLM engine. Arg names must match vLLM's engine args.
-  # To specify a vLLM engine arg in the CLI override, use the format: +generator.vllm_engine_kwargs.arg_name=value
-  vllm_engine_kwargs: {}
+  # Inference engine arguments. Arguments are passed directly to the vLLM or SGLang engine, so names must match
+  # the engine's args. To specify an engine arg in the CLI override, use the format: +generator.engine_init_kwargs.arg_name=value
+  engine_init_kwargs: {}
 
   override_existing_update_group: "auto" # "auto", "enable", "disable"
   # sampling params for generation phase

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -195,6 +195,11 @@ generator:
   http_endpoint_port: 8000
   max_turns: 1
 
+  # vLLM Engine Argumentss, which are passed directly to the vLLM engine. Arg names must match vLLM's engine args.
+  # To specify a vLLM engine arg in the CLI override, use the format: +generator.vllm_engine_kwargs.arg_name=value
+  vllm_engine_kwargs: {}
+
+
   override_existing_update_group: "auto" # "auto", "enable", "disable"
   # sampling params for generation phase
   sampling_params:

--- a/skyrl-train/skyrl_train/entrypoints/main_base.py
+++ b/skyrl-train/skyrl_train/entrypoints/main_base.py
@@ -57,6 +57,7 @@ def create_ray_wrapped_inference_engines_from_config(cfg: DictConfig, colocate_p
         max_num_seqs=cfg.generator.max_num_seqs,
         tokenizer=tokenizer,
         backend=cfg.generator.backend,
+        vllm_engine_kwargs=cfg.generator.vllm_engine_kwargs,
     )
 
 

--- a/skyrl-train/skyrl_train/entrypoints/main_base.py
+++ b/skyrl-train/skyrl_train/entrypoints/main_base.py
@@ -57,7 +57,7 @@ def create_ray_wrapped_inference_engines_from_config(cfg: DictConfig, colocate_p
         max_num_seqs=cfg.generator.max_num_seqs,
         tokenizer=tokenizer,
         backend=cfg.generator.backend,
-        vllm_engine_kwargs=cfg.generator.vllm_engine_kwargs,
+        engine_init_kwargs=cfg.generator.engine_init_kwargs,
     )
 
 

--- a/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -79,7 +79,7 @@ def create_ray_wrapped_inference_engines(
     max_num_seqs=1024,
     tokenizer=None,
     backend="vllm",
-    vllm_engine_kwargs : Dict[str, Any] = {},
+    vllm_engine_kwargs: Dict[str, Any] = {},
 ) -> List[InferenceEngineInterface]:
     """
     Create a list of RayWrappedInferenceEngine instances wrapping Ray actor handles to InferenceEngineInterface instances.

--- a/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -79,7 +79,7 @@ def create_ray_wrapped_inference_engines(
     max_num_seqs=1024,
     tokenizer=None,
     backend="vllm",
-    vllm_engine_kwargs: Dict[str, Any] = {},
+    engine_init_kwargs: Dict[str, Any] = {},
 ) -> List[InferenceEngineInterface]:
     """
     Create a list of RayWrappedInferenceEngine instances wrapping Ray actor handles to InferenceEngineInterface instances.
@@ -168,7 +168,7 @@ def create_ray_wrapped_inference_engines(
                 max_num_seqs=max_num_seqs,
                 # only need the logprobs for the chosen token if any
                 max_logprobs=1,
-                **vllm_engine_kwargs,
+                **engine_init_kwargs,
             )
         elif backend == "sglang":
             # NOTE: there is no async / sync engine distinction in SGLang
@@ -213,6 +213,7 @@ def create_ray_wrapped_inference_engines(
                     bundle_indices=bundle_indices,
                     num_gpus=0.2 if use_hybrid_engine else 1,
                     tokenizer=tokenizer,
+                    **engine_init_kwargs,
                 )
                 return engine
 

--- a/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -79,6 +79,7 @@ def create_ray_wrapped_inference_engines(
     max_num_seqs=1024,
     tokenizer=None,
     backend="vllm",
+    vllm_engine_kwargs : Dict[str, Any] = {},
 ) -> List[InferenceEngineInterface]:
     """
     Create a list of RayWrappedInferenceEngine instances wrapping Ray actor handles to InferenceEngineInterface instances.
@@ -167,6 +168,7 @@ def create_ray_wrapped_inference_engines(
                 max_num_seqs=max_num_seqs,
                 # only need the logprobs for the chosen token if any
                 max_logprobs=1,
+                **vllm_engine_kwargs,
             )
         elif backend == "sglang":
             # NOTE: there is no async / sync engine distinction in SGLang


### PR DESCRIPTION
Resolves #318 

## What does this PR do?
Adds support for specifying inference engine args in the training config and CLI override arguments, which are passed directly to the vLLM or SGLang Engine init. For example, to specify vLLM's tool params, you can add the following to the training script (note the `+`, which is required):
```
+generator.engine_init_kwargs.enable_auto_tool_choice=true \
+generator.engine_init_kwargs.tool_call_parser="hermes"
```