### PR TITLE
Build skyrl-train docs on MacOS

### DIFF
--- a/skyrl-train/docs/build.sh
+++ b/skyrl-train/docs/build.sh
@@ -2,9 +2,16 @@
 set -e
 
 # Ensure a valid UTF-8 locale to avoid "unsupported locale setting"
-export LC_ALL=${LC_ALL:-C.UTF-8}
-export LANG=${LANG:-C.UTF-8}
-export LANGUAGE=${LANGUAGE:-C.UTF-8}
+# Use en_US.UTF-8 on macOS, C.UTF-8 elsewhere
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    export LC_ALL=${LC_ALL:-en_US.UTF-8}
+    export LANG=${LANG:-en_US.UTF-8}
+    export LANGUAGE=${LANGUAGE:-en_US.UTF-8}
+else
+    export LC_ALL=${LC_ALL:-C.UTF-8}
+    export LANG=${LANG:-C.UTF-8}
+    export LANGUAGE=${LANGUAGE:-C.UTF-8}
+fi
 
 # Build and serve the documentation with live reload
 # Usage: ./build.sh [--build-only]
@@ -12,8 +19,21 @@ export LANGUAGE=${LANGUAGE:-C.UTF-8}
 
 cd "$(dirname "$0")"  # Ensure we're in the docs directory
 
-if [ "$1" = "--build-only" ]; then
-    uv run --extra docs --isolated sphinx-build -b html . _build/html $@
+# Simple flag handling - if more flags are added, consider using case statement or getopts
+BUILD_ONLY=false
+ARGS=()
+
+# Parse arguments to extract --build-only flag
+for arg in "$@"; do
+    if [ "$arg" = "--build-only" ]; then
+        BUILD_ONLY=true
+    else
+        ARGS+=("$arg")
+    fi
+done
+
+if [ "$BUILD_ONLY" = true ]; then
+    uv run --extra docs --extra cpu --isolated sphinx-build -b html . _build/html "${ARGS[@]}"
 else
-    uv run --extra docs --isolated sphinx-autobuild . _build/html $@
+    uv run --extra docs --extra cpu --isolated sphinx-autobuild . _build/html "${ARGS[@]}"
 fi

--- a/skyrl-train/pyproject.toml
+++ b/skyrl-train/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "tensordict",
     "jaxtyping",
     "skyrl-gym",
-    "flash-attn",
+    "flash-attn; extra != 'cpu'",
     "polars",
 ]
 
@@ -65,8 +65,15 @@ conflicts = [
 
 [tool.uv.sources]
 skyrl-gym = { path = "./skyrl-gym" , editable = true }
-torch = { index = "pytorch-cu128" }
-torchvision = { index = "pytorch-cu128" }
+# Torch sources: GPU by default, CPU when 'cpu' extra is used
+torch = [
+    { index = "pytorch-cu128", marker = "extra != 'cpu'" },  # Default GPU version
+    { index = "pytorch-cpu", marker = "extra == 'cpu'" }  # CPU version when cpu extra is used
+]
+torchvision = [
+    { index = "pytorch-cu128", marker = "extra != 'cpu'" },  # Default GPU version
+    { index = "pytorch-cpu", marker = "extra == 'cpu'" }  # CPU version when cpu extra is used
+]
 flash-attn = { url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.0.post2/flash_attn-2.8.0.post2+cu12torch2.7cxx11abiFALSE-cp312-cp312-linux_x86_64.whl" }
 # NOTE (sumanthrh): We explictly use a flashinfer wheel from their index. 
 # The wheels on PyPI don't come with pre-compiled kernels and the package will JIT compile them at runtime which is slow.
@@ -78,6 +85,9 @@ flashinfer-python = [
 
 
 [project.optional-dependencies]
+cpu = [
+    # CPU-only versions for documentation building and development on machines without CUDA
+]
 deepspeed = [
     "deepspeed==0.16.5"
 ]
@@ -148,6 +158,11 @@ miniswe = [
 [[tool.uv.index]]
 name = "pytorch-cu128"
 url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Addresses #280 

  Changes:
  - Add cpu extra for CPU-only PyTorch installation
  - Make flash-attn conditional: installed by default, excluded with cpu extra
  - Add CPU PyTorch index and conditional sources in pyproject.toml
  - Update docs/build.sh to use --extra cpu for macOS compatibility
  - Fix macOS locale handling in build script

  Result:
  Documentation builds successfully on macOS without manual pyproject.toml modifications. GPU dependencies remain default (opt-out behavior), CPU dependencies available via --extra cpu.

  Testing:
  Verified on macOS (darwin) - builds complete successfully with CPU PyTorch and no flash-attn compatibility errors.