### PR TITLE
[tx] Optimize checkpoint creation

### DIFF
--- a/skyrl-tx/tx/utils/storage.py
+++ b/skyrl-tx/tx/utils/storage.py
@@ -22,6 +22,7 @@ def pack_and_upload(dest: AnyPath) -> Generator[Path, None, None]:
         dest.parent.mkdir(parents=True, exist_ok=True)
 
         with dest.open("wb") as f:
+            # Use compresslevel=0 to prioritize speed, as checkpoint files don't compress well.
             with tarfile.open(fileobj=f, mode="w|gz", compresslevel=0) as tar:
                 tar.add(tmp_path, arcname="")
 


### PR DESCRIPTION
I saw that gzip compression can take a noticeable amount of time currently, so this PR switches it off (checkpoints don't compress very well anyways). It keeps the gzip frame, this way we have some optionality to put compression back in going forward. However, if we want to compress going forward it might be better to use zstd, but that would require an external library.