### PR TITLE
TerminalBenchGenerator: logprobs + session ID

### DIFF
--- a/skyrl-train/examples/terminal_bench/generator/terminal_bench_generator.py
+++ b/skyrl-train/examples/terminal_bench/generator/terminal_bench_generator.py
@@ -89,7 +89,7 @@ class TerminalBenchGenerator(GeneratorInterface):
         """
         Run a single terminal_bench agent.
         """
-        # Generate session_id for prefix cache routing
+        # Generate session_id for sticky routing to inference engines
         # All LLM requests in this trial will share the same session_id
         session_id = uuid4().hex
 


### PR DESCRIPTION
With https://github.com/laude-institute/sandboxes/pull/45, Sandboxes now returns logprobs for terminus agent, so TerminalBenchGenerator could leverage it if applicable. This PR doesn't enable `trainer.algorithm.use_tis=true` so it should be a no-op.

With https://github.com/laude-institute/sandboxes/pull/50, Terminus agent now accepts "session_id" parameter, and it will show up in the litellm request body. TerminalBenchGenerator could leverage this for better routing.

Note that I don't have access to GPU yet so this is not tested.