### PR TITLE
[docs] Mark Megatron strategy as Supported

### DIFF
--- a/docs/content/docs/tinker/overview.mdx
+++ b/docs/content/docs/tinker/overview.mdx
@@ -38,7 +38,7 @@ SkyRL brings the Tinker API to your own hardware. By utilizing the fully Tinker 
 | LoRA adapters | Supported |
 | Full-parameter fine-tuning | Supported |
 | FSDP2 strategy | Supported |
-| Megatron strategy | Experimental |
+| Megatron strategy | Supported |
 | Multi-tenant LoRA | Not yet supported |
 | Multi-model sampling | Not yet supported |
 | Multi-model training | Not yet supported |


### PR DESCRIPTION
## Summary
- Update Megatron strategy status from "Experimental" to "Supported" in the Tinker overview feature table
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
