### PR TITLE
[tx] Add support for GLM-4.7 Flash

### DIFF
--- a/skyrl-tx/tx/models/deepseekv3.py
+++ b/skyrl-tx/tx/models/deepseekv3.py
@@ -580,4 +580,5 @@ class DeepseekV3ForCausalLM(nnx.Module, ModelForCausalLM, GeneratorMixin, Logits
             hidden_states=outputs.hidden_states,
         )
 
+
 Glm4MoeLiteForCausalLM = DeepseekV3ForCausalLM


### PR DESCRIPTION
The architecture is the same as DeepseekV3ForCausalLM which we already support with https://github.com/NovaSky-AI/SkyRL/pull/889