### PR TITLE
[tx] Pin jax to <0.9 to fix CI

### DIFF
--- a/skyrl-tx/pyproject.toml
+++ b/skyrl-tx/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "peft",
     "hf_transfer",
     "cloudpathlib>=0.23.0",
-    "jax>=0.8",
+    "jax>=0.8,<0.9",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Just to unblock the CI for now, and then we can fix the errors and remove the pin.