### PR TITLE
[skyrl-train] Use trainer config for megatron gradient checkpointing

### DIFF
--- a/skyrl-train/skyrl_train/config/megatron_config/policy.yaml
+++ b/skyrl-train/skyrl_train/config/megatron_config/policy.yaml
@@ -40,7 +40,7 @@ transformer_config_kwargs:
   # Recompute config - used for gradient/activation checkpointing
   # for details see: https://github.com/NVIDIA/Megatron-LM/blob/core_r0.13.0/megatron/core/transformer/transformer_config.py#L33
   # for the most aggresive memory savings, set recompute_granularity to "full", recompute_method to "uniform", and recompute_num_layers to 1
-  recompute_granularity: null
+  recompute_granularity: full
   recompute_modules: ["core_attn"]
-  recompute_method: null
-  recompute_num_layers: null
+  recompute_method: uniform
+  recompute_num_layers: 1

--- a/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
@@ -61,15 +61,7 @@ class MegatronWorker:
         transformer_config_kwargs = OmegaConf.to_container(transformer_config_kwargs, resolve=True)
         transformer_config_kwargs["attention_backend"] = "flash" if flash_attn else "fused"
 
-        if self.cfg.trainer.gradient_checkpointing:
-            defaults = {
-                "recompute_granularity": "full",
-                "recompute_method": "uniform",
-                "recompute_num_layers": 1,
-            }
-            for key, value in defaults.items():
-                transformer_config_kwargs.setdefault(key, value)
-        else:
+        if not self.cfg.trainer.gradient_checkpointing:
             for key in ("recompute_granularity", "recompute_method", "recompute_num_layers"):
                 transformer_config_kwargs[key] = None
 


### PR DESCRIPTION
Gradient checkpointing is now controlled by trainer.gradient_checkpointing (when set to True). The user is still able to provide overrides for the megatron_config.transformer_config_kwargs as long as the trainer.gradient_checkpointing is set to true. Otherwise, the params are set to None. Addresses #700 
