### PR TITLE
[NCCL] Add stricter checks for P2P and set NCCL_P2P/SHM_DISABLE if needed, fix watchdog timeout

### DIFF
--- a/skyrl-train/skyrl_train/utils/p2p_check_utils.py
+++ b/skyrl-train/skyrl_train/utils/p2p_check_utils.py
@@ -8,6 +8,7 @@ import torch.multiprocessing as mp
 import time
 from datetime import timedelta
 
+
 def _nccl_reduce_worker(rank: int, world_size: int, master_addr: str, master_port: int, env_overrides: dict):
     for k, v in (env_overrides or {}).items():
         os.environ[str(k)] = str(v)

--- a/skyrl-train/skyrl_train/utils/p2p_check_utils.py
+++ b/skyrl-train/skyrl_train/utils/p2p_check_utils.py
@@ -1,0 +1,88 @@
+"""Utils methods for checking. Caller uses `run_nccl_torch_distributed_check()` to determine if NCCL P2P/SHM is supported."""
+
+import os
+import torch
+import socket
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import time
+from datetime import timedelta
+
+def _nccl_reduce_worker(rank: int, world_size: int, master_addr: str, master_port: int, env_overrides: dict):
+    for k, v in (env_overrides or {}).items():
+        os.environ[str(k)] = str(v)
+
+    os.environ["MASTER_ADDR"] = master_addr
+    os.environ["MASTER_PORT"] = str(master_port)
+
+    torch.cuda.set_device(rank)
+    # Short process-group timeout to fail fast inside worker if possible
+    try:
+        dist.init_process_group(
+            backend="nccl",
+            rank=rank,
+            world_size=world_size,
+            timeout=timedelta(seconds=10),
+        )
+    except Exception:
+        # Ensure non-zero exit on failure to init
+        raise
+
+    try:
+        tensor = torch.ones(1, device=torch.device(f"cuda:{rank}"))
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
+        if abs(float(tensor.item()) - float(world_size)) > 1e-3:
+            raise RuntimeError(f"Unexpected all_reduce result: {tensor.item()} vs {world_size}")
+    finally:
+        try:
+            dist.destroy_process_group()
+        except Exception:
+            pass
+
+
+def run_nccl_torch_distributed_check(env_overrides: dict | None, timeout_s: int = 15) -> bool:
+    world_size = torch.cuda.device_count()
+    assert world_size >= 2
+
+    # Allocate a free TCP port for init_method
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    ctx = mp.get_context("spawn")
+    procs: list[mp.Process] = []
+    for rank in range(world_size):
+        p = ctx.Process(
+            target=_nccl_reduce_worker,
+            args=(rank, world_size, "127.0.0.1", port, env_overrides or {}),
+        )
+        p.daemon = True
+        procs.append(p)
+
+    start = time.time()
+    for p in procs:
+        p.start()
+
+    success = True
+    while time.time() - start < timeout_s:
+        if all(p.exitcode is not None for p in procs):
+            break
+        time.sleep(0.1)
+
+    # If any are still alive after timeout, terminate and mark failure
+    for p in procs:
+        if p.exitcode is None:
+            try:
+                p.terminate()
+            except Exception:
+                pass
+            success = False
+
+    # Check exit codes
+    for p in procs:
+        p.join(timeout=1)
+        if p.exitcode != 0:
+            success = False
+
+    return success

--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -661,9 +661,7 @@ def _get_env_vars_for_p2p_access_helper() -> dict[str, str]:
         logger.info("NCCL P2P/SHM checks passed with NCCL_P2P_DISABLE AND NCCL_SHM_DISABLE")
         return {"NCCL_P2P_DISABLE": "1", "NCCL_SHM_DISABLE": "1"}
 
-    raise RuntimeError(
-        "NCCL P2P/SHM checks failed even with fallbacks. Please verify drivers and interconnect."
-    )
+    raise RuntimeError("NCCL P2P/SHM checks failed even with fallbacks. Please verify drivers and interconnect.")
 
 
 def get_env_vars_for_p2p_access(max_num_gpus_per_node: int) -> dict[str, str]:

--- a/skyrl-train/tests/gpu/gpu_ci/conftest.py
+++ b/skyrl-train/tests/gpu/gpu_ci/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import ray
 from loguru import logger
 from functools import lru_cache
-from skyrl_train.utils.utils import peer_access_supported
+from skyrl_train.utils.utils import get_env_vars_override_for_peer_access
 
 
 @lru_cache(5)
@@ -16,9 +16,10 @@ def ray_init_fixture():
     if ray.is_initialized():
         ray.shutdown()
     env_vars = {}
-    if not peer_access_supported(max_num_gpus_per_node=2):
-        log_once("Disabling NCCL P2P for CI environment")
-        env_vars = {"NCCL_P2P_DISABLE": "1", "NCCL_SHM_DISABLE": "1"}
+    overrides = get_env_vars_override_for_peer_access(max_num_gpus_per_node=2)
+    if overrides != {}:
+        log_once(f"Disabling NCCL P2P for test environment, setting the following env vars: {overrides}")
+        env_vars = overrides
     ray.init(runtime_env={"env_vars": env_vars})
     yield
     # call ray shutdown after a test regardless

--- a/skyrl-train/tests/gpu/gpu_ci/conftest.py
+++ b/skyrl-train/tests/gpu/gpu_ci/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import ray
 from loguru import logger
 from functools import lru_cache
-from skyrl_train.utils.utils import get_env_vars_override_for_peer_access
+from skyrl_train.utils.utils import get_env_vars_for_p2p_access
 
 
 @lru_cache(5)
@@ -16,7 +16,7 @@ def ray_init_fixture():
     if ray.is_initialized():
         ray.shutdown()
     env_vars = {}
-    overrides = get_env_vars_override_for_peer_access(max_num_gpus_per_node=2)
+    overrides = get_env_vars_for_p2p_access(max_num_gpus_per_node=2)
     if overrides != {}:
         log_once(f"Disabling NCCL P2P for test environment, setting the following env vars: {overrides}")
         env_vars = overrides

--- a/skyrl-train/tests/gpu/utils.py
+++ b/skyrl-train/tests/gpu/utils.py
@@ -22,7 +22,7 @@ from skyrl_train.entrypoints.main_base import config_dir
 from skyrl_train.utils import get_ray_pg_ready_with_timeout
 from skyrl_train.distributed.dispatch import concatenate_outputs_after_mesh_dispatch
 from skyrl_train.generators.base import GeneratorInput, ConversationType
-from skyrl_train.utils.utils import get_env_vars_override_for_peer_access, print_mem, initialize_ray, validate_cfg
+from skyrl_train.utils.utils import get_env_vars_for_p2p_access, print_mem, initialize_ray, validate_cfg
 from skyrl_train.inference_engines.ray_wrapped_inference_engine import create_ray_wrapped_inference_engines
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
 from skyrl_train.inference_engines.base import InferenceEngineInput
@@ -350,7 +350,7 @@ def log_once(msg):
 
 def ray_init_for_tests():
     env_vars = {}
-    overrides = get_env_vars_override_for_peer_access(max_num_gpus_per_node=4)
+    overrides = get_env_vars_for_p2p_access(max_num_gpus_per_node=4)
     if overrides != {}:
         log_once(f"Disabling NCCL P2P for test environment, setting the following env vars: {overrides}")
         env_vars = overrides

--- a/skyrl-train/tests/gpu/utils.py
+++ b/skyrl-train/tests/gpu/utils.py
@@ -22,7 +22,7 @@ from skyrl_train.entrypoints.main_base import config_dir
 from skyrl_train.utils import get_ray_pg_ready_with_timeout
 from skyrl_train.distributed.dispatch import concatenate_outputs_after_mesh_dispatch
 from skyrl_train.generators.base import GeneratorInput, ConversationType
-from skyrl_train.utils.utils import peer_access_supported, print_mem, initialize_ray, validate_cfg
+from skyrl_train.utils.utils import get_env_vars_override_for_peer_access, print_mem, initialize_ray, validate_cfg
 from skyrl_train.inference_engines.ray_wrapped_inference_engine import create_ray_wrapped_inference_engines
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
 from skyrl_train.inference_engines.base import InferenceEngineInput
@@ -350,9 +350,10 @@ def log_once(msg):
 
 def ray_init_for_tests():
     env_vars = {}
-    if not peer_access_supported(max_num_gpus_per_node=4):
-        log_once("Disabling NCCL P2P for test environment")
-        env_vars = {"NCCL_P2P_DISABLE": "1", "NCCL_SHM_DISABLE": "1"}
+    overrides = get_env_vars_override_for_peer_access(max_num_gpus_per_node=4)
+    if overrides != {}:
+        log_once(f"Disabling NCCL P2P for test environment, setting the following env vars: {overrides}")
+        env_vars = overrides
     ray.init(runtime_env={"env_vars": env_vars})
 
 


### PR DESCRIPTION
### Before this PR

Some users (including myself) have observed that the experiments that require more than 1 GPU occasionally run into the following error after hanging for 10 minutes

```
   (FSDPRefRayActorBase pid=31857) [rank1]:[E918 23:18:00.308397639 ProcessGroupNCCL.cpp:632] [Rank 1] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=1, OpType=BROADCAST, NumelIn=233373696, NumelOut=233373696, Timeout(ms)=600000) ran for 600023 milliseconds before timing out.
```

Example full log: https://gist.github.com/CharlieFRuan/64ecd3003933b94ba2906d64800edf76

This is likely due to some NCCL P2P issues on the machine's hardware/driver. A simple torch.distributed test can illustrate the problem. That is, for this test: https://gist.github.com/CharlieFRuan/316bee4dfe1137c4da89582624058ea0, if running ``torchrun --standalone --nproc_per_node=NUM_GPUS test_distributed.py`` hangs and ``NCCL_P2P_DISABLE=1 torchrun --standalone --nproc_per_node=4 test_distributed.py`` works, it means that the NCCL P2P access is not supported on your machine.

### This PR

While we have a util `run_p2p_access_check()`, which when fails add `NCCL_P2P_DISABLE=1` and `NCCL_SHM_DISABLE=1` when initializing ray, it did not cover these cases.

This PR adds a `run_nccl_torch_distributed_check()` that does a similar basic torch.distributed check. Besides, instead of having a boolean `peer_access_supported()` check, we use `get_env_vars_for_p2p_access()` that returns one of the following, progressively when the previous fails:
- `{}`
- `{"NCCL_SHM_DISABLE": "1"}`
- `{"NCCL_P2P_DISABLE": "1", "NCCL_SHM_DISABLE": "1"}`

Notably, if we do not run the `_get_env_vars_for_p2p_access_helper()` in a ray placement group, it may pass the test despite later on we still run into the same old hanging issue.

### Tests

- The previously hanging machine (4xL40s, 4xA40 on runpod) now can run `run_gsm8k.sh`.
- The previously working 4xA100 on runpod still works
- GPU CI running
- Need some multinode test?

### References
- https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
- https://docs.vllm.ai/en/latest/usage/troubleshooting.html#incorrect-hardwaredriver
