### PR TITLE
Bump vLLM version to 0.11.0

### DIFF
--- a/skyrl-train/pyproject.toml
+++ b/skyrl-train/pyproject.toml
@@ -70,12 +70,11 @@ conflicts = [
 skyrl-gym = { path = "./skyrl-gym" , editable = true }
 torch = { index = "pytorch-cu128" }
 torchvision = { index = "pytorch-cu128" }
-flash-attn = { url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.0.post2/flash_attn-2.8.0.post2+cu12torch2.7cxx11abiFALSE-cp312-cp312-linux_x86_64.whl" }
-# NOTE (sumanthrh): We explictly use a flashinfer wheel from their index.
-# The wheels on PyPI don't come with pre-compiled kernels and the package will JIT compile them at runtime which is slow.
-# additionally, different inference engines may pin different compatible flashinfer versions, so we provide the option to pin different versions for vllm/sglang
+flash-attn = { url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.8cxx11abiFALSE-cp312-cp312-linux_x86_64.whl" }
+# We use `flashinfer-jit-cache` to avoid slow JIT compilation on first run.
+# Different inference engines may pin different compatible flashinfer versions, so we provide the option to pin different versions for vllm/sglang
+flashinfer-jit-cache = { index = "flashinfer-cu128", marker = "extra == 'vllm'" }
 flashinfer-python = [
-    { url = "https://download.pytorch.org/whl/cu128/flashinfer/flashinfer_python-0.2.6.post1%2Bcu128torch2.7-cp39-abi3-linux_x86_64.whl", marker = "extra =='vllm'" },
     { url = "https://download.pytorch.org/whl/cu128/flashinfer/flashinfer_python-0.2.6.post1%2Bcu128torch2.7-cp39-abi3-linux_x86_64.whl", marker = "extra == 'sglang' and extra != 'vllm'" }
 ]
 
@@ -104,9 +103,10 @@ sandboxes = [
     "litellm[proxy]>=1.67.5",
 ]
 vllm = [
-    "vllm==0.10.1.1",
-    "torch==2.7.1",
+    "vllm==0.11.0",
+    "torch==2.8.0",
     "flashinfer-python",
+    "flashinfer-jit-cache",
     "torchvision"
 ]
 sglang = [
@@ -146,6 +146,11 @@ miniswe = [
 [[tool.uv.index]]
 name = "pytorch-cu128"
 url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
+[[tool.uv.index]]
+name = "flashinfer-cu128"
+url = "https://flashinfer.ai/whl/cu128"
 explicit = true
 
 [tool.setuptools]


### PR DESCRIPTION
This required a flashinfer bump, which we now install from pypi directly, but they now provide prebuilt jit compilation caches! So startup is still fast.