### PR TITLE
[lora] fix lora with vllm offline engine

### DIFF
--- a/skyrl-train/examples/lora/run_qwen2_5_0.5b_gsm8k_grpo_lora.sh
+++ b/skyrl-train/examples/lora/run_qwen2_5_0.5b_gsm8k_grpo_lora.sh
@@ -47,7 +47,7 @@ uv run --isolated --extra $INFERENCE_BACKEND -m skyrl_train.entrypoints.main_bas
   generator.backend=$INFERENCE_BACKEND \
   generator.run_engines_locally=true \
   generator.weight_sync_backend=nccl \
-  generator.async_engine=false \
+  generator.async_engine=true \
   generator.batched=true \
   environment.env_class=gsm8k \
   generator.n_samples_per_prompt=5 \


### PR DESCRIPTION
Previously, the offline engine code path was broken with LoRA, this PR changes it to do `self.llm.llm_engine.add_lora()` to fix 

now running (before it broke):
<img width="472" height="251" alt="image" src="https://github.com/user-attachments/assets/72a5c286-6d99-497e-8e58-fdf3bcb67b02" />
