### PR TITLE
Remove KL penalty and prompt logprobs from overview

### DIFF
--- a/docs/content/docs/tinker/overview.mdx
+++ b/docs/content/docs/tinker/overview.mdx
@@ -40,8 +40,6 @@ SkyRL brings the Tinker API to your own hardware. By utilizing the fully Tinker 
 | FSDP2 strategy | Supported |
 | Megatron strategy | Experimental |
 | Multi-tenant LoRA | Not yet supported |
-| KL penalty | Not yet supported |
-| Prompt logprobs in `sample()` | Not yet supported |
 | Multi-model sampling | Not yet supported |
 | Multi-model training | Not yet supported |
 | Vision models | Not yet supported |


### PR DESCRIPTION
## Summary
- Remove "KL penalty" and "Prompt logprobs in `sample()`" rows from the overview feature table
- These are niche limitations not relevant to any cookbook recipe — keep them on the limitations page only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
