### PR TITLE
[CI][fix] Fix test_abort_generation_vllm_engine to fire to engine not client

### DIFF
--- a/skyrl-train/tests/gpu/gpu_ci/test_pause_and_continue_generation.py
+++ b/skyrl-train/tests/gpu/gpu_ci/test_pause_and_continue_generation.py
@@ -276,7 +276,7 @@ def test_continue_generation_generate_vllm_engine_generation(ray_init_fixture):
 @pytest.mark.vllm
 def test_abort_generation_vllm_engine(ray_init_fixture):
     """
-    We send 4 requests that are really long to `InferenceEngineInterface.chat_completion`
+    We send 4 requests that are really long to `InferenceEngineClient.engines[0].chat_completion`
     and then call abort. We set max_num_seqs=2 to test aborting 2 running requests and 2 waiting
     requests. We expect 2 requests to be returned with completion_tokens=0 and 2 with non-zero
     completion_tokens. We also expect the finish_reason to be "abort" for all requests.


### PR DESCRIPTION
Currently the test hangs because it uses `client.chat_completion()`, then pauses, then expects the completion to return. However, there is a while loop that will never return, making the test hang.

This was a bug introduced in https://github.com/NovaSky-AI/SkyRL/pull/1038

The original intention of the test is to test vllm (per-engine) level request abort.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
