### PR TITLE
fix(skyrl-agent): use packages.find to include all subpackages

### DIFF
--- a/skyrl-agent/pyproject.toml
+++ b/skyrl-agent/pyproject.toml
@@ -97,8 +97,8 @@ flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE"}
 # -------------------------------
 # tool.setuptools - Additional config
 # -------------------------------
-[tool.setuptools]
-packages = ["skyrl_agent"]
+[tool.setuptools.packages.find]
+include = ["skyrl_agent*"]
 
 # We read the version from a file in 'skyagent/version/version'
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Problem

The `skyrl-agent` package is missing all subpackages (`agents/`, `tasks/`, `dispatcher/`, etc.) when installed via pip/uv from git.

**Error when importing:**
```
>>> from skyrl_agent.agents.base import BaseTrajectory
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../skyrl_agent/__init__.py", line 1, in <module>
    from .auto import AutoAgentRunner
  File ".../skyrl_agent/auto.py", line 6, in <module>
    from skyrl_agent.agents.mapping import AGENT_GENERATOR_REGISTRY
ModuleNotFoundError: No module named 'skyrl_agent.agents'
```

**Installed package contents (broken):**
```
$ ls .venv/lib/python3.12/site-packages/skyrl_agent/
__init__.py
__pycache__
auto.py
# Missing: agents/, tasks/, dispatcher/, config/, functional/, integrations/, tools/
```

## Root Cause

In `skyrl-agent/pyproject.toml`, the setuptools configuration explicitly lists only the top-level package:

```toml
[tool.setuptools]
packages = ["skyrl_agent"]
```

This tells setuptools to only include the `skyrl_agent/` directory itself, not its subdirectories.

## Fix

Use `packages.find` with a wildcard pattern to automatically discover and include all subpackages:

```toml
[tool.setuptools.packages.find]
include = ["skyrl_agent*"]
```

This matches the pattern already used by `skyrl-train` and `skyrl-gym`:

| Package | Configuration | Status |
|---------|---------------|--------|
| `skyrl-train` | `packages.find includes = ["skyrl_train*"]` | ✅ Correct |
| `skyrl-gym` | `packages.find include = ["skyrl_gym*"]` | ✅ Correct |
| `skyrl-agent` | `packages = ["skyrl_agent"]` | ❌ Broken |

## Testing

**Before fix (non-editable install):**
```
$ uv sync
$ python -c "from skyrl_agent.agents.base import BaseTrajectory"
ModuleNotFoundError: No module named 'skyrl_agent.agents'
```

**After fix (non-editable install):**
```
$ uv sync
$ python -c "from skyrl_agent.agents.base import BaseTrajectory"
# Success - no error
```

Note: The bug does not manifest with editable installs (`editable = true`) because Python imports directly from the source directory, bypassing the packaging.

## Changes

- `skyrl-agent/pyproject.toml`: Replace `packages = ["skyrl_agent"]` with `packages.find include = ["skyrl_agent*"]`
