### PR TITLE
[fix] abort all requests before sleep

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -310,7 +310,8 @@ class VLLMInferenceEngine(BaseVLLMInferenceEngine):
         if output_processor.has_unfinished_requests():
             logger.warning(
                 "Calling sleep() with unfinished requests in vLLM engine. This is unexpected since all "
-                "generation should be done before sleep() is called. Will abort all unfinished requests."
+                "generation should be done before sleep() is called. Check for potential failures or "
+                "dangling requests in your Generator/Env. Aborting all unfinished requests."
             )
             unfinished_request_ids = list(output_processor.request_states.keys())
             await asyncio.to_thread(engine.abort_request, unfinished_request_ids)
@@ -475,7 +476,8 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
         if output_processor.has_unfinished_requests():
             logger.warning(
                 "Calling sleep() with unfinished requests in vLLM engine. This is unexpected since all "
-                "generation should be done before sleep() is called. Will abort all unfinished requests."
+                "generation should be done before sleep() is called. Check for potential failures or "
+                "dangling requests in your Generator/Env. Aborting all unfinished requests."
             )
             unfinished_request_ids = list(output_processor.request_states.keys())
             await engine.abort(unfinished_request_ids)


### PR DESCRIPTION
This fixes the issue described in https://github.com/NovaSky-AI/SkyRL/issues/428.

We assume all requests that come in after sleep() are "unexpected" and abort them while printing a warning to the user.

I tested this fix with TerminalBenchGenerator (with async_engine=True) and it was able to successfully abort unwanted requests.

<img width="905" height="147" alt="Screenshot 2025-10-10 at 10 29 35 PM" src="https://github.com/user-attachments/assets/b520b72f-a416-4312-bf47-3a59dacf1e1e" />

Running examples/gsm8k/run_gsm8k.sh with async_engine=False also works. 

