### PR TITLE
[4/N] Fix CI paths for new `skyrl` code now that we have removed one level of nesting

### DIFF
--- a/.github/workflows/cpu_skyrl.yaml
+++ b/.github/workflows/cpu_skyrl.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'skyrl/**'
+      - '**'
       - '.github/workflows/cpu_skyrl.yaml'
   pull_request:
     paths:
-      - 'skyrl/**'
+      - '**'
       - '.github/workflows/cpu_skyrl.yaml'
   workflow_dispatch:
 
@@ -27,7 +27,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ./skyrl
+        working-directory: .
     steps:
     - uses: actions/checkout@v4
     - name: Install uv

--- a/.github/workflows/cpu_skyrl_train.yaml
+++ b/.github/workflows/cpu_skyrl_train.yaml
@@ -50,7 +50,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ./skyrl
+        working-directory: .
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gpu_skyrl.yaml
+++ b/.github/workflows/gpu_skyrl.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'skyrl/**'
+      - '**'
       - '.github/workflows/gpu_skyrl.yaml'
   pull_request:
     paths:
-      - 'skyrl/**'
+      - '**'
       - '.github/workflows/gpu_skyrl.yaml'
   workflow_dispatch:
 
@@ -26,7 +26,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ./skyrl
+        working-directory: .
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -5,12 +5,12 @@ on:
     branches: 
       - main
     paths:
-      - 'skyrl/skyrl/backends/skyrl_train/**'
-      - 'skyrl/skyrl/train/**'
-      - 'skyrl/tests/backends/skyrl_train/**'
-      - 'skyrl/pyproject.toml'
-      - '!skyrl/docs/**'
-      - '!skyrl/examples/**'
+      - 'skyrl/backends/skyrl_train/**'
+      - 'skyrl/train/**'
+      - 'tests/backends/skyrl_train/**'
+      - 'pyproject.toml'
+      - '!docs/**'
+      - '!examples/**'
       - '.github/workflows/**'
   workflow_dispatch:
 
@@ -26,7 +26,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ./skyrl
+        working-directory: .
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -5,14 +5,14 @@ on:
     branches: 
       - main
     paths:
-      - 'skyrl/skyrl/backends/skyrl_train/workers/**'
-      - 'skyrl/skyrl/backends/skyrl_train/distributed/megatron/**'
-      - 'skyrl/skyrl/train/config/**'
-      - 'skyrl/skyrl/train/trainer.py'
-      - 'skyrl/tests/backends/skyrl_train/gpu/gpu_ci/**'
-      - 'skyrl/pyproject.toml'
-      - '!skyrl/docs/**'
-      - '!skyrl/examples/**'
+      - 'skyrl/backends/skyrl_train/workers/**'
+      - 'skyrl/backends/skyrl_train/distributed/megatron/**'
+      - 'skyrl/train/config/**'
+      - 'skyrl/train/trainer.py'
+      - 'tests/backends/skyrl_train/gpu/gpu_ci/**'
+      - 'pyproject.toml'
+      - '!docs/**'
+      - '!examples/**'
       - '.github/workflows/**'
   workflow_dispatch:
 
@@ -28,7 +28,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ./skyrl
+        working-directory: .
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes `skyrl` targeted CI.

See #1138, #1139, #1140 for details on the code changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
