### PR TITLE
Stack expert tensors on CPUs then shard to devices

### DIFF
--- a/skyrl-tx/tx/models/qwen3.py
+++ b/skyrl-tx/tx/models/qwen3.py
@@ -37,7 +37,7 @@ class Qwen3Attention(nnx.Module):
         self.num_kv_heads = config.num_key_value_heads
         tp = get_abstract_mesh().shape.get("tp", 1)
         assert self.num_heads % tp == 0, f"num_heads={self.num_heads} must be divisible by tp={tp}"
-        # assert self.num_kv_heads % tp == 0, f"num_kv_heads={self.num_kv_heads} must be divisible by tp={tp}"
+        assert self.num_kv_heads % tp == 0, f"num_kv_heads={self.num_kv_heads} must be divisible by tp={tp}"
         self.head_dim = getattr(config, "head_dim", None) or config.hidden_size // self.num_heads
         max_lora_adapters = getattr(config, "max_lora_adapters", 0)
         max_lora_rank = getattr(config, "max_lora_rank", 8)


### PR DESCRIPTION
To avoid OOMs during model loading, we first stack tensors on CPU then shard to devices. Previously tensors were stacked on GPU without sharding, cause OOMs.