### PR TITLE
[skyrl-train] Fix typo in dapo data prep script

### DIFF
--- a/skyrl-train/examples/algorithms/dapo/run_dapo_aime_qwen3_4b_aime.sh
+++ b/skyrl-train/examples/algorithms/dapo/run_dapo_aime_qwen3_4b_aime.sh
@@ -1,7 +1,7 @@
 set -x
 
 # Colocated DAPO training+generation for Qwen3-4B-Base on DAPO training data and validate on AIME 2024.
-# uv run examples/algorithms/dapo/prepare_dapo_data.sh
+# bash examples/algorithms/dapo/prepare_dapo_data.sh
 # bash examples/algorithms/dapo/run_dapo_aime_qwen3_4b_aime.sh
 
 MODEL_NAME="Qwen/Qwen3-4B-Base"

--- a/skyrl-train/examples/algorithms/dapo/run_dapo_qwen2.5_32b_aime.sh
+++ b/skyrl-train/examples/algorithms/dapo/run_dapo_qwen2.5_32b_aime.sh
@@ -1,7 +1,7 @@
 set -x
 
 # Colocated DAPO training+generation for Qwen2.5-32B-Instruct on DAPO training data and validate on AIME 2024.
-# uv run examples/algorithms/dapo/prepare_dapo_data.sh
+# bash examples/algorithms/dapo/prepare_dapo_data.sh
 # bash examples/algorithms/dapo/run_dapo_qwen2.5_32b_aime.sh
 
 MODEL_NAME="Qwen/Qwen2.5-32B"

--- a/skyrl-train/examples/algorithms/dapo/run_dapo_qwen2.5_math_7b_aime.sh
+++ b/skyrl-train/examples/algorithms/dapo/run_dapo_qwen2.5_math_7b_aime.sh
@@ -1,7 +1,7 @@
 set -x
 
 # Colocated DAPO training+generation for Qwen2.5-1.5B-Instruct on DAPO training data and validate on AIME 2024.
-# uv run examples/algorithms/dapo/prepare_dapo_data.sh
+# bash examples/algorithms/dapo/prepare_dapo_data.sh
 # bash examples/algorithms/dapo/run_dapo_qwen2.5_math_7b_aime.sh
 
 # download the model from huggingface and modify the max_position_embeddings in config.json to 32768

--- a/skyrl-train/examples/algorithms/dapo/run_dapo_qwen3_1.7b_aime.sh
+++ b/skyrl-train/examples/algorithms/dapo/run_dapo_qwen3_1.7b_aime.sh
@@ -1,7 +1,7 @@
 set -x
 
 # Colocated DAPO training+generation for Qwen3-1.7B-Base on DAPO training data and validate on AIME 2024.
-# uv run examples/algorithms/dapo/prepare_dapo_data.sh
+# bash examples/algorithms/dapo/prepare_dapo_data.sh
 # bash examples/algorithms/dapo/run_dapo_qwen3_1.7b_aime.sh
 
 MODEL_NAME="Qwen/Qwen3-1.7B-Base"

--- a/skyrl-train/examples/on_policy_distillation/run_on_policy_distill_math_qwen3_1.7b.sh
+++ b/skyrl-train/examples/on_policy_distillation/run_on_policy_distill_math_qwen3_1.7b.sh
@@ -2,7 +2,7 @@ set -x
 
 # Running on policy distillation for Math on the DAPO math dataset, with eval on AIME 2024.
 # Uses Qwen-3-1.7B-Base as the student model and an RL trained Qwen-3-4B as the teacher model
-# uv run examples/algorithms/dapo/prepare_dapo_data.sh
+# bash examples/algorithms/dapo/prepare_dapo_data.sh
 # bash examples/on_policy_distillation/run_on_policy_distill_math_qwen3_1.7b.sh
 
 DATA_DIR="$HOME/data/dapo"

--- a/skyrl-train/examples/on_policy_distillation/run_on_policy_distill_math_qwen3_4b.sh
+++ b/skyrl-train/examples/on_policy_distillation/run_on_policy_distill_math_qwen3_4b.sh
@@ -2,7 +2,7 @@ set -x
 
 # Running on policy distillation for Math on the DAPO math dataset, with eval on AIME 2024.
 # Uses Qwen-3-4B-Base as the student model and an RL trained Qwen-3-4B as the teacher model
-# uv run examples/algorithms/dapo/prepare_dapo_data.sh
+# bash examples/algorithms/dapo/prepare_dapo_data.sh
 # bash examples/on_policy_distillation/run_on_policy_distill_math_qwen3_4b.sh
 
 DATA_DIR="$HOME/data/dapo"


### PR DESCRIPTION
Clean up same typo as in #745 elsewhere in the codebase