### PR TITLE
[skyrl-train] Updated FSDP Weight Sync Implementation with Bucketing for Minimizing CUDA IPC Overhead

### DIFF
--- a/skyrl-train/tests/gpu/gpu_e2e_test/gsm8k_colocate.sh
+++ b/skyrl-train/tests/gpu/gpu_e2e_test/gsm8k_colocate.sh
@@ -8,4 +8,4 @@ bash examples/gsm8k/run_gsm8k.sh \
   trainer.micro_forward_batch_size_per_gpu=16 \
   trainer.micro_train_batch_size_per_gpu=16 \
   trainer.project_name=\"gsm8k_ci\" \
-  trainer.run_name=\"gsm8k_colocate\" \
+  trainer.run_name=\"gsm8k_colocate\"


### PR DESCRIPTION
Changed the current FSDP weight sync implementation which batches parameters as we go by first flattening and packing flatten/pack all the params into a single tensor to avoid cuda ipc opening overhead

on a 4xL4 setup with GSM8K (need to test on more complex tasks)

<img width="1078" height="87" alt="image" src="https://github.com/user-attachments/assets/916587fe-9662-4dc1-b85f-155d5d34b197" />
<img width="720" height="60" alt="image" src="https://github.com/user-attachments/assets/9e13877d-bcde-40cb-8397-afb575005bdd" />


Refer to Issue #725 