### PR TITLE
[tx] Print warning if sample_max_num_sequences or train_micro_batch_size not set

### DIFF
--- a/skyrl-tx/tx/tinker/backends/jax.py
+++ b/skyrl-tx/tx/tinker/backends/jax.py
@@ -209,15 +209,15 @@ class JaxBackendImpl(AbstractBackend):
 
         if config.train_micro_batch_size <= 0:
             logger.warning(
-                "train_micro_batch_size is not set. This can lead to OOMs. "
-                "Consider setting train_micro_batch_size to limit memory usage during training. "
+                '"train_micro_batch_size" is not set. This can lead to OOMs. '
+                'Consider setting "train_micro_batch_size" via --backend-config to limit memory usage during training. '
                 "In the future, we plan to add a heuristic to set this automatically: "
                 "https://github.com/NovaSky-AI/SkyRL/issues/1048"
             )
         if config.sample_max_num_sequences <= 0:
             logger.warning(
-                "sample_max_num_sequences is not set. This can lead to OOMs. "
-                "Consider setting sample_max_num_sequences to limit memory usage during sampling. "
+                '"sample_max_num_sequences" is not set. This can lead to OOMs. '
+                'Consider setting "sample_max_num_sequences" via --backend-config to limit memory usage during sampling. '
                 "In the future, we plan to add a heuristic to set this automatically: "
                 "https://github.com/NovaSky-AI/SkyRL/issues/1048"
             )


### PR DESCRIPTION
By default we will currently process the full batch, so most users should set the micro batch sizes. We should improve this going forward, see https://github.com/NovaSky-AI/SkyRL/issues/1048.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
