### PR TITLE
Guard against Divide 0 error for NUMA nodes count

### DIFF
--- a/skyrl-train/skyrl_train/workers/worker.py
+++ b/skyrl-train/skyrl_train/workers/worker.py
@@ -172,7 +172,7 @@ class DistributedTorchRayActor:
             LIBNUMA.numa_set_membind(bitmask)
 
         numa_nodes = LIBNUMA.numa_num_configured_nodes()
-        if not numa_nodes or numa_nodes <= 0:
+        if numa_nodes <= 0:
             numa_nodes = 1
         num_gpu_pre_numa_node = 8 // numa_nodes
         numa_bind(self._local_rank // num_gpu_pre_numa_node)


### PR DESCRIPTION
When running remotely on cloud VMs (and most Docker setups), the NUMA nodes count may not be accessible to the container.

So this is a guarding feature that sets NUMA to 1 (default) if the `numa_nodes` count is found to be zero, so calculating `num_gpu_pre_numa_node` is not undefined