### PR TITLE
Redirect to new Harbor integration documentation

### DIFF
--- a/skyrl-train/examples/harbor/README.md
+++ b/skyrl-train/examples/harbor/README.md
@@ -1,7 +1,7 @@
 ## Harbor Integration
 
 > [!IMPORTANT]
-> Please refer to [`SkyRL/examples/train_integrations/harbor`](/examples/train_integrations/harbor) instead, as SkyRL is undergoing a repo reorganization into the `SkyRL/skyrl` folder, which unifies the skyrl libraries below into a single package. The existing packages (e.g. `skyrl-train`) are fully functional but will be migrated to new paths shortly. See issue: https://github.com/NovaSky-AI/SkyRL/issues/1145
+> Please refer to [`SkyRL/examples/train_integrations/harbor`](/examples/train_integrations/harbor) instead, as SkyRL is undergoing a repo reorganization into the `SkyRL/skyrl` folder, which unifies the skyrl libraries into a single package. The existing packages (e.g. `skyrl-train`) are fully functional but will be migrated to new paths shortly. See issue: https://github.com/NovaSky-AI/SkyRL/issues/1145
 
 RL training with [Harbor](https://github.com/laude-institute/harbor) as the environment and reward source. See the [full documentation](https://docs.skyrl.ai/docs/harbor) for details.
 


### PR DESCRIPTION
Will no longer make updates to `skyrl-train/examples/harbor` (will still be functional). Instead will make all changes to https://github.com/NovaSky-AI/SkyRL/tree/main/examples/train_integrations/harbor

Since the migration should be done in 1-2 weeks. Perhaps will update `skyrl-train/examples/harbor` every once in a while
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
