### PR TITLE
Fix broken hyperlinks in documentation

### DIFF
--- a/docs/content/docs/algorithms/custom_algorithms.mdx
+++ b/docs/content/docs/algorithms/custom_algorithms.mdx
@@ -4,12 +4,12 @@ title: "Implementing Custom Algorithms"
 
 
 SkyRL-Train provides a registry system for easily implementing custom algorithms (advantage estimators, policy loss) without modifying the core codebase. 
-The API for the registry system can be found in the [registry API](../api/registry).
+The API for the registry system can be found in [skyrl_train/utils/ppo_utils.py](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl-train/skyrl_train/utils/ppo_utils.py).
 Example scripts of using the registry can be found at `examples/algorithms/`.
 
 Additionally for more control, you can subclass the `BasePPOExp` class from `skyrl_train/entrypoints/main_base.py` and override the `BasePPOExp.get_trainer` method to return a custom trainer class.
 This allows you to have full control over the training loop and implementing custom reward functions and output postprocessing.
-We provide an example of this for applying custom reward penalties in our [DAPO example](./dapo.mdx#creating-a-custom-trainer).
+We provide an example of this for applying custom reward penalties in our [DAPO example](./dapo#creating-a-custom-trainer).
 
 ### Registering a Custom Advantage Estimator
 
@@ -90,7 +90,7 @@ def skyrl_entrypoint(cfg: DictConfig):
 ### Creating a Custom Trainer
 
 To create a custom trainer for full control of your training loop, you can subclass the `BasePPOExp` class from `skyrl_train/entrypoints/main_base.py` and override the `BasePPOExp.get_trainer` method to return a custom trainer class.
-We show the outline of creating a custom trainer below, and you can find a full running example in our [DAPO example](./dapo.mdx#creating-a-custom-trainer).
+We show the outline of creating a custom trainer below, and you can find a full running example in our [DAPO example](./dapo#creating-a-custom-trainer).
 
 ```python
 class CustomTrainer(RayPPOTrainer):

--- a/docs/content/docs/checkpointing-logging/checkpointing.mdx
+++ b/docs/content/docs/checkpointing-logging/checkpointing.mdx
@@ -82,7 +82,7 @@ This comes with support for reloading checkpoints in a different parallelism sch
 
 ## Key Configuration Parameters
 
-Checkpointing behavior is controlled by several parameters in the YAML configuration (see [configuration guide](../configuration/config.mdx) for the full training config):
+Checkpointing behavior is controlled by several parameters in the YAML configuration (see [configuration guide](../configuration/config) for the full training config):
 
 **Checkpoint Saving**
 

--- a/docs/content/docs/examples/megatron.mdx
+++ b/docs/content/docs/examples/megatron.mdx
@@ -6,7 +6,7 @@ title: "Megatron Backend for 5D Parallelism"
 SkyRL supports NVIDIA's [Megatron-Core](https://developer.nvidia.com/megatron-core) library as an RL training backend, inheriting support for 5D parallelism (tensor+sequence, pipeline, context, expert, and data parallelism), and optimized performance for large scale models.
 
 We provide example scripts for running efficient large scale MoE training with models like `Qwen3-30B-A3B` using Megatron in the [examples/megatron](https://github.com/NovaSky-AI/SkyRL/tree/main/skyrl-train/examples/megatron) directory.
-For details on configuring the Megatron backend, and enabling checkpointing, see the [Megatron configuration guide](../configuration/config.mdx#megatron-configuration) and the [Megatron checkpointing guide](../checkpointing-logging/checkpointing.mdx#megatron-checkpointing).
+For details on configuring the Megatron backend, and enabling checkpointing, see the [Megatron configuration guide](../configuration/config#megatron-configuration) and the [Megatron checkpointing guide](../checkpointing-logging/checkpointing#megatron-checkpointing).
 
 ## When to use the Megatron backend
 
@@ -35,7 +35,7 @@ A script for running the Qwen3-30B-A3B experiment can be found [here](https://gi
 Additionally, we provide a script for running basic GSM8K training on Qwen3-235B-A22B with Megatron [here](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl-train/examples/megatron/run_megatron_qwen3-235b-a22b.sh). 
 Note that although training at 100B+ scale using Megatron is currently possible, we are in the process of further optimizing peformance.
 
-For more details on configuring the Megatron backend, and enabling checkpointing, see [Megatron configuration guide](../configuration/config.mdx#megatron-configuration), and [Megatron checkpointing guide](../checkpointing-logging/checkpointing.mdx#megatron-checkpointing).
+For more details on configuring the Megatron backend, and enabling checkpointing, see [Megatron configuration guide](../configuration/config#megatron-configuration), and [Megatron checkpointing guide](../checkpointing-logging/checkpointing#megatron-checkpointing).
 
 ## Installation
 
@@ -52,7 +52,7 @@ This is handled in the `pyproject.toml` file for the `mcore` extra.
 ## Configuration
 
 We provide the following options for fully configuring the Megatron backend, exposing the underlying Megatron optimizer, DDP, and model config objects
-for advanced users to fully take advantage of all of Megatron-Core's feature flags. For more details, see the [Megatron configuration guide](../configuration/config.mdx#megatron-configuration) section.
+for advanced users to fully take advantage of all of Megatron-Core's feature flags. For more details, see the [Megatron configuration guide](../configuration/config#megatron-configuration) section.
 
 ```yaml title="config/megatron/policy.yaml"
 # @package megatron_config.policy

--- a/docs/content/docs/getting-started/development.mdx
+++ b/docs/content/docs/getting-started/development.mdx
@@ -19,7 +19,7 @@ Same as the above: your custom code can be placed anywhere and we typically use 
 Follow the guide for [implementing custom algorithms](../algorithms/custom_algorithms). See `examples/algorithms` for examples of various custom algorithm implementations.
 
 **Looking to modify the training loop for full control?**
-Follow the guide for [creating a custom trainer](../algorithms/custom_algorithms.mdx#creating-a-custom-trainer). See `examples/algorithms/dapo/main_dapo.py` for an example of how to modify the Trainer class for DAPO.
+Follow the guide for [creating a custom trainer](../algorithms/custom_algorithms#creating-a-custom-trainer). See `examples/algorithms/dapo/main_dapo.py` for an example of how to modify the Trainer class for DAPO.
 
 **Modifying the existing environment code (ex: adding a custom method for all Env classes, improving the SearchEnv implementation)?**
 You would modify the code in [skyrl-gym](https://github.com/NovaSky-AI/SkyRL/tree/main/skyrl-gym/). Note: you do **not** have to modify the `skyrl-gym` package for adding a new environment or task. 

--- a/docs/content/docs/platforms/runpod.mdx
+++ b/docs/content/docs/platforms/runpod.mdx
@@ -23,7 +23,7 @@ conda init --all
 ```
 
 Close the terminal and reopen it to activate the base conda environment. Then run the following
-snippet. The NUMA installation follows the [system dependencies guide](../getting-started/installation.mdx#system-dependencies).
+snippet. The NUMA installation follows the [system dependencies guide](../getting-started/installation#system-dependencies).
 
 ```bash
 cd $HOME

--- a/docs/content/docs/tutorials/new_env.mdx
+++ b/docs/content/docs/tutorials/new_env.mdx
@@ -41,7 +41,7 @@ class BaseTextEnv(Env[ConversationType, str]):
 
 ```
 
-This class inherits from `Env`, which is a generic environment interface (i.e., not specific to text-based tasks). An API reference for `Env` can be found in [Environment API](../api/env).
+This class inherits from `Env`, which is a generic environment interface (i.e., not specific to text-based tasks). The `Env` class can be found in [skyrl_gym/core.py](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl-gym/skyrl_gym/core.py).
 
 For our multiplication environment, we only need to implement the `step` method above because we don't have any initialization or cleanup to do.
 

--- a/docs/content/docs/tutorials/tools_guide.mdx
+++ b/docs/content/docs/tutorials/tools_guide.mdx
@@ -172,11 +172,11 @@ class AdvancedEnvironment(BaseTextEnv):
 
 ```
 
-## API Reference
+## Source Code Reference
 
-For a reference of the tool APIs, see the following links:
+For the source code of the tool and environment APIs, see:
 
-- [Tools API](../api/tools)
-- [Environment API](../api/env)
+- [skyrl_gym/tools/](https://github.com/NovaSky-AI/SkyRL/tree/main/skyrl-gym/skyrl_gym/tools) - Tool interface and implementations
+- [skyrl_gym/core.py](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl-gym/skyrl_gym/core.py) - Base environment interface
 
 That's it! You've learned how to use tools in SkyRL-Gym environments. The same pattern works for any tool-based task you want to build.


### PR DESCRIPTION
Remove `.mdx` extension from internal links (fumadocs doesn't need them)
Replace broken API reference links with direct GitHub source links
