### PR TITLE
[docs] Add Tinker integration callout to overview

### DIFF
--- a/docs/content/docs/tinker/overview.mdx
+++ b/docs/content/docs/tinker/overview.mdx
@@ -2,6 +2,10 @@
 title: "Tinker API"
 ---
 
+<Callout type="info">
+**New: Tinker Integration** — Run any Tinker API training script on your own hardware with zero code changes. See the [Quickstart](./quickstart) to get started.
+</Callout>
+
 SkyRL implements the [Tinker API](https://tinker-docs.thinkingmachines.ai/), a simple training and sampling API introduced by Thinking Machines Lab that cleanly separates algorithm logic from infrastructure logic. This means any training script written against the Tinker API can run locally on your own hardware using SkyRL's backends (FSDP2, Megatron, vLLM) with zero code changes.
 
 ## What is Tinker?


### PR DESCRIPTION
## Summary
- Add a light blue info callout at the top of the Tinker overview page highlighting the new integration and linking to the quickstart

🤖 Generated with [Claude Code](https://claude.com/claude-code)