### PR TITLE
fix linting error in skyrl-cpu CI (ignore agent and examples) and change CI scope

### DIFF
--- a/.github/workflows/cpu_skyrl.yaml
+++ b/.github/workflows/cpu_skyrl.yaml
@@ -4,11 +4,17 @@ on:
   push:
     branches: [ main ]
     paths:
-      - '**'
+      - 'ci/**'
+      - 'skyrl/**'
+      - 'tests/**'
+      - 'pyproject.toml'
       - '.github/workflows/cpu_skyrl.yaml'
   pull_request:
     paths:
-      - '**'
+      - 'ci/**'
+      - 'skyrl/**'
+      - 'tests/**'
+      - 'pyproject.toml'
       - '.github/workflows/cpu_skyrl.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/cpu_skyrl_train.yaml
+++ b/.github/workflows/cpu_skyrl_train.yaml
@@ -6,12 +6,18 @@ on:
       - main 
       - rc/**
     paths:
+      - 'ci/**'
       - 'skyrl/**'
+      - 'tests/**'
+      - 'pyproject.toml'
       - 'skyrl-gym/**'
       - '.github/workflows/cpu_skyrl_train.yaml'
   pull_request:
     paths:
+      - 'ci/**'
       - 'skyrl/**'
+      - 'tests/**'
+      - 'pyproject.toml'
       - 'skyrl-gym/**'
       - '.github/workflows/cpu_skyrl_train.yaml'
 

--- a/.github/workflows/gpu_skyrl.yaml
+++ b/.github/workflows/gpu_skyrl.yaml
@@ -4,11 +4,17 @@ on:
   push:
     branches: [ main ]
     paths:
-      - '**'
+      - 'ci/**'
+      - 'skyrl/**'
+      - 'tests/**'
+      - 'pyproject.toml'
       - '.github/workflows/gpu_skyrl.yaml'
   pull_request:
     paths:
-      - '**'
+      - 'ci/**'
+      - 'skyrl/**'
+      - 'tests/**'
+      - 'pyproject.toml'
       - '.github/workflows/gpu_skyrl.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -5,6 +5,7 @@ on:
     branches: 
       - main
     paths:
+      - 'ci/**'
       - 'skyrl/backends/skyrl_train/**'
       - 'skyrl/train/**'
       - 'tests/backends/skyrl_train/**'

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -5,6 +5,7 @@ on:
     branches: 
       - main
     paths:
+      - 'ci/**'
       - 'skyrl/backends/skyrl_train/workers/**'
       - 'skyrl/backends/skyrl_train/distributed/megatron/**'
       - 'skyrl/train/config/**'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,6 +286,12 @@ extend-ignore = [
     "W605",
 ]
 
+[tool.ruff]
+exclude = [
+    "skyrl-agent/",
+    "examples/",
+]
+
 [tool.ruff.lint]
 ignore = [
     "F722" # Syntax error in annotation - ignored because this doesn't play well with jaxtyping


### PR DESCRIPTION
Changes the scope of CI running for the previously TX related tests (`cpu_skyrl.yaml`, `gpu_skyrl.yaml`) to be:

```
- 'ci/**'
- 'skyrl/**'
- 'tests/**'
- 'pyproject.toml'
 ```

and changes the scope of previously train related tests (`cpu_skyrl_train.yaml`, `gpu_skyrl_train.yaml`, ...) to be more inclusive.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
