### PR TITLE
Increase timeout for GPU CI

### DIFF
--- a/.github/workflows/gpu_ci.yaml
+++ b/.github/workflows/gpu_ci.yaml
@@ -46,5 +46,5 @@ jobs:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
           ANYSCALE_HOST: https://console.anyscale.com
         run: |
-          anyscale job submit -f ci/anyscale_gpu_ci.yaml --timeout 3600
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-ci --timeout 3600
+          anyscale job submit -f ci/anyscale_gpu_ci.yaml --timeout 5000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-ci --timeout 5000


### PR DESCRIPTION
With more tests passing instead of failing immediately, we frequently hit test timeout. Bumps from 3600 to 5000s 