### PR TITLE
[train][fix] Fix incorrect method names for `RemoteInferenceClient` in `tests/`

### DIFF
--- a/skyrl-train/tests/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/skyrl-train/tests/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -312,7 +312,7 @@ class TestWeightUpdateFlow:
                 dtypes=weight_info["dtypes"],
                 shapes=weight_info["shapes"],
             )
-            result = await client.update_weights(update_request)
+            result = await client.update_named_weights(update_request)
             for server_url, resp in result.items():
                 assert resp["status"] == 200, f"Server {server_url} update weights failed: {resp}"
 


### PR DESCRIPTION
# What does this PR do? 

Fixes two incorrect method names for `RemoteInferenceClient` in tests. 

Tests pass after this fix. However, I have noticed another issue: test `inference_servers/test_weight_sync.py` hang at fixture cleanup (i.e after the test runs successfully): 

```bash
(base) ray@ip-10-0-153-235:~/default/SkyRL$ nvidia-smi
Mon Feb  2 17:23:58 2026       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.163.01             Driver Version: 550.163.01     CUDA Version: 12.8     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA H100 80GB HBM3          Off |   00000000:53:00.0 Off |                    0 |
| N/A   30C    P0            114W /  700W |    2509MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA H100 80GB HBM3          Off |   00000000:64:00.0 Off |                    0 |
| N/A   29C    P0             68W /  700W |       4MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA H100 80GB HBM3          Off |   00000000:75:00.0 Off |                    0 |
| N/A   30C    P0            111W /  700W |   43867MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   3  NVIDIA H100 80GB HBM3          Off |   00000000:86:00.0 Off |                    0 |
| N/A   34C    P0            115W /  700W |   43867MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   4  NVIDIA H100 80GB HBM3          Off |   00000000:97:00.0 Off |                    0 |
| N/A   28C    P0             66W /  700W |       4MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   5  NVIDIA H100 80GB HBM3          Off |   00000000:A8:00.0 Off |                    0 |
| N/A   27C    P0             68W /  700W |       4MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   6  NVIDIA H100 80GB HBM3          Off |   00000000:B9:00.0 Off |                    0 |
| N/A   27C    P0             66W /  700W |       4MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   7  NVIDIA H100 80GB HBM3          Off |   00000000:CA:00.0 Off |                    0 |
| N/A   26C    P0             67W /  700W |       4MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A   2953992      C   ray::Trainer.teardown                        2500MiB |
|    2   N/A  N/A   2955201      C   ray::RayWorkerWrapper                       43858MiB |
|    3   N/A  N/A   2955200      C   ray::RayWorkerWrapper                       43858MiB |
```

This will be fixed in a follow-up PR. 