### PR TITLE
[docs] Add GitHub link to navbar

### DIFF
--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -5,5 +5,6 @@ export function baseOptions(): BaseLayoutProps {
     nav: {
       title: 'SkyRL',
     },
+    githubUrl: 'https://github.com/NovaSky-AI/SkyRL',
   };
 }


### PR DESCRIPTION
## Summary
- Add `githubUrl` to fumadocs layout config, rendering a GitHub icon in the top navbar next to the theme toggle

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
