### PR TITLE
[skyrl-tx] Change package name

### DIFF
--- a/skyrl-tx/README.md
+++ b/skyrl-tx/README.md
@@ -1,9 +1,10 @@
 # SkyRL tx: Unified API for training and inference
 
-⚠️  The project is currently very early with lots of missing features
-(e.g. currently LoRA is only supported for the MLP layer, pure inference
-is not supported, model sharding is in a very early state). Many of
-these are easy to implement and we welcome contributions!
+> ⚠️  The project is currently very early with lots of missing features
+> (e.g. currently LoRA is only supported for the MLP layer, pure inference
+> is not supported, model sharding is in a very early state). Many of
+> these are easy to implement and we welcome contributions! ⚠️
+
 
 SkyRL tx is an open-source cross-platform library that allows users to
 set up their own service exposing a

--- a/skyrl-tx/README.md
+++ b/skyrl-tx/README.md
@@ -16,20 +16,6 @@ infrastructure challenges of managing GPUs.
 The `t` in `tx` stands for transformers, training, or tinker, and the `x`
 stands for "cross-platform".
 
-## Key Features
-
-**Unified Engine**: A single engine for both inference and training
-  eliminates numerical discrepancies and the need for expensive
-  checkpoint transfers.
-
-**Seamless Online Learning**: Models can be updated in real-time.
-
-**Reduced Operational Complexity**: Manage one API and one system for
-  both training and serving, simplifying deployment strategies.
-
-**Cost-Effective Multi-Tenancy**: Using techniques like LoRA, a single
-  base model can serve thousands of users with personalized adapters.
-
 ## Project Status
 
 This is a very early release of SkyRL tx. While the project is

--- a/skyrl-tx/README.md
+++ b/skyrl-tx/README.md
@@ -15,8 +15,7 @@ stands for "cross-platform".
   eliminates numerical discrepancies and the need for expensive
   checkpoint transfers.
 
-**Seamless Online Learning**: Models can be updated in real-time with
-  new data without service interruptions.
+**Seamless Online Learning**: Models can be updated in real-time.
 
 **Reduced Operational Complexity**: Manage one API and one system for
   both training and serving, simplifying deployment strategies.
@@ -26,6 +25,7 @@ stands for "cross-platform".
 
 ## Project Status
 
-This is an early release of SkyRL tx. While the project is functional
-end-to-end, there is still a lot of work to be done. We are sharing it
-with the community to invite feedback, testing, and contributions.
+This is a very early release of SkyRL tx. While the project is
+functional end-to-end, there is still a lot of work to be done. We are
+sharing it with the community to invite feedback, testing, and
+contributions.

--- a/skyrl-tx/README.md
+++ b/skyrl-tx/README.md
@@ -1,25 +1,31 @@
-# tx: Cross-Platform Transformer Training
+# SkyRL tx: Unified API for training and inference
 
-tx (**t**ransformers **x**-platform) is a JAX/OpenXLA-based library
-designed for training transformers and other neural networks. Since it
-is based on OpenXLA, tx enables you to run the same code across
-diverse hardware platforms like GPUs, TPUs, AWS Trainium, and
-Tenstorrent accelerators, without the complexity of adapting to
-platform-specific APIs or execution models like you would need if you
-switch from PyTorch to PyTorch/XLA.
+SkyRL tx is an open-source cross-platform library that allows users to
+set up their own service exposing a Tinker API like REST API for
+neural network forward and backward passes. It unifies inference and
+training into a single, common API, abstracting away the
+infrastructure challenges of managing GPUs.
 
-We try to keep the code simple but powerful and write the library in a
-way that feels intuitive to developers in the PyTorch and HuggingFace
-ecosystems.
+The `t` in `tx` stands for transformers, training, or tinker, and the `x`
+stands for "cross-platform".
 
-Key Benefits:
-- **Write once, run anywhere**: Single codebase that works across all major AI accelerators
-- **Familiar conventions**: Designed with PyTorch and Hugging Face developers in mind
-- **Clean and maintainable**: Simple, powerful code that doesn't compromise on capability
+## Key Features
 
-The code is very early, features we want to support going forward:
-- More flexible dataset support
-- More model architectures like MoE models
-- More optimizations
+**Unified Engine**: A single engine for both inference and training
+  eliminates numerical discrepancies and the need for expensive
+  checkpoint transfers.
 
-Contributions are welcome! Please keep the code as simple as possible :)
+**Seamless Online Learning**: Models can be updated in real-time with
+  new data without service interruptions.
+
+**Reduced Operational Complexity**: Manage one API and one system for
+  both training and serving, simplifying deployment strategies.
+
+**Cost-Effective Multi-Tenancy**: Using techniques like LoRA, a single
+  base model can serve thousands of users with personalized adapters.
+
+## Project Status
+
+This is an early release of SkyRL tx. While the project is functional
+end-to-end, there is still a lot of work to be done. We are sharing it
+with the community to invite feedback, testing, and contributions.

--- a/skyrl-tx/README.md
+++ b/skyrl-tx/README.md
@@ -1,7 +1,8 @@
 # SkyRL tx: Unified API for training and inference
 
 SkyRL tx is an open-source cross-platform library that allows users to
-set up their own service exposing a Tinker API like REST API for
+set up their own service exposing a
+[Tinker](https://tinker-docs.thinkingmachines.ai/) like REST API for
 neural network forward and backward passes. It unifies inference and
 training into a single, common API, abstracting away the
 infrastructure challenges of managing GPUs.

--- a/skyrl-tx/README.md
+++ b/skyrl-tx/README.md
@@ -1,5 +1,10 @@
 # SkyRL tx: Unified API for training and inference
 
+⚠️  The project is currently very early with lots of missing features
+(e.g. currently LoRA is only supported for the MLP layer, pure inference
+is not supported, model sharding is in a very early state). Many of
+these are easy to implement and we welcome contributions!
+
 SkyRL tx is an open-source cross-platform library that allows users to
 set up their own service exposing a
 [Tinker](https://tinker-docs.thinkingmachines.ai/) like REST API for

--- a/skyrl-tx/pyproject.toml
+++ b/skyrl-tx/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "tx"
+name = "skyrl-tx"
 dynamic = ["version"]
-description = "Cross-platform neural network training"
+description = "API for unifying training and inference"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/skyrl-tx/pyproject.toml
+++ b/skyrl-tx/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "skyrl-tx"
 dynamic = ["version"]
-description = "API for unifying training and inference"
+description = "Unified API for training and inference"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
This changes the package name and uploads the package to pypi so we can reserve it. Likely the pypi package name will keep being `skyrl-tx` going forward and the python folder will keep being `tx` so the imports and executable are short.