### PR TITLE
[skyrl-train] Add GDPO Support to PPO Utils

### DIFF
--- a/skyrl-train/skyrl_train/utils/ppo_utils.py
+++ b/skyrl-train/skyrl_train/utils/ppo_utils.py
@@ -1087,7 +1087,7 @@ def compute_gdpo_outcome_advantage(
     response_mask: torch.Tensor,
     index: np.ndarray,
     epsilon: float = 1e-6,
-    gdpo_norm_by_std: bool = True,
+    grpo_norm_by_std: bool = True,
     **kwargs,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
@@ -1098,12 +1098,14 @@ def compute_gdpo_outcome_advantage(
         - response_mask: Float[torch.Tensor, "batch_size seqlen"]
         - index: np.ndarray (batch_size)
         - epsilon: float
-        - gdpo_norm_by_std: bool
+        - grpo_norm_by_std: bool (used for GDPO as well)
 
     Returns:
         - advantages: Float[torch.Tensor, "batch_size seqlen"]
         - returns: Float[torch.Tensor, "batch_size seqlen"]
     """
+
+    gdpo_norm_by_std = grpo_norm_by_std
 
     # this assumes reward-level rewards assigned as well as single scalar outcome reward for each response
     scores = token_level_rewards.sum(dim=-2)
@@ -1126,7 +1128,7 @@ def compute_gdpo_outcome_advantage(
                 rwd_fn_means = torch.mean(reward_fn_scores, dim=0)
                 rwd_fn_stds = torch.std(reward_fn_scores, dim=0, unbiased=False)
                 if gdpo_norm_by_std:
-                    reward_fn_scores = (reward_fn_scores - rwd_fn_means) / (rwd_fn_stds) + epsilon
+                    reward_fn_scores = (reward_fn_scores - rwd_fn_means) / (rwd_fn_stds + epsilon)
                 else:
                     reward_fn_scores = reward_fn_scores - rwd_fn_means
 


### PR DESCRIPTION
GDPO is an extension of GRPO for multi-reward settings where we do group-wise normalization of each reward function prior to computing the advantage. This is then followed by a batch-norm across all prompts belonging to a given batch and it's respective advantages ( [`GDPO Paper`](https://arxiv.org/pdf/2601.05242)) 

Points of clarification: 
- How does skyrl handle multiple reward functions (if at all)? -> we assume token-level rewards also contain an extra dimension for N objectives
- Should we port from VERL? It seems like it only supports max 2 rewards -> https://github.com/NVlabs/GDPO/blob/main/verl-GDPO/verl/trainer/ppo/ray_trainer.py

TODOs:

- [ ] add multiple reward functionality
- [ ] test GDPO performance against GRPO