### PR TITLE
[docs] clarify server command in tinker cookbook

### DIFF
--- a/docs/content/docs/tinker/cookbook.mdx
+++ b/docs/content/docs/tinker/cookbook.mdx
@@ -22,7 +22,7 @@ uv run --extra tinker --extra fsdp -m skyrl.tinker.api \
     --base-model "Qwen/Qwen3-0.6B" --backend fsdp
 ```
 
-The same server can be reused across all recipes below. For more detail on configuration options for the training backend, see [Configuration](./configuration).
+The same server command can be reused across all recipes below. For more detail on configuration options for the training backend, see [Configuration](./configuration).
 
 ## Recipes
 


### PR DESCRIPTION
the same server cannot currently be reused across recipes - but the same server command can
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
