### PR TITLE
[tx] Fix engine config to support boolean flags that are true by default

### DIFF
--- a/skyrl-tx/tx/tinker/config.py
+++ b/skyrl-tx/tx/tinker/config.py
@@ -68,10 +68,7 @@ def config_to_argv(cfg: BaseModel) -> list[str]:
         arg_name = field_name.replace("_", "-")
 
         if field.annotation is bool:
-            if value:
-                argv.append(f"--{arg_name}")
-            else:
-                argv.append(f"--no-{arg_name}")
+            argv.append(f"--{arg_name}" if value else f"--no-{arg_name}")
         else:
             argv.append(f"--{arg_name}")
             argv.append(str(value))


### PR DESCRIPTION
This is a follow up on https://github.com/NovaSky-AI/SkyRL/pull/491, currently there is an error if the flag is not explicitly passed in, and also currently it can't be turned off via the CLI.

Note: This allows both specifying --flag and --no-flag, and the last one wins, which seems like the desired behavior.