### PR TITLE
[Gemini] Disable PR reviews on draft PRs

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -8,4 +8,5 @@ code_review:
     # disable PR summaries
     summary: false
     code_review: true
+    include_drafts: false
 ignore_patterns: []


### PR DESCRIPTION
It looks like Gemini behaviour has changed recently - Gemini is providing reviews on draft PRs, which can be annoying. This PR disables it.

Reference: https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#config.yaml-schema
