### PR TITLE
[fix] Fix broken default arguments in generation entrypoint

### DIFF
--- a/skyrl-train/examples/gsm8k/run_generation_gsm8k.sh
+++ b/skyrl-train/examples/gsm8k/run_generation_gsm8k.sh
@@ -17,6 +17,7 @@ uv run --isolated --extra $INFERENCE_BACKEND \
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.policy.model.path="Qwen/Qwen2.5-0.5B-Instruct" \
   trainer.logger="$LOGGER" \
+  trainer.placement.colocate_all=false \
   generator.backend=$INFERENCE_BACKEND \
   generator.num_inference_engines=$NUM_GPUS \
   generator.inference_engine_tensor_parallel_size=1 \


### PR DESCRIPTION
By default we sleep() the inference engines after construction so that we can initialize the training workers. When we created the generation-only entrypoint, we still followed this sleep() code path, but had to wake_up() the inference engines for generation, and wake_up() can corrupt weights. 

This PR disables `colocate_all` in the example script as a quick fix. I will send out a (hopefully more elegant) solution to this, and add a test to cover it