### PR TITLE
[skyrl-train/tx] Default to 1 GPU, support backend config overrides

### DIFF
--- a/skyrl-train/skyrl_train/config/config.py
+++ b/skyrl-train/skyrl_train/config/config.py
@@ -168,11 +168,11 @@ class PlacementConfig(BaseConfig):
     colocate_all: bool = True
     colocate_policy_ref: bool = True
     policy_num_nodes: int = 1
-    policy_num_gpus_per_node: int = 4
+    policy_num_gpus_per_node: int = 1
     critic_num_nodes: int = 1
-    critic_num_gpus_per_node: int = 4
+    critic_num_gpus_per_node: int = 1
     ref_num_nodes: int = 1
-    ref_num_gpus_per_node: int = 4
+    ref_num_gpus_per_node: int = 1
 
 
 # ---------------------------------------------------------------------------
@@ -352,7 +352,7 @@ class GeneratorConfig(BaseConfig):
     backend: str = "vllm"
     weight_sync_backend: str = "nccl"
     weight_transfer_threshold_cuda_ipc_GB: float = 1.0
-    inference_engine_tensor_parallel_size: int = 4
+    inference_engine_tensor_parallel_size: int = 1
     inference_engine_pipeline_parallel_size: int = 1
     inference_engine_expert_parallel_size: int = 1
     inference_engine_data_parallel_size: int = 1

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -14,11 +14,11 @@ trainer:
     colocate_all: true
     colocate_policy_ref: true
     policy_num_nodes: 1
-    policy_num_gpus_per_node: 4
+    policy_num_gpus_per_node: 1
     critic_num_nodes: 1
-    critic_num_gpus_per_node: 4
+    critic_num_gpus_per_node: 1
     ref_num_nodes: 1
-    ref_num_gpus_per_node: 4
+    ref_num_gpus_per_node: 1
   sequence_parallel_backend: "ulysses"
   strategy: fsdp2
   policy:
@@ -263,7 +263,7 @@ generator:
   external_proxy_url: null       # Data plane URL (load-balanced router)
   external_server_urls: null     # Control plane URLs (direct backend access)
 
-  inference_engine_tensor_parallel_size: 4
+  inference_engine_tensor_parallel_size: 1
   inference_engine_pipeline_parallel_size: 1
   inference_engine_expert_parallel_size: 1
   inference_engine_data_parallel_size: 1


### PR DESCRIPTION
## Summary
- Default `ppo_base_config.yaml` and dataclass defaults to 1 GPU (`policy_num_gpus_per_node`, `critic_num_gpus_per_node`, `ref_num_gpus_per_node`, `inference_engine_tensor_parallel_size` all changed from 4 to 1). Every single example script (65+) explicitly sets these values, so no existing scripts are affected.
- Support SkyRL-Train config overrides via `--backend-config` using dot-notation keys, e.g. `--backend-config '{"trainer.strategy": "fsdp2", "generator.num_inference_engines": 2}'`. Invalid keys are rejected by OmegaConf's struct validation.
- Disable `use_kl_loss` in the Tinker backend's `_build_config()` to avoid creating an unnecessary reference model.