### PR TITLE
[tx] Use ragged_dot to implement the MultiLoRA routing

### DIFF
--- a/skyrl-tx/tx/layers/util.py
+++ b/skyrl-tx/tx/layers/util.py
@@ -1,6 +1,27 @@
 from flax import nnx
+import jax
 from jax import numpy as jnp
 
 
 def Param(*shape: int, dtype: jnp.dtype, kernel_init: nnx.Initializer, rngs: nnx.Rngs):
     return nnx.Param(kernel_init(rngs.param(), shape, dtype))
+
+
+def prepare_routing(tokens: jax.Array, indices: jax.Array, num_groups: int):
+    """Prepare inputs for ragged_dot operations by sorting tokens by group.
+
+    Args:
+        tokens: Array of shape (num_tokens, ...) to be sorted by group
+        indices: Array of shape (num_tokens,) indicating group assignment for each token
+        num_groups: Total number of groups
+
+    Returns:
+        sorted_tokens: Tokens sorted by group index
+        group_sizes: Number of tokens in each group
+        unsort_indices: Indices to restore original order after ragged operations
+    """
+    sort_indices = jnp.argsort(indices)
+    sorted_tokens = tokens[sort_indices]
+    group_sizes = jnp.bincount(indices, length=num_groups)
+    unsort_indices = jnp.argsort(sort_indices)
+    return sorted_tokens, group_sizes, unsort_indices

--- a/skyrl-tx/tx/models/qwen3.py
+++ b/skyrl-tx/tx/models/qwen3.py
@@ -4,7 +4,7 @@ from jax import numpy as jnp
 from transformers import Qwen3Config
 
 from tx.layers.lora import LoRALinear
-from tx.layers.util import Param
+from tx.layers.util import Param, prepare_routing
 
 
 class RMSNorm(nnx.Module):
@@ -142,9 +142,9 @@ class Qwen3Experts(nnx.Module):
         # Prepare for ragged_dot by sorting tokens based on their assigned expert
         selected_experts_flat = selected_experts.ravel()
         hidden_states_expanded = jnp.repeat(hidden_states, self.config.num_experts_per_tok, axis=0)
-        sort_indices = jnp.argsort(selected_experts_flat)
-        hidden_states_sorted = hidden_states_expanded[sort_indices]
-        group_sizes = jnp.bincount(selected_experts_flat, length=self.config.num_experts)
+        hidden_states_sorted, group_sizes, unsort_indices = prepare_routing(
+            hidden_states_expanded, selected_experts_flat, self.config.num_experts
+        )
 
         # Apply expert layers using ragged_dot
         gate_out = jax.lax.ragged_dot(hidden_states_sorted, self.gate_proj.value, group_sizes)
@@ -154,7 +154,6 @@ class Qwen3Experts(nnx.Module):
         )
 
         # Unsort and combine the expert outputs
-        unsort_indices = jnp.argsort(sort_indices)
         unsorted_out = down_out[unsort_indices]
         reshaped_out = unsorted_out.reshape(-1, self.config.num_experts_per_tok, self.config.hidden_size)
         return jnp.sum(reshaped_out * routing_weights[..., None], axis=1)


### PR DESCRIPTION
For https://github.com/NovaSky-AI/SkyRL/pull/421, we might need to implement combined routing of LoRA adapters and experts, to get warmed up for that, this is an implementation of MultiLoRA with ragged_dot.