### PR TITLE
[skyrl-train][logging] rename loss/avg_raw_rewards to loss/avg_final_rewards for clarity

### DIFF
--- a/skyrl-train/examples/step_wise/step_wise_trainer.py
+++ b/skyrl-train/examples/step_wise/step_wise_trainer.py
@@ -249,10 +249,10 @@ class StepWiseTrainer(RayPPOTrainer):
             }
         )
 
-        logger.info(f"avg_rewards: {avg_rewards}, avg_response_length: {avg_response_length}")
+        logger.info(f"avg_final_rewards: {avg_rewards}, avg_response_length: {avg_response_length}")
         self.all_metrics.update(
             {
-                "loss/avg_rewards": avg_rewards,
+                "loss/avg_final_rewards": avg_rewards,
                 "loss/avg_raw_advantages": avg_advantages,
                 "loss/avg_raw_advantages_abs": avg_advantages_abs,
             }

--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -657,17 +657,17 @@ class RayPPOTrainer:
             data.metadata["metrics"] = {}
         data.metadata["metrics"].update(
             {
-                "avg_rewards": avg_rewards,
+                "avg_final_rewards": avg_rewards,
                 "avg_response_length": avg_response_length,
                 "avg_advantages": avg_advantages,
                 "avg_advantages_abs": avg_advantages_abs,
             }
         )
 
-        logger.info(f"avg_rewards: {avg_rewards}, avg_response_length: {avg_response_length}")
+        logger.info(f"avg_final_rewards: {avg_rewards}, avg_response_length: {avg_response_length}")
         self.all_metrics.update(
             {
-                "loss/avg_rewards": avg_rewards,
+                "loss/avg_final_rewards": avg_rewards,
                 "loss/avg_raw_advantages": avg_advantages,
                 "loss/avg_raw_advantages_abs": avg_advantages_abs,
             }

--- a/skyrl-train/tests/cpu/test_trainer.py
+++ b/skyrl-train/tests/cpu/test_trainer.py
@@ -162,7 +162,7 @@ def test_calc_advantages_and_returns(mock_compute_adv_and_ret, dummy_config):
     assert torch.allclose(data["advantages"], mock_advantages)
     assert torch.allclose(data["returns"], mock_returns)
     assert isinstance(metrics, dict)
-    assert "avg_rewards" in metrics
+    assert "avg_final_rewards" in metrics
     assert "avg_response_length" in metrics
     assert "avg_advantages_abs" in metrics
     assert metrics["avg_advantages"] == approx(


### PR DESCRIPTION
Rename `loss/avg_raw_rewards` as a logging metric, since the difference from this and `reward/avg_raw_reward` is that `loss/avg_raw_rewards` can potentially include the kl penalty is `use_kl_in_reward` is set to true. 