### PR TITLE
Fix the probability diff operation

### DIFF
--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -953,14 +953,14 @@ class RayPPOTrainer:
             logprobs_diff = (
                 training_input["rollout_logprobs"][training_input["loss_mask"] > 0]
                 - action_log_probs[training_input["loss_mask"] > 0]
-            )
-            prob_diff = logprobs_diff.abs().exp()
-            prob_diff_mean = prob_diff.mean().item()
-            prob_diff_std = prob_diff.std().item()
+            ).abs()
+
+            logprobs_diff_mean = logprobs_diff.mean().item()
+            logprobs_diff_std = logprobs_diff.std().item()
             self.all_metrics.update(
                 {
-                    "policy/rollout_train_prob_diff_mean": prob_diff_mean,
-                    "policy/rollout_train_prob_diff_std": prob_diff_std,
+                    "policy/rollout_train_logprobs_abs_diff_mean": logprobs_diff_mean,
+                    "policy/rollout_train_logprobs_abs_diff_std": logprobs_diff_std,
                 }
             )
         return training_input


### PR DESCRIPTION
This PR adds a small fix to the `prob_diff` variable used to compare the difference between trainer and generator log probabilities.