### PR TITLE
[skyrl-train] fix docs link to async off by one

### DIFF
--- a/skyrl-train/docs/examples/ppo.rst
+++ b/skyrl-train/docs/examples/ppo.rst
@@ -92,7 +92,7 @@ What's Next?
 
 Now that you've got basic colocated PPO training down, you might want to explore some more advanced features:
 
-- :doc:`../tutorials/async`: Asynchronous off-by-one training in < 100 lines of code!
+- :doc:`../tutorials/one_step_off_async`: Asynchronous off-by-one training in < 100 lines of code!
 - :doc:`../examples/remote_server`: Training with a remote inference engine
 
 

--- a/skyrl-train/docs/examples/remote_server.rst
+++ b/skyrl-train/docs/examples/remote_server.rst
@@ -125,5 +125,5 @@ What's Next?
 
 Now that you've set up training with a remote inference engine, you might want to explore ways of speeding up training:
 
-- :doc:`../tutorials/async`: Asynchronous off-by-one training in < 100 lines of code!
+- :doc:`../tutorials/one_step_off_async`: Asynchronous off-by-one training in < 100 lines of code!
 

--- a/skyrl-train/docs/getting-started/quickstart.rst
+++ b/skyrl-train/docs/getting-started/quickstart.rst
@@ -96,6 +96,6 @@ What's Next?
 Now that you've got the basics down, you might want to explore:
 
 - :doc:`../tutorials/new_env`: Creating a new environment without touching the training loop
-- :doc:`../tutorials/async`: Asynchronous off-by-one training in < 100 lines of code!
+- :doc:`../tutorials/one_step_off_async`: Asynchronous off-by-one training in < 100 lines of code!
 - :doc:`../recipes/overview`: A collection of end-to-end recipes with SkyRL.
 


### PR DESCRIPTION
^
Was broken post merging full async support
<img width="781" height="215" alt="image" src="https://github.com/user-attachments/assets/5313f6eb-3e8d-40b7-a07d-bd0d51d2ed28" />


Fixed:
 
<img width="611" height="189" alt="image" src="https://github.com/user-attachments/assets/2c19196f-b807-4ef7-9db8-08b826bb6815" />

