### PR TITLE
[docs] Use full-parameter fine-tuning consistently

### DIFF
--- a/docs/content/docs/tinker/configuration.mdx
+++ b/docs/content/docs/tinker/configuration.mdx
@@ -50,11 +50,11 @@ LoRA is configured from the **client side**, not the server. When creating a mod
 # LoRA training (default in most recipes)
 python -m tinker_cookbook.recipes.sl_loop ... lora_rank=32
 
-# Full fine-tuning
+# Full-parameter fine-tuning
 python -m tinker_cookbook.recipes.sl_loop ... lora_rank=0
 ```
 
-No server-side configuration is needed to switch between LoRA and full fine-tuning.
+No server-side configuration is needed to switch between LoRA and full-parameter fine-tuning.
 
 ## Full Config Reference
 

--- a/docs/content/docs/tinker/cookbook.mdx
+++ b/docs/content/docs/tinker/cookbook.mdx
@@ -26,7 +26,7 @@ The same server can be reused across all recipes below. For more detail on confi
 
 ## Recipes
 
-All of the cookbook recipes default to LoRA training (e.g., with `lora_rank=32`), but full fine-tuning (FFT) is supported on SkyRL by setting `lora_rank=0`. Per [Thinking Machines' learning rate guide](https://tinker-docs.thinkingmachines.ai/supervised-learning/sl-hyperparams), use a ~10x lower learning rate when switching to FFT. 
+All of the cookbook recipes default to LoRA training (e.g., with `lora_rank=32`), but full-parameter fine-tuning (FFT) is supported on SkyRL by setting `lora_rank=0`. Per [Thinking Machines' learning rate guide](https://tinker-docs.thinkingmachines.ai/supervised-learning/sl-hyperparams), use a ~10x lower learning rate when switching to FFT. 
 
 ### Supervised Learning Loop (`sl_loop`)
 
@@ -44,7 +44,7 @@ TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets \
 ![SL NLL over steps](/images/tinker/nll_over_steps.png)
 </div>
 
-For full fine-tuning (no LoRA), set `lora_rank=0` and lower the learning rate:
+For full-parameter fine-tuning (no LoRA), set `lora_rank=0` and lower the learning rate:
 
 ```bash
 TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets \
@@ -70,7 +70,7 @@ TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets --with torch \
 ![RL reward over steps](/images/tinker/reward_over_steps.png)
 </div>
 
-For full fine-tuning (no LoRA), set `lora_rank=0` and lower the learning rate:
+For full-parameter fine-tuning (no LoRA), set `lora_rank=0` and lower the learning rate:
 
 ```bash
 TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets --with torch \


### PR DESCRIPTION
## Summary
- Replace "full fine-tuning" with "full-parameter fine-tuning" in cookbook and configuration pages to match the overview page

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
