### PR TITLE
[CI][Megatron] Use `ray_init_fixture` in `test_megatron_policy_weight_sync`

### DIFF
--- a/skyrl-train/tests/gpu/gpu_ci/test_megatron_worker.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_megatron_worker.py
@@ -116,7 +116,7 @@ def get_test_training_batch(batch_size=4) -> TrainingInputBatch:
 )
 @pytest.mark.megatron
 def test_megatron_policy_weight_sync(
-    colocate_all, inference_tp, megatron_tp, megatron_pp, megatron_ep, megatron_etp, lora
+    ray_init_fixture, colocate_all, inference_tp, megatron_tp, megatron_pp, megatron_ep, megatron_etp, lora
 ):
     """
     Test that we can sync weights between policy and inference for megatron then run inference

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
@@ -116,7 +116,7 @@ def get_test_training_batch(batch_size=4) -> TrainingInputBatch:
 )
 @pytest.mark.megatron
 def test_megatron_policy_weight_sync(
-    colocate_all, inference_tp, megatron_tp, megatron_pp, megatron_ep, megatron_etp, lora
+    ray_init_fixture, colocate_all, inference_tp, megatron_tp, megatron_pp, megatron_ep, megatron_etp, lora
 ):
     """
     Test that we can sync weights between policy and inference for megatron then run inference


### PR DESCRIPTION
# What does this PR do?

Fixes CI failure for the `skyrl-train-gpu-ci-megatron` workflow on `main`: https://github.com/NovaSky-AI/SkyRL/actions/runs/22164496318/job/64088699265

```bash
FAILED tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py::test_megatron_policy_weight_sync[colocate_all] - ray.exceptions.RayTaskError(DistBackendError): ray::MegatronPolicyWorkerBase.init_model() (pid=12748, ip=10.0.33.65, actor_id=ca9d3e9dc0614bcf1885ac5302000000, repr=<skyrl.backends.skyrl_train.workers.megatron.megatron_worker.MegatronPolicyWorkerBase object at 0x721120d28f80>)
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
           ^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-02-19_01-15-29_383226_3389/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_d8da908caae696293cdb69cb7eb88779/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py", line 456, in init_model
    self.actor_module = self.make_megatron_module(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-02-19_01-15-29_383226_3389/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_d8da908caae696293cdb69cb7eb88779/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py", line 320, in make_megatron_module
    model = self.provider.provide_distributed_model(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmph4V3Ct/lib/python3.12/site-packages/megatron/bridge/models/model_provider.py", line 189, in provide_distributed_model
    model = get_model(
            ^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmph4V3Ct/lib/python3.12/site-packages/megatron/bridge/models/model_provider.py", line 539, in get_model
    model = _create_model(model_provider, model_type, pg_collection=pg_collection)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmph4V3Ct/lib/python3.12/site-packages/megatron/bridge/models/model_provider.py", line 640, in _create_model
    model = model_provider.provide(
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmph4V3Ct/lib/python3.12/site-packages/megatron/bridge/models/gpt_provider.py", line 285, in provide
    model = MCoreGPTModel(
            ^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmph4V3Ct/lib/python3.12/site-packages/megatron/core/models/gpt/gpt_model.py", line 250, in __init__
    self.setup_embeddings_and_output_layer()
  File "/home/ray/.cache/uv/builds-v0/.tmph4V3Ct/lib/python3.12/site-packages/megatron/core/models/common/language_module/language_module.py", line 234, in setup_embeddings_and_output_layer
    torch.distributed.all_reduce(weight.data, group=self.embd_group)
  File "/home/ray/.cache/uv/builds-v0/.tmph4V3Ct/lib/python3.12/site-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmph4V3Ct/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py", line 2935, in all_reduce
    work = group.allreduce([tensor], opts)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch.distributed.DistBackendError: NCCL error in: /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:3690, unhandled cuda error (run with NCCL_DEBUG=INFO for details), NCCL version 2.27.5
ncclUnhandledCudaError: Call to CUDA function failed.
Last error:
Cuda failure 217 'peer access is not supported between these two devices'
=== 1 failed, 26 passed, 100 deselected, 103 warnings in 3545.31s (0:59:05) ====
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

The fix is to use the `ray_init_fixture` so that p2p access is disabled for L4 GPUs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
