### PR TITLE
[tx] Log execution time for executing engine requests

### DIFF
--- a/skyrl-tx/tx/tinker/engine.py
+++ b/skyrl-tx/tx/tinker/engine.py
@@ -48,7 +48,7 @@ def log_timing(request: str):
         yield
     finally:
         elapsed = time.perf_counter() - start_time
-        logger.info(f"(request timing) {request} took {elapsed:.3f}s")
+        logger.info(f"(timing) {request} took {elapsed:.3f}s")
 
 
 def pad(xs, pad_to: int, *, fill):


### PR DESCRIPTION
This PR adds logging to the engine so we know how long each of the requests takes. Added `(timing)` to the logs so they are easily greppable.