### PR TITLE
Use truncated responses ids for overlong filtering instead of strings

### DIFF
--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -401,7 +401,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         rollout_metrics = get_rollout_metrics(responses, rewards, env_metrics, env_classes)
 
         if self.generator_cfg.apply_overlong_filtering:
-            loss_masks = apply_overlong_filtering(loss_masks, responses, self.tokenizer.eos_token_id)
+            loss_masks = apply_overlong_filtering(loss_masks, truncated_responses, self.tokenizer.eos_token_id)
 
         generator_output: GeneratorOutput = {
             "prompt_token_ids": prompt_token_ids,


### PR DESCRIPTION
apply_overlong_filtering method expects response_ids such it can compare the last element to a token_id. In the current code it passes strings instead of ids such that the apply_overlong_filtering method masks all of the tokens.