### PR TITLE
[skyrl-train] replace huggingface-cli with hf

### DIFF
--- a/skyrl-train/docs/examples/multi_turn_text2sql.rst
+++ b/skyrl-train/docs/examples/multi_turn_text2sql.rst
@@ -64,8 +64,8 @@ the database files are quite large - around 50GB in total). We reproduce the com
 
 .. code-block:: bash
 
-    huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
-    huggingface-cli download seeklhy/OmniSQL-datasets data.zip --repo-type dataset --local-dir <path_to_file.zip>
+    hf download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+    hf download seeklhy/OmniSQL-datasets data.zip --repo-type dataset --local-dir <path_to_file.zip>
     unzip <path_to_file.zip>
 
 Training Configuration

--- a/skyrl-train/docs/recipes/skyrl-sql.rst
+++ b/skyrl-train/docs/recipes/skyrl-sql.rst
@@ -28,7 +28,7 @@ You can download the dataset by running the following command
 
 .. code-block:: bash
 
-    huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+    hf download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
 
 
 DB environment 
@@ -48,7 +48,7 @@ Unzip `data.zip` in this folder, and set the corresponding `DB_PATH` in the trai
 
 .. code-block:: bash
 
-    huggingface-cli download seeklhy/OmniSQL-datasets data.zip --repo-type dataset --local-dir <path_to_file.zip>
+    hf download seeklhy/OmniSQL-datasets data.zip --repo-type dataset --local-dir <path_to_file.zip>
     unzip <path_to_file.zip>
 
 Running the scripts 

--- a/skyrl-train/examples/megatron/run_megatron_moonlight.sh
+++ b/skyrl-train/examples/megatron/run_megatron_moonlight.sh
@@ -8,7 +8,7 @@ set -x
 # bash examples/megatron/run_megatron_moonlight.sh
 
 # running moonlight16b
-# huggingface-cli download moonshotai/Moonlight-16B-A3B-Instruct --local-dir ~/moonlight16b
+# hf download moonshotai/Moonlight-16B-A3B-Instruct --local-dir ~/moonlight16b
 
 DATA_DIR="$HOME/data/gsm8k"
 LOGGER="wandb"  # change to "console" to print to stdout

--- a/skyrl-train/examples/megatron/run_megatron_qwen3-235b-a22b.sh
+++ b/skyrl-train/examples/megatron/run_megatron_qwen3-235b-a22b.sh
@@ -13,7 +13,7 @@ LOGGER="wandb"  # change to "console" to print to stdout
 DATA_DIR="$HOME/data/gsm8k"
 # download Qwen/Qwen3-235B-A22B-Instruct-2507 from huggingface
 # `pip install huggingface_hub hf_transfer`
-# `HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download Qwen/Qwen3-235B-A22B-Instruct-2507 --local-dir ~/qwen235b`
+# `HF_HUB_ENABLE_HF_TRANSFER=1 hf download Qwen/Qwen3-235B-A22B-Instruct-2507 --local-dir ~/qwen235b`
 MODEL_NAME="$HOME/qwen235b"
 
 NUM_NODES=8

--- a/skyrl-train/examples/step_wise/run_skyrl_sql_step_wise.sh
+++ b/skyrl-train/examples/step_wise/run_skyrl_sql_step_wise.sh
@@ -2,7 +2,7 @@ set -x
 
 # Colocated GRPO training+generation for Qwen2.5-Coder-7B-Instruct on SkyRL-SQL-653 data.
 # Uses 1 node with 8 GPUs.
-# huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+# hf download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
 # export WANDB_API_KEY=<your_key_here>
 # bash examples/step_wise/run_skyrl_sql_step_wise.sh
 

--- a/skyrl-train/examples/step_wise/run_skyrl_sql_step_wise_qwen3.sh
+++ b/skyrl-train/examples/step_wise/run_skyrl_sql_step_wise_qwen3.sh
@@ -2,7 +2,7 @@ set -x
 
 # Colocated GRPO training+generation for Qwen3-4B on SkyRL-SQL-653 data with step-wise training
 # Uses 1 node with 8 GPUs.
-# huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+# hf download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
 # export WANDB_API_KEY=<your_key_here>
 # bash examples/step_wise/run_skyrl_sql_step_wise_qwen3.sh
 

--- a/skyrl-train/examples/text_to_sql/run_skyrl_sql.sh
+++ b/skyrl-train/examples/text_to_sql/run_skyrl_sql.sh
@@ -2,7 +2,7 @@ set -x
 
 # Colocated GRPO training+generation for Qwen2.5-Coder-7B-Instruct on SkyRL-SQL-653 data.
 # Uses 1 node with 8 GPUs.
-# huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+# hf download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
 # export WANDB_API_KEY=<your_key_here>
 # bash examples/text_to_sql/run_skyrl_sql.sh
 

--- a/skyrl-train/examples/text_to_sql/run_skyrl_sql_conversation_format.sh
+++ b/skyrl-train/examples/text_to_sql/run_skyrl_sql_conversation_format.sh
@@ -9,7 +9,7 @@ set -x
 
 # Colocated GRPO training+generation for Qwen2.5-Coder-7B-Instruct on SkyRL-SQL-653 data.
 # Uses 1 node with 8 GPUs.
-# huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+# hf download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
 # export WANDB_API_KEY=<your_key_here>
 # bash examples/text_to_sql/run_skyrl_sql_conversation_format.sh
 

--- a/skyrl-train/examples/text_to_sql/run_sql_deepspeed.sh
+++ b/skyrl-train/examples/text_to_sql/run_sql_deepspeed.sh
@@ -2,7 +2,7 @@ set -x
 
 # Colocated GRPO training+generation for Qwen2.5-Coder-3B-Instruct on SkyRL-SQL-653 data.
 # uses deepspeed and 1 node with 8 GPUs.
-# huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+# hf download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
 # export WANDB_API_KEY=<your_key_here>
 # bash examples/text_to_sql/run_sql_deepspeed.sh
 

--- a/skyrl-train/examples/text_to_sql/run_sql_fsdp.sh
+++ b/skyrl-train/examples/text_to_sql/run_sql_fsdp.sh
@@ -2,7 +2,7 @@ set -x
 
 # Colocated GRPO training+generation for Qwen2.5-Coder-7B-Instruct on SkyRL-SQL-653 data.
 # Uses 1 node with 8 GPUs.
-# huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+# hf download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
 # export WANDB_API_KEY=<your_key_here>
 # bash examples/text_to_sql/run_sql_fsdp.sh
 

--- a/skyrl-train/examples/text_to_sql/run_sql_fsdp_2node.sh
+++ b/skyrl-train/examples/text_to_sql/run_sql_fsdp_2node.sh
@@ -4,7 +4,7 @@ set -x
 # Uses 2 nodes with 8 GPUs each.
 # NOTE: you may need to download the DB files for env interaction onto each node for multi-node training, since the driver worker 
 # will be scheduled on a worker node
-# huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+# hf download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
 # export WANDB_API_KEY=<your_key_here>
 # bash examples/text_to_sql/run_sql_fsdp_2node.sh
 

--- a/skyrl-train/examples/text_to_sql/sql.md
+++ b/skyrl-train/examples/text_to_sql/sql.md
@@ -5,7 +5,7 @@ We provide the training set we used on HuggingFace: https://huggingface.co/datas
 You can download the dataset by running the following command:
 
 ```bash
-huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+hf download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
 ```
 
 ## DB environment 
@@ -22,7 +22,7 @@ The dataset download is 22.2GB and include BIRD, Spider, ScienceBenchmark, EHRSQ
 To download, run:
 
 ```bash
-huggingface-cli download seeklhy/OmniSQL-datasets data.zip --repo-type dataset --local-dir $HOME/data/sql/db_files/
+hf download seeklhy/OmniSQL-datasets data.zip --repo-type dataset --local-dir $HOME/data/sql/db_files/
 
 unzip $HOME/data/sql/db_files/data.zip -d $HOME/data/sql/db_files/
 ```


### PR DESCRIPTION
^
`huggingface-cli` was deprecated. Replace instances of it in our docs/examples with the correct hf: https://huggingface.co/docs/huggingface_hub/en/package_reference/cli