### PR TITLE
Add empty_cuda_cache flag in the megatron config

### DIFF
--- a/skyrl-train/skyrl_train/config/megatron_config/policy.yaml
+++ b/skyrl-train/skyrl_train/config/megatron_config/policy.yaml
@@ -44,3 +44,7 @@ transformer_config_kwargs:
   recompute_modules: ["core_attn"]
   recompute_method: uniform
   recompute_num_layers: 1
+
+# flag to manually empty torch's cuda cache between the forward/backward pass and the optimizer step
+# this will free reserved but unallocated memory, and can help avoid OoMs in the optimizer
+empty_cuda_cache: true

--- a/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
@@ -332,6 +332,8 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
                 self.param_buckets[-1].append(task)
                 curr_size += size
 
+        self.empty_cuda_cache = self.cfg.trainer.policy.megatron_config.empty_cuda_cache
+
     def ppo_train(self, train_data) -> "TrainingOutputBatch":
         """
         Overrides `PolicyWorkerBase.ppo_train` for megatron.
@@ -399,6 +401,9 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
                         micro_batch_size=micro_bsz,
                         temperature=self.cfg.generator.sampling_params.temperature,
                     )
+
+                    if self.empty_cuda_cache:
+                        torch.cuda.empty_cache()
 
                     grad_norm = self.strategy.optimizer_step(self.optimizer, self.model, self.scheduler, name="actor")
 


### PR DESCRIPTION
This PR adds a `empty_cuda_cache` flag in the megatron config of the policy to indicate that torch's cuda cache should be manually cleared between the forward/backward pass and the optimizer step

We found out that reserved but unallocated memory was high at this point, and frequent OoMs happened in the next step, likely indicating the cache wasn't automatically cleared even when needed in the optimizer (our hypothesis is because the NCCL distribution handles allocation at a low level directly and isn't compatible with torch's reservation). Manually clearing the cache at this point generally made tests and trainings more stable, and even allowed training that previous consistently threw OoM errors