### PR TITLE
[tx] Fix stacked sharding for flax >= 0.12.4

### DIFF
--- a/skyrl-tx/tx/layers/stacked.py
+++ b/skyrl-tx/tx/layers/stacked.py
@@ -87,8 +87,8 @@ class StackedDecoderLayers(nnx.Module):
 
         # Build a treedef with stacked partition metadata so tree_unflatten
         # reconstructs Variables with the correct leading-layer sharding axis.
-        first_state = nnx.spmd.add_axis(first_state, 0, {nnx.PARTITION_NAME: None})
-        _, stacked_treedef = jax.tree_util.tree_flatten(first_state)
+        stacked_first_state = nnx.spmd.add_axis(first_state, 0, {nnx.PARTITION_NAME: None})
+        _, stacked_treedef = jax.tree_util.tree_flatten(stacked_first_state)
 
         # Pre-allocate stacked arrays with correct sharding
         stacked_flat = []


### PR DESCRIPTION
Recently, the sharding metadata name has been changed in flax (https://github.com/google/flax/compare/v0.12.3...v0.12.4), this PR uses a method that doesn't depend on the metadata name.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
