### PR TITLE
[tx] Fix checkpoint loading for MoE models

### DIFF
--- a/skyrl-tx/tx/utils/models.py
+++ b/skyrl-tx/tx/utils/models.py
@@ -173,13 +173,11 @@ def load_safetensors(
             expert_keys = [get_expert_key(path, i) for i in range(num_experts)]
             missing_keys = [expert_key for expert_key in expert_keys if expert_key not in tensors]
             if missing_keys:
-                logger.warning(f"Missing keys while loading from {checkpoint_dir}: {missing_keys}")
-                continue
+                raise RuntimeError(f"Missing keys while loading from {checkpoint_dir}: {missing_keys}")
             tensor = np.stack([tensors[expert_key].T for expert_key in expert_keys], axis=0)
         else:
             if key not in tensors:
-                logger.warning(f"Missing key while loading from {checkpoint_dir}: {key}")
-                continue
+                raise RuntimeError(f"Missing key while loading from {checkpoint_dir}: {key}")
             tensor = tensors[key] if "embed_tokens" in key else tensors[key].T
         adapter_idx = get_adapter_slice(path, adapter_index, rank)
         if adapter_idx is not None:

--- a/skyrl/tx/utils/models.py
+++ b/skyrl/tx/utils/models.py
@@ -167,11 +167,17 @@ def load_safetensors(
         # Skip connector parameters
         if skip_lora and is_connector_path(path):
             continue
-        if key not in tensors:
-            continue
         if "experts" in path:
-            tensor = np.stack([tensors[get_expert_key(path, i)].T for i in range(config.get_num_experts())], axis=0)
+            num_experts = config.get_num_experts()
+            assert num_experts is not None
+            expert_keys = [get_expert_key(path, i) for i in range(num_experts)]
+            missing_keys = [expert_key for expert_key in expert_keys if expert_key not in tensors]
+            if missing_keys:
+                raise RuntimeError(f"Missing keys while loading from {checkpoint_dir}: {missing_keys}")
+            tensor = np.stack([tensors[expert_key].T for expert_key in expert_keys], axis=0)
         else:
+            if key not in tensors:
+                raise RuntimeError(f"Missing key while loading from {checkpoint_dir}: {key}")
             tensor = tensors[key] if "embed_tokens" in key else tensors[key].T
         adapter_idx = get_adapter_slice(path, adapter_index, rank)
         if adapter_idx is not None:


### PR DESCRIPTION
This PR fixes an error introduced in https://github.com/NovaSky-AI/SkyRL/pull/1079/changes#diff-efa0926ec29680ccfada41bd1e8d7d3197c57fbf89c26486496edbaec26d59e6R167 that would lead to MoE weights not being loaded. We now make weights not being loaded an error so things like this can't happen any more in the future.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
