### PR TITLE
Use the last LoRA path in the vLLM inference engine instead of "dummy_lora_path"

### DIFF
--- a/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl-train/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -419,9 +419,7 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
                 # Use last loaded LoRA path or a dummy path for placeholder
                 # (actual loading done in add_lora())
                 lora_path = self._last_lora_path or "/dummy_lora_path"
-                lora_request = LoRARequest(
-                    lora_name=f"{lora_int_id}", lora_int_id=lora_int_id, lora_path=lora_path
-                )
+                lora_request = LoRARequest(lora_name=f"{lora_int_id}", lora_int_id=lora_int_id, lora_path=lora_path)
 
         async for request_output in self.llm.generate(
             prompt=TokensPrompt(prompt_token_ids=prompt_token_ids),


### PR DESCRIPTION
# Problem description

When running fully async training with LoRA, vLLM sometimes crashes with:

```
FileNotFoundError: [Errno 2] No such file or directory: '/dummy_lora_path/adapter_config.json'
```

The error originates in vLLM's `LRUCacheWorkerLoRAManager.add_adapter()` (in `vllm/lora/worker_manager.py`), which is called during generation when the worker tries to activate a LoRA adapter for an incoming request. The config uses `max_loras=1` (set in `create_ray_wrapped_inference_engines_from_config` in `main_base.py`), meaning the worker's `LRUCacheWorkerLoRAManager` can only hold one adapter at a time.

My understanding is that when using async training, a generation request may arrive when the LoRA adapter cache has been evicted and the new adapter hasn't been loaded yet (e.g., during weight sync). This cache miss makes `LRUCacheWorkerLoRAManager.add_adapter()` falls back to loading from the `lora_path` in the `LoRARequest`, which is `"dummy_lora_path"`.

# Proposed fix

This PR saves the last used LoRA path and uses that as the default instead of `"dummy_lora_path"`. The LoRA adapter weights are saved to a persistent directory on disk during each weight sync, so the path should remain valid throughout training.

# Full stack trace

```
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m Process EngineCore_0:
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m Traceback (most recent call last):
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/lora/worker_manager.py", line 103, in _load_adapter
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     peft_helper = PEFTHelper.from_local_dir(
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/lora/peft_helper.py", line 107, in from_local_dir
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     with open(lora_config_path) as f:
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m          ^^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m FileNotFoundError: [Errno 2] No such file or directory: '/dummy_lora_path/adapter_config.json'
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m 
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m The above exception was the direct cause of the following exception:
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m 
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m Traceback (most recent call last):
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     self.run()
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 108, in run
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     self._target(*self._args, **self._kwargs)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 704, in run_engine_core
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     raise e
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 693, in run_engine_core
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     engine_core.run_busy_loop()
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 720, in run_busy_loop
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     self._process_engine_step()
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 745, in _process_engine_step
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     outputs, model_executed = self.step_fn()
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m                               ^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 288, in step
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     model_output = self.execute_model_with_error_logging(
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 274, in execute_model_with_error_logging
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     raise err
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 265, in execute_model_with_error_logging
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     return model_fn(scheduler_output)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/executor/abstract.py", line 87, in execute_model
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     output = self.collective_rpc("execute_model",
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/executor/uniproc_executor.py", line 58, in collective_rpc
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     answer = run_method(self.driver_worker, method, args, kwargs)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/utils/__init__.py", line 3007, in run_method
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     return func(*args, **kwargs)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m            ^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     return func(*args, **kwargs)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m            ^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/worker/gpu_worker.py", line 362, in execute_model
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     output = self.model_runner.execute_model(scheduler_output,
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     return func(*args, **kwargs)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m            ^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py", line 1522, in execute_model
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     max_query_len) = (self._prepare_inputs(scheduler_output))
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py", line 939, in _prepare_inputs
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     self.set_active_loras(self.input_batch, num_scheduled_tokens)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/worker/lora_model_runner_mixin.py", line 84, in set_active_loras
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     return self._set_active_loras(prompt_lora_mapping, token_lora_mapping,
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/v1/worker/lora_model_runner_mixin.py", line 73, in _set_active_loras
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     self.lora_manager.set_active_adapters(lora_requests, lora_mapping)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/lora/worker_manager.py", line 167, in set_active_adapters
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     set_active_adapters_worker(requests, mapping, self._apply_adapters,
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/adapter_commons/utils.py", line 55, in set_active_adapters_worker
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     apply_adapters_func(requests)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/lora/worker_manager.py", line 227, in _apply_adapters
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     self.add_adapter(lora)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/lora/worker_manager.py", line 240, in add_adapter
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     lora = self._load_adapter(lora_request)
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m   File "/nas/ucb/ebronstein/venvs/code-assistant/lib/python3.12/site-packages/vllm/lora/worker_manager.py", line 136, in _load_adapter
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m     raise ValueError(
[36m(AsyncVLLMInferenceEngine pid=1010235)[0m [1;36m(EngineCore_0 pid=1010386)[0;0m ValueError: Loading lora 549119024 failed: No adapter found for /dummy_lora_path
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
