### PR TITLE
[skyrl-train] assert that the policy loss type is regular/dual clip for tis

### DIFF
--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -292,7 +292,10 @@ def validate_cfg(cfg: DictConfig):
             raise ValueError(
                 "Gneration with `trainer.algorithm.use_tis` needs to be batched with only single turn generation"
             )
-        assert cfg.trainer.algorithm.policy_loss_type in ["regular", "dual_clip"], "TIS is only implemented for regular and dual_clip policy loss types"
+        assert cfg.trainer.algorithm.policy_loss_type in [
+            "regular",
+            "dual_clip",
+        ], "TIS is only implemented for regular and dual_clip policy loss types"
 
     if cfg.trainer.policy.model.lora.rank > 0:
         # LoRA enabled


### PR DESCRIPTION
TIS is currently only enabled for policy loss types that use the `ppo_policy_loss` code path