### PR TITLE
[docs] Clean up math_rl description

### DIFF
--- a/docs/content/docs/tinker/cookbook.mdx
+++ b/docs/content/docs/tinker/cookbook.mdx
@@ -96,7 +96,7 @@ TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets --with torch \
 
 ### Math RL (`math_rl`)
 
-RL training specifically for mathematical reasoning, with specialized reward grading.
+RL training specifically for mathematical reasoning.
 
 ```bash
 TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets --with torch \


### PR DESCRIPTION
## Summary
- Remove "with specialized reward grading" from math_rl description

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
