### PR TITLE
Fix: Megatron Autograd Warning for Broadcast Kernel

### DIFF
--- a/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
@@ -175,7 +175,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         if not torch.distributed.is_initialized():
             torch.distributed.init_process_group(backend="nccl")
 
-        if not getattr(torch.distributed, "_broadcast_no_grad", False):
+        if not getattr(torch.distributed, "_skyrl_broadcast_no_grad_patched", False):
             _orig_broadcast = torch.distributed.broadcast
 
             def _broadcast_no_grad(*args, **kwargs):
@@ -183,7 +183,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
                     return _orig_broadcast(*args, **kwargs)
 
             torch.distributed.broadcast = _broadcast_no_grad
-            torch.distributed._broadcast_no_grad = True
+            torch.distributed._skyrl_broadcast_no_grad_patched = True
 
         self.strategy = MegatronStrategy(
             megatron_config=self.cfg.trainer.policy.megatron_config,


### PR DESCRIPTION
#370 The broadcast kernel from torch.distributed is being called implicitly during `ppo_train` backprop. Training with Megatron leads to the following autograd warning: 

`[36m(MegatronPolicyWorkerBase pid=26429, ip=10.76.2.247)[0m /workspace/SkyRL/skyrl-train/.venv/lib/python3.12/site-packages/torch/autograd/graph.py:824: UserWarning: c10d::broadcast_: an autograd kernel was not registered to the Autograd key(s) but we are trying to backprop through it. This may lead to silently incorrect behavior. This behavior is deprecated and will be removed in a future version of PyTorch. If your operator is differentiable, please ensure you have registered an autograd kernel to the correct Autograd key (e.g. DispatchKey::Autograd, DispatchKey::CompositeImplicitAutograd). If your operator is not differentiable, or to squash this warning and use the previous behavior, please register torch::CppFunction::makeFallthrough() to DispatchKey::Autograd. (Triggered internally at /pytorch/torch/csrc/autograd/autograd_not_implemented_fallback.cpp:62.)
`

To prevent the autograd engine from registering broadcast, we should only be using this kernel with `torch.no_grad()`.  We explicitly set broadcast to be called with this decorator wrapped around it to override the function behaviour. 