### PR TITLE
[tx] Fix sampling bug where prompts were right-padded instead of left-padded

### DIFF
--- a/skyrl-tx/tx/tinker/engine.py
+++ b/skyrl-tx/tx/tinker/engine.py
@@ -55,6 +55,9 @@ def pad_batch(sequences: list[list], max_length: int, dtype, left: bool = False)
         left: If True, use left-padding (tokens at end). Required for autoregressive
             generation so the last position corresponds to the last real token.
             If False (default), use right-padding (tokens at start).
+
+    Returns:
+        A JAX array of shape (batch_size, max_length) with the padded sequences.
     """
     batch_size = len(sequences)
     padded = np.zeros((batch_size, max_length), dtype=dtype)


### PR DESCRIPTION
This took a while to debug since I first thought the problem was in the model / generation logic. With this fix, it seems the results are now very close to vllm (pending some more validations).