### PR TITLE
[Fix] Fix GPT-OSS example

### DIFF
--- a/skyrl-train/examples/gptoss/run_gsm8k_gptoss.sh
+++ b/skyrl-train/examples/gptoss/run_gsm8k_gptoss.sh
@@ -59,6 +59,6 @@ uv run --isolated --extra $INFERENCE_BACKEND -m skyrl_train.entrypoints.main_bas
   trainer.run_name="gsm8k_test_gptoss_low" \
   trainer.resume_mode=latest \
   trainer.ckpt_path="$HOME/ckpts/gsm8k_1.5B_ckpt_gptoss" \
-  generator.chat_template_kwargs={reasoning_effort:'low'} \
+  +generator.chat_template_kwargs={reasoning_effort:'low'} \
   trainer.dump_data_batch=true \
   $@


### PR DESCRIPTION
The config parameter `reasoning_effort` needs a + otherwise you'll see: 

```bash
Could not override 'generator.chat_template_kwargs'.
To append to your config use +generator.chat_template_kwargs={reasoning_effort:low}
Key 'reasoning_effort' is not in struct
    full_key: generator.chat_template_kwargs.reasoning_effort
    object_type=dict
```

This was added by mistake in #390 while I was testing the script