### PR TITLE
fix: rope_scaling for vLLM and HuggingFace context extension

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -179,9 +179,19 @@ def create_ray_wrapped_inference_engines(
             }
 
             rope_engine_kwargs = {}
-            if rope_scaling:
-                rope_engine_kwargs["rope_scaling"] = rope_scaling
-                if "max_model_len" not in engine_init_kwargs:
+            # rope_scaling and rope_theta must be passed via hf_overrides.rope_parameters
+            # for vLLM >= 0.8.3. See: https://docs.vllm.ai/en/latest/examples/offline_inference/context_extension/
+            # Use .get() since OmegaConf DictConfig in struct mode doesn't support .pop()
+            hf_overrides = dict(engine_init_kwargs.get("hf_overrides", {}) or {})
+            if rope_scaling or rope_theta is not None:
+                # Convert to regular dict to avoid OmegaConf struct mode issues in vLLM
+                # vLLM expects rope_parameters, not rope_scaling
+                rope_parameters = dict(rope_scaling) if rope_scaling else {}
+                if rope_theta is not None:
+                    rope_parameters["rope_theta"] = rope_theta
+                hf_overrides["rope_parameters"] = rope_parameters
+
+                if rope_scaling and "max_model_len" not in engine_init_kwargs:
                     rope_factor = rope_scaling.get("factor", None)
                     rope_max_pos = rope_scaling.get("original_max_position_embeddings", None)
                     assert rope_factor is not None, "Please provide rope scaling `factor` to compute model max length"
@@ -189,8 +199,8 @@ def create_ray_wrapped_inference_engines(
                         rope_max_pos is not None
                     ), "Please provide rope `original_max_position_embeddings` to compute model max length"
                     rope_engine_kwargs["max_model_len"] = int(rope_factor * rope_max_pos)
-            if rope_theta is not None:
-                rope_engine_kwargs["rope_theta"] = rope_theta
+            if hf_overrides:
+                rope_engine_kwargs["hf_overrides"] = hf_overrides
 
             other_kwargs = {}
 

--- a/skyrl-train/skyrl_train/model_wrapper.py
+++ b/skyrl-train/skyrl_train/model_wrapper.py
@@ -97,11 +97,12 @@ class HFModelWrapper(nn.Module):
 
             model_config = AutoConfig.from_pretrained(pretrain_or_model, trust_remote_code=True, **model_config_kwargs)
 
-            rope_scaling_kwargs = {}
+            # Set rope_scaling on config (not as kwarg to from_pretrained)
+            # HuggingFace models don't accept rope_scaling as a constructor kwarg
             if rope_scaling:
-                rope_scaling_kwargs["rope_scaling"] = rope_scaling
+                model_config.rope_scaling = dict(rope_scaling) if hasattr(rope_scaling, "keys") else rope_scaling
             if rope_theta:
-                rope_scaling_kwargs["rope_theta"] = rope_theta
+                model_config.rope_theta = rope_theta
 
             self.model = model_class.from_pretrained(
                 pretrain_or_model,
@@ -111,7 +112,6 @@ class HFModelWrapper(nn.Module):
                 quantization_config=nf4_config,
                 torch_dtype=torch.bfloat16 if bf16 else torch.float32,
                 device_map=device_map,
-                **rope_scaling_kwargs,
             )
 
             # gpt oss


### PR DESCRIPTION
## Summary
Fixes rope_scaling handling for both vLLM inference engines and HuggingFace FSDP training to enable YaRN context extension.

## Problem
When using rope_scaling config (e.g., YaRN for context extension), training fails with:
1. **vLLM**: `TypeError: AsyncEngineArgs.__init__() got an unexpected keyword argument 'rope_scaling'`
2. **HuggingFace**: `TypeError: Qwen3ForCausalLM.__init__() got an unexpected keyword argument 'rope_scaling'`

## Solution

### vLLM Fix (`ray_wrapped_inference_engine.py`)
- vLLM >= 0.8.3 removed direct `rope_scaling` parameter
- Must pass via `hf_overrides["rope_parameters"]` instead
- Convert OmegaConf DictConfig to regular dict to avoid struct mode errors
- Reference: https://docs.vllm.ai/en/latest/examples/offline_inference/context_extension/

```python
# Before (wrong)
rope_engine_kwargs["rope_scaling"] = rope_scaling

# After (correct)
hf_overrides["rope_parameters"] = dict(rope_scaling)
rope_engine_kwargs["hf_overrides"] = hf_overrides
```

### HuggingFace Fix (`model_wrapper.py`)
- HuggingFace models don't accept `rope_scaling` as a `from_pretrained()` kwarg
- Must set on the model config object instead

```python
# Before (wrong)
self.model = model_class.from_pretrained(..., rope_scaling=rope_scaling)

# After (correct)
model_config.rope_scaling = dict(rope_scaling)
self.model = model_class.from_pretrained(..., config=model_config)
```

## Files Changed
- `skyrl_train/inference_engines/ray_wrapped_inference_engine.py`
- `skyrl_train/model_wrapper.py`

## Test Plan
- [ ] Run training with YaRN rope scaling config:
  ```yaml
  ++trainer.rope_scaling.rope_type=yarn
  ++trainer.rope_scaling.factor=2.0
  ++trainer.rope_scaling.original_max_position_embeddings=32768
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)