### PR TITLE
[Docs] Fix image in OpenEnv doc

### DIFF
--- a/skyrl-train/docs/examples/openenv.rst
+++ b/skyrl-train/docs/examples/openenv.rst
@@ -106,16 +106,12 @@ Supporting environments are: ``echo_env``, ``coding_env``, ``openspiel-env``, ``
 
 Example Reward Curve 
 --------
+
 Here's how the reward curve for the above example script looks like after a few steps: 
 
-.. list-table::
-   :widths: 50 50
-   :header-rows: 0
-
-   * - .. image:: images/openenv-reward.png
-         :width: 400px
-         :align: center
-
+..  image:: images/openenv-reward.png
+    :scale: 60%
+    :align: center
 Tips
 ~~~~~
 


### PR DESCRIPTION
Fixes the image:

Before:
<img width="748" height="119" alt="Screenshot 2025-10-23 at 2 35 03 PM" src="https://github.com/user-attachments/assets/ac6a83ab-efec-4851-9113-95018ed2b0f3" />


After:
<img width="755" height="480" alt="Screenshot 2025-10-23 at 2 34 54 PM" src="https://github.com/user-attachments/assets/1b610e22-d86c-49c3-a2b3-7e2a596a3291" />

