### PR TITLE
[trivial][CI] Fix GPU CI after default config changes

### DIFF
--- a/skyrl-train/tests/gpu/gpu_ci/test_save_load_checkpoint.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_save_load_checkpoint.py
@@ -41,6 +41,7 @@ def get_test_actor_config(strategy: str) -> SkyRLConfig:
     cfg = SkyRLConfig()
     cfg.trainer.policy.model.path = MODEL_NAME
     cfg.trainer.placement.policy_num_gpus_per_node = NUM_GPUS
+    cfg.generator.inference_engine_tensor_parallel_size = NUM_GPUS
     cfg.trainer.strategy = strategy
 
     cfg.trainer.ckpt_path = CKPT_PATH


### PR DESCRIPTION
After the PR https://github.com/NovaSky-AI/SkyRL/pull/1064, some GPU CI failed because it assumed different config (4 rollout GPUs). This PR fixes them:

```
FAILED tests/gpu/gpu_ci/test_save_load_checkpoint.py::test_save_load_checkpoint[fsdp-False] - AssertionError: num_policy_gpus (4) and num_rollout_gpus (1) must be the same when colocating all models
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
