### PR TITLE
Emit loss_fn_outputs with logprobs for RL losses in forward_backward

### DIFF
--- a/skyrl-train/skyrl_train/workers/worker.py
+++ b/skyrl-train/skyrl_train/workers/worker.py
@@ -832,11 +832,10 @@ class PolicyWorkerBase(Worker):
                 else:
                     valid_len = action_log_probs.shape[1]
 
-                start = max(action_log_probs.shape[1] - valid_len, 0)
                 loss_fn_outputs.append(
                     {
-                        "logprobs": action_log_probs[i, start:].detach().cpu().tolist(),
-                        "elementwise_loss": elementwise_loss[i, start:].detach().cpu().tolist(),
+                        "logprobs": action_log_probs[i, :valid_len].detach().cpu().tolist(),
+                        "elementwise_loss": elementwise_loss[i, :valid_len].detach().cpu().tolist(),
                     }
                 )
 
@@ -876,20 +875,25 @@ class PolicyWorkerBase(Worker):
             loss = policy_loss + kl_loss_term - entropy_loss_term
             self.strategy.backward(loss, self.model, self.optimizer)
 
-            # Build per-sequence loss_fn_outputs with logprobs for the Tinker API.
+            # Build per-sequence loss_fn_outputs with logprobs.
             batch_size = action_log_probs.shape[0]
+            seq_len = action_log_probs.shape[1]
+
+            if action_mask is not None:
+                valid_lens = action_mask.sum(dim=1).int().tolist()
+            elif loss_mask is not None:
+                valid_lens = loss_mask.sum(dim=1).int().tolist()
+            else:
+                valid_lens = [seq_len] * batch_size
+
+            detached_log_probs = action_log_probs.detach().cpu()
             loss_fn_outputs = []
-            for i in range(batch_size):
-                if action_mask is not None:
-                    valid_len = int(action_mask[i].sum().item())
-                elif loss_mask is not None:
-                    valid_len = int(loss_mask[i].sum().item())
-                else:
-                    valid_len = action_log_probs.shape[1]
-                start = max(action_log_probs.shape[1] - valid_len, 0)
-                loss_fn_outputs.append({
-                    "logprobs": action_log_probs[i, start:].detach().cpu().tolist(),
-                })
+            for i, valid_len in enumerate(valid_lens):
+                loss_fn_outputs.append(
+                    {
+                        "logprobs": detached_log_probs[i, :valid_len].tolist(),
+                    }
+                )
 
             status = {
                 "final_loss": loss.item(),


### PR DESCRIPTION
## Summary
- The RL branch of `_forward_backward_micro()` now packages per-sample logprobs into `loss_fn_outputs`, matching the existing `cross_entropy` branch
- Required by tinker-cookbook's `_training_logprobs_from_fwd_bwd()` which reads `fwd_bwd_result.loss_fn_outputs[i]["logprobs"]` for KL diagnostics
- Without this, `code_rl` and `math_rl` recipes crash with `KeyError: 'loss_fn_outputs'`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
