### PR TITLE
[tx] early exit decode loop when all sequences have stopped

### DIFF
--- a/skyrl-tx/tx/tinker/api.py
+++ b/skyrl-tx/tx/tinker/api.py
@@ -357,6 +357,8 @@ class SamplingParams(BaseModel):
     def to_types(self) -> types.SamplingParams:
         if self.max_tokens is None:
             raise HTTPException(status_code=400, detail="max_tokens is currently required")
+        if self.max_tokens <= 0:
+            raise HTTPException(status_code=400, detail="max_tokens must be a positive number")
 
         # Generate a random seed if not provided
         seed = self.seed if self.seed is not None else random.randint(0, 2**31 - 1)

--- a/skyrl-tx/tx/utils/generator.py
+++ b/skyrl-tx/tx/utils/generator.py
@@ -303,8 +303,6 @@ class GeneratorMixin:
         batch_size, prompt_length = input_ids.shape
         assert len(sampling_params) == batch_size
         max_new_tokens = max(sampling_param.max_tokens for sampling_param in sampling_params)
-        if max_new_tokens < 1:
-            raise ValueError(f"max_tokens must be >= 1, got {max_new_tokens}")
         max_length = tx.utils.models.round_up_seq_len(prompt_length + max_new_tokens)
         temperatures = jnp.array([sampling_param.temperature for sampling_param in sampling_params])
         top_k_values = jnp.array([sampling_param.top_k for sampling_param in sampling_params], dtype=jnp.int32)


### PR DESCRIPTION
Replace jax.lax.scan (fixed max_new_tokens iterations) with jax.lax.while_loop that exits as soon as every sequence in the batch has hit a stop token.

Reduced per-sample call latency from 10 secs to 1-4 secs for [search tool](https://github.com/thinking-machines-lab/tinker-cookbook/tree/main/tinker_cookbook/recipes/search_tool)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
