### PR TITLE
[skyrl-train] Fix num_training_steps for workers being set incorrectly

### DIFF
--- a/skyrl-train/examples/async/async_trainer.py
+++ b/skyrl-train/examples/async/async_trainer.py
@@ -44,7 +44,7 @@ class AsyncRayPPOTrainer(RayPPOTrainer):
                 self.tracker.log(eval_metrics, step=self.global_step)
 
         # main training loop
-        pbar = tqdm(total=self.total_training_steps, initial=self.global_step, desc="Training Batch Progress")
+        pbar = tqdm(total=self.total_training_steps, initial=self.global_step, desc="Training Step Progress")
         start_epoch = self.global_step // len(self.train_dataloader)
         # Start from step 1
         self.global_step += 1

--- a/skyrl-train/skyrl_train/fully_async_trainer.py
+++ b/skyrl-train/skyrl_train/fully_async_trainer.py
@@ -359,7 +359,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 self.tracker.log(eval_metrics, step=self.global_step)
 
         # main training loop
-        pbar = tqdm(total=self.total_training_steps, initial=self.global_step, desc="Training Batch Progress")
+        pbar = tqdm(total=self.total_training_steps, initial=self.global_step, desc="Training Step Progress")
         start_epoch = self.global_step // self.num_steps_per_epoch
         self.global_step += 1  # start training at global_step 1
         for epoch in range(start_epoch, self.cfg.trainer.epochs):


### PR DESCRIPTION
`num_training_steps` was being set to the number of training batch steps rather than the number of optimizer (mini-batch) steps, causing learning rate decay to progress too quickly if using a non-constant learning rate scheduler.


renames to `num_training_batches` for clarity, since each training batch can contain several optimizer steps.

Closes #872