### PR TITLE
[tx] Fix training checkpoints being overwritten by sampling checkpoints

### DIFF
--- a/skyrl-tx/tests/tinker/test_api.py
+++ b/skyrl-tx/tests/tinker/test_api.py
@@ -94,6 +94,8 @@ def test_training_workflow(service_client):
 
     # Save the optimizer state
     resume_path = training_client.save_state(name="0000").result().path
+    # Make sure if we save the sampler weights it will not override training weights
+    training_client.save_weights_for_sampler(name="0000").result()
     # Get the training run ID from the first save
     parsed_resume = urlparse(resume_path)
     original_training_run_id = parsed_resume.netloc

--- a/skyrl-tx/tx/tinker/api.py
+++ b/skyrl-tx/tx/tinker/api.py
@@ -764,8 +764,8 @@ async def validate_checkpoint(
     if checkpoint_db.status == CheckpointStatus.FAILED:
         raise HTTPException(status_code=500, detail=f"Checkpoint creation failed: {checkpoint_db.error_message}")
 
-    checkpoint_path = request.app.state.engine_config.checkpoints_base / unique_id / f"{checkpoint_id}.tar.gz"
-    return checkpoint_path
+    subdir = "sampler_weights" if checkpoint_type == types.CheckpointType.SAMPLER else ""
+    return request.app.state.engine_config.checkpoints_base / unique_id / subdir / f"{checkpoint_id}.tar.gz"
 
 
 @app.get("/api/v1/training_runs/{unique_id}/checkpoints/{checkpoint_id}/archive")


### PR DESCRIPTION
While working on merging https://github.com/NovaSky-AI/SkyRL/pull/664, I noticed that currently training checkpoints are overwritten by sampling checkpoints which results in an error. This PR fixes it by storing sampling checkpoints in a subdirectory (much in the same way the `tinker://` paths are structured).