### PR TITLE
[fix] Pop and normalize OpenAI kwargs in engine init

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/vllm/utils.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/utils.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any
 
+
 def pop_openai_kwargs(engine_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     """
     Normalize & remove OpenAI-serving-only kwargs from engine_kwargs.

--- a/skyrl-train/skyrl_train/inference_engines/vllm/utils.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/utils.py
@@ -1,0 +1,17 @@
+from typing import Dict, Any
+
+def extract_openai_kwargs(engine_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Normalize & remove OpenAI-serving-only kwargs from engine_kwargs.
+    """
+    openai_kwargs: Dict[str, Any] = {}
+
+    enable_auto_tools = engine_kwargs.pop("enable_auto_tools", engine_kwargs.pop("enable_auto_tool_choice", None))
+    if enable_auto_tools is not None:
+        openai_kwargs["enable_auto_tools"] = bool(enable_auto_tools)
+
+    tool_parser = engine_kwargs.pop("tool_parser", engine_kwargs.pop("tool_call_parser", None))
+    if tool_parser is not None:
+        openai_kwargs["tool_parser"] = tool_parser
+
+    return openai_kwargs

--- a/skyrl-train/skyrl_train/inference_engines/vllm/utils.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/utils.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any
 
-def extract_openai_kwargs(engine_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def pop_openai_kwargs(engine_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     """
     Normalize & remove OpenAI-serving-only kwargs from engine_kwargs.
     """

--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -30,7 +30,7 @@ from skyrl_train.inference_engines.base import (
     InferenceEngineOutput,
     NamedWeightsUpdateRequest,
 )
-from skyrl_train.inference_engines.vllm.utils import extract_openai_kwargs
+from skyrl_train.inference_engines.vllm.utils import pop_openai_kwargs
 from loguru import logger
 from skyrl_train.utils import str_to_torch_dtype
 
@@ -335,8 +335,8 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
     """Asynchronous VLLM engine."""
 
     def _create_engine(self, *args, **kwargs):
+        openai_kwargs = pop_openai_kwargs(kwargs)
         # TODO (erictang000): potentially enable log requests for a debugging mode
-        openai_kwargs = extract_openai_kwargs(kwargs)
         engine_args = vllm.AsyncEngineArgs(enable_log_requests=False, **kwargs)
         engine = vllm.AsyncLLMEngine.from_engine_args(engine_args)
 

--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -30,6 +30,7 @@ from skyrl_train.inference_engines.base import (
     InferenceEngineOutput,
     NamedWeightsUpdateRequest,
 )
+from skyrl_train.inference_engines.vllm.utils import extract_openai_kwargs
 from loguru import logger
 from skyrl_train.utils import str_to_torch_dtype
 
@@ -335,6 +336,7 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
 
     def _create_engine(self, *args, **kwargs):
         # TODO (erictang000): potentially enable log requests for a debugging mode
+        openai_kwargs = extract_openai_kwargs(kwargs)
         engine_args = vllm.AsyncEngineArgs(enable_log_requests=False, **kwargs)
         engine = vllm.AsyncLLMEngine.from_engine_args(engine_args)
 
@@ -356,6 +358,7 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
             request_logger=None,
             chat_template=None,
             chat_template_content_format="auto",
+            **openai_kwargs,
         )
 
         # TODO(Charlie): revisit kwargs `return_tokens_as_token_ids`,

--- a/skyrl-train/tests/cpu/inf_engines/vllm/utils.py
+++ b/skyrl-train/tests/cpu/inf_engines/vllm/utils.py
@@ -1,0 +1,25 @@
+from copy import deepcopy
+
+from skyrl_train.inference_engines.vllm.utils import pop_openai_kwargs
+
+
+def test_pop_openai_kwargs():
+    """
+    Test pop_openai_kwargs with both primary and alias.
+    Ensure OpenAI kwargs are popped, non-OpenAI kwargs are kept.
+    """
+    engine_kwargs = {
+        "enable_auto_tools": 1,
+        "tool_parser": "json",
+        "other": "keep",
+    }
+    openai_kwargs = pop_openai_kwargs(engine_kwargs)
+
+    assert openai_kwargs == {"enable_auto_tools": True, "tool_parser": "json"}
+    assert engine_kwargs == {"other": "keep"}
+
+    engine_kwargs = {"enable_auto_tool_choice": 0, "tool_call_parser": "proto"}
+    openai_kwargs = pop_openai_kwargs(engine_kwargs)
+
+    assert openai_kwargs == {"enable_auto_tools": False, "tool_parser": "proto"}
+    assert engine_kwargs == {} 


### PR DESCRIPTION
PR #322 supported plumbing inference engine init kwargs directly to the inference engines but, for vLLM, some of these args should not be passed to the engine and rather be plumbed to the `OpenAIServingChat` object. 

This PR pops and normalizes these OpenAI kwargs, starting with `enable_auto_tools` and `tool_parser` (as well as their alias naming). 