### PR TITLE
[fix] Fix loss mean to not include masked tokens

### DIFF
--- a/skyrl-tx/tests/tinker/test_engine.py
+++ b/skyrl-tx/tests/tinker/test_engine.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import jax
 import numpy as np
-import jax.numpy as jnp
 
 from tx.tinker.engine import TinkerEngine
 from tx.tinker.config import EngineConfig

--- a/skyrl-tx/tx/tinker/engine.py
+++ b/skyrl-tx/tx/tinker/engine.py
@@ -128,8 +128,9 @@ class TinkerEngine:
             per_token_losses = optax.softmax_cross_entropy_with_integer_labels(
                 logits=logits, labels=target_ids, where=loss_mask
             )  # [B, T]
+            per_seq_loss = (per_token_losses * loss_mask).sum(axis=-1) / loss_mask.sum(axis=-1)
             # Return sum of losses (we'll divide gradients by per-adapter batch size later)
-            return per_token_losses.mean(axis=-1).sum(), (logits, per_token_losses)
+            return per_seq_loss.sum(), (logits, per_token_losses)
 
         loss_and_grad_fn = nnx.value_and_grad(loss_for_lora, has_aux=True)
         (_, (logits, per_token_losses)), lora_grads = loss_and_grad_fn(self.lora_params)


### PR DESCRIPTION
The average token loss previously included padded tokens, which results in an incorrect average. This PR removes padding tokens from the average token loss computation