### PR TITLE
[tx] weights_info to fix CI

### DIFF
--- a/skyrl-tx/tx/tinker/api.py
+++ b/skyrl-tx/tx/tinker/api.py
@@ -421,6 +421,7 @@ class WeightsInfoRequest(BaseModel):
 
 class WeightsInfoResponse(BaseModel):
     """Minimal information for loading public checkpoints."""
+
     # from: https://github.com/thinking-machines-lab/tinker/blob/main/src/tinker/types/weights_info_response.py
     base_model: str
     is_lora: bool


### PR DESCRIPTION
Some tests are failing due to the api not implementing `/api/v1/weights_info`

Seems like it's been the case with previously merged PRs as well eg: https://github.com/NovaSky-AI/SkyRL/pull/701

This adds the endpoint

cc @pcmoritz @tyler-griggs 