### PR TITLE
[tests] Fix template path in `test_inference_engine_http_endpoint`

### DIFF
--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_inference_engine_client_http_endpoint.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_inference_engine_client_http_endpoint.py
@@ -770,8 +770,6 @@ def test_http_endpoint_custom_chat_template(ray_init_fixture, use_custom_templat
         cfg.trainer.strategy = "fsdp2"
         engine_init_kwargs = {}
         if use_custom_template:
-            # use relative path to workspace root
-            # __file__ is skyrl-train/tests/gpu/gpu_ci/test_inference_engine_client_http_endpoint.py
             engine_init_kwargs["chat_template"] = TEMPLATE_PATH
 
         engines = InferenceEngineState.create(


### PR DESCRIPTION
# What does this PR do?

Fixes the chat template path in `test_inference_engine_http_endpoint` . 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
