### PR TITLE
[fix] Megatron dist checkpoint should use spawn, not fork

### DIFF
--- a/skyrl-train/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl-train/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -56,9 +56,9 @@ class MegatronStrategy(DistributedStrategy):
         self.seed = seed
         self.hf_config = None  # Set by the megatron worker once configs are initialized.
 
-        # NOTE: Set multiprocessing start method to `spawn` to avoid `os.fork()` in the
-        # Megatron dist checkpoint, which does not work well with Ray.
-        mp.set_start_method("spawn", force=True)
+        # NOTE: Set Megatron dist checkpoint async backend to persistent to avoid `os.fork()`-ing
+        # short-lived background workers, which does not work well with Ray.
+        ckpt_base.async_calls = AsyncCallsQueue(persistent=True)
 
     def set_seed(self, seed: int) -> None:
         random.seed(seed)

--- a/skyrl-train/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl-train/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -9,7 +9,6 @@ import torch
 import torch.nn as nn
 from torch import optim
 from torch import distributed as dist
-import multiprocessing as mp
 
 from skyrl_train.distributed.strategy import DistributedStrategy
 from skyrl_train.distributed.utils import ModelOrModelOptimPair
@@ -22,6 +21,10 @@ from skyrl_train.distributed.megatron.megatron_utils import (
     offload_megatron_optimizer,
     load_megatron_optimizer,
 )
+
+from megatron.core.dist_checkpointing.strategies import base as ckpt_base
+from megatron.core.dist_checkpointing.strategies.async_utils import AsyncCallsQueue
+
 from megatron.core import dist_checkpointing
 from megatron.core.dist_checkpointing.serialization import (
     get_default_load_sharded_strategy,

--- a/skyrl-train/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl-train/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 from torch import optim
 from torch import distributed as dist
+import multiprocessing as mp
 
 from skyrl_train.distributed.strategy import DistributedStrategy
 from skyrl_train.distributed.utils import ModelOrModelOptimPair
@@ -51,6 +52,10 @@ class MegatronStrategy(DistributedStrategy):
         self.optimizer_config = optimizer_config
         self.seed = seed
         self.hf_config = None  # Set by the megatron worker once configs are initialized.
+
+        # NOTE: Set multiprocessing start method to `spawn` to avoid `os.fork()` in the
+        # Megatron dist checkpoint, which does not work well with Ray.
+        mp.set_start_method("spawn", force=True)
 
     def set_seed(self, seed: int) -> None:
         random.seed(seed)


### PR DESCRIPTION
Megatron's multi-node distributed checkpointing creates short-lived background workers to handle checkpointing, which are spawned with `os.fork()`. The kernel generally must ensure a full copy-on-write can be made of the parent process, which is memory heavy during trining. Ray explicitly recommends not forking in application code and to use spawn / Ray actors instead.

These PR updates the checkpoint worker to by persistent, which avoids `fork` and instead `spawn`s the persistent worker. This matches Megatron's (not so well publicized) findings discussed briefly [here](https://github.com/NVIDIA/nvidia-resiliency-ext/pull/108#issue-3203755296). 

For reference, we originally saw this error during checkpointing:
```
(skyrl_entrypoint pid=819281, ip=172.25.105.154)   File "/home/ray/.cache/uv/builds-v0/.tmppStuxn/lib/python3.12/site-packages/megatron/core/dist_checkpointing/strategies/async_utils.py", line 204, in schedule_async_call
(skyrl_entrypoint pid=819281, ip=172.25.105.154)     self.process.start()
(skyrl_entrypoint pid=819281, ip=172.25.105.154)   File "/home/ray/anaconda3/lib/python3.12/multiprocessing/process.py", line 121, in start
(skyrl_entrypoint pid=819281, ip=172.25.105.154)     self._popen = self._Popen(self)
(skyrl_entrypoint pid=819281, ip=172.25.105.154)                   ^^^^^^^^^^^^^^^^^
(skyrl_entrypoint pid=819281, ip=172.25.105.154)   File "/home/ray/anaconda3/lib/python3.12/multiprocessing/context.py", line 282, in _Popen
(skyrl_entrypoint pid=819281, ip=172.25.105.154)     return Popen(process_obj)
(skyrl_entrypoint pid=819281, ip=172.25.105.154)            ^^^^^^^^^^^^^^^^^^
(skyrl_entrypoint pid=819281, ip=172.25.105.154)   File "/home/ray/anaconda3/lib/python3.12/multiprocessing/popen_fork.py", line 19, in __init__
(skyrl_entrypoint pid=819281, ip=172.25.105.154)     self._launch(process_obj)
(skyrl_entrypoint pid=819281, ip=172.25.105.154)   File "/home/ray/anaconda3/lib/python3.12/multiprocessing/popen_fork.py", line 66, in _launch
(skyrl_entrypoint pid=819281, ip=172.25.105.154)     self.pid = os.fork()
(skyrl_entrypoint pid=819281, ip=172.25.105.154)                ^^^^^^^^^
(skyrl_entrypoint pid=819281, ip=172.25.105.154) OSError: [Errno 12] Cannot allocate memory
```

## Testing
Ran multi-node training on 2 4xL40S nodes. With `fork`, I get the error above. After using `spawn` in this PR, I don't get an error.