### PR TITLE
[skyrl-train] Add `max_tokens_per_microbatch` configuration

### DIFF
--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -184,6 +184,7 @@ trainer:
   critic_mini_batch_size: 256
   micro_train_batch_size_per_gpu: 1
   micro_forward_batch_size_per_gpu: 1
+  max_tokens_per_microbatch: -1 # TODO: Maybe split this between forward and train; -1 means no token-based chunking
   update_ref_every_epoch: false
   use_sample_packing: true
   eval_batch_size: 1024

--- a/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
@@ -30,7 +30,7 @@ from skyrl_train.distributed.megatron.megatron_utils import print_model_size, br
 from skyrl_train.utils.utils import update_model_config, str_to_torch_dtype
 from skyrl_train.utils.constants import SKYRL_WORKER_NCCL_TIMEOUT_IN_S
 from skyrl_train.training_batch import TrainingOutputBatch
-from skyrl_train.workers.worker_utils import BatchIterator, reduce_metrics
+from skyrl_train.workers.worker_utils import SampleBasedBatchIterator, reduce_metrics
 from skyrl_train.workers.worker import (
     PolicyWorkerBase,
     RefWorkerBase,
@@ -512,7 +512,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         Since we want megatron to handle gradient accumulation over micro batches, we directly pass mini batches into the
         worker MegatronModelWrapper.forward_backward_mini_batch method.
         """
-        dataloader = BatchIterator(
+        dataloader = SampleBasedBatchIterator(
             train_data, sample_batch_size=self.cfg.trainer.micro_train_batch_size_per_gpu, drop_last=False
         )
 
@@ -538,7 +538,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             # TODO: Convert this into 2 loops for minibatches and microbatches.
             micro_buffer = []
             for local_step, microbatch in enumerate(pbar):
-                experience = BatchIterator.batch_to_experience(microbatch)
+                experience = SampleBasedBatchIterator.batch_to_experience(microbatch)
                 experience.to_device(torch.cuda.current_device())
                 sequences = experience.sequences
                 attention_mask = experience.attention_mask

--- a/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl-train/skyrl_train/workers/megatron/megatron_worker.py
@@ -30,7 +30,7 @@ from skyrl_train.distributed.megatron.megatron_utils import print_model_size, br
 from skyrl_train.utils.utils import update_model_config, str_to_torch_dtype
 from skyrl_train.utils.constants import SKYRL_WORKER_NCCL_TIMEOUT_IN_S
 from skyrl_train.training_batch import TrainingOutputBatch
-from skyrl_train.workers.worker_utils import SampleBasedBatchIterator, reduce_metrics
+from skyrl_train.workers.worker_utils import BaseBatchIterator, SampleBasedBatchIterator, reduce_metrics
 from skyrl_train.workers.worker import (
     PolicyWorkerBase,
     RefWorkerBase,
@@ -538,7 +538,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             # TODO: Convert this into 2 loops for minibatches and microbatches.
             micro_buffer = []
             for local_step, microbatch in enumerate(pbar):
-                experience = SampleBasedBatchIterator.batch_to_experience(microbatch)
+                experience = BaseBatchIterator.batch_to_experience(microbatch)
                 experience.to_device(torch.cuda.current_device())
                 sequences = experience.sequences
                 attention_mask = experience.attention_mask

--- a/skyrl-train/skyrl_train/workers/worker.py
+++ b/skyrl-train/skyrl_train/workers/worker.py
@@ -32,7 +32,7 @@ from transformers import PreTrainedModel
 from loguru import logger
 from skyrl_train.distributed.ulysses import set_ulysses_sequence_parallel_group, apply_monkey_patch
 from skyrl_train.utils.ppo_utils import PolicyLossRegistry, ppo_critic_loss, compute_approx_kl
-from skyrl_train.workers.worker_utils import SampleBasedBatchIterator, reduce_metrics
+from skyrl_train.workers.worker_utils import BaseBatchIterator, SampleBasedBatchIterator, reduce_metrics
 from skyrl_train.dataset.replay_buffer import Experience
 from skyrl_train.training_batch import TrainingInputBatch, TrainingOutputBatch
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
@@ -794,7 +794,7 @@ class PolicyWorkerBase(Worker):
                 microbatch_weight = 1.0 / num_microbatches
 
                 for microbatch_idx, microbatch in enumerate(microbatch_iterator):
-                    microbatch_experience = SampleBasedBatchIterator.batch_to_experience(microbatch)
+                    microbatch_experience = BaseBatchIterator.batch_to_experience(microbatch)
                     status = self.forward_backward(microbatch_experience, microbatch_weight=microbatch_weight)
 
                     # Record status for all but the last microbatch in the minibatch.
@@ -1029,7 +1029,7 @@ class CriticWorkerBase(Worker):
                 microbatch_weight = 1.0 / num_microbatches
 
                 for microbatch_idx, microbatch in enumerate(microbatch_iterator):
-                    microbatch_experience = SampleBasedBatchIterator.batch_to_experience(microbatch)
+                    microbatch_experience = BaseBatchIterator.batch_to_experience(microbatch)
                     status = self.forward_backward(microbatch_experience, microbatch_weight=microbatch_weight)
 
                     if microbatch_idx < num_microbatches - 1:

--- a/skyrl-train/skyrl_train/workers/worker.py
+++ b/skyrl-train/skyrl_train/workers/worker.py
@@ -32,7 +32,7 @@ from transformers import PreTrainedModel
 from loguru import logger
 from skyrl_train.distributed.ulysses import set_ulysses_sequence_parallel_group, apply_monkey_patch
 from skyrl_train.utils.ppo_utils import PolicyLossRegistry, ppo_critic_loss, compute_approx_kl
-from skyrl_train.workers.worker_utils import BatchIterator, reduce_metrics
+from skyrl_train.workers.worker_utils import SampleBasedBatchIterator, reduce_metrics
 from skyrl_train.dataset.replay_buffer import Experience
 from skyrl_train.training_batch import TrainingInputBatch, TrainingOutputBatch
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
@@ -724,7 +724,7 @@ class PolicyWorkerBase(Worker):
 
     def ppo_train(self, train_data: TrainingInputBatch) -> TrainingOutputBatch:
         global_step = train_data.metadata["global_step"]
-        minibatch_iterator = BatchIterator(
+        minibatch_iterator = SampleBasedBatchIterator(
             train_data, sample_batch_size=self.policy_mini_batch_size_per_gpu, drop_last=False
         )
 
@@ -784,14 +784,14 @@ class PolicyWorkerBase(Worker):
                 disable=not self.strategy.is_rank_0(),
             )
             for minibatch in minibatch_pbar:
-                microbatch_iterator = BatchIterator(
+                microbatch_iterator = SampleBasedBatchIterator(
                     minibatch, sample_batch_size=self.cfg.trainer.micro_train_batch_size_per_gpu, drop_last=False
                 )
                 num_microbatches = len(microbatch_iterator)
                 microbatch_weight = 1.0 / num_microbatches
 
                 for microbatch_idx, microbatch in enumerate(microbatch_iterator):
-                    microbatch_experience = BatchIterator.batch_to_experience(microbatch)
+                    microbatch_experience = SampleBasedBatchIterator.batch_to_experience(microbatch)
                     status = self.forward_backward(microbatch_experience, microbatch_weight=microbatch_weight)
 
                     # Record status for all but the last microbatch in the minibatch.
@@ -991,7 +991,7 @@ class CriticWorkerBase(Worker):
 
     def ppo_train(self, train_data: TrainingInputBatch) -> TrainingOutputBatch:
         global_step = train_data.metadata["global_step"]
-        minibatch_iterator = BatchIterator(
+        minibatch_iterator = SampleBasedBatchIterator(
             train_data, sample_batch_size=self.critic_mini_batch_size_per_gpu, drop_last=False
         )
 
@@ -1019,14 +1019,14 @@ class CriticWorkerBase(Worker):
                 disable=not self.strategy.is_rank_0(),
             )
             for minibatch in minibatch_pbar:
-                microbatch_iterator = BatchIterator(
+                microbatch_iterator = SampleBasedBatchIterator(
                     minibatch, sample_batch_size=self.cfg.trainer.micro_train_batch_size_per_gpu, drop_last=False
                 )
                 num_microbatches = len(microbatch_iterator)
                 microbatch_weight = 1.0 / num_microbatches
 
                 for microbatch_idx, microbatch in enumerate(microbatch_iterator):
-                    microbatch_experience = BatchIterator.batch_to_experience(microbatch)
+                    microbatch_experience = SampleBasedBatchIterator.batch_to_experience(microbatch)
                     status = self.forward_backward(microbatch_experience, microbatch_weight=microbatch_weight)
 
                     if microbatch_idx < num_microbatches - 1:

--- a/skyrl-train/skyrl_train/workers/worker.py
+++ b/skyrl-train/skyrl_train/workers/worker.py
@@ -319,9 +319,10 @@ class Worker(DistributedTorchRayActor):
     ) -> TrainingOutputBatch:
         """Run forward pass on the input batch in inference mode.
 
-        This is a wrapper around `_forward_micro_batch` that runs in micro batches of `cfg.trainer.micro_forward_batch_size_per_gpu`.
+        This is a wrapper around `_forward_micro_batch` that runs in micro batches.
+        Uses token-based chunking if `max_tokens_per_microbatch` is configured, otherwise
+        falls back to sample-based chunking with `micro_forward_batch_size_per_gpu`.
         """
-        # run in micro batches of cfg.trainer.micro_forward_batch_size_per_gpu
         # TODO (sumanthrh): this can be in the policy/critic impl if the micro batch size can be specific to policy, critic, etc.
         microbatch_iterator = _get_microbatch_iterator(
             data,

--- a/skyrl-train/skyrl_train/workers/worker_utils.py
+++ b/skyrl-train/skyrl_train/workers/worker_utils.py
@@ -243,16 +243,18 @@ class TokenBasedBatchIterator(BaseBatchIterator):
         for _ in range(self._num_padding_microbatches):
             yield self._create_padding_microbatch()
 
-    def reorder_microbatches(self, microbatches: List[TensorBatch]) -> TensorBatch:
-        """Reorder microbatch data into a single batch with the same order as the original data.
+    def reorder_and_combine_batches(self, batches: List[TensorBatch]) -> TensorBatch:
+        """Reorder and combine output batches into a single batch with
+        the same order as the original input data.
+
         Example: [[0, 2], [1, 3]] -> [0, 1, 2, 3]
+
         Args:
-            microbatches: List of microbatches to reorder.
+            batches: List of microbatches to reorder.
         Returns:
             A single reordered batch.
         """
-        # TODO: Move this stuff to utility functions.
-        non_padding_microbatches = microbatches[: len(microbatches) - self._num_padding_microbatches]
+        non_padding_microbatches = batches[: len(batches) - self._num_padding_microbatches]
 
         if not non_padding_microbatches:
             # TODO: Can this happen?

--- a/skyrl-train/skyrl_train/workers/worker_utils.py
+++ b/skyrl-train/skyrl_train/workers/worker_utils.py
@@ -1,6 +1,11 @@
+import heapq
 import math
+from typing import List, Dict, Iterator
+
+import torch
+import torch.distributed as dist
+
 from skyrl_train.dataset.replay_buffer import Experience
-from typing import List, Dict
 from skyrl_train.training_batch import TrainingInputBatch, TensorBatch
 
 
@@ -23,11 +28,8 @@ class BaseBatchIterator:
     def __len__(self):
         raise NotImplementedError
 
-    def __next__(self) -> TrainingInputBatch:
+    def __iter__(self) -> Iterator[TrainingInputBatch]:
         raise NotImplementedError
-
-    def __iter__(self):
-        return self
 
     def reorder_and_combine_batches(self, batches: List[TensorBatch]) -> TensorBatch:
         """Reorder and combine output batches to form a single output."""
@@ -92,3 +94,200 @@ class SampleBasedBatchIterator(BaseBatchIterator):
         This iterator evenly splits the input into batches of the same size,
         so there's no need to reorder."""
         return TensorBatch.cat(batches)
+
+
+def balanced_binpacking(token_counts: List[int], max_tokens_per_microbatch: int) -> List[List[int]]:
+    """Chunk a list of token counts into microbatches so that each
+    microbatch's total token count does not exceed `max_tokens_per_microbatch`,
+    and the microbatches roughly balanced.
+
+    Roughly balance by assigning sequences to the microbatch with
+    the least number of tokens so far.
+
+    Args:
+        token_counts: List of token counts for each sample.
+        max_tokens_per_microbatch: Maximum total tokens allowed per microbatch.
+
+    Returns:
+        A list of microbatches, where each microbatch is a list of indices (ints)
+        referring to entries in `token_counts`.
+
+    >>> balanced_binpacking([10, 10, 5, 5], 15)
+    [[0, 2], [1, 3]]
+    >>> balanced_binpacking([10, 1, 1, 1, 1, 1], 10)
+    [[0], [1, 2, 3, 4, 5]]
+    >>> balanced_binpacking([8, 3, 5, 6, 2, 7], 11)
+    [[0, 4], [5, 1], [3, 2]]
+    """
+    # TODO: Handle max(token_counts) > max_tokens_per_microbatch
+
+    # Create list of (index, token_count) pairs and sort by token count descending
+    seq_lens = [(i, seq_len) for i, seq_len in enumerate(token_counts)]
+    seq_lens.sort(key=lambda x: x[1], reverse=True)
+
+    # Track microbatch indices and their current token counts
+    microbatch_indices: List[List[int]] = []
+
+    # Heap to track the total number of tokens in each microbatch
+    microbatch_tokens_heap = []  # (current_total, bin_idx)
+
+    for idx, seq_len in seq_lens:
+        placed = False
+
+        # Look for an existing microbatch with the least number of tokens
+        # that can fit the sequence without exceeding the token limit.
+        if microbatch_tokens_heap:
+            microbatch_len, i = microbatch_tokens_heap[0]
+            new_microbatch_len = microbatch_len + seq_len
+            if new_microbatch_len <= max_tokens_per_microbatch:
+                microbatch_indices[i].append(idx)
+                heapq.heapreplace(microbatch_tokens_heap, (new_microbatch_len, i))
+                placed = True
+
+        # If no microbatch can fit the sequence, create a new microbatch.
+        if not placed:
+            microbatch_indices.append([idx])
+            heapq.heappush(microbatch_tokens_heap, (seq_len, len(microbatch_indices) - 1))
+
+    return microbatch_indices
+
+
+class TokenBasedBatchIterator(BaseBatchIterator):
+    """An iterator that chunks microbatches based on real token count.
+    Packs samples into microbatches, ensuring each microbatch doesn't exceed
+    max_tokens_per_microbatch. All data parallel workers will have the same number of
+    microbatches (where padding microbatches are added if needed).
+    """
+
+    def __init__(
+        self,
+        data: TrainingInputBatch,
+        max_tokens_per_microbatch: int,
+    ):
+        """
+        Args:
+            data: The training input batch to chunk
+            max_tokens_per_microbatch: Maximum number of tokens per microbatch
+        """
+        self._data = data
+        self._max_tokens_per_microbatch = max_tokens_per_microbatch
+
+        # Compute token counts per sample using attention_mask
+        attention_mask = data["attention_mask"]
+        # Count non-padding tokens per sample
+        self._token_counts = attention_mask.sum(dim=1).cpu().tolist()  # [batch_size]
+
+        # Create microbatches based on token count
+        # TODO: Allow for different chunking strategies.
+        self._microbatches = balanced_binpacking(self._token_counts, self._max_tokens_per_microbatch)
+
+        # Synchronize the number of microbatches across all DP workers
+        max_num_microbatches = self._sync_num_microbatches()
+
+        self._num_padding_microbatches = max_num_microbatches - len(self._microbatches)
+
+    @property
+    def num_microbatches(self) -> int:
+        return len(self._microbatches) + self._num_padding_microbatches
+
+    def _create_microbatch_from_indices(self, indices: List[int]) -> TrainingInputBatch:
+        """Create a TrainingInputBatch from a list of sample indices."""
+        indices_tensor = torch.tensor(indices, dtype=torch.long, device="cpu")
+        selected_data = {}
+        for key, value in self._data.items():
+            selected_data[key] = value[indices_tensor]
+        microbatch = TrainingInputBatch(selected_data)
+        microbatch.metadata = self._data.metadata
+        return microbatch
+
+    def _create_padding_microbatch(self) -> TrainingInputBatch:
+        """Create a padding microbatch."""
+        data = TrainingInputBatch(
+            {
+                "sequences": torch.ones((1, 1), dtype=int, device="cpu"),
+                "attention_mask": torch.zeros((1, 1), dtype=int, device="cpu"),
+                "action_log_probs": torch.zeros((1, 1), device="cpu"),
+                "base_action_log_probs": torch.zeros((1, 1), device="cpu"),
+                "values": torch.zeros((1, 1), device="cpu"),
+                "returns": torch.zeros((1, 1), device="cpu"),
+                "advantages": torch.zeros((1, 1), device="cpu"),
+                "loss_mask": torch.zeros((1, 1), dtype=int, device="cpu"),
+                "response_mask": torch.zeros((1, 1), dtype=int, device="cpu"),
+            }
+        )
+        data.metadata = self._data.metadata
+        return data
+
+    def _sync_num_microbatches(self) -> int:
+        """Ensure all DP workers have the same number of micro batches."""
+        local_num_microbatches = len(self._microbatches)
+
+        if not dist.is_initialized():
+            return local_num_microbatches
+
+        # Get the maximum number of batches across all DP workers
+        if torch.cuda.is_available():
+            device = torch.cuda.current_device()
+        else:
+            device = torch.device("cpu")
+        num_microbatches_tensor = torch.tensor(local_num_microbatches, dtype=torch.long, device=device)
+        dist.all_reduce(num_microbatches_tensor, op=dist.ReduceOp.MAX)
+        return num_microbatches_tensor.item()
+
+    def __len__(self):
+        return len(self._microbatches) + self._num_padding_microbatches
+
+    def __iter__(self):
+        for microbatch in self._microbatches:
+            yield self._create_microbatch_from_indices(microbatch)
+        for _ in range(self._num_padding_microbatches):
+            yield self._create_padding_microbatch()
+
+    def reorder_microbatches(self, microbatches: List[TensorBatch]) -> TensorBatch:
+        """Reorder microbatch data into a single batch with the same order as the original data.
+        Example: [[0, 2], [1, 3]] -> [0, 1, 2, 3]
+        Args:
+            microbatches: List of microbatches to reorder.
+        Returns:
+            A single reordered batch.
+        """
+        # TODO: Move this stuff to utility functions.
+        non_padding_microbatches = microbatches[: len(microbatches) - self._num_padding_microbatches]
+
+        if not non_padding_microbatches:
+            # TODO: Can this happen?
+            raise ValueError("Cannot reorder an empty list of microbatches.")
+
+        # Create a reverse mapping of original idx -> (microbatch idx, sample idx)
+        original_idx_to_microbatch_idx = {}
+
+        for microbatch_idx, original_indices in enumerate(self._microbatches):
+            for sample_idx, original_idx in enumerate(original_indices):
+                original_idx_to_microbatch_idx[original_idx] = (microbatch_idx, sample_idx)
+
+        # Get reference microbatch to know keys and tensor shapes
+        ref_microbatch = non_padding_microbatches[0]
+        reordered_data = {}
+
+        for key, ref_value in ref_microbatch.items():
+            # Get shape of a single sample (remove batch dimension)
+            sample_shape = ref_value.shape[1:]
+            device = ref_value.device
+            dtype = ref_value.dtype
+
+            # Pre-allocate output tensor: [batch_size, *sample_shape]
+            batch_size = len(self._token_counts)
+            output_tensor = torch.zeros((batch_size, *sample_shape), dtype=dtype, device=device)
+
+            # Copy each sample directly into the correct position
+            for original_idx in range(batch_size):
+                microbatch_idx, sample_idx = original_idx_to_microbatch_idx[original_idx]
+                source_tensor = non_padding_microbatches[microbatch_idx][key]
+                output_tensor[original_idx] = source_tensor[sample_idx]
+
+            reordered_data[key] = output_tensor
+
+        # Create single TensorBatch with reordered data
+        reordered_batch = type(ref_microbatch)(reordered_data)
+        reordered_batch.metadata = ref_microbatch.metadata
+        return reordered_batch

--- a/skyrl-train/skyrl_train/workers/worker_utils.py
+++ b/skyrl-train/skyrl_train/workers/worker_utils.py
@@ -29,8 +29,8 @@ class BaseBatchIterator:
     def __iter__(self):
         return self
 
-    def reorder_microbatches(self, microbatches: List[TensorBatch]) -> TensorBatch:
-        """Reorder and combine output microbatches to form a single minibatch output."""
+    def reorder_and_combine_batches(self, batches: List[TensorBatch]) -> TensorBatch:
+        """Reorder and combine output batches to form a single output."""
         raise NotImplementedError
 
     @staticmethod
@@ -58,8 +58,8 @@ class BaseBatchIterator:
         return exp
 
 
-class SampleBasedBatchIterator:
-    """A simple iterator to yield microbatches of the same size from the training batch."""
+class SampleBasedBatchIterator(BaseBatchIterator):
+    """A simple iterator to yield batches of the same size from the training input."""
 
     def __init__(self, data: TrainingInputBatch, sample_batch_size: int, drop_last: bool = False):
         self.data = data
@@ -86,9 +86,9 @@ class SampleBasedBatchIterator:
             self._iter = iter(self._chunks)
             raise StopIteration
 
-    def reorder_microbatches(self, microbatches: List[TensorBatch]) -> TensorBatch:
-        """Concatenate output microbatches to form a single minibatch output.
+    def reorder_and_combine_batches(self, batches: List[TensorBatch]) -> TensorBatch:
+        """Concatenate output batches to form a single output.
 
-        This iterator evenly splits the minibatch into microbatches of the same size,
+        This iterator evenly splits the input into batches of the same size,
         so there's no need to reorder."""
-        return TensorBatch.cat(microbatches)
+        return TensorBatch.cat(batches)

--- a/skyrl-train/tests/cpu/test_trainer.py
+++ b/skyrl-train/tests/cpu/test_trainer.py
@@ -14,7 +14,7 @@ from skyrl_train.trainer import RayPPOTrainer
 from skyrl_train.training_batch import TrainingInputBatch
 import numpy as np
 from skyrl_train.workers.worker import PolicyWorkerBase, CriticWorkerBase
-from skyrl_train.workers.worker_utils import BatchIterator
+from skyrl_train.workers.worker_utils import SampleBasedBatchIterator
 from skyrl_train.utils.utils import validate_batch_sizes
 from skyrl_train.config.utils import get_default_config
 from tests.cpu.util import example_dummy_config
@@ -559,7 +559,7 @@ def test_ppo_train_batch_calculations():
     policy_worker.record_memory = False
 
     # Calculate expected values based on new accumulation logic
-    dataloader = BatchIterator(
+    dataloader = SampleBasedBatchIterator(
         dummy_databatch, sample_batch_size=cfg.trainer.micro_train_batch_size_per_gpu, drop_last=False
     )
     total_micro_batches = len(dataloader)  # Should be 6


### PR DESCRIPTION
## Summary

Introduces token-based chunking  for microbatches, enforcing a `max_tokens_per_microbatch` limit on the total number of real tokens in a microbatch.

Replaces the even sample-based chunking `BatchIterator` with a `BalancedBatchIterator` that respects the microbatch token limits.

<img width="1191" height="630" alt="Screenshot 2026-01-06 at 2 55 33 PM" src="https://github.com/user-attachments/assets/38b2f85f-cfc2-4e27-a0b1-ba8ab0ee2195" />

After this PR, the global training batch sharding and forming minibatches is still even sample-based chunking. The new functionality is adding token-based chunking at the bottom microbatching layer, which enforces a total token maximum per microbatch.

## Problem
Previously, microbatches created by chunking sequences evenly so that each microbatch was a certain batch size (`micro_train_batch_size_per_gpu`), which could lead to:
* Sequence-packed microbatches can exceed GPU memory limits when sequences vary in length, so you need to conservatively set the micro batch size.
* Inefficient GPU utilization due to uneven token distribution across microbatches. Token imbalance across DP workers leads to stragglers.

## Solution
Introduce `balanced_binpacking` and `TokenBasedBatchIterator` utilities that:
* Enforce max_tokens_per_microbatch — no microbatch exceeds the token limit
* Roughly balance the microbatches so that we avoid straggler microbatches.
* Ensure that every worker still receives the same number of microbatches by adding padding batches to satisfy FSDP requirements (every DP worker must do the same number of forward/backward passes).

## API changes

* External: added a `config.trainer.max_tokens_per_microbatch` configuration. Defaults to the old behavior (sample based microbatching).
* Adds `TokenBasedBatchIterator` and renames `BatchIterator -> SampleBasedBatchIterator`.
* Unifies `Worker.forward` to also use the `BatchIterator` interface, rather than call `TrainingBatch.chunk` directly.
* Use `TokenBasedBatchIterator` when `max_tokens_per_microbatch` is set for the `forward`, `Critic.ppo_train` and `Policy.ppo_train` methods.

## Example

Example ppo_train call from the unit test:

```
minibatch_sequences=tensor([[88, 96,  3, 23, 44, 65, 55,  0, 66, 49],
        [25, 85, 10, 86, 31, 55, 31, 51,  4, 56],
        [28, 38, 76,  8,  0,  0,  0,  0,  0,  0],
        [21, 97, 46, 75, 73,  0,  0,  0,  0,  0]])
minibatch_attention_mask=tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
        [1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
        [1, 1, 1, 1, 1, 0, 0, 0, 0, 0]])
Policy Train epoch [1/1]:   0%|          | 0/2 [00:00<?, ?it/s]
(DeepSpeedPolicyWorkerBase pid=182679) micro_batches_per_mini_batch=2
(DeepSpeedPolicyWorkerBase pid=182679) experience.sequences=tensor([[88, 96,  3, 23, 44, 65, 55,  0, 66, 49],
(DeepSpeedPolicyWorkerBase pid=182679)         [28, 38, 76,  8,  0,  0,  0,  0,  0,  0]])
Policy Train epoch [1/1]:  50%|█████     | 1/2 [00:01<00:01,  1.28s/it, pg=-0.203, glen=4, policy_lr=1e-6, ent=3.08]
(DeepSpeedPolicyWorkerBase pid=182679) experience.sequences=tensor([[25, 85, 10, 86, 31, 55, 31, 51,  4, 56],
(DeepSpeedPolicyWorkerBase pid=182679)         [21, 97, 46, 75, 73,  0,  0,  0,  0,  0]])
```

## Follow-up

This only does balanced microbatching at the individual worker level. We can further balance at the minibatch level sent to each worker at a global level to ensure every DP worker has roughly the same amount of work.

There's also different algorithms that we could plug into the microbatch chunking step.

We should also update the megatron codepath as a followup.