### PR TITLE
Increase busy timeout for sqlite to avoid `database is locked` error

### DIFF
--- a/skyrl-tx/tx/tinker/db_models.py
+++ b/skyrl-tx/tx/tinker/db_models.py
@@ -9,6 +9,7 @@ from sqlalchemy.engine import url as sqlalchemy_url
 
 from tx.tinker import types
 
+
 def enable_sqlite_wal(engine) -> None:
     """Enable WAL mode and busy timeout for SQLite engines.
 

--- a/skyrl/skyrl/tinker/db_models.py
+++ b/skyrl/skyrl/tinker/db_models.py
@@ -9,6 +9,7 @@ from sqlalchemy.engine import url as sqlalchemy_url
 
 from skyrl.tinker import types
 
+
 def enable_sqlite_wal(engine) -> None:
     """Enable WAL mode and busy timeout for SQLite engines.
 


### PR DESCRIPTION
This PR increases the busy timeout introduced in https://github.com/NovaSky-AI/SkyRL/pull/1054 from 5s to 30s. If two writers to the database are active at the same time, the second writer will wait up to busy_timeout milliseconds and give an error `database is locked` if it cannot get a lock during that time.

In a separate PR, I will also go through all the write transaction and make sure they are short lived (e.g. the transactions shouldn't be open while a checkpoint is written).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
