### PR TITLE
[trainer][fix] Only record rollout logprobs metrics when we have it

### DIFF
--- a/skyrl-train/skyrl_train/trainer.py
+++ b/skyrl-train/skyrl_train/trainer.py
@@ -947,7 +947,7 @@ class RayPPOTrainer:
         training_input["action_log_probs"] = action_log_probs
         training_input["values"] = values
 
-        if self.cfg.generator.sampling_params.logprobs is not None:
+        if training_input.get("rollout_logprobs", None) is not None:
             # calculates the difference in probs between inference and trainer components
             # only consider response tokens
             logprobs_diff = (


### PR DESCRIPTION
A previous PR sets logprobs=0 by default in the sampling parameters: https://github.com/NovaSky-AI/SkyRL/pull/758

However, the sampling parameters are only used by `SkyRLGymGenerator`, not the other custom generators.

Therefore, before this fix, the logprobs being set to 0 by default will trigger us to enter the if branch

```python
if self.cfg.generator.sampling_params.logprobs is not None:
```

and attempt to read `training_input["rollout_logprobs"]` while it is not there for custom generators, causing `TypeError: 'NoneType' object is not subscriptable`.

Therefore, this PR only calculates `logprobs_diff` for metrics recording based on the presence of `training_input["rollout_logprobs"]` instead of sampling parameters.

Side note: the actual application of TIS is controlled by the flag `use_tis` rather than the sampling params.