### PR TITLE
[megatron] cleaning up examples + bump mbridge version

### DIFF
--- a/skyrl-train/examples/megatron/run_fsdp_baseline.sh
+++ b/skyrl-train/examples/megatron/run_fsdp_baseline.sh
@@ -4,7 +4,7 @@ set -x
 
 # uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 # export WANDB_API_KEY=<your_key_here>
-# bash examples/training_backends/megatron/run_fsdp_baseline.sh
+# bash examples/megatron/run_fsdp_baseline.sh
 
 DATA_DIR="$HOME/data/gsm8k"
 NUM_GPUS=4

--- a/skyrl-train/examples/megatron/run_megatron.sh
+++ b/skyrl-train/examples/megatron/run_megatron.sh
@@ -4,7 +4,7 @@ set -x
 
 # uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 # export WANDB_API_KEY=<your_key_here>
-# bash examples/training_backends/megatron/run_megatron.sh
+# bash examples/megatron/run_megatron.sh
 
 DATA_DIR="$HOME/data/gsm8k"
 NUM_GPUS=4
@@ -23,6 +23,8 @@ RANKS_TO_PROFILE="[0]"
 SAVE_PATH="$HOME/megatron_prof/tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}_${MODEL_NAME}"
 
 export SKYRL_PYTHONPATH_EXPORT=1
+# make sure PYTHONPATH is set to the location of TransformerEngine installation
+export PYTHONPATH="$HOME/anaconda3/lib/python3.12/site-packages"
 
 uv run --isolated --extra $INFERENCE_BACKEND --extra mcore -m skyrl_train.entrypoints.main_base \
   data.train_data="['$DATA_DIR/train.parquet']" \

--- a/skyrl-train/examples/megatron/run_megatron_moonlight.sh
+++ b/skyrl-train/examples/megatron/run_megatron_moonlight.sh
@@ -4,7 +4,7 @@ set -x
 
 # uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 # export WANDB_API_KEY=<your_key_here>
-# bash examples/training_backends/megatron/run_megatron_moonlight.sh
+# bash examples/megatron/run_megatron_moonlight.sh
 
 # running moonlight16b
 # huggingface-cli download moonshotai/Moonlight-16B-A3B-Instruct --local-dir ~/moonlight16b
@@ -32,6 +32,8 @@ INFERENCE_ENGINE_TP=8
 FLASH_ATTN=false
 
 export SKYRL_PYTHONPATH_EXPORT=1
+# make sure PYTHONPATH is set to the location of TransformerEngine installation
+export PYTHONPATH="$HOME/anaconda3/lib/python3.12/site-packages"
 
 uv run --isolated --extra $INFERENCE_BACKEND --extra mcore --with blobfile -m skyrl_train.entrypoints.main_base \
   data.train_data="['$DATA_DIR/train.parquet']" \

--- a/skyrl-train/examples/megatron/run_megatron_qwen3-235b-a22b.sh
+++ b/skyrl-train/examples/megatron/run_megatron_qwen3-235b-a22b.sh
@@ -4,7 +4,7 @@ set -x
 
 # uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 # export WANDB_API_KEY=<your_key_here>
-# bash examples/training_backends/megatron/run_megatron_qwen3-235b-a22b.sh
+# bash examples/megatron/run_megatron_qwen3-235b-a22b.sh
 
 LOGGER="wandb"  # change to "console" to print to stdout
 
@@ -47,6 +47,8 @@ INFERENCE_ENGINE_MAX_MODEL_LEN=2048
 USE_KL_LOSS=false
 
 export SKYRL_PYTHONPATH_EXPORT=1
+# make sure PYTHONPATH is set to the location of TransformerEngine installation
+export PYTHONPATH="$HOME/anaconda3/lib/python3.12/site-packages"
 
 uv run --isolated --extra $INFERENCE_BACKEND --extra mcore -m skyrl_train.entrypoints.main_base \
   data.train_data="['$DATA_DIR/train.parquet']" \

--- a/skyrl-train/examples/megatron/run_megatron_qwen3-30b-a3b.sh
+++ b/skyrl-train/examples/megatron/run_megatron_qwen3-30b-a3b.sh
@@ -4,7 +4,7 @@ set -x
 
 # uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 # export WANDB_API_KEY=<your_key_here>
-# bash examples/training_backends/megatron/run_megatron_qwen3-30b-a3b.sh
+# bash examples/megatron/run_megatron_qwen3-30b-a3b.sh
 
 DATA_DIR="$HOME/data/gsm8k"
 LOGGER="wandb"  # change to "console" to print to stdout
@@ -26,6 +26,8 @@ INFERENCE_ENGINE_TP=8
 FLASH_ATTN=true
 
 export SKYRL_PYTHONPATH_EXPORT=1
+# make sure PYTHONPATH is set to the location of TransformerEngine installation
+export PYTHONPATH="$HOME/anaconda3/lib/python3.12/site-packages"
 
 uv run --isolated --extra $INFERENCE_BACKEND --extra mcore -m skyrl_train.entrypoints.main_base \
   data.train_data="['$DATA_DIR/train.parquet']" \

--- a/skyrl-train/examples/megatron/run_search_megatron.sh
+++ b/skyrl-train/examples/megatron/run_search_megatron.sh
@@ -4,7 +4,7 @@ set -x
 # follow the instructions in examples/search/README.md for setting up the dataset
 # and for starting the local search server
 # export WANDB_API_KEY=<your_key_here>
-# bash examples/training_backends/megatron/run_search_megatron.sh
+# bash examples/megatron/run_search_megatron.sh
 
 # path for dataset (.parquet files) containing the prompts and metadata for each question
 MODEL_NAME="Qwen/Qwen3-30B-A3B"
@@ -26,8 +26,10 @@ NUM_INFERENCE_ENGINES=4
 INFERENCE_ENGINE_TP=8
 
 export SKYRL_PYTHONPATH_EXPORT=1
+# make sure PYTHONPATH is set to the location of TransformerEngine installation
+export PYTHONPATH="$HOME/anaconda3/lib/python3.12/site-packages"
 
-uv run --isolated --frozen --extra mcore --extra vllm --env-file .env -m skyrl_train.entrypoints.main_base \
+uv run --isolated --frozen --extra mcore --extra vllm -m skyrl_train.entrypoints.main_base \
   data.train_data="['${DATA_DIR}/train.parquet']" \
   data.val_data="['${DATA_DIR}/validation.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \

--- a/skyrl-train/pyproject.toml
+++ b/skyrl-train/pyproject.toml
@@ -126,7 +126,7 @@ mcore = [
   # export LD_LIBRARY_PATH="$CUDNN_PATH/lib:${LD_LIBRARY_PATH:-}"
   # uv pip install --no-build-isolation "transformer_engine[pytorch]==2.5.0" --verbose
   # "transformer-engine[pytorch]==2.5.0",
-  "mbridge==0.13.1",
+  "mbridge==0.15.1",
   "megatron-core@git+https://github.com/NVIDIA/Megatron-LM.git@core_r0.13.0",
 ]
 flashrl = [

--- a/skyrl-train/skyrl_train/config/megatron_config/policy.yaml
+++ b/skyrl-train/skyrl_train/config/megatron_config/policy.yaml
@@ -31,7 +31,6 @@ optimizer_config_kwargs:
 # kwargs to override the Megatron TransformerConfig object
 transformer_config_kwargs:
   # Recompute config - used for gradient/activation checkpointing
-  # We enable gradient checkpointing by default
   # for details see: https://github.com/NVIDIA/Megatron-LM/blob/core_r0.13.0/megatron/core/transformer/transformer_config.py#L33
   # options: ["full", "selective", null]
   recompute_granularity: null

--- a/skyrl-train/skyrl_train/config/megatron_config/policy.yaml
+++ b/skyrl-train/skyrl_train/config/megatron_config/policy.yaml
@@ -31,18 +31,19 @@ optimizer_config_kwargs:
 # kwargs to override the Megatron TransformerConfig object
 transformer_config_kwargs:
   # Recompute config - used for gradient/activation checkpointing
-  # default use minimal performance-interference recompute methods
-  # Recompute granualarity, choices: ["full", "selective"]
+  # We enable gradient checkpointing by default
+  # for details see: https://github.com/NVIDIA/Megatron-LM/blob/core_r0.13.0/megatron/core/transformer/transformer_config.py#L33
+  # options: ["full", "selective", null]
   recompute_granularity: null
 
-  # Recompute modules, multiple choices: ["core_attn", "moe_act", "layernorm", "mla_up_proj", "mlp", "moe"]
-  # Please use correct module in matched model
   recompute_modules: ["core_attn"]
 
-  # 'uniform', 'block'
+  # options: ["uniform", "block", null]
   # 'uniform' divides the total number of transformer layers and checkpoints the input activation of each chunk
   # 'block' checkpoints the specified number of layers per pipeline stage at the specified granularity
   recompute_method: null
 
-  # 'full' will checkpoint the entire transformer layer and 'selective' only checkpoints memory intensive part of attention
+  # when recompute_method is uniform, recompute_num_layers is the number of transformer layers in each recompute unit
+  # when recompute_method is block, recompute_num_layers is the number of transformer layers to recompute in each block
+  # must be set to None when recompute_granularity is "selective"
   recompute_num_layers: null

--- a/skyrl-train/skyrl_train/config/megatron_config/ref.yaml
+++ b/skyrl-train/skyrl_train/config/megatron_config/ref.yaml
@@ -8,21 +8,5 @@ expert_tensor_parallel_size: 1
 
 model_config_kwargs: {}
 
-# additional transformer config like: num_layers_in_first(/last)_pipeline_stage
-transformer_config_kwargs:
-  # Recompute configuration, same as in megatron.training.arguments
-  # default use minimal performance-interference recompute methods
-  # Recompute granualarity, choices: ["full", "selective"]
-  recompute_granularity: null
-
-  # Recompute modules, multiple choices: ["core_attn", "moe_act", "layernorm", "mla_up_proj", "mlp", "moe"]
-  # Please use correct module in matched model
-  recompute_modules: ["core_attn"]
-
-  # 'uniform', 'block'
-  # 'uniform' divides the total number of transformer layers and checkpoints the input activation of each chunk
-  # 'block' checkpoints the specified number of layers per pipeline stage at the specified granularity
-  recompute_method: null
-
-  # 'full' will checkpoint the entire transformer layer and 'selective' only checkpoints memory intensive part of attention
-  recompute_num_layers: null
+# kwargs to override the Megatron TransformerConfig object
+transformer_config_kwargs: {}

--- a/skyrl-train/uv.lock
+++ b/skyrl-train/uv.lock
@@ -1986,11 +1986,11 @@ wheels = [
 
 [[package]]
 name = "mbridge"
-version = "0.13.1"
+version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/10/42be17b46b0e0214b8bb960421b7e1eb53e351b07cff98ca08f9d32ff3c2/mbridge-0.13.1.tar.gz", hash = "sha256:2507f9fa3d258acdfb713ab9aeacd9f3c9a03233f2bb8fa131eaf4277ce08c04", size = 69017, upload-time = "2025-09-05T08:58:52.734Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/3f/04534fb2b4ddf6b293ee41f839de8ae6542ef2dc1b32c7d25a4b5b18c1bb/mbridge-0.15.1.tar.gz", hash = "sha256:26028dbe7dc9193c6c6b3de56e82691c9a484f46ded1ed18a41f2747a08e8104", size = 99287, upload-time = "2025-09-22T09:48:30.141Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/06/9cc5ca552973590b8c88a2298f7e3252916ed095e83670411cf25509813f/mbridge-0.13.1-py3-none-any.whl", hash = "sha256:9798f88d90c20c546e13326aca757539821a112b28d9cb8fbe097fe46eb491d8", size = 85785, upload-time = "2025-09-05T08:58:51.262Z" },
+    { url = "https://files.pythonhosted.org/packages/51/dc/8208746f41ff08d0b6eb8c261569d57af97648ee0d1631ea273e68c627dc/mbridge-0.15.1-py3-none-any.whl", hash = "sha256:5c7c007c2eb13bb2d0ce9bd6b313537024d0a7fad52179ff367635eafe5cd4cd", size = 122168, upload-time = "2025-09-22T09:48:28.384Z" },
 ]
 
 [[package]]
@@ -4011,7 +4011,7 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'miniswe'" },
     { name = "litellm", extras = ["proxy"], marker = "extra == 'sandboxes'", specifier = ">=1.67.5" },
     { name = "loguru" },
-    { name = "mbridge", marker = "extra == 'mcore'", specifier = "==0.13.1" },
+    { name = "mbridge", marker = "extra == 'mcore'", specifier = "==0.15.1" },
     { name = "megatron-core", marker = "extra == 'mcore'", git = "https://github.com/NVIDIA/Megatron-LM.git?rev=core_r0.13.0" },
     { name = "mini-swe-agent", marker = "extra == 'miniswe'", specifier = ">=1.12.0" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0.0" },


### PR DESCRIPTION
More cleanup for megatron examples, and bump mbridge version to 0.15.1 for some bug fixes with tied weight embeddings.