### PR TITLE
[train][OpenAI] Make engine_init_kwargs.chat_template config apply to vllm /chat/completions

### DIFF
--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -243,7 +243,9 @@ generator:
   http_endpoint_port: 8000
   max_turns: 1
 
-  # chat template configuration
+  # chat template configuration for SkyRLGymGenerator.
+  # For `/chat/completions` with vllm via the HTTP endpoint for rollout, instead use say
+  # `+generator.engine_init_kwargs.chat_template=/path/to/templates/qwen3_acc_thinking.jinja2`
   chat_template:
     source: "name"  # "name" or "file"
     name_or_path: null  # e.g., "qwen3_with_thinking" or "/path/to/template.j2"

--- a/skyrl-train/skyrl_train/inference_engines/vllm/utils.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/utils.py
@@ -1,5 +1,7 @@
 from typing import Dict, Any
 
+from skyrl_train.generators.utils import get_custom_chat_template
+
 
 def pop_openai_kwargs(engine_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     """
@@ -18,5 +20,14 @@ def pop_openai_kwargs(engine_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     reasoning_parser = engine_kwargs.pop("reasoning_parser", None)
     if reasoning_parser is not None:
         openai_kwargs["reasoning_parser"] = reasoning_parser
+
+    # Since we use OpenAIServingChat() ourselves, which requires the content of
+    # the chat template, not the path (unlike --chat-template in vllm serve CLI args)
+    chat_template = engine_kwargs.pop("chat_template", None)
+    if chat_template is not None:
+        openai_kwargs["chat_template"] = get_custom_chat_template(
+            chat_template_config={"source": "file", "name_or_path": chat_template}
+        )
+        assert openai_kwargs["chat_template"] is not None, "Failed to get custom chat template"
 
     return openai_kwargs

--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -373,7 +373,7 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
             models=models,
             response_role="assistant",
             request_logger=None,
-            chat_template=None,
+            chat_template=openai_kwargs.pop("chat_template", None),  # used to template /chat/completions requests
             chat_template_content_format="auto",
             **openai_kwargs,
         )

--- a/skyrl-train/skyrl_train/utils/templates/README.md
+++ b/skyrl-train/skyrl_train/utils/templates/README.md
@@ -1,0 +1,50 @@
+This folder contains customized chat templates.
+
+### `qwen3_acc_thinking.jinja2`
+
+Exactly the same as [the official Qwen3 jinja template](https://huggingface.co/Qwen/Qwen3-8B/blob/895c8d171bc03c30e113cd7a28c02494b5e068b7/tokenizer_config.json#L230)
+except that we do not read `reasoning_content` at all and always do `{{- '<|im_start|>' + message.role + '\n' + content }}` for assistant messages. Therefore, you
+should not parse the thinking content and pass in all generated text as part of `content`.
+
+The motivation is to not strip thinking tokens and keep the chat history in multi-turn training strictly appending, making the training on-policy without performing step-wise training.
+
+Specifically, we change from
+
+```jinja2
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {%- if loop.last or (not loop.last and reasoning_content) %}
+                {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content.strip('\n') + '\n</think>\n\n' + content.lstrip('\n') }}
+            {%- else %}
+                {{- '<|im_start|>' + message.role + '\n' + content }}
+            {%- endif %}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls %}
+        ...
+```
+
+to
+
+```jinja2
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- if message.tool_calls %}
+        ...
+```
+
+When using `/chat/completions` with vllm via the HTTP endpoint for rollout, you can pass this in with 
+
+```bash
++generator.engine_init_kwargs.chat_template=/path/to/templates/qwen3_acc_thinking.jinja2
+```

--- a/skyrl-train/skyrl_train/utils/templates/qwen3_acc_thinking.jinja2
+++ b/skyrl-train/skyrl_train/utils/templates/qwen3_acc_thinking.jinja2
@@ -1,0 +1,72 @@
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {{- messages[0].content + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" and message.content is string and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}
+        {%- set ns.multi_step_tool = false %}
+        {%- set ns.last_query_index = index %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if message.content is string %}
+        {%- set content = message.content %}
+    {%- else %}
+        {%- set content = '' %}
+    {%- endif %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- if message.tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- endif %}
+{%- endif %}

--- a/skyrl-train/tests/gpu/utils.py
+++ b/skyrl-train/tests/gpu/utils.py
@@ -358,6 +358,7 @@ def init_inference_engines(
     sleep_level=2,  # use level 1 in unit tests that do not explicitly sync weights or for LoRA
     enable_lora=False,
     max_num_seqs=1024,
+    engine_init_kwargs={},
 ):
     assert use_local, "This test does not yet support remote engines."
     assert backend in ["vllm", "sglang"]
@@ -390,6 +391,7 @@ def init_inference_engines(
         backend=backend,
         sleep_level=sleep_level,
         enable_lora=enable_lora,
+        engine_init_kwargs=engine_init_kwargs,
     )
     client = InferenceEngineClient(eps, tokenizer, cfg)
     if sleep:


### PR DESCRIPTION
The goal of this PR is to allow `/chat/completions` requests to vllm to be able to templated by a custom chat template. One motivation is to not strip thinking tokens when training `Qwen3` models.

Users can now do it with `+generator.engine_init_kwargs.chat_template=/path/to/templates/qwen3_acc_thinking.jinja2`.

We enable this by parsing the `engine_init_kwargs.chat_template` configuration and passing it in to vllm's `OpenAIServingChat` in our `vllm_engine.py`.

The effect can be seen in the added unit test.

This is only used when: `run_engines_locally: True`, `backend: "vllm"`.

We add a folder of `skyrl_train/utils/template` to include the Qwen3 template that does not strip thinking tokens (detailed description in the folder's README)

The `generator.chat_template` still only applies to `SkyRLGymGenerator`.

A part of https://github.com/NovaSky-AI/SkyRL/issues/866

Corresponds to the PRs in the OpenThoughts-Agent fork:
- https://github.com/mlfoundations/SkyRL/pull/10
- https://github.com/mlfoundations/SkyRL/pull/12