### PR TITLE
[Tests] Fix GPU CI failures after #298

### DIFF
--- a/skyrl-train/ci/gpu_ci_run.sh
+++ b/skyrl-train/ci/gpu_ci_run.sh
@@ -6,7 +6,7 @@ export CI=true
 uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 uv run examples/search/searchr1_dataset.py --local_dir $HOME/data/searchR1 --split test
 # Run all non-SGLang tests
-uv run --directory . --isolated --extra dev --extra vllm --extra deepspeed pytest -s tests/gpu/gpu_ci -m "not (sglang or integrations)"
+uv run --directory . --isolated --extra dev --extra vllm --extra deepspeed pytest -s tests/gpu/gpu_ci -m "not (sglang or integrations or megatron)"
 
 # Run tests for "integrations" folder
 if add_integrations=$(uv add --active wordle --index https://hub.primeintellect.ai/will/simple/ 2>&1); then

--- a/skyrl-train/ci/gpu_ci_run.sh
+++ b/skyrl-train/ci/gpu_ci_run.sh
@@ -6,6 +6,7 @@ export CI=true
 uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 uv run examples/search/searchr1_dataset.py --local_dir $HOME/data/searchR1 --split test
 # Run all non-SGLang tests
+# TODO: enable megatron when tests and dependencies are fixed
 uv run --directory . --isolated --extra dev --extra vllm --extra deepspeed pytest -s tests/gpu/gpu_ci -m "not (sglang or integrations or megatron)"
 
 # Run tests for "integrations" folder

--- a/skyrl-train/tests/gpu/gpu_ci/test_trainer_full_checkpointing.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_trainer_full_checkpointing.py
@@ -30,7 +30,7 @@ from tests.gpu.utils import import_worker, ray_init_for_tests
 from skyrl_train.entrypoints.main_base import config_dir
 
 MODEL_NAME = "Qwen/Qwen3-0.6B"
-NUM_GPUS = 4
+NUM_GPUS = 2
 
 
 class DummyDataset(Dataset):

--- a/skyrl-train/tests/gpu/gpu_ci/test_trainer_full_checkpointing.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_trainer_full_checkpointing.py
@@ -138,7 +138,9 @@ def create_minimal_trainer(cfg: DictConfig):
         ("fsdp2", False),
         ("fsdp2", True),
         # FIXME (erictang000): Add megatron test when dependencies work
-        # pytest.param("megatron", False, marks=pytest.mark.megatron),
+        pytest.param(
+            "megatron", False, marks=pytest.mark.skip(reason="Skipping megatron test until dependency issues are fixed")
+        ),
     ],
 )
 def test_trainer_full_checkpointing(ray_init_fixture, strategy, fsdp2_cpu_offload):

--- a/skyrl-train/tests/gpu/gpu_ci/test_trainer_full_checkpointing.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_trainer_full_checkpointing.py
@@ -137,7 +137,8 @@ def create_minimal_trainer(cfg: DictConfig):
         ("fsdp", False),
         ("fsdp2", False),
         ("fsdp2", True),
-        pytest.param("megatron", False, marks=pytest.mark.megatron),
+        # FIXME (erictang000): Add megatron test when dependencies work
+        # pytest.param("megatron", False, marks=pytest.mark.megatron),
     ],
 )
 def test_trainer_full_checkpointing(ray_init_fixture, strategy, fsdp2_cpu_offload):

--- a/skyrl-train/tests/gpu/gpu_ci/test_trainer_full_checkpointing.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_trainer_full_checkpointing.py
@@ -80,7 +80,6 @@ def get_test_trainer_config(strategy: str, fsdp2_cpu_offload: bool = False) -> D
 
     # Megatron-specific
     if strategy == "megatron":
-        # FIXME: confirm this runs with 4 GPUs since that is what is used in CI
         cfg.trainer.policy.megatron_config.tensor_model_parallel_size = 2
         cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = 2
         cfg.trainer.placement.policy_num_gpus_per_node = 4
@@ -138,10 +137,7 @@ def create_minimal_trainer(cfg: DictConfig):
         ("fsdp", False),
         ("fsdp2", False),
         ("fsdp2", True),
-        # FIXME (erictang000): Add megatron test when dependencies work
-        pytest.param(
-            "megatron", False, marks=pytest.mark.skip(reason="Skipping megatron test until dependency issues are fixed")
-        ),
+        pytest.param("megatron", False, marks=pytest.mark.megatron),
     ],
 )
 def test_trainer_full_checkpointing(ray_init_fixture, strategy, fsdp2_cpu_offload):

--- a/skyrl-train/tests/gpu/gpu_ci/test_trainer_full_checkpointing.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_trainer_full_checkpointing.py
@@ -80,6 +80,7 @@ def get_test_trainer_config(strategy: str, fsdp2_cpu_offload: bool = False) -> D
 
     # Megatron-specific
     if strategy == "megatron":
+        # FIXME: confirm this runs with 4 GPUs since that is what is used in CI
         cfg.trainer.policy.megatron_config.tensor_model_parallel_size = 2
         cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = 2
         cfg.trainer.placement.policy_num_gpus_per_node = 4


### PR DESCRIPTION
# What does this PR do?

#298 broke GPU CI a bit: 
1. Megatron related dependencies have not been resolved properly on `main` yet, and this test should be skipped.
2. We use a simple 4xL4 instance, but then the test was modified in #298 to request 8 GPUs (non-colocated training)