### PR TITLE
[tx] Improve polling futures from database

### DIFF
--- a/skyrl-tx/tx/tinker/api.py
+++ b/skyrl-tx/tx/tinker/api.py
@@ -759,9 +759,9 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
                 # First, only query the status to avoid deserializing JSON data
                 statement = select(FutureDB.status).where(FutureDB.request_id == int(request.request_id))
                 result = await session.exec(statement)
-                status = result.scalar_one_or_none()
+                status = result.first()
 
-                if status is None:
+                if not status:
                     raise HTTPException(status_code=404, detail="Future not found")
 
                 # Only fetch full record if status is terminal (completed or failed)


### PR DESCRIPTION
This improves the polling of futures from the database if there are many requests in-flight. Going forward for postgres we can use `NOTIFY` to make this more efficient, but for now it is best to be database agnostic.