### PR TITLE
[docs] Fix tinker-cookbook GitHub URL

### DIFF
--- a/docs/content/docs/tinker/cookbook.mdx
+++ b/docs/content/docs/tinker/cookbook.mdx
@@ -2,14 +2,14 @@
 title: "Cookbook Scripts"
 ---
 
-The [tinker-cookbook](https://github.com/ThinkingMachinesLab/tinker-cookbook) is a library provided by Thinking Machines with ready-to-run training recipes. This page describes how to run a few example recipes on SkyRL, and provides example curves from our experiments.
+The [tinker-cookbook](https://github.com/thinking-machines-lab/tinker-cookbook) is a library provided by Thinking Machines with ready-to-run training recipes. This page describes how to run a few example recipes on SkyRL, and provides example curves from our experiments.
 
 ## Setup
 
 Follow the [Quickstart](./quickstart) to install SkyRL and start the Tinker server. Then clone the cookbook:
 
 ```bash
-git clone https://github.com/ThinkingMachinesLab/tinker-cookbook.git
+git clone https://github.com/thinking-machines-lab/tinker-cookbook.git
 cd tinker-cookbook
 ```
 

--- a/docs/content/docs/tinker/quickstart.mdx
+++ b/docs/content/docs/tinker/quickstart.mdx
@@ -49,10 +49,10 @@ The server is ready when you see `Uvicorn running on http://0.0.0.0:8000`.
 
 ## 3. Run a Training Script
 
-In a separate terminal, run the supervised learning loop from the [tinker-cookbook](https://github.com/ThinkingMachinesLab/tinker-cookbook):
+In a separate terminal, run the supervised learning loop from the [tinker-cookbook](https://github.com/thinking-machines-lab/tinker-cookbook):
 
 ```bash
-git clone https://github.com/ThinkingMachinesLab/tinker-cookbook.git
+git clone https://github.com/thinking-machines-lab/tinker-cookbook.git
 cd tinker-cookbook
 
 TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets \
@@ -68,6 +68,6 @@ Congratulations! You've run your first Tinker training script on SkyRL.
 
 ## 4. More Recipes
 
-In general, **zero** code changes are required to execute [tinker-cookbook](https://github.com/ThinkingMachinesLab/tinker-cookbook) scripts on SkyRL. Simply update the `base_url` to point to your local Tinker server (e.g., `http://localhost:8000` above).
+In general, **zero** code changes are required to execute [tinker-cookbook](https://github.com/thinking-machines-lab/tinker-cookbook) scripts on SkyRL. Simply update the `base_url` to point to your local Tinker server (e.g., `http://localhost:8000` above).
 
 See [Cookbook Scripts](./cookbook) for a few example commands and recipes that have been validated on SkyRL.


### PR DESCRIPTION
## Summary
- Fix incorrect `ThinkingMachinesLab/tinker-cookbook` URL to `thinking-machines-lab/tinker-cookbook` in quickstart and cookbook docs

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
