### PR TITLE
[trainer][CI] Fix GPU CI after refactoring

### DIFF
--- a/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_engine_generation.py
@@ -61,7 +61,8 @@ def init_ray_inference_engines(backend: str, tp_size: int, pp_size: int, dp_size
         backend=backend,
         gpu_memory_utilization=0.8,
         num_inference_engines=1,
-        sleep_level=1 if backend == "vllm" else 2,  # "SGLang always discards weights, so sleep_level is not applicable."
+        # SGLang always discards weights, so sleep_level is not applicable.
+        sleep_level=1 if backend == "vllm" else 2,
     )
     return client, pg, router, server_group
 


### PR DESCRIPTION
Fix SGLang-related GPU CI after https://github.com/NovaSky-AI/SkyRL/pull/1016

Sleep level 2 is not applicable to SGLang, would leave to

```python
  elif backend == "sglang":
      # NOTE(Charlie): we always need to sync weights after waking up,
      # see: https://github.com/sgl-project/sglang/issues/7939 for more details.
      assert sleep_level == 2, "SGLang always discards weights, so sleep_level is not applicable."
```