### PR TITLE
[train][Fix] Fix process group creation with vLLM for `run_engines_locally=false`

### DIFF
--- a/skyrl-train/skyrl_train/distributed/utils.py
+++ b/skyrl-train/skyrl_train/distributed/utils.py
@@ -41,13 +41,10 @@ def get_free_port():
         return sock.getsockname()[1]
 
 
+# Reference: https://github.com/vllm-project/vllm/blob/196cdc3224112df7f68c901fe4c5314875a65be8/examples/offline_inference/rlhf.py
 def stateless_init_process_group(master_address, master_port, rank, world_size, device):
-    """
-    vLLM provides `StatelessProcessGroup` to create a process group
+    """Uses vLLM's `StatelessProcessGroup` to create a process group
     without considering the global process group in torch.distributed.
-    It is recommended to create `StatelessProcessGroup`, and then initialize
-    the data-plane communication (NCCL) between external (train processes)
-    and vLLM workers.
     """
     from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
     from vllm.distributed.utils import StatelessProcessGroup

--- a/skyrl-train/skyrl_train/distributed/utils.py
+++ b/skyrl-train/skyrl_train/distributed/utils.py
@@ -41,6 +41,22 @@ def get_free_port():
         return sock.getsockname()[1]
 
 
+def stateless_init_process_group(master_address, master_port, rank, world_size, device):
+    """
+    vLLM provides `StatelessProcessGroup` to create a process group
+    without considering the global process group in torch.distributed.
+    It is recommended to create `StatelessProcessGroup`, and then initialize
+    the data-plane communication (NCCL) between external (train processes)
+    and vLLM workers.
+    """
+    from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+    from vllm.distributed.utils import StatelessProcessGroup
+
+    pg = StatelessProcessGroup.create(host=master_address, port=master_port, rank=rank, world_size=world_size)
+    pynccl = PyNcclCommunicator(pg, device=device)
+    return pynccl
+
+
 # Copy from pytorch to allow creating multiple main groups.
 # https://github.com/pytorch/pytorch/blob/main/torch/distributed/distributed_c10d.py
 # https://github.com/OpenRLHF/OpenRLHF/blob/main/openrlhf/utils/distributed_util.py

--- a/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
+++ b/skyrl-train/skyrl_train/workers/deepspeed/deepspeed_worker.py
@@ -222,7 +222,10 @@ class DeepSpeedPolicyWorkerBase(PolicyWorkerBase):
                 # Broadcast tensor
                 def broadcast_tensor(tensor):
                     if torch.distributed.get_rank() == 0:
-                        torch.distributed.broadcast(tensor.data, 0, group=self._model_update_group)
+                        if self.cfg.generator.weight_sync_backend == "nccl" and self.cfg.generator.backend == "vllm":
+                            self._model_update_group.broadcast(tensor.data, src=0, stream=torch.cuda.current_stream())
+                        else:
+                            torch.distributed.broadcast(tensor.data, 0, group=self._model_update_group)
 
                 await asyncio.to_thread(broadcast_tensor, tensor)
                 if torch.distributed.get_rank() == 0:

--- a/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -248,7 +248,10 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
                 # Broadcast tensor
                 def broadcast_tensor(tensor):
                     if torch.distributed.get_rank() == 0:
-                        torch.distributed.broadcast(tensor.data, 0, group=self._model_update_group)
+                        if self.cfg.generator.weight_sync_backend == "nccl" and self.cfg.generator.backend == "vllm":
+                            self._model_update_group.broadcast(tensor.data, src=0, stream=torch.cuda.current_stream())
+                        else:
+                            torch.distributed(tensor.data, 0, group=self._model_update_group)
 
                 await asyncio.to_thread(broadcast_tensor, tensor)
                 if torch.distributed.get_rank() == 0:

--- a/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -251,7 +251,7 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
                         if self.cfg.generator.weight_sync_backend == "nccl" and self.cfg.generator.backend == "vllm":
                             self._model_update_group.broadcast(tensor.data, src=0, stream=torch.cuda.current_stream())
                         else:
-                            torch.distributed(tensor.data, 0, group=self._model_update_group)
+                            torch.distributed.broadcast(tensor.data, 0, group=self._model_update_group)
 
                 await asyncio.to_thread(broadcast_tensor, tensor)
                 if torch.distributed.get_rank() == 0:


### PR DESCRIPTION
# What does this PR do?

Fixes process group creation with vLLM for `run_engines_locally=false`. Currently, weight syncing with `run_engines_locally` is broken, and the remote engine example https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl-train/examples/remote_inference_engine/run_remote.sh  fails with `NCCL error : invalid argument`

This is because of our custom process group creation logic - I suspect this broke after a PyTorch upgrade. It is recommended to use vLLM's StatelessProcessGroup abstraction for creating multiple process groups without polluting global state. 

This PR only modifies the vLLM + NCCL backend codepath to use the new process group creation logic. Fixes for Sglang will follow in a follow-up PR