### PR TITLE
[skyrl-train] Fix SkyRL-SQL memory leak and add megatron lora repro script

### DIFF
--- a/skyrl-gym/skyrl_gym/tools/sql.py
+++ b/skyrl-gym/skyrl_gym/tools/sql.py
@@ -1,9 +1,9 @@
-from func_timeout import func_timeout, FunctionTimedOut
 from skyrl_gym.tools.core import tool, ToolGroup
 import pandas as pd
 import sqlite3
 import sys
 import os
+import threading
 
 
 class SQLCodeExecutorToolGroup(ToolGroup):
@@ -13,43 +13,76 @@ class SQLCodeExecutorToolGroup(ToolGroup):
 
     @tool
     def sql(self, db_id, sql, turns_left, timeout=5) -> str:
-        def _execute_sql(db_file, sql):
-            try:
-                conn = sqlite3.connect(db_file)
-                cursor = conn.cursor()
-                conn.execute("BEGIN TRANSACTION;")
-                cursor.execute(sql)
-                execution_res = frozenset(cursor.fetchall())
-                conn.rollback()
-                conn.close()
-                return execution_res
-            except Exception as e:
-                conn.rollback()
-                conn.close()
-                return f"Error executing SQL: {str(e)}, db file: {db_file}"
-
         def _execute_sql_wrapper(db_file, sql, timeout=5) -> str:
-            try:
-                res = func_timeout(timeout, _execute_sql, args=(db_file, sql))
-                if isinstance(res, frozenset):
-                    df = pd.DataFrame(res)
-                    res = df.to_string(index=False)
-                    # NOTE: observation too long, just truncate
-                    if len(res) > 9000:
-                        # just truncate
-                        truncated_df = df.head(50)
-                        res = "Truncated to 50 lines since returned response too long: " + truncated_df.to_string(
-                            index=False
-                        )  # or index=True if you want row numbers
-                else:
-                    res = str(res)
+            """
+            Execute SQL with a timeout using a worker thread and conn.interrupt().
+            Ensures long-running queries are interrupted and connections are closed.
+            """
+            res_holder = {"value": None}
+            done = threading.Event()
+            conn_holder = {"conn": None}
 
+            def worker():
+                conn = None
+                result = None
+                try:
+                    conn = sqlite3.connect(db_file, check_same_thread=False)
+                    conn_holder["conn"] = conn
+                    cursor = conn.cursor()
+                    conn.execute("BEGIN TRANSACTION;")
+                    cursor.execute(sql)
+                    execution_res = frozenset(cursor.fetchall())
+                    conn.rollback()
+                    result = execution_res
+                except Exception as e:
+                    result = f"Error executing SQL: {str(e)}, db file: {db_file}"
+                finally:
+                    if conn is not None:
+                        try:
+                            conn.rollback()
+                        except Exception:
+                            pass
+                        try:
+                            conn.close()
+                        except Exception:
+                            pass
+                    res_holder["value"] = result
+                    done.set()
+
+            threading.Thread(target=worker, daemon=True).start()
+
+            timeout_occurred = False
+            try:
+                if not done.wait(timeout):
+                    timeout_occurred = True
+                    conn = conn_holder.get("conn")
+                    if conn is not None:
+                        try:
+                            conn.interrupt()
+                        except Exception:
+                            pass
+                    # Wait for worker to clean up its connection
+                    done.wait()
             except KeyboardInterrupt:
                 sys.exit(0)
-            except FunctionTimedOut:
-                res = f"SQL Timeout:\n{sql}"
             except Exception as e:
-                res = str(e)
+                res_holder["value"] = str(e)
+
+            if timeout_occurred:
+                return f"SQL Timeout:\n{sql}"
+
+            res = res_holder["value"]
+            if isinstance(res, frozenset):
+                df = pd.DataFrame(res)
+                res = df.to_string(index=False)
+                # NOTE: observation too long, just truncate
+                if len(res) > 9000:
+                    truncated_df = df.head(50)
+                    res = "Truncated to 50 lines since returned response too long: " + truncated_df.to_string(
+                        index=False
+                    )  # or index=True if you want row numbers
+            else:
+                res = str(res)
 
             return res
 

--- a/skyrl-train/examples/text_to_sql/run_skyrl_sql_megatron_lora.sh
+++ b/skyrl-train/examples/text_to_sql/run_skyrl_sql_megatron_lora.sh
@@ -1,0 +1,94 @@
+set -x
+
+# Colocated GRPO training+generation for Qwen2.5-Coder-7B-Instruct on SkyRL-SQL-653 data using Megatron and LoRA.
+# Uses 1 node with 8 GPUs.
+# huggingface-cli download NovaSky-AI/SkyRL-SQL-653-data-newfmt --local-dir $HOME/data/sql --repo-type dataset
+# export WANDB_API_KEY=<your_key_here>
+# bash examples/text_to_sql/run_skyrl_sql_megatron_lora.sh
+
+# change these paths to your own
+DATA_DIR="$HOME/data/sql"
+DB_PATH="$HOME/data/sql/db_files/data"
+CKPT_PATH="$HOME/ckpts/skyrl_sql_7B_ckpt"
+
+LORA_RANK=32
+LORA_ALPHA=64
+LORA_A_INIT_METHOD="kaiming"
+
+NUM_NODES=1
+NUM_GPUS=8
+NUM_INFERENCE_ENGINES=2
+TP_SIZE=4
+MAX_INPUT_LENGTH=29000
+MAX_GENERATE_LENGTH=3000
+TRAIN_BATCH_SIZE=256
+
+# Megatron parameters
+MEGATRON_TP=4
+MEGATRON_PP=1
+MEGATRON_CP=1
+MEGATRON_EP=1
+MEGATRON_ETP=null
+
+# TIS parameters
+TIS_IMP_RATIO_CAP=2.0
+USE_TIS=true
+
+uv run --isolated --extra mcore -m skyrl_train.entrypoints.main_base \
+  trainer.algorithm.advantage_estimator="grpo" \
+  data.train_data="['$DATA_DIR/train.parquet']" \
+  data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.policy.model.path="Qwen/Qwen2.5-Coder-7B-Instruct" \
+  trainer.policy.model.lora.rank=$LORA_RANK \
+  trainer.policy.model.lora.alpha=$LORA_ALPHA \
+  trainer.policy.model.lora.init_method=$LORA_A_INIT_METHOD \
+  trainer.epochs=30 \
+  trainer.placement.colocate_all=true \
+  trainer.strategy=megatron \
+  trainer.placement.policy_num_nodes=$NUM_NODES \
+  trainer.placement.policy_num_gpus_per_node=$NUM_GPUS \
+  generator.num_inference_engines=$NUM_INFERENCE_ENGINES \
+  generator.inference_engine_tensor_parallel_size=$TP_SIZE \
+  trainer.policy.megatron_config.tensor_model_parallel_size=$MEGATRON_TP \
+  trainer.policy.megatron_config.pipeline_model_parallel_size=$MEGATRON_PP \
+  trainer.policy.megatron_config.context_parallel_size=$MEGATRON_CP \
+  trainer.policy.megatron_config.expert_model_parallel_size=$MEGATRON_EP \
+  trainer.policy.megatron_config.expert_tensor_parallel_size=$MEGATRON_ETP \
+  trainer.train_batch_size=$TRAIN_BATCH_SIZE \
+  trainer.micro_forward_batch_size_per_gpu=2 \
+  trainer.micro_train_batch_size_per_gpu=2 \
+  trainer.max_prompt_length=6000 \
+  generator.max_input_length=$MAX_INPUT_LENGTH \
+  generator.sampling_params.max_generate_length=$MAX_GENERATE_LENGTH \
+  trainer.policy.optimizer_config.lr=3.0e-5 \
+  trainer.policy_mini_batch_size=256 \
+  trainer.algorithm.use_kl_loss=false \
+  trainer.algorithm.use_tis=$USE_TIS \
+  trainer.algorithm.tis_imp_ratio_cap=$TIS_IMP_RATIO_CAP \
+  trainer.ckpt_interval=60 \
+  trainer.hf_save_interval=30 \
+  trainer.dump_data_batch=true \
+  generator.backend=vllm \
+  generator.run_engines_locally=true \
+  generator.weight_sync_backend=nccl \
+  generator.async_engine=true \
+  generator.batched=false \
+  environment.env_class=text2sql \
+  generator.use_conversation_multi_turn=false \
+  generator.n_samples_per_prompt=5 \
+  generator.gpu_memory_utilization=0.7 \
+  generator.max_turns=6 \
+  generator.sampling_params.temperature=0.6 \
+  generator.sampling_params.top_p=0.95 \
+  generator.sampling_params.stop='["</sql>", "</solution>"]' \
+  generator.eval_sampling_params.stop='["</sql>", "</solution>"]' \
+  environment.skyrl_gym.text2sql.db_path=$DB_PATH \
+  trainer.logger="wandb" \
+  trainer.project_name="skyrlsql" \
+  trainer.run_name="skyrlsql_repro_megatron_tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}_lora_rank${LORA_RANK}_alpha${LORA_ALPHA}" \
+  trainer.resume_mode=latest \
+  trainer.ckpt_path=$CKPT_PATH \
+  trainer.eval_batch_size=1024 \
+  trainer.eval_before_train=true \
+  trainer.eval_interval=5 \
+  $@


### PR DESCRIPTION
Fixes #683 and adds script for using megatron + lora to reproduce SkyRL-SQL

Megatron LoRA  (tp=4, rank 32, alpha 64) vs FSDP full finetune:
<img width="767" height="239" alt="image" src="https://github.com/user-attachments/assets/9177702a-8e01-45ad-9a94-b6cce8074ec4" />


Disk usage over time before vs after:

<img width="385" height="235" alt="image" src="https://github.com/user-attachments/assets/8cfd52e2-f6f2-4188-ac87-08780ce66f15" />