### PR TITLE
[tx] remove compresslevel parameter from streaming tarfile mode

### DIFF
--- a/skyrl-tx/tx/utils/storage.py
+++ b/skyrl-tx/tx/utils/storage.py
@@ -23,7 +23,7 @@ def pack_and_upload(dest: AnyPath) -> Generator[Path, None, None]:
         dest.parent.mkdir(parents=True, exist_ok=True)
 
         with dest.open("wb") as f:
-            # Use streaming mode for speed, as checkpoint files don't compress well.
+            # Use compresslevel=0 to prioritize speed, as checkpoint files don't compress well.
             with gzip.GzipFile(fileobj=f, mode="wb", compresslevel=0) as gz_stream:
                 with tarfile.open(fileobj=gz_stream, mode="w:") as tar:
                     tar.add(tmp_path, arcname="")


### PR DESCRIPTION
The compresslevel parameter is not supported with streaming mode 'w|gz' in Python's tarfile module, causing BadRequestError in tests.

Fixes test_api.py::test_training_workflow and test_api.py::test_sample[lora_model]

Before
```
=================================================================== test session starts ===================================================================
platform linux -- Python 3.12.11, pytest-9.0.2, pluggy-1.6.0 -- /venv/main/bin/python
cachedir: .pytest_cache
rootdir: /workspace/SkyRL/skyrl-tx
configfile: pyproject.toml
plugins: anyio-4.12.0, forked-1.6.0
collected 4 items                                                                                                                                         

test_api.py::test_capabilities PASSED
merges.txt: 1.67MB [00:00, 49.9MB/s]
chat_template.jinja: 4.15kB [00:00, 15.2MB/s]
FAILED
test_api.py::test_sample[base_model] PASSED
test_api.py::test_sample[lora_model] FAILED

======================================================================== FAILURES =========================================================================
_
E               ValueError: Error retrieving result: Error code: 400 - {'detail': "TarFile.__init__() got an unexpected keyword argument 'compresslevel'"} with status code e.status_code=400 for self.request_id='8' and expected type self.model_cls=<class 'tinker.types.save_weights_for_sampler_response.SaveWeightsForSamplerResponseInternal'>

/venv/main/lib/python3.12/site-packages/tinker/lib/api_future_impl.py:171: ValueError
================================================================= short test summary info =================================================================
FAILED test_api.py::test_training_workflow - ValueError: Error retrieving result: Error code: 400 - {'detail': "TarFile.__init__() got an unexpected keyword argument 'compresslevel'"} with status code e.status_code=400 for self.request_id='2' and expected type self.model_cls=<class 'tinker.types.save_weights_response.SaveWeightsResponse'>
FAILED test_api.py::test_sample[lora_model] - ValueError: Error retrieving result: Error code: 400 - {'detail': "TarFile.__init__() got an unexpected keyword argument 'compresslevel'"} with status code e.status_code=400 for self.request_id='8' and expected type self.model_cls=<class 'tinker.types.save_weights_for_sampler_response.SaveWeightsForSamplerResponseInternal'>
========================================================= 2 failed, 2 passed in 75.28s (0:01:15) ==========================================================

```

After
```
=================================================================== test session starts ===================================================================
platform linux -- Python 3.12.11, pytest-9.0.2, pluggy-1.6.0 -- /venv/main/bin/python
cachedir: .pytest_cache
rootdir: /workspace/SkyRL/skyrl-tx
configfile: pyproject.toml
plugins: anyio-4.12.0, forked-1.6.0
collected 4 items                                                                                                                                         

test_api.py::test_capabilities PASSED
test_api.py::test_training_workflow PASSED
test_api.py::test_sample[base_model] PASSED
test_api.py::test_sample[lora_model] PASSED

=================================================================== 4 passed in 51.50s ====================================================================

```