### PR TITLE
[megatron] Added non cuda ipc wt sync to megatron workers

### DIFF
--- a/skyrl-train/skyrl_train/utils/utils.py
+++ b/skyrl-train/skyrl_train/utils/utils.py
@@ -166,7 +166,6 @@ def validate_megatron_cfg(cfg: DictConfig):
     # not yet supported + tested features
     assert cfg.generator.weight_sync_backend == "nccl", "only nccl is supported for megatron weight sync"
     assert cfg.generator.backend == "vllm", "only vllm is supported for with megatron"
-    assert cfg.trainer.placement.colocate_all, "only colocate_all=True is supported for megatron training"
     assert cfg.trainer.critic.model.path is None, "only GRPO training is currently supported for megatron"
 
     if cfg.trainer.flash_attn:


### PR DESCRIPTION
- Currently megatron workers support weight sync only for colocated training (with cuda ipc).
- This PR:
    - adds support for weight sync with torch broadcasting (without cuda ipc) for megatron backend, which is required for training with `colocate_all=false`.
    - Fixes a bug which causes crashes while loading the reference model because it assumes the model exists on local disk, which may or may not have been downloaded by the policy worker before. 
- Tested on 4 nodes with `Qwen/Qwen3-30B-A3B` async RL training
