### PR TITLE
[OpenAI] Add traceback for internal server errors for HTTP inference endpoint

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/inference_engine_client_http_endpoint.py
+++ b/skyrl-train/skyrl_train/inference_engines/inference_engine_client_http_endpoint.py
@@ -164,12 +164,12 @@ async def handle_openai_request(raw_request: Request, endpoint: str) -> JSONResp
         )
         return JSONResponse(content=error_response.model_dump(), status_code=HTTPStatus.BAD_REQUEST.value)
     except Exception as e:
-        # Include full traceback for debugging
+        # Log full traceback server-side for debugging, but don't expose to client (CWE-209)
         tb = traceback.format_exc()
         logger.error(f"Error when handling {endpoint} request in SkyRL:\n{tb}")
         error_response = ErrorResponse(
             error=ErrorInfo(
-                message=f"Error when handling {endpoint} request in SkyRL: {str(e)}\n\nTraceback:\n{tb}",
+                message=f"Error when handling {endpoint} request in SkyRL: {str(e)}",
                 type=HTTPStatus.INTERNAL_SERVER_ERROR.phrase,
                 code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
             ),


### PR DESCRIPTION
Before this PR, it is hard to see what the root cause of an error is when we hit an `INTERNAL_SERVER_ERROR`.

This PR adds Traceback. We test that the traceback is indeed there in the unit test by mocking an error.