### PR TITLE
Clarifying installation instructions for getting started

### DIFF
--- a/skyrl-train/docs/getting-started/installation.rst
+++ b/skyrl-train/docs/getting-started/installation.rst
@@ -39,7 +39,7 @@ We provide a docker image with the base dependencies ``novaskyai/skyrl-train-ray
     cd SkyRL/skyrl-train
 
 
-That is it! After installing dependencies and initializing the ray cluster as described in the following sections, you should now be able to run our :doc:`quick start example <quickstart>`.
+That is it! After initializing the ray cluster as described below, you should now be able to run our :doc:`quick start example <quickstart>`.
 
 .. warning::
 


### PR DESCRIPTION
Updated instructions to note the need to complete later steps in the installation instructions before proceeding – the link and saying "you're all done" was misleading because when immediately proceeding to Quickstart, the run would fail.