### PR TITLE
[tx][skyrl-train] remove use of trainer for building models and worker dispatch in skyrl-train backend

### DIFF
--- a/skyrl-tx/tx/utils/storage.py
+++ b/skyrl-tx/tx/utils/storage.py
@@ -20,8 +20,6 @@ def pack_and_upload(dest: AnyPath, rank: Optional[int] = None) -> Generator[Path
         rank: Process rank for multi-rank deduplication. If provided and a probe
               file exists at {dest}.probe, only rank 0 writes.
     """
-    import jax
-
     with TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
 


### PR DESCRIPTION
Directly copy over logic for building models so we don't need to import the trainer. Directly import PPORayActorGroup, WorkerDispatch,     return create_ray_wrapped_inference_engines etc.. 

Otherwise the server side logic depends on a client side class
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
