### PR TITLE
Deepcopy env_extras dicts for each sample when preparing generator input

### DIFF
--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -380,11 +380,7 @@ def prepare_generator_input(
     ]
 
     # all the other columns are env_extras
-    env_extras = [
-        copy.deepcopy(prompt["env_extras"])
-        for prompt in prompts
-        for _ in range(n_samples_per_prompt)
-    ]
+    env_extras = [copy.deepcopy(prompt["env_extras"]) for prompt in prompts for _ in range(n_samples_per_prompt)]
 
     # Create TrajectoryID objects - one UID per row, repetition_id for multiple samples
     trajectory_ids = []


### PR DESCRIPTION
When preparing `GeneratorInput`, the same `env_extras` is used for each sample per prompt. Since the dictionaries are not copied, this can lead to bugs where changing the dictionary for one sample changes them for all samples in that group (for the same prompt).

This PR makes a deep copy of the `env_extras` for each sample.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
