### PR TITLE
[Cleanup] Remove get_latest_checkpoint_step as not used anywhere

### DIFF
--- a/skyrl-train/skyrl_train/utils/trainer_utils.py
+++ b/skyrl-train/skyrl_train/utils/trainer_utils.py
@@ -91,30 +91,6 @@ def extract_step_from_path(path: str) -> int:
     return -1
 
 
-def get_latest_checkpoint_step(checkpoint_base_path: str) -> int:
-    """
-    Get the latest global step from checkpoint directory by reading latest_ckpt_global_step.txt.
-
-    Args:
-        checkpoint_base_path: Base path where checkpoints are stored
-
-    Returns:
-        int: Latest global step, or 0 if no checkpoint found
-    """
-    latest_file_path = os.path.join(checkpoint_base_path, "latest_ckpt_global_step.txt")
-
-    if not io.exists(latest_file_path):
-        return 0
-
-    try:
-        with io.open_file(latest_file_path, "r") as f:
-            content = f.read().strip()
-        return int(content)
-    except (ValueError, IOError) as e:
-        logger.warning(f"Failed to read latest checkpoint step from {latest_file_path}: {e}")
-        return 0
-
-
 def list_checkpoint_dirs(checkpoint_base_path: str) -> list[str]:
     """
     List all checkpoint directories in the base path.

--- a/skyrl-train/tests/cpu/utils/test_io.py
+++ b/skyrl-train/tests/cpu/utils/test_io.py
@@ -276,7 +276,9 @@ class TestCheckpointScenarios:
             assert exists(latest_checkpoint_file)
 
             # Verify latest step can be retrieved
-            assert get_latest_checkpoint_step(temp_dir) == global_step
+            with open_file(latest_checkpoint_file, "r") as f:
+                ckpt_iteration = int(f.read().strip())
+            assert ckpt_iteration == global_step
 
 
 class TestContextManagers:

--- a/skyrl-train/tests/cpu/utils/test_io.py
+++ b/skyrl-train/tests/cpu/utils/test_io.py
@@ -21,7 +21,6 @@ from skyrl_train.utils.io import (
     list_dir,
 )
 from skyrl_train.utils.trainer_utils import (
-    get_latest_checkpoint_step,
     list_checkpoint_dirs,
     cleanup_old_checkpoints,
 )
@@ -151,24 +150,6 @@ class TestCheckpointUtilities:
         non_existent_path = "/non/existent/path"
         found_dirs = list_checkpoint_dirs(non_existent_path)
         assert found_dirs == []
-
-    def test_get_latest_checkpoint_step_local(self):
-        """Test getting latest checkpoint step for local paths."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            latest_file = os.path.join(temp_dir, "latest_ckpt_global_step.txt")
-
-            # Test non-existent file
-            assert get_latest_checkpoint_step(temp_dir) == 0
-
-            # Test with valid step
-            with open_file(latest_file, "w") as f:
-                f.write("1500")
-            assert get_latest_checkpoint_step(temp_dir) == 1500
-
-            # Test with whitespace
-            with open_file(latest_file, "w") as f:
-                f.write("  2000  \n")
-            assert get_latest_checkpoint_step(temp_dir) == 2000
 
     def test_cleanup_old_checkpoints_local(self):
         """Test cleanup of old checkpoints for local paths."""


### PR DESCRIPTION
Minor clean up. Remove `get_latest_checkpoint_step()` and its unit test since it is not used anywhere. Instead we have been using `Trainer.load_checkpoints` directly.