### PR TITLE
[Harbor] Update TBenchGenerator to catch ContextLengthExceededError and AgentTimeoutError

### DIFF
--- a/skyrl-train/examples/terminal_bench/generator/terminal_bench_generator.py
+++ b/skyrl-train/examples/terminal_bench/generator/terminal_bench_generator.py
@@ -276,7 +276,7 @@ class TerminalBenchGenerator(GeneratorInterface):
             stop_reason = "agent_timeout" if is_agent_timeout_error else "error"
             error_message = f"Trajectory {trajectory_id} failed (stop_reason={stop_reason}), will set loss mask to [0]."
             if stop_reason == "error":
-                error_message += f"Results: {results}"
+                error_message += f" Results: {results}"
             logger.warning(error_message)
             return TerminalBenchAgentOutput(
                 response_ids=[0],


### PR DESCRIPTION
This PR slightly reorganizes the terminal bench generator (soon to be renamed as Harbor generator).

In this PR, we catch `ContextLengthExceededError` and `AgentTimeoutError` raised from Harbor, treat them correspondingly (former gets reward zero, latter gets skipped for training).

In addition, we create a new `Trial()` every time we want to retry. Previously we call `trial.run()` for retry on the same trial object, which is wrong and will likely always lead to issues.

We also factor out some output post processing logics in `generate()` to a helper method `_mask_failed_instances_and_compute_metrics()`.

Some of these retry logics might be removed if we decide to use higher level constructs like `Job` or `Orchestrator` in Harbor.

For now these suffice.

We also improve loggings by making some trajectory-specific loggings to `logger.debug` level. 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
