### PR TITLE
[Fix] Fix async trainer after #298

### DIFF
--- a/skyrl-train/examples/async/async_run_gsm8k.sh
+++ b/skyrl-train/examples/async/async_run_gsm8k.sh
@@ -15,9 +15,9 @@ uv run --isolated --extra vllm -m examples.async.main_async \
   trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \
   trainer.placement.colocate_all=false \
   trainer.strategy=fsdp2 \
-  trainer.placement.policy_num_gpus_per_node=4 \
-  trainer.placement.ref_num_gpus_per_node=4 \
-  generator.num_inference_engines=4 \
+  trainer.placement.policy_num_gpus_per_node=2 \
+  trainer.placement.ref_num_gpus_per_node=2 \
+  generator.num_inference_engines=2 \
   generator.inference_engine_tensor_parallel_size=1 \
   trainer.epochs=20 \
   trainer.eval_batch_size=1024 \

--- a/skyrl-train/examples/async/async_run_gsm8k.sh
+++ b/skyrl-train/examples/async/async_run_gsm8k.sh
@@ -15,9 +15,9 @@ uv run --isolated --extra vllm -m examples.async.main_async \
   trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \
   trainer.placement.colocate_all=false \
   trainer.strategy=fsdp2 \
-  trainer.placement.policy_num_gpus_per_node=2 \
-  trainer.placement.ref_num_gpus_per_node=2 \
-  generator.num_inference_engines=2 \
+  trainer.placement.policy_num_gpus_per_node=4 \
+  trainer.placement.ref_num_gpus_per_node=4 \
+  generator.num_inference_engines=4 \
   generator.inference_engine_tensor_parallel_size=1 \
   trainer.epochs=20 \
   trainer.eval_batch_size=1024 \

--- a/skyrl-train/examples/async/async_trainer.py
+++ b/skyrl-train/examples/async/async_trainer.py
@@ -34,7 +34,7 @@ class AsyncRayPPOTrainer(RayPPOTrainer):
                 self.load_checkpoints()
                 logger.info(f"Resumed training from global_step {self.global_step}")
 
-        # create rank0 policy model and inference_engines groups, then broadcast weights to inference_engines
+        # Initialize weight sync state
         with Timer("init_weight_sync_state"):
             self.init_weight_sync_state()
 

--- a/skyrl-train/examples/async/async_trainer.py
+++ b/skyrl-train/examples/async/async_trainer.py
@@ -35,8 +35,8 @@ class AsyncRayPPOTrainer(RayPPOTrainer):
                 logger.info(f"Resumed training from global_step {self.global_step}")
 
         # create rank0 policy model and inference_engines groups, then broadcast weights to inference_engines
-        with Timer("setup_policy_and_generator"):
-            self.setup_policy_and_generator()
+        with Timer("init_weight_sync_state"):
+            self.init_weight_sync_state()
 
         # Eval before training
         if self.cfg.trainer.eval_interval > 0 and self.cfg.trainer.eval_before_train:

--- a/skyrl-train/scripts/full_context/trainer_full_ctx.py
+++ b/skyrl-train/scripts/full_context/trainer_full_ctx.py
@@ -20,7 +20,7 @@ class FullCtxTrainer(RayPPOTrainer):
 
         self.global_step = 0
 
-        # Setup policy and generator
+        # Initialize weight sync state
         with Timer("init_weight_sync_state", self.all_timings):
             self.init_weight_sync_state()
 

--- a/skyrl-train/scripts/full_context/trainer_full_ctx.py
+++ b/skyrl-train/scripts/full_context/trainer_full_ctx.py
@@ -21,8 +21,8 @@ class FullCtxTrainer(RayPPOTrainer):
         self.global_step = 0
 
         # Setup policy and generator
-        with Timer("setup_policy_and_generator", self.all_timings):
-            self.setup_policy_and_generator()
+        with Timer("init_weight_sync_state", self.all_timings):
+            self.init_weight_sync_state()
 
         # Run a few training steps
         self.global_step += 1  # start from 1

--- a/skyrl-train/tests/gpu/test_grpo_sp_sanity.py
+++ b/skyrl-train/tests/gpu/test_grpo_sp_sanity.py
@@ -51,7 +51,7 @@ class RayPPOTestTrainer(RayPPOTrainer):
         self.all_metrics = {}
         self.all_timings = {}
 
-        # create rank0 policy model and inference_engines groups, then broadcast weights to inference_engines
+        # Initialize weight sync state
         with Timer("init_weight_sync_state"):
             self.init_weight_sync_state()
 

--- a/skyrl-train/tests/gpu/test_grpo_sp_sanity.py
+++ b/skyrl-train/tests/gpu/test_grpo_sp_sanity.py
@@ -52,8 +52,8 @@ class RayPPOTestTrainer(RayPPOTrainer):
         self.all_timings = {}
 
         # create rank0 policy model and inference_engines groups, then broadcast weights to inference_engines
-        with Timer("setup_policy_and_generator"):
-            self.setup_policy_and_generator()
+        with Timer("init_weight_sync_state"):
+            self.init_weight_sync_state()
 
         # main training loop
         consumed_samples = 0


### PR DESCRIPTION
# What does this PR do?


Fixes async trainer example after #298. We renamed `setup_policy_and_generator` to `init_weight_sync_state` 