### PR TITLE
[tx] Use jit for saving and loading LoRA adapters (take 2)

### DIFF
--- a/skyrl-tx/tx/utils/models.py
+++ b/skyrl-tx/tx/utils/models.py
@@ -208,6 +208,7 @@ def get_optimizer(optimizer_name: OptimizerName, optimizer_args: dict) -> optax.
             raise ValueError("The 'learning_rate' key must be provided in optimizer_args.")
 
 
+@nnx.jit(static_argnames=("adapter_index", "rank"))
 def extract_adapter_state(adapter_index: int, lora_params: nnx.GraphState, rank: int) -> nnx.GraphState:
     "Helper function to extract the adapter parameters for a specific adapter index."
 
@@ -223,6 +224,8 @@ def extract_adapter_state(adapter_index: int, lora_params: nnx.GraphState, rank:
     return jax.tree.map_with_path(extract_state, lora_params)
 
 
+# We need to use nnx.jit here instead of jax.jit so the nnx.update will be handled correctly
+@nnx.jit(static_argnames=("adapter_index", "rank"))
 def insert_adapter_state(
     adapter_index: int, lora_params: nnx.GraphState, new_params: nnx.GraphState, rank: int
 ) -> None:


### PR DESCRIPTION
This speeds up saving and loading lora adapters.

Flamegraph before:

<img width="531" height="457" alt="Screenshot 2025-11-19 at 1 51 45 PM" src="https://github.com/user-attachments/assets/b66e600d-d784-4aa2-a45c-09b4de56517e" />

Flamegraph after:

<img width="506" height="549" alt="Screenshot 2025-11-19 at 2 29 08 PM" src="https://github.com/user-attachments/assets/2a31a8ad-30f0-4a7d-be8d-84d2824b8764" />
