### PR TITLE
[Fix] Fix n samples for evaluation in trainer

### DIFF
--- a/skyagent/examples/run_skyrl/trainer.py
+++ b/skyagent/examples/run_skyrl/trainer.py
@@ -62,7 +62,7 @@ class SkyAgentPPOTrainer(RayPPOTrainer):
         all_envs = sum(
             [
                 [prompt["env_class"] if prompt["env_class"] is not None else self.cfg.environment.env_class]
-                * self.cfg.generator.n_samples_per_prompt
+                * n_samples_per_prompt
                 for prompt in rand_prompts
             ],
             [],

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -416,7 +416,7 @@ class RayPPOTrainer:
         all_envs = sum(
             [
                 [prompt["env_class"] if prompt["env_class"] is not None else self.cfg.environment.env_class]
-                * self.cfg.generator.n_samples_per_prompt
+                * n_samples_per_prompt
                 for prompt in rand_prompts
             ],
             [],


### PR DESCRIPTION
# What does this PR do?

Fixes `all_envs` repetition in `_prepare_generator_input` for evaluation. 