### PR TITLE
[tx] Do not log path of Python file and line number

### DIFF
--- a/skyrl-tx/tx/utils/log.py
+++ b/skyrl-tx/tx/utils/log.py
@@ -24,7 +24,7 @@ def _setup_root_logger() -> None:
             console.print(msg, highlight=True)
 
     handler = RichStreamHandler()
-    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    handler.setFormatter(logging.Formatter("%(levelname)s:     %(message)s"))
     logger.addHandler(handler)
 
 


### PR DESCRIPTION
Currently, that path and line number of the python statement generating the log is logged, in a right aligned fashion. While this sounds useful, it practice it isn't really and makes working with the logs somewhat annoying (since there is a lot of white space and dependence on the terminal size).