### PR TITLE
[tx] Add separate JIT vs post-JIT timing measurement to memory benchmark

### DIFF
--- a/skyrl-tx/benchmarks/benchmark_memory.py
+++ b/skyrl-tx/benchmarks/benchmark_memory.py
@@ -503,6 +503,7 @@ class BenchmarkRunner:
             request = sampling_client.sample(
                 prompt=prompt,
                 sampling_params=types.SamplingParams(temperature=0.7, max_tokens=gen_len, seed=42),
+                num_samples=batch_size,
             )
             # Poll with small timeout to allow server aliveness checks
             while True:


### PR DESCRIPTION
  ## Summary
  - Separate JIT compilation time from post-JIT runtime measurement by sending multiple requests per test
  - First request triggers JIT compilation and is measured separately
  - Subsequent requests (default: 3) measure actual post-JIT performance and are averaged
  - Extract common timing logic into `_run_timed_requests` helper method
  - Use random tokens (with fixed seed) for reproducible benchmarks

  ## Changes
  - Add `jit_e2e_sec` field to capture first request (JIT) time
  - Rename `client_e2e_sec` to `post_jit_e2e_sec` for clarity
  - Add `--num-measurement-iters` flag (default: 3) for post-JIT iterations
  - Update CSV output and summary tables to show both metrics
