### PR TITLE
[skyrl-train] Enforce eager by default

### DIFF
--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -189,6 +189,7 @@ generator:
   enable_prefix_caching: true
   enable_chunked_prefill: true
   max_num_batched_tokens: 8192
+  # Disable CUDA graphs by default for stability. Set to false for higher performance, but this may affect convergence for long-running and/or long context training jobs.
   enforce_eager: true
   gpu_memory_utilization: 0.8
   max_num_seqs: 1024


### PR DESCRIPTION
# What does this PR do?

Set `enforce_eager` to true by default. 

We've seen issues with cuda graphs affecting convergence on some training runs. This is likely drift due to train <> rollout logprobs mismatch, but we need to investigate this better. 

Until then, it is best to turn off cuda graphs by default. Training runs are stable by default, more performant if the user chooses so. 