### PR TITLE
[tx] Lazy inference engine initialization

### DIFF
--- a/skyrl/skyrl/backends/skyrl_train.py
+++ b/skyrl/skyrl/backends/skyrl_train.py
@@ -75,6 +75,11 @@ def _build_config(
     assert config.strategy in ("fsdp2", "megatron"), "Only fsdp and megatron are supported for SkyRL-Train backend"
     cfg.trainer.strategy = config.strategy
 
+    # Apply LoRA configuration
+    if lora_config is not None and lora_config.rank > 0:
+        cfg.trainer.policy.model.lora.rank = lora_config.rank
+        cfg.trainer.policy.model.lora.alpha = int(lora_config.alpha)
+
     # Apply user overrides from backend_config
     for key, value in config.model_extra.items():
         OmegaConf.update(cfg, key, value)


### PR DESCRIPTION
## Summary
- Defer vLLM inference engine creation from `create_model()` to first sampling-related call (`save_sampler_checkpoint` or `sample`)
- SFT scripts that never sample no longer spin up inference engines
- RL scripts lazily initialize engines on first `save_weights_and_get_sampling_client()` call
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
