### PR TITLE
Restrict mini-swe-agent version to <2.0

### DIFF
--- a/skyrl-train/pyproject.toml
+++ b/skyrl-train/pyproject.toml
@@ -168,7 +168,7 @@ flashrl = [
 ]
 miniswe = [
     # NOTE (sumanthrh): Needs to be a commit after https://github.com/SWE-agent/mini-swe-agent/commit/4f5d445e99d13b5482478c23508bf2fbf7c0670c
-    "mini-swe-agent>=1.12.0,<2.0",
+    "mini-swe-agent>=1.12.0,<2.0",  # v2.0 is incompatible with the example RL code
     "litellm",
 ]
 


### PR DESCRIPTION
mini-swe-agent version 2.0 is incompatible with the example RL code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
