### PR TITLE
[docs] Add learning rate guidance and server command to cookbook

### DIFF
--- a/docs/content/docs/tinker/cookbook.mdx
+++ b/docs/content/docs/tinker/cookbook.mdx
@@ -26,7 +26,7 @@ The same server can be reused across all recipes below. For more detail on confi
 
 ## Recipes
 
-Cookbook recipes default to LoRA training (`lora_rank=32`). When switching to full fine-tuning (`lora_rank=0`), use a ~10x lower learning rate. See [Thinking Machines' SL hyperparams guide](https://tinker-docs.thinkingmachines.ai/supervised-learning/sl-hyperparams) for more detail.
+All of the cookbook recipes default to LoRA training (e.g., with `lora_rank=32`), but full fine-tuning (FFT) is supported on SkyRL by setting `lora_rank=0`. Per [Thinking Machines' learning rate guide](https://tinker-docs.thinkingmachines.ai/supervised-learning/sl-hyperparams), use a ~10x lower learning rate when switching to FFT. 
 
 ### Supervised Learning Loop (`sl_loop`)
 


### PR DESCRIPTION
## Summary
- Add server launch command to cookbook page so users don't have to flip back to quickstart
- Add note that the same server works across all recipes, with link to Configuration page
- Add learning rate guidance: cookbook recipes default to LoRA (`lora_rank=32`); when switching to FFT (`lora_rank=0`), use ~10x lower LR per [Thinking Machines' hyperparams guide](https://tinker-docs.thinkingmachines.ai/supervised-learning/sl-hyperparams)
- Update all FFT examples with appropriate learning rates (`sl_loop`: 1e-5, `rl_loop`: 4e-6, `code_rl`/`math_rl`: 1e-6)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
