### PR TITLE
add doc page for using skyrl-train as a library

### DIFF
--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -190,30 +190,6 @@ pip install ray==2.46.0 omegaconf==2.3.0 loguru==0.7.3 jaxtyping==0.3.2 pyarrow=
 
 > **Warning:**     ⚠️ We do not recommend using uv versions 0.8.0, 0.8.1, or 0.8.2 due to a [bug](https://github.com/astral-sh/uv/issues/14860) in the `--with` flag behaviour.
 
-## Installing SkyRL-Train from PyPI
-
-We publish wheels for SkyRL-Train on PyPI: https://pypi.org/project/skyrl-train/. For using the latest release of SkyRL-Train (0.3.0) as a dependency in your project, you will need to configure your `pyproject.toml` to correctly install `skyrl-train` and its dependencies that depend on custom indexes/ wheels, such as `flash-attn` and `flashinfer-jit-cache`. Below is an example configuration using `uv`:
-
-```toml
-[project]
-dependencies = [
-    "skyrl-train==0.2.0",
-    "flashinfer-jit-cache",
-    # Find the appropriate wheel for your CUDA/PyTorch version from their [releases page](https://github.com/Dao-AILab/flash-attention/releases)
-    # Alternatively use the match-runtime feature from uv: https://docs.astral.sh/uv/concepts/projects/config/#augmenting-build-dependencies
-    "flash-attn @ https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.8/flash_attn-2.5.8+cu122torch2.3-cp312-cp312-linux_x86_64.whl"
-]
-
-[tool.uv.sources]
-flashinfer-jit-cache = { index = "flashinfer-cu128" }
-
-[[tool.uv.index]]
-name = "flashinfer-cu128"
-url = "https://flashinfer.ai/whl/cu128"
-explicit = true
-
-```
-
 ## Development
 
 For development, refer to the [development guide](development).

--- a/docs/content/docs/getting-started/library.mdx
+++ b/docs/content/docs/getting-started/library.mdx
@@ -1,0 +1,38 @@
+---
+title: Using SkyRL as a Library
+---
+
+To use SkyRL-Train as a dependency in your project, configure your `pyproject.toml` with `uv`. You can install from either PyPI (stable releases) or Git (latest development version).
+
+Some additional dependencies that depend on custom indexes/wheels, such as flash-attn and flashinfer-jit-cache. Below is an example configuration using uv:
+
+```toml
+[project]
+dependencies = [
+    # Option A: Install from PyPI (stable release)
+    "skyrl-train[vllm]==0.3.1",
+    # Option B: Install from Git (latest)
+    # "skyrl-train[vllm]",
+
+    "flashinfer-jit-cache==0.5.3",
+    "flash-attn==2.8.3"
+]
+
+[tool.uv.extra-build-dependencies]
+flash-attn = [{requirement = "torch", match-runtime = true}]
+
+[tool.uv.sources]
+flashinfer-jit-cache = { index = "flashinfer-cu128" }
+# Only needed for Option B (Git install):
+# skyrl-gym = { git = "https://github.com/NovaSky-AI/SkyRL", subdirectory = "skyrl-gym" }
+# skyrl-train = { git = "https://github.com/NovaSky-AI/SkyRL", subdirectory = "skyrl-train" }
+
+[[tool.uv.index]]
+name = "flashinfer-cu128"
+url = "https://flashinfer.ai/whl/cu128"
+explicit = true
+```
+
+**Option A (PyPI)**: Use the pinned version `skyrl-train[vllm]==0.3.1`. No additional sources needed.
+
+**Option B (Git)**: Remove the version pin and uncomment the `skyrl-gym` and `skyrl-train` sources to install from the latest commit.


### PR DESCRIPTION
Add docs page for using skyrl as a library, we should add a more robust example of running something like the DAPO or on policy distillation script here, but we should wait until the pythonic config handling is cleaner to avoid having to have a bash script to override configs