### PR TITLE
[train][Test] Clean up http server setup in unit test

### DIFF
--- a/skyrl-train/tests/gpu/gpu_ci/test_inference_engine_client_http_endpoint.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_inference_engine_client_http_endpoint.py
@@ -90,6 +90,7 @@ def set_up_http_server(client: InferenceEngineClient) -> Tuple[threading.Thread,
     def _find_available_port(host: str) -> int:
         """Find an available port by binding to port 0."""
         import socket
+
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind((host, 0))
             return s.getsockname()[1]


### PR DESCRIPTION
Remove redundant code by extracting out `set_up_http_server()` in `skyrl-train/tests/gpu/gpu_ci/test_inference_engine_client_http_endpoint.py`