### PR TITLE
[Docs] Fix Runpod example to use the new `skyrl` package

### DIFF
--- a/docs/content/docs/platforms/runpod.mdx
+++ b/docs/content/docs/platforms/runpod.mdx
@@ -67,6 +67,7 @@ commands. For more, see [quickstart](quickstart).
 ```bash
 cd $HOME
 git clone https://github.com/NovaSky-AI/SkyRL
+cd SkyRL/
 pip install uv
 uv run --isolated python examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 NUM_GPUS=1 LOGGER=console bash examples/train/gsm8k/run_gsm8k.sh


### PR DESCRIPTION
# What does this PR do?

Fixes the Runpod example to use the new `skyrl` package
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
