### PR TITLE
[docs] Fix Tinker docs paths and cleanup

### DIFF
--- a/docs/content/docs/tinker/architecture.mdx
+++ b/docs/content/docs/tinker/architecture.mdx
@@ -10,7 +10,7 @@ The integration is organized in three high-level layers:
 
 1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests, stores them in a database, and returns future IDs for async polling
 2. **Engine Layer** (`skyrl.tinker.engine`) - Background subprocess that polls the database, batches pending requests, and dispatches them to the backend
-3. **Backend Layer** (`skyrl.tinker.backends` and `skyrl-train`) - Translates Tinker operations into SkyRL-Train calls, managing Ray workers, training, and inference
+3. **Backend Layer** (`skyrl.backends`) - Translates Tinker operations into training and inference calls, managing Ray workers, FSDP2/Megatron training, and vLLM inference
 
 ## Model Creation
 

--- a/docs/content/docs/tinker/cookbook.mdx
+++ b/docs/content/docs/tinker/cookbook.mdx
@@ -24,7 +24,6 @@ TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets \
     python -m tinker_cookbook.recipes.sl_loop \
     base_url=http://localhost:8000 \
     model_name="Qwen/Qwen3-0.6B" \
-    log_path="/tmp/tinker-sl" \
     train_on_what=LAST_ASSISTANT_MESSAGE
 ```
 
@@ -35,7 +34,6 @@ TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets \
     python -m tinker_cookbook.recipes.sl_loop \
     base_url=http://localhost:8000 \
     model_name="Qwen/Qwen3-0.6B" \
-    log_path="/tmp/tinker-sl" \
     train_on_what=LAST_ASSISTANT_MESSAGE \
     lora_rank=0
 ```
@@ -53,7 +51,6 @@ TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets --with torch \
     python -m tinker_cookbook.recipes.rl_loop \
     base_url=http://localhost:8000 \
     model_name="Qwen/Qwen3-0.6B" \
-    log_path="/tmp/tinker-rl" \
     lora_rank=0
 ```
 

--- a/docs/content/docs/tinker/limitations.mdx
+++ b/docs/content/docs/tinker/limitations.mdx
@@ -2,7 +2,7 @@
 title: "Limitations & Roadmap"
 ---
 
-The Tinker integration is under active development as we continue to close the feature gap between SkyRL and Thinking Machines' hosted service. This page documents current limitations and planned improvements.
+The Tinker integration is under active development. This page documents current limitations.
 
 ## Current Limitations
 
@@ -34,25 +34,3 @@ KL penalty (`kl_penalty_coef > 0`) is not yet supported. This requires prompt lo
 
 Only `cross_entropy` and `importance_sampling` are currently wired through the Tinker data conversion path. SkyRL's `PolicyLossRegistry` contains implementations for PPO (`regular`), `cispo`, and others, but these are not yet validated through the Tinker API.
 
-## Roadmap
-
-### Near-Term
-
-- **PPO loss alias**: Register `ppo` as an alias for `regular` in `PolicyLossRegistry`
-- **DRO loss**: Implement and register `dro` (Distributionally Robust Optimization) loss function
-- **`forward_backward_custom` support**: Validate end-to-end once `forward()` is implemented, enabling DPO and other custom loss recipes
-- **Prompt logprobs** in `sample()` responses
-- **Automatic database cleanup** on server startup
-- **Multi-model support** for serving multiple LoRA adapters concurrently
-
-### Medium-Term
-
-- **Full tinker-cookbook validation** across all recipe categories (distillation, preference, multi-player RL)
-- **Training curves** demonstrating convergence parity with other Tinker backends
-- **Megatron strategy** testing and stabilization for large-scale models
-
-### Long-Term
-
-- **Multi-node deployment** with Ray clusters spanning multiple machines
-- **Dynamic batching** in the engine layer for better GPU utilization
-- **Streaming metrics** via WebSocket or SSE instead of polling

--- a/docs/content/docs/tinker/quickstart.mdx
+++ b/docs/content/docs/tinker/quickstart.mdx
@@ -44,8 +44,8 @@ The server is ready when you see `Uvicorn running on http://0.0.0.0:8000`.
 | `--base-model` | (required) | HuggingFace model name or path |
 | `--backend` | (required) | Backend type (`fsdp` or `megatron`) |
 | `--port` | 8000 | API server port |
-| `--checkpoints-base` | `/tmp/tx_checkpoints` | Directory for checkpoint storage |
-| `--database-url` | `sqlite:///tinker.db` | Database URL for request tracking |
+| `--checkpoints-base` | `/tmp/skyrl_checkpoints` | Directory for checkpoint storage |
+| `--database-url` | `sqlite:///...tinker.db` | Database URL for request tracking |
 
 ## 3. Run a Training Script
 
@@ -59,7 +59,6 @@ TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets \
     python -m tinker_cookbook.recipes.sl_loop \
     base_url=http://localhost:8000 \
     model_name="Qwen/Qwen3-0.6B" \
-    log_path="/tmp/tinker-sl" \
     train_on_what=LAST_ASSISTANT_MESSAGE
 ```
 
@@ -69,6 +68,6 @@ Congratulations! You've run your first Tinker training script on SkyRL.
 
 ## 4. More Recipes
 
-In general, **zero** code changes are required to execute [tinker-cookbook](https://github.com/ThinkingMachinesLab/tinker-cookbook) scripts on SkyRL. Simply update the `base_url` of the `ServiceClient` to point to the address and port of the local Tinker API server (e.g., `http://localhost:8000` above).
+In general, **zero** code changes are required to execute [tinker-cookbook](https://github.com/ThinkingMachinesLab/tinker-cookbook) scripts on SkyRL. Simply update the `base_url` to point to your local Tinker server (e.g., `http://localhost:8000` above).
 
-See [Cookbook Scripts](./cookbook) for example commands and recipes that have been validated on SkyRL.
+See [Cookbook Scripts](./cookbook) for a few example commands and recipes that have been validated on SkyRL.


### PR DESCRIPTION
## Summary
- Fix backend layer path in architecture docs (`skyrl.tinker.backends` -> `skyrl.backends`)
- Fix `--checkpoints-base` default (`/tmp/tx_checkpoints` -> `/tmp/skyrl_checkpoints`)
- Remove Roadmap section from limitations page
- Remove `log_path` from example commands (recipes have sensible defaults)
- Update "Limitations & Roadmap" references to just "Limitations"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
