### PR TITLE
[tpu] set local_device_ids in jax.distributed.initialize to avoid auto init

### DIFF
--- a/skyrl/backends/jax.py
+++ b/skyrl/backends/jax.py
@@ -1073,14 +1073,13 @@ class JaxBackend(JaxBackendImpl):
             tpu_worker_id = int(os.environ.get("TPU_WORKER_ID"))
 
             jax.distributed.initialize(
-                cluster_detection_method="deactivate",
                 coordinator_address=config.coordinator_address,
                 num_processes=config.num_processes,
-                process_id=0,
-                local_device_ids=range(config.tensor_parallel_size),
+                # process_id=0,
+                # local_device_ids=range(config.tensor_parallel_size),
             )
             logger.info(
-                f"JAX distributed initialized: input_process_id=0, "
+                f"JAX distributed initialized: tpu_worker_id={tpu_worker_id}, input_process_id=0, "
                 f"rocess_id={jax.process_index()} ({jax.process_count()} total), "
                 f"local devices: {jax.local_device_count()}, total devices: {jax.device_count()}"
             )
@@ -1144,15 +1143,14 @@ def run_worker(coordinator_address: str, num_processes: int, process_id: int, te
         raise ValueError("Worker process_id must be > 0 (process 0 is the coordinator)")
     tpu_worker_id = int(os.environ.get("TPU_WORKER_ID"))
     jax.distributed.initialize(
-        cluster_detection_method="deactivate",
         coordinator_address=coordinator_address,
         num_processes=num_processes,
-        process_id=process_id,
-        local_device_ids=range(tensor_parallel_size),
+        # process_id=process_id,
+        # local_device_ids=range(tensor_parallel_size),
     )
 
     logger.info(
-        f"Worker input_process_id={process_id} process_id={jax.process_index()} ({jax.process_count()} total) initialized, waiting for config from coordinator..."
+        f"Worker tpu_worker_id={tpu_worker_id} input_process_id={process_id} process_id={jax.process_index()} ({jax.process_count()} total) initialized, waiting for config from coordinator..."
     )
 
     # Receive INIT payload with base_model and config from coordinator


### PR DESCRIPTION
[jax.distributed.initialize()](https://github.com/jax-ml/jax/blob/main/jax/_src/distributed.py#L86-L95) calls auto_detect_unset_distributed_params if either `coordinator_address`, `num_processes`, `process_id` or  `local_device_ids` is not set. 

For TPUs I suepect the call to auto_detect_unset_distributed_params reassigns JAX process IDs which breaks the current examples that assume process ID is set from `--process-id`. This PR also sets `local_device_ids` to skip  reinitialization from JAX.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
