### PR TITLE
[fix] Broken method call in test

### DIFF
--- a/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py
@@ -235,13 +235,7 @@ def test_token_based_generation(ray_init_fixture, backend: str, tp_size: int, dp
         prompts, add_generation_prompt=True, tokenize=True, return_dict=True
     )["input_ids"]
 
-    llm_client = init_ray_inference_engines(
-        backend, 
-        tp_size=tp_size,
-        pp_size=1,
-        dp_size=dp_size, 
-        config=cfg
-    )
+    llm_client = init_ray_inference_engines(backend, tp_size=tp_size, pp_size=1, dp_size=dp_size, config=cfg)
     sampling_params = get_sampling_params_for_backend(cfg.generator.backend, cfg.generator.sampling_params)
 
     # Test batch generation with tokens


### PR DESCRIPTION
CI failed after #555 due to method call missing a argument. 