### PR TITLE
Return init_prompts in generate_batched

### DIFF
--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -396,7 +396,6 @@ class SkyRLGymGenerator(GeneratorInterface):
         prompt_token_ids = self.tokenizer.apply_chat_template(
             init_prompts,
             add_generation_prompt=True,
-            add_special_tokens=False,
             tokenize=True,
         )
         rollout_metrics = get_rollout_metrics(responses, rewards, env_metrics, env_classes)


### PR DESCRIPTION
`generate_batched` should return the prompts returned by `env.init`, which are the ones passed to the inference engine, rather than the prompts stored in the dataset. It should also return the response token IDs, not the response string.

This matches the behavior of `agent_loop`.