### PR TITLE
Add --extra jax to CI test command

### DIFF
--- a/.github/workflows/cpu_skyrl_tx.yaml
+++ b/.github/workflows/cpu_skyrl_tx.yaml
@@ -47,7 +47,7 @@ jobs:
     #     uv run --extra tinker --extra dev ty check
     - name: Run pytest
       run: |
-        uv run --extra tinker --extra dev pytest --forked -s tests --ignore=tests/gpu
+        uv run --extra tinker --extra jax --extra dev pytest --forked -s tests --ignore=tests/gpu
     - name: Run a single training step
       run: |
         uv run tx train --model pcmoritz/qwen3-tiny-test --dataset mahiatlinux/TinyStories-GPT4-V2-50K-SUBSET --output-dir /tmp --batch-size 2 --max-steps 1 --optimizer-args '{"learning_rate": 0.002, "weight_decay": 0.1}'


### PR DESCRIPTION
# Add --extra jax to CI test command

Fixes CI test failures from #1004 where JAX was made optional.

## Changes

- Updated `.github/workflows/cpu_skyrl_tx.yaml` to include `--extra jax` in pytest command
- This ensures JAX is installed and all JAX tests run in CI

## Why this approach?

Making JAX optional allows users to install without JAX when using only the skyrl-train backend. However, in CI we want to test all functionality including JAX tests.

The fix is simple: add `--extra jax` to the CI command so JAX gets installed for testing.

## Before
```bash
uv run --extra tinker --extra dev pytest --forked -s tests --ignore=tests/gpu
```

## After
```bash
uv run --extra tinker --extra jax --extra dev pytest --forked -s tests --ignore=tests/gpu
```