### PR TITLE
[Metrics] Ignore observation tokens while calculating rollout train logprobs difference 

### DIFF
--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -890,9 +890,11 @@ class RayPPOTrainer:
 
         if self.cfg.generator.sampling_params.logprobs is not None:
             # calculates the difference in probs between inference and trainer components
-            logprobs_diff = training_input["rollout_logprobs"] - action_log_probs
             # only consider response tokens
-            logprobs_diff = logprobs_diff[training_input["loss_mask"] > 0]
+            logprobs_diff = (
+                training_input["rollout_logprobs"][training_input["loss_mask"] > 0]
+                - action_log_probs[training_input["loss_mask"] > 0]
+            )
             prob_diff = logprobs_diff.exp().abs()
             prob_diff_mean = prob_diff.mean().item()
             prob_diff_std = prob_diff.std().item()

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -891,6 +891,8 @@ class RayPPOTrainer:
         if self.cfg.generator.sampling_params.logprobs is not None:
             # calculates the difference in probs between inference and trainer components
             prob_diff = (training_input["rollout_logprobs"].exp() - action_log_probs.exp()).abs()
+            # only consider response tokens
+            prob_diff = prob_diff[training_input["loss_mask"] > 0]
             prob_diff_mean = prob_diff.mean().item()
             prob_diff_std = prob_diff.std().item()
             self.all_metrics.update(

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -890,9 +890,10 @@ class RayPPOTrainer:
 
         if self.cfg.generator.sampling_params.logprobs is not None:
             # calculates the difference in probs between inference and trainer components
-            prob_diff = (training_input["rollout_logprobs"].exp() - action_log_probs.exp()).abs()
+            logprobs_diff = training_input["rollout_logprobs"] - action_log_probs
             # only consider response tokens
-            prob_diff = prob_diff[training_input["loss_mask"] > 0]
+            logprobs_diff = logprobs_diff[training_input["loss_mask"] > 0]
+            prob_diff = logprobs_diff.exp().abs()
             prob_diff_mean = prob_diff.mean().item()
             prob_diff_std = prob_diff.std().item()
             self.all_metrics.update(


### PR DESCRIPTION
As title. We need to exclude the observation tokens because the rollout logprobs for these tokens will be 0 (dummy) and thus the overall logprobs difference will be artificially inflated. 