### PR TITLE
[Harbor] Replace asyncio.gather with TaskGroup for proper cancellation

### DIFF
--- a/examples/train_integrations/harbor/harbor_generator.py
+++ b/examples/train_integrations/harbor/harbor_generator.py
@@ -104,8 +104,7 @@ class HarborGenerator(GeneratorInterface):
             raise ValueError("`trajectory_ids` is required in the input batch")
         if len(prompts) != len(trajectory_ids):
             raise ValueError(
-                f"Prompt count ({len(prompts)}) doesn't match "
-                f"trajectory_ids count ({len(trajectory_ids)})"
+                f"Prompt count ({len(prompts)}) doesn't match " f"trajectory_ids count ({len(trajectory_ids)})"
             )
 
         all_outputs: List[HarborAgentOutput] = [None] * len(prompts)  # type: ignore[list-item]

--- a/skyrl-train/examples/harbor/harbor_generator.py
+++ b/skyrl-train/examples/harbor/harbor_generator.py
@@ -104,8 +104,7 @@ class HarborGenerator(GeneratorInterface):
             raise ValueError("`trajectory_ids` is required in the input batch")
         if len(prompts) != len(trajectory_ids):
             raise ValueError(
-                f"Prompt count ({len(prompts)}) doesn't match "
-                f"trajectory_ids count ({len(trajectory_ids)})"
+                f"Prompt count ({len(prompts)}) doesn't match " f"trajectory_ids count ({len(trajectory_ids)})"
             )
 
         all_outputs: List[HarborAgentOutput] = [None] * len(prompts)  # type: ignore[list-item]


### PR DESCRIPTION
As part of fixing https://github.com/laude-institute/harbor/issues/656 — when users interrupt RL with Ctrl+C during sandbox rollout, sandboxes do not clean up properly.

asyncio.TaskGroup propagates cancellation to all child tasks, ensuring Harbor trials (Daytona/Modal sandboxes) are cleaned up on KeyboardInterrupt.

However, this PR alone may not be enough to solve all the issues, see https://github.com/NovaSky-AI/SkyRL/issues/1194
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
