### PR TITLE
[train][fullyAsync] Fix abort/pause broken after vllm 0.16.0 bump

### DIFF
--- a/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -170,6 +170,18 @@ class BaseVLLMInferenceEngine(InferenceEngineInterface):
         """Get the underlying engine for RPC calls."""
         return self.llm.engine if hasattr(self.llm, "engine") else self.llm
 
+    @staticmethod
+    def _get_unfinished_request_ids(output_processor) -> list:
+        """Get unfinished request IDs suitable for abort/abort_request calls.
+
+        In vllm 0.16.0+, request_states is keyed by internal IDs (with a random suffix),
+        while abort() expects external IDs by default. We use external_req_ids when
+        available and fall back to request_states keys for older vllm versions.
+        """
+        if hasattr(output_processor, "external_req_ids"):
+            return list(output_processor.external_req_ids.keys())
+        return list(output_processor.request_states.keys())
+
     def reset_prefix_cache(self):
         """Reset the prefix cache. Subclasses override for async version."""
         return self.llm.llm_engine.reset_prefix_cache()
@@ -245,7 +257,7 @@ class VLLMInferenceEngine(BaseVLLMInferenceEngine):
                 "generation should be done before sleep() is called. Check for potential failures or "
                 "dangling requests in your Generator/Env. Aborting all unfinished requests."
             )
-            unfinished_request_ids = list(output_processor.request_states.keys())
+            unfinished_request_ids = self._get_unfinished_request_ids(output_processor)
             await asyncio.to_thread(engine.abort_request, unfinished_request_ids)
 
         level = 1 if self._is_lora else kwargs.get("level", 2)
@@ -457,7 +469,7 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
                 "generation should be done before sleep() is called. Check for potential failures or "
                 "dangling requests in your Generator/Env. Aborting all unfinished requests."
             )
-            unfinished_request_ids = list(output_processor.request_states.keys())
+            unfinished_request_ids = self._get_unfinished_request_ids(output_processor)
             await engine.abort(unfinished_request_ids)
 
         # TODO(team): remove once vllm fixes this
@@ -608,8 +620,7 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
         already-generated tokens with a stop_reason of "abort".
         """
         engine = self._get_engine()
-        # Collect all request IDs currently tracked by the scheduler/output processor
-        unfinished_request_ids = list(engine.output_processor.request_states.keys())
+        unfinished_request_ids = self._get_unfinished_request_ids(engine.output_processor)
         if unfinished_request_ids:
             await engine.abort(unfinished_request_ids)
         await engine.reset_prefix_cache()  # avoid KV-cache pollution


### PR DESCRIPTION
### Summary

- Fix `abort_generation()` and `sleep()` abort logic that broke silently after the vllm 0.16.0 bump (#1240)
- Add backward-compatible `_get_unfinished_request_ids()` helper to resolve internal vs external request ID mismatch
- Fixes #1243

### Root Cause

In vllm 0.16.0, [`InputProcessor.assign_request_id()`](https://github.com/vllm-project/vllm/blob/main/vllm/v1/engine/input_processor.py) now creates **internal** request IDs (with a random suffix) that are distinct from the user-provided **external** request IDs:

```python
request.external_req_id = request.request_id                       # save original as external
request.request_id = f"{request.external_req_id}-{random_uuid():.8}"  # new internal ID
```

Our code was reading request IDs from `output_processor.request_states.keys()` (which are now **internal** IDs) and passing them to `engine.abort()` with `internal=False` (the default). The abort looked them up in the `external_req_ids` mapping, found nothing, and **silently did nothing**. Requests completed normally with `finish_reason="length"` instead of `"abort"`.

This broke fully async RL's pause/resume flow, which relies on abort returning partial outputs with `finish_reason="abort"` so the retry loop can re-submit with accumulated tokens.

Related vllm changes:
- https://github.com/vllm-project/vllm/issues/32103
- https://github.com/vllm-project/vllm/pull/32351
- https://github.com/vllm-project/vllm/pull/34125
- https://github.com/vllm-project/vllm/pull/34528

### Fix

Add a `_get_unfinished_request_ids()` static method on `BaseVLLMInferenceEngine` that:
- Uses `output_processor.external_req_ids.keys()` when available (vllm 0.16.0+)
- Falls back to `output_processor.request_states.keys()` for older vllm versions

Applied to all three abort call sites:
1. `AsyncVLLMInferenceEngine.abort_generation()` — used by fully async pause/resume
2. `AsyncVLLMInferenceEngine.sleep()` — cleanup before sleep
3. `VLLMInferenceEngine.sleep()` — sync engine cleanup before sleep

### Test plan

- [x] `test_abort_generation_vllm_engine` — passes (was failing with `assert 'length' == 'abort'`)
- [x] `test_continue_generation_vllm_engine_chat_completion` — passes
- [x] `test_continue_generation_generate_vllm_engine_generation` — passes
- [x] E2E fully async gsm8k (`gsm8k_fully_async_ci` project) — ran ~12 training steps successfully with pause/resume working correctly

Light blue is the run after this fix (our nightly gsm8k fully async CI) https://wandb.ai/sky-posttraining-uc-berkeley/gsm8k_fully_async_ci

<img width="2163" height="976" alt="image" src="https://github.com/user-attachments/assets/eaece0dc-ca53-4dd1-b3d1-2f6e308a8a47" />


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
