### PR TITLE
[skyrl-train] logprobs for batched:false

### DIFF
--- a/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
+++ b/skyrl-train/skyrl_train/generators/skyrl_gym_generator.py
@@ -224,7 +224,7 @@ class SkyRLGymGenerator(GeneratorInterface):
                 if output.endswith(tuple(stop_strs)) and output_ids[-1] != self.tokenizer.eos_token_id:
                     output_ids.append(self.tokenizer.eos_token_id)
                     added_eos = True
-                    if get_logprobs and rollout_logprobs is not None:
+                    if get_logprobs:
                         rollout_logprobs.append(0.0)
 
             # 2. Environment step

--- a/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
+++ b/skyrl-train/tests/cpu/generators/test_skyrl_gym_generator.py
@@ -264,7 +264,7 @@ async def test_agent_loop_single_turn(
     def mock_generate(_):
         result = {
             "responses": ["4"],
-            "response_ids": [[1, 2, 3, 4]],
+            "response_ids": [MOCK_LLM_OUTPUT_IDS.copy()],
             "stop_reasons": ["stop"],
         }
         if logprobs_setting is not None:


### PR DESCRIPTION
Follow up PR to #758 and to Issue #699 

cc @erictang000 

logprobs collection for non-batched generation mode (`batched:false`)


## Changes

### `skyrl_gym_generator.py`
- Removed validation blocking
- Initialize `rollout_logprobs` list in `agent_loop()` when enabled
- Collect logprobs from engine output after each generation
- Handle observation tokens with placeholder logprobs (0.0)
- Handle manually added EOS tokens
- Fixed type bug: observation logprobs now use `0.0` (float) instead of `1` (int)

### `test_skyrl_generator.py`
- Extended `test_agent_loop_single_turn` to parametrize over `logprobs_setting`
