### PR TITLE
Bug Fix: Flash Attention 2 compatibility issue 

### DIFF
--- a/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl-train/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -116,7 +116,9 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
         # Update per-gpu mini batch size based on device mesh
         self._normalize_mini_batch_size()
 
-        model_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        model_config = AutoConfig.from_pretrained(model_path,
+                                                    torch_dtype=torch.bfloat16 if self.cfg.trainer.bf16 else None,
+                                                   trust_remote_code=True)
         init_context = get_init_weight_context_manager(
             use_meta_tensor=not model_config.tie_word_embeddings, mesh=self.strategy.device_mesh
         )


### PR DESCRIPTION
Flash Attention 2 only works with `torch.float16` or `torch.bfloat16`, but many Qwen models default to being loaded with dtype of `torch.float32`. The HFModelWrapper doesn't wrap the model anymore with the correct dtype so will sometimes lead to compatibility related bugs.

Ex.
```m(FSDPPolicyWorkerBase pid=123348)[0m Flash Attention 2 only supports torch.float16 and torch.bfloat16 dtypes, but the current dype in Qwen2ForCausalLM is torch.float32. You should run training or inference using Automatic Mixed-Precision via the `with torch.autocast(device_type='torch_device'):` decorator, or load the model with the `dtype` argument. Example: `model = AutoModel.from_pretrained("openai/whisper-tiny", attn_implementation="flash_attention_2", dtype=torch.float16)`
[36m(FSDPPolicyWorkerBase pid=123348)[0m Flash Attention 2 only supports torch.float16 and torch.bfloat16 dtypes, but the current dype in Qwen2Model is torch.float32. You should run training or inference using Automatic Mixed-Precision via the `with torch.autocast(device_type='torch_device'):` decorator, or load the model with the `dtype` argument. Example: `model = AutoModel.from_pretrained("openai/whisper-tiny", attn_implementation="flash_attention_2", dtype=torch.float16)`
[36m(FSD```

Fix allows the AutoConfig to load model with custom dtype so that Flash Attention 2 is compatible
