### PR TITLE
Fix tests when JAX is not installed

### DIFF
--- a/skyrl-tx/tests/conftest.py
+++ b/skyrl-tx/tests/conftest.py
@@ -1,9 +1,15 @@
-import jax
 import pytest
+
+try:
+    import jax
+
+    HAS_JAX = True
+except ImportError:
+    HAS_JAX = False
 
 
 @pytest.fixture(scope="session", autouse=True)
 def configure_jax_cpu_devices():
     """Configure JAX to use 2 CPU devices for testing parallelism."""
-    if not jax._src.xla_bridge.backends_are_initialized():
+    if HAS_JAX and not jax._src.xla_bridge.backends_are_initialized():
         jax.config.update("jax_num_cpu_devices", 2)


### PR DESCRIPTION
# Fix tests when JAX is not installed

Fixes test failures from #1004 when running without the `[jax]` extra.

## Changes

- Make JAX import optional in `tests/conftest.py`
- Only configure JAX devices if JAX is available
- Allows tests to run with `--extra tinker --extra dev` (without `--extra jax`)

## Test plan

```bash
uv run --extra tinker --extra dev pytest --forked -s tests --ignore=tests/gpu
```

Should now pass for tests that don't require JAX.