### PR TITLE
[Fix] Fix chat templating in Mini-SWE-Agent and Terminal-Bench examples

### DIFF
--- a/skyrl-train/examples/mini_swe_agent/mini_swe_generator.py
+++ b/skyrl-train/examples/mini_swe_agent/mini_swe_generator.py
@@ -19,6 +19,7 @@ from skyrl_train.inference_engines.inference_engine_client import InferenceEngin
 from skyrl_train.inference_engines.utils import get_sampling_params_for_backend
 from skyrl_train.generators.utils import (
     get_rollout_metrics,
+    encode_messages_subset,
 )
 
 
@@ -128,6 +129,9 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
         self.model_name = model_name
         self.litellm_model_name = "openai/" + self.model_name
 
+        if self.generator_cfg.chat_template.name_or_path is not None:
+            raise NotImplementedError("MiniSWEAgentGenerator doesn't support custom chat template")
+
     async def minisweagent_agent_loop(
         self,
         prompt: ConversationType,
@@ -182,7 +186,7 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
 
         for message in response_messages:
             # Apply chat template and tokenize each message
-            msg_encoding = self.tokenizer.apply_chat_template([message], add_generation_prompt=False, tokenize=True)
+            msg_encoding = encode_messages_subset([message], self.tokenizer)
 
             # Extend response_ids with the tokens
             response_ids.extend(msg_encoding)

--- a/skyrl-train/examples/terminal_bench/generator/terminal_bench_generator.py
+++ b/skyrl-train/examples/terminal_bench/generator/terminal_bench_generator.py
@@ -2,7 +2,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import List
 from skyrl_train.generators.base import GeneratorInterface, GeneratorInput, GeneratorOutput
-from skyrl_train.generators.utils import get_rollout_metrics
+from skyrl_train.generators.utils import get_rollout_metrics, encode_messages_subset
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
 from skyrl_train.inference_engines.base import ConversationType
 from omegaconf import DictConfig
@@ -134,7 +134,7 @@ class TerminalBenchGenerator(GeneratorInterface):
 
         for message in response_messages:
             # Apply chat template and tokenize each message
-            msg_encoding = self.tokenizer.apply_chat_template([message], add_generation_prompt=False, tokenize=True)
+            msg_encoding = encode_messages_subset([message], self.tokenizer)
 
             # Extend response_ids with the tokens
             response_ids.extend(msg_encoding)

--- a/skyrl-train/skyrl_train/generators/utils.py
+++ b/skyrl-train/skyrl_train/generators/utils.py
@@ -302,4 +302,11 @@ def encode_messages_subset(messages, tokenizer):
         add_generation_prompt=False,
         tokenize=True,
     )
-    return full_conversation_token_ids[len(base_conversation_token_ids) :]
+    conversation_token_ids = full_conversation_token_ids[len(base_conversation_token_ids) :]
+    # Remove tokens after the last EOS token if it's a assistant message, so that it is captured in a future user/tool turn
+    if messages[-1]["role"] == "assistant" and tokenizer.eos_token_id in conversation_token_ids:
+        last_eos_token_index = (
+            len(conversation_token_ids) - 1 - conversation_token_ids[::-1].index(tokenizer.eos_token_id)
+        )
+        conversation_token_ids = conversation_token_ids[: last_eos_token_index + 1]
+    return conversation_token_ids

--- a/skyrl-train/tests/cpu/generators/test_utils.py
+++ b/skyrl-train/tests/cpu/generators/test_utils.py
@@ -176,7 +176,7 @@ def qwen_tokenizer():
         # Test case 1: Single assistant message
         (
             [{"role": "assistant", "content": "Hello, I can help you."}],
-            "<|im_start|>assistant\nHello, I can help you.<|im_end|>\n",
+            "<|im_start|>assistant\nHello, I can help you.<|im_end|>",
         ),
         # Test case 2: Single user message - additional \n because the expectation is that there is a previous assistant turn
         (
@@ -186,8 +186,9 @@ def qwen_tokenizer():
         # Test case 3: Multiple messages (user-assistant exchange)
         (
             [{"role": "user", "content": "What is 2+2?"}, {"role": "assistant", "content": "The answer is 4."}],
-            # additional \n because the expectation is that there is a previous assistant turn
-            "\n<|im_start|>user\nWhat is 2+2?<|im_end|>\n<|im_start|>assistant\nThe answer is 4.<|im_end|>\n",
+            # NOTE: Additional \n because the expectation is that there is a previous assistant turn.
+            # All tokens after EOS in the previous turn get pushed into the next user/tool message.
+            "\n<|im_start|>user\nWhat is 2+2?<|im_end|>\n<|im_start|>assistant\nThe answer is 4.<|im_end|>",
         ),
         # Test case 4: Multiple messages starting with assistant
         (
@@ -196,7 +197,7 @@ def qwen_tokenizer():
                 {"role": "user", "content": "Can you explain Python?"},
                 {"role": "assistant", "content": "Python is a programming language."},
             ],
-            "<|im_start|>assistant\nI'm here to help.<|im_end|>\n<|im_start|>user\nCan you explain Python?<|im_end|>\n<|im_start|>assistant\nPython is a programming language.<|im_end|>\n",
+            "<|im_start|>assistant\nI'm here to help.<|im_end|>\n<|im_start|>user\nCan you explain Python?<|im_end|>\n<|im_start|>assistant\nPython is a programming language.<|im_end|>",
         ),
     ],
 )

--- a/skyrl-train/tests/cpu/generators/test_utils.py
+++ b/skyrl-train/tests/cpu/generators/test_utils.py
@@ -160,6 +160,8 @@ def tokenizer_w_dummy_template():
     ],
 )
 def test_encode_messages(messages, tokenizer_w_dummy_template):
+    # For a simple chat template, the fixed base approach is expected to behave the same
+    # as `apply_chat_template`
     expected_token_ids = tokenizer_w_dummy_template.apply_chat_template(messages)
     actual_token_ids = encode_messages_subset(messages, tokenizer_w_dummy_template)
     assert expected_token_ids == actual_token_ids

--- a/skyrl-train/tests/cpu/generators/test_utils.py
+++ b/skyrl-train/tests/cpu/generators/test_utils.py
@@ -3,7 +3,8 @@ uv run --extra dev --isolated pytest tests/cpu/generators/test_utils.py
 """
 
 import pytest
-from skyrl_train.generators.utils import apply_overlong_filtering
+from skyrl_train.generators.utils import apply_overlong_filtering, encode_messages_subset
+from transformers import AutoTokenizer
 
 
 @pytest.mark.parametrize(
@@ -116,3 +117,90 @@ def test_apply_overlong_filtering_length_mismatch_assertion(loss_masks, response
     eos_token_id = 4
     with pytest.raises(AssertionError, match="loss_masks and response_ids must have the same length"):
         apply_overlong_filtering(loss_masks, response_ids, eos_token_id)
+
+
+dummy_chat_template = (
+    "{%- for message in messages %}"
+    "{%- if message['role'] == 'user' %}"
+    "<USER>{{ message['content'] }}</s>\n"
+    "{%- elif message['role'] == 'assistant' %}"
+    "<ASSISTANT>{{ message['content'] }}</s>\n"
+    "{%- elif message['role'] == 'system' %}"
+    "<SYSTEM>{{ message['content'] }}</s>\n"
+    "{%- endif %}"
+    "{%- endfor %}"
+    "{%- if add_generation_prompt %}"
+    "<ASSISTANT>"
+    "{%- endif %}"
+)
+
+
+@pytest.fixture
+def tokenizer_w_dummy_template():
+    tokenizer = AutoTokenizer.from_pretrained("unsloth/llama-2-7b")
+    tokenizer.chat_template = dummy_chat_template
+    return tokenizer
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        # Test case 1: Single assistant message
+        [{"role": "assistant", "content": "Hello, I can help you."}],
+        # Test case 2: Single user message
+        [{"role": "user", "content": "What is the weather today?"}],
+        # Test case 3: Multiple messages (user-assistant exchange)
+        [{"role": "user", "content": "What is 2+2?"}, {"role": "assistant", "content": "The answer is 4."}],
+        # Test case 4: Multiple messages starting with assistant
+        [
+            {"role": "assistant", "content": "I'm here to help."},
+            {"role": "user", "content": "Can you explain Python?"},
+            {"role": "assistant", "content": "Python is a programming language."},
+        ],
+    ],
+)
+def test_encode_messages(messages, tokenizer_w_dummy_template):
+    expected_token_ids = tokenizer_w_dummy_template.apply_chat_template(messages)
+    actual_token_ids = encode_messages_subset(messages, tokenizer_w_dummy_template)
+    assert expected_token_ids == actual_token_ids
+
+
+@pytest.fixture
+def qwen_tokenizer():
+    return AutoTokenizer.from_pretrained("Qwen/Qwen2.5-1.5B-Instruct")
+
+
+@pytest.mark.parametrize(
+    "messages, expected_str",
+    [
+        # Test case 1: Single assistant message
+        (
+            [{"role": "assistant", "content": "Hello, I can help you."}],
+            "<|im_start|>assistant\nHello, I can help you.<|im_end|>\n",
+        ),
+        # Test case 2: Single user message - additional \n because the expectation is that there is a previous assistant turn
+        (
+            [{"role": "user", "content": "What is the weather today?"}],
+            "\n<|im_start|>user\nWhat is the weather today?<|im_end|>\n",
+        ),
+        # Test case 3: Multiple messages (user-assistant exchange)
+        (
+            [{"role": "user", "content": "What is 2+2?"}, {"role": "assistant", "content": "The answer is 4."}],
+            # additional \n because the expectation is that there is a previous assistant turn
+            "\n<|im_start|>user\nWhat is 2+2?<|im_end|>\n<|im_start|>assistant\nThe answer is 4.<|im_end|>\n",
+        ),
+        # Test case 4: Multiple messages starting with assistant
+        (
+            [
+                {"role": "assistant", "content": "I'm here to help."},
+                {"role": "user", "content": "Can you explain Python?"},
+                {"role": "assistant", "content": "Python is a programming language."},
+            ],
+            "<|im_start|>assistant\nI'm here to help.<|im_end|>\n<|im_start|>user\nCan you explain Python?<|im_end|>\n<|im_start|>assistant\nPython is a programming language.<|im_end|>\n",
+        ),
+    ],
+)
+def test_encode_messages_qwen(messages, expected_str, qwen_tokenizer):
+    expected_token_ids = qwen_tokenizer.encode(expected_str)
+    actual_token_ids = encode_messages_subset(messages, qwen_tokenizer)
+    assert expected_token_ids == actual_token_ids, f"Got actual tokens: {qwen_tokenizer.decode(actual_token_ids)}"


### PR DESCRIPTION
# What does this PR do?

Fixes chat templating in the Mini-swe-agent and the terminal bench examples. 


Previously, we were naively callling `.apply_chat_template` to encode response messages turn by turn - but this can append system messages for each turn depending on the model. 

We use the fixed base approach similar to what we do in the SkyRLGymGenerator. 

