### PR TITLE
[Fix] Fix `fsdp2_load_state_dict` with HSDP

### DIFF
--- a/skyrl-train/skyrl_train/distributed/fsdp_utils.py
+++ b/skyrl-train/skyrl_train/distributed/fsdp_utils.py
@@ -28,7 +28,6 @@ from torch.distributed.fsdp._runtime_utils import _lazy_init
 from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
 from transformers.trainer_pt_utils import get_module_class_from_name
 from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.distributed_c10d import _get_default_group
 from collections import OrderedDict
 
 from packaging import version
@@ -283,7 +282,7 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_sd: dict, cpu_offloa
         for (param_name, full_param), sharded_param in zip(full_sd.items(), meta_sharded_sd.values()):
             full_param = full_param.detach().cuda()
             mesh = sharded_param.device_mesh
-            dist.broadcast(full_param, src=0, group=_get_default_group())
+            dist.broadcast(full_param, src=0)
             sharded_tensor = distribute_tensor(full_param, mesh, sharded_param.placements)
             to_contiguous, casting_dtype = _infer_parameter_dtype(
                 model,
@@ -297,7 +296,7 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_sd: dict, cpu_offloa
         for param_name, sharded_param in meta_sharded_sd.items():
             full_tensor = torch.empty(sharded_param.size(), device="cuda", dtype=sharded_param.dtype)
             mesh = sharded_param.device_mesh
-            dist.broadcast(full_tensor, src=0, group=_get_default_group())
+            dist.broadcast(full_tensor, src=0)
             sharded_tensor = distribute_tensor(full_tensor, mesh, sharded_param.placements)
             to_contiguous, casting_dtype = _infer_parameter_dtype(
                 model,


### PR DESCRIPTION
# What does this PR do?

HSDP is broken on `main` right now, likely after upgrade to torch 2.7.1:


```bash
RuntimeError: ('Found the DeviceMesh have 2 dimensions', 'Optional kwarg `mesh_dim` needs to be specified when device_mesh.ndim > 1
.', 'If you want to get the list of all the ProcessGroups in the DeviceMesh,please use `get_all_groups()` instead.')
```

We switch to using the default process group directly now since that was the previous behaviour. 