### PR TITLE
[tx] Add top_p sampling feature and basic test implementations

### DIFF
--- a/skyrl-tx/tx/tinker/api.py
+++ b/skyrl-tx/tx/tinker/api.py
@@ -281,8 +281,6 @@ class SamplingParams(BaseModel):
 
         if self.top_k != -1:
             raise HTTPException(status_code=501, detail="'top_k' parameter is not yet implemented")
-        if self.top_p != 1.0:
-            raise HTTPException(status_code=501, detail="'top_p' parameter is not yet implemented")
 
         # Generate a random seed if not provided
         seed = self.seed if self.seed is not None else random.randint(0, 2**31 - 1)
@@ -292,6 +290,7 @@ class SamplingParams(BaseModel):
             max_tokens=self.max_tokens,
             seed=seed,
             stop=self.stop,
+            top_p=self.top_p,
         )
 
 

--- a/skyrl-tx/tx/tinker/types.py
+++ b/skyrl-tx/tx/tinker/types.py
@@ -158,6 +158,7 @@ class SamplingParams(BaseModel):
     max_tokens: int
     seed: int
     stop: list[int] | None = None
+    top_p: float = 1
 
 
 class ModelMetadata(BaseModel):


### PR DESCRIPTION
## Summary
Implements `top_p`  sampling for skyrl-tx, complementing the existing `top_k` implementation in #680.
Adds feature requested in #533 

## Changes
- Added `top_p` parameter to `SamplingParams` in types and API
- Implemented core logic in `apply_top_p()` function for sampling
- Added tests 

## Testing
- Unit tests: `tests/utils/test_generator.py::test_top_p_sampling`
- `tests/tinker/test_api.py::test_sample_top_p`