### PR TITLE
[tx] Stack weights — Llama3

### DIFF
--- a/skyrl-tx/tx/utils/generator.py
+++ b/skyrl-tx/tx/utils/generator.py
@@ -85,21 +85,6 @@ class KVCache:
             cache_position=self.cache_position,
         )
 
-    @property
-    def num_layers(self) -> int:
-        """Number of layers in the cache."""
-        return len(self.keys)
-
-    @property
-    def batch_size(self) -> int:
-        """Batch size."""
-        return self.keys[0].shape[0]
-
-    @property
-    def seq_len(self) -> int:
-        """Current sequence length."""
-        return self.keys[0].shape[1]
-
 
 @jax.tree_util.register_dataclass
 @dataclass


### PR DESCRIPTION
## Summary
- Convert Llama3 model from `nnx.List` + Python for-loop to `StackedDecoderLayers` + scan-based forward pass
- Same pattern as the Qwen3 conversion in #1079

Stacks on #1079.

## Test plan
- [x] `pytest tests/models/test_llama3.py tests/models/test_llama3_lora_training.py -x`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
