### PR TITLE
Allow response field to be None in openai response

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py
@@ -693,9 +693,7 @@ def _parse_partial_response_and_inplace_update_accum(
     choice = partial_response["choices"][0]
     finish_reason: str = choice["finish_reason"]
     stop_reason: Optional[str] = choice.get("stop_reason", None)
-    new_content: str = choice["message"]["content"]
-    if new_content is None:
-        new_content = ""
+    new_content: str = choice["message"]["content"] or ""
 
     assert (
         partial_response["usage"] is not None and partial_response["usage"]["completion_tokens"] is not None


### PR DESCRIPTION
Potentially fixes [this](https://github.com/NovaSky-AI/SkyRL/issues/796) issue and is a bug in general.

Current behaviour: Currently the code assumes that the response field in the openai-style response will always be non-null and contain a string when executing [this line of code](https://github.com/NovaSky-AI/SkyRL/blob/c123fa75b053c19dbc3f1a982bcca740490175e3/skyrl-train/skyrl_train/inference_engines/inference_engine_client.py#L711). 

Actual behaviour: If the model is a reasoning variant and/or simply generated a tool-call without any text then those fields will be parsed in `reasoning_content` and `tool` fields and not in `content` fields which is None. So the above line of code actually tries to concatenate a NoneType to a str which raises an error which is not caught. On the client side (which in my case uses LiteLLM), this reflects as an internal server error with a low-level error message complaining about this concatenation.

The fix: If the response is a None, concatenate an empty string in above line.
Testing: After this fix, I can use Qwen/Qwen3-4B-Instruct-2507 which makes only tool-calls but doesn't generate any text without any errors.