### PR TITLE
[tx] Improve sharding efficiency by not capturing over model params

### DIFF
--- a/skyrl-tx/tx/tinker/engine.py
+++ b/skyrl-tx/tx/tinker/engine.py
@@ -144,7 +144,7 @@ class TinkerEngine:
             attention_mask: jax.Array,
             adapter_indices: jax.Array,
             target_ids: jax.Array,
-            loss_mask: jax.Array
+            loss_mask: jax.Array,
         ) -> tuple[jax.Array, tuple[jax.Array, jax.Array]]:
             model = nnx.merge(self.graphdef, lora_params, non_lora_params)
             logits = model(input_ids, attention_mask=attention_mask, adapter_indices=adapter_indices)[


### PR DESCRIPTION
Currently we capture over the whole non lora params in `loss_for_lora`, instead we need to trace it. See also https://github.com/jax-ml/jax/pull/28157.