### PR TITLE
[tx] Refactor LoRA training test utilities

### DIFF
--- a/skyrl-tx/tests/models/lora_test_utils.py
+++ b/skyrl-tx/tests/models/lora_test_utils.py
@@ -1,0 +1,65 @@
+import jax
+import jax.numpy as jnp
+
+
+def get_adapter_params(params, adapter_idx):
+    """Extract adapter params at specific index."""
+    return jax.tree.map(lambda p: p[adapter_idx].copy(), params)
+
+
+def get_out_of_rank_params(params, adapter_idx, rank):
+    """Extract out-of-rank params for an adapter."""
+
+    def slice_param(path, p):
+        if "lora_A" in str(path):
+            return p[adapter_idx, :, rank:].copy()
+        elif "lora_B" in str(path):
+            return p[adapter_idx, rank:, :].copy()
+        return p
+
+    return jax.tree.map_with_path(slice_param, params)
+
+
+def verify_params_unchanged(initial_params, final_params, error_msg_prefix):
+    """Verify that params have not changed between initial and final states."""
+    for (path, initial), (_, final) in zip(
+        jax.tree.leaves_with_path(initial_params), jax.tree.leaves_with_path(final_params)
+    ):
+        assert jnp.allclose(initial, final), f"{error_msg_prefix} for {path}"
+
+
+def _is_routed_expert_path(path) -> bool:
+    """Disambiguate shared_experts and experts"""
+    keys = []
+    for p in path:
+        if hasattr(p, "key"):
+            keys.append(str(p.key))
+        elif hasattr(p, "name"):
+            keys.append(str(p.name))
+
+    for i, key in enumerate(keys):
+        if key == "experts" and i > 0 and keys[i - 1] == "mlp":
+            return True
+    return False
+
+
+def get_moe_out_of_rank_params(params, adapter_idx: int, rank: int, num_experts: int):
+    """Extract out-of-rank params, using effective rank for routed expert layers."""
+
+    def slice_param(path, p):
+        path_str = str(path)
+
+        if _is_routed_expert_path(path):
+            effective_rank = max(1, rank // num_experts)
+        else:
+            effective_rank = rank
+
+        if "lora_A" in path_str:
+            # lora_A shape: [adapters, ..., max_rank] - slice last dim
+            return p[adapter_idx, ..., effective_rank:].copy()
+        elif "lora_B" in path_str:
+            # lora_B shape: [adapters, ..., max_rank, out] - slice second-to-last dim
+            return p[adapter_idx, ..., effective_rank:, :].copy()
+        return p
+
+    return jax.tree.map_with_path(slice_param, params)

--- a/skyrl-tx/tests/models/test_llama3_lora_training.py
+++ b/skyrl-tx/tests/models/test_llama3_lora_training.py
@@ -10,6 +10,7 @@ from tx.models.llama3 import Llama3ForCausalLM
 from tx.utils.models import get_dtype, load_safetensors
 from tx.layers.lora import init_lora_adapter
 from tx.tinker.types import LoraConfig
+from tests.models.lora_test_utils import get_adapter_params, get_out_of_rank_params, verify_params_unchanged
 
 
 def test_lora_training():
@@ -45,21 +46,6 @@ def test_lora_training():
         # that we want to compute gradients for
         graphdef, lora_params, non_lora_params = nnx.split(model, model.is_lora_param, ...)
 
-        # Helper to extract adapter params at specific index
-        def get_adapter_params(params, adapter_idx):
-            return jax.tree.map(lambda p: p[adapter_idx].copy(), params)
-
-        # Helper to extract out-of-rank params for an adapter
-        def get_out_of_rank_params(params, adapter_idx, rank):
-            def slice_param(path, p):
-                if "lora_A" in str(path):
-                    return p[adapter_idx, :, rank:].copy()
-                elif "lora_B" in str(path):
-                    return p[adapter_idx, rank:, :].copy()
-                return p
-
-            return jax.tree.map_with_path(slice_param, params)
-
         # Save initial states
         initial_adapter_2_params = get_adapter_params(lora_params, 2)
         initial_adapter_0_out_of_rank = get_out_of_rank_params(lora_params, 0, 16)
@@ -78,12 +64,6 @@ def test_lora_training():
             optimizer.update(lora_params, lora_grads)
 
             print(f"Step {step}: loss = {float(loss):.4f}")
-
-        def verify_params_unchanged(initial_params, final_params, error_msg_prefix):
-            for (path, initial), (_, final) in zip(
-                jax.tree.leaves_with_path(initial_params), jax.tree.leaves_with_path(final_params)
-            ):
-                assert jnp.allclose(initial, final), f"{error_msg_prefix} for {path}"
 
         # Verify adapter 2 (unused) was not modified
         final_adapter_2_params = get_adapter_params(lora_params, 2)


### PR DESCRIPTION
  ## Summary
  - Extract shared LoRA test helpers (`get_adapter_params`, `get_out_of_rank_params`, `verify_params_unchanged`,
  `get_moe_out_of_rank_params`) into `tests/models/lora_test_utils.py`
  - Remove duplicated helper definitions from `test_qwen3_lora_training.py`, `test_llama3_lora_training.py`, and
  `test_deepseekv3_lora_training.py`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
