### PR TITLE
Keep returns separate from advantages in GRPO

### DIFF
--- a/skyrl-train/skyrl_train/utils/ppo_utils.py
+++ b/skyrl-train/skyrl_train/utils/ppo_utils.py
@@ -1076,6 +1076,7 @@ def compute_grpo_outcome_advantage(
             else:
                 scores[i] = scores[i] - id2mean[index[i]]
         scores = scores.unsqueeze(-1) * response_mask
+        returns = returns.unsqueeze(-1) * response_mask
 
     return scores, returns
 


### PR DESCRIPTION
The GRPO advantage computation returns the normalized `scores` for both the advantages and returns even though it represents the advantages. This PR makes `compute_grpo_outcome_advantage` return the sequence-level sum of rewards for the returns, separately from the `scores` (i.e., advantages).