### PR TITLE
[readme] on-policy distillation readmefix

### DIFF
--- a/skyrl-train/examples/on_policy_distillation/README.md
+++ b/skyrl-train/examples/on_policy_distillation/README.md
@@ -15,6 +15,7 @@ In `main_on_policy_distill.py` we provide a simple example for modifying SkyRL t
 To get started, first set up the dataset from the DAPO example:
 
 ```bash
+# Run from the `skyrl-train` directory
 bash examples/algorithms/dapo/prepare_dapo_data.sh
 ```
 


### PR DESCRIPTION
This PR fixes how the DAPO data preparation script is invoked. Previously, the documentation suggested 

```bash
uv run examples/algorithms/dapo/prepare_dapo_data.sh
```

However, prepare_dapo_data.sh is a shell script that already calls uv run, so wrapping it with uv run causes a Permission denied error.