### PR TITLE
[skyrl-train] add graceful error handling and safer pretty print logging

### DIFF
--- a/skyrl-train/skyrl_train/utils/logging_utils.py
+++ b/skyrl-train/skyrl_train/utils/logging_utils.py
@@ -5,13 +5,12 @@ NEGATIVE_RESPONSE_COLOR = "yellow"
 BASE_PROMPT_COLOR = "cyan"
 
 
-def _color_block_format_and_args(
+def _color_block_format_and_kwargs(
     text: str,
     color: str,
     field_prefix: str,
 ) -> tuple[str, dict]:
-    """
-    Build a format string and kwargs for a multi-line colored block.
+    """Build a format string and kwargs for a multi-line colored block.
 
     The format string will look like:
         "<color>{p0}</color>\n<color>{p1}</color>\n..."
@@ -22,16 +21,16 @@ def _color_block_format_and_args(
     lines = text.splitlines() or [""]
 
     fmt_lines = []
-    args: dict[str, str] = {}
+    kwargs: dict[str, str] = {}
 
     for i, line in enumerate(lines):
         key = f"{field_prefix}{i}"
         # NOTE: double braces {{ }} so that {key} survives into str.format
         fmt_lines.append(f"<{color}>{{{key}}}</{color}>")
-        args[key] = line
+        kwargs[key] = line
 
     fmt = "\n".join(fmt_lines)
-    return fmt, args
+    return fmt, kwargs
 
 
 def log_example(
@@ -69,17 +68,17 @@ def log_example(
             response_color = NEGATIVE_RESPONSE_COLOR
 
         # --- Build per-line colored blocks in the *format string* ---
-        prompt_fmt, prompt_args = _color_block_format_and_args(prompt_str, BASE_PROMPT_COLOR, "p")
-        response_fmt, response_args = _color_block_format_and_args(response_str, response_color, "r")
+        prompt_fmt, prompt_kwargs = _color_block_format_and_kwargs(prompt_str, BASE_PROMPT_COLOR, "p")
+        response_fmt, response_kwargs = _color_block_format_and_kwargs(response_str, response_color, "r")
 
         # Single format string with only our own markup and placeholders
-        log_format = "Example:\n" f"  Input: {prompt_fmt}\n" "  Output (Reward: {reward}):\n" f"{response_fmt}"
+        log_format = "Example:\n" f"  Input: {prompt_fmt}\n" "  Output (Total Reward: {reward}):\n" f"{response_fmt}"
 
         # Merge all args for str.format
-        format_args = {**prompt_args, **response_args, "reward": reward_str}
+        format_kwargs = {**prompt_kwargs, **response_kwargs, "reward": reward_str}
 
         # Let Loguru parse tags in log_format and then substitute arguments.
-        logger.opt(colors=True).info(log_format, **format_args)
+        logger.opt(colors=True).info(log_format, **format_kwargs)
     except Exception as e:
         print(f"Error pretty printing example, debug printing instead: {e}")
-        print(f"Example:\n  Input: {prompt}\n  Output (Reward: {reward_str}):\n{response}")
+        print(f"Example:\n  Input: {prompt}\n  Output (Total Reward: {reward_str}):\n{response}")

--- a/skyrl-train/tests/cpu/utils/test_logging_utils.py
+++ b/skyrl-train/tests/cpu/utils/test_logging_utils.py
@@ -8,7 +8,7 @@ from skyrl_train.utils.logging_utils import (
     BASE_PROMPT_COLOR,
     NEGATIVE_RESPONSE_COLOR,
     POSITIVE_RESPONSE_COLOR,
-    _color_block_format_and_args,
+    _color_block_format_and_kwargs,
     log_example,
 )
 
@@ -31,19 +31,19 @@ class StubLogger:
         self.last_kwargs = kwargs
 
 
-def test_color_block_format_and_args_single_line():
-    fmt, args = _color_block_format_and_args("hello", "red", "p")
+def test_color_block_format_and_kwargs_single_line():
+    fmt, kwargs = _color_block_format_and_kwargs("hello", "red", "p")
 
     assert fmt == "<red>{p0}</red>"
-    assert args == {"p0": "hello"}
+    assert kwargs == {"p0": "hello"}
 
 
-def test_color_block_format_and_args_multi_line():
+def test_color_block_format_and_kwargs_multi_line():
     text = "line1\nline2"
-    fmt, args = _color_block_format_and_args(text, "blue", "x")
+    fmt, kwargs = _color_block_format_and_kwargs(text, "blue", "x")
 
     assert fmt == "<blue>{x0}</blue>\n<blue>{x1}</blue>"
-    assert args == {"x0": "line1", "x1": "line2"}
+    assert kwargs == {"x0": "line1", "x1": "line2"}
 
 
 @pytest.mark.parametrize(
@@ -66,7 +66,7 @@ def test_log_example_uses_expected_colors_and_reward_string(reward, expected_col
 
     # Basic structure checks
     assert logger.last_message.startswith("Example:\n  Input: ")
-    assert "Output (Reward: {reward}):" in logger.last_message
+    assert "Output (Total Reward: {reward}):" in logger.last_message
 
     # Placeholder keys from helper should be present
     assert "p0" in logger.last_kwargs
@@ -99,16 +99,14 @@ def test_log_example_uses_expected_colors_and_reward_string(reward, expected_col
 
 
 def test_log_example_handles_exceptions_gracefully(monkeypatch, capsys):
-    """
-    Force an exception inside log_example and ensure the fallback path prints.
-    """
+    """Force an exception inside log_example and ensure the fallback path prints."""
 
     def broken_color_block(*args, **kwargs):
         raise RuntimeError("boom")
 
     # Patch the helper to raise
     monkeypatch.setattr(
-        "skyrl_train.utils.logging_utils._color_block_format_and_args",
+        "skyrl_train.utils.logging_utils._color_block_format_and_kwargs",
         broken_color_block,
     )
 
@@ -120,5 +118,5 @@ def test_log_example_handles_exceptions_gracefully(monkeypatch, capsys):
     assert "Error pretty printing example" in captured.out
     assert "Example:" in captured.out
     assert "Input: [{'role': 'user', 'content': 'p'}]" in captured.out
-    assert "Output (Reward: N/A):" in captured.out
+    assert "Output (Total Reward: N/A):" in captured.out
     assert "r" in captured.out


### PR DESCRIPTION
Addresses #772. Adds try except logic for when logic can potentially fail for arbitrary strings, and passes format args to the logger.info call rather than formatting the string outside, which can potentially cause issues (source: https://github.com/Delgan/loguru/issues/988).

Adds a cpu test to test new behavior.

Pretty print logging still in action:
<img width="1269" height="143" alt="image" src="https://github.com/user-attachments/assets/5e1ae2fe-bfa4-4a09-990d-cb0c73120738" />
<img width="1278" height="306" alt="image" src="https://github.com/user-attachments/assets/5803ae0b-4091-4e6c-b4aa-d4a46ed671cf" />

