### PR TITLE
[train] Fix NUMA and checkpoint serialization for optimizer CPU offload

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -555,6 +555,11 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         )
         self.optimizer = get_megatron_optimizer(self.actor_module, optim_config)
 
+        # Skip optimizer state in checkpoints when using CPU offload to avoid
+        # system OOM during serialization.
+        if optim_config.optimizer_cpu_offload:
+            self._skip_optimizer_checkpoint = True
+
         # create scheduler
         self.scheduler = get_megatron_optimizer_param_scheduler(
             optimizer=self.optimizer,

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -206,7 +206,16 @@ class DistributedTorchRayActor:
         def numa_bind(nid: int):
             bitmask = LIBNUMA.numa_parse_nodestring(bytes(str(nid), "ascii"))
             LIBNUMA.numa_run_on_node_mask(bitmask)
-            LIBNUMA.numa_set_membind(bitmask)
+            # Use interleave instead of membind to spread memory across all
+            # NUMA nodes. With optimizer CPU offload, binding to one node
+            # causes OOM during checkpoint serialization.
+            try:
+                LIBNUMA.numa_set_interleave_mask.argtypes = [POINTER(bitmask_t)]
+                LIBNUMA.numa_set_interleave_mask.restype = c_void_p
+                all_nodes = LIBNUMA.numa_parse_nodestring(b"all")
+                LIBNUMA.numa_set_interleave_mask(all_nodes)
+            except Exception:
+                LIBNUMA.numa_set_membind(bitmask)
 
         numa_nodes = LIBNUMA.numa_num_configured_nodes()
         if numa_nodes <= 0:
@@ -983,10 +992,18 @@ class PolicyWorkerBase(Worker):
         torch.distributed.barrier()
 
     def save_checkpoint(self, ckpt_dir: Path, tokenizer=None):
+        # When optimizer CPU offload is enabled, skip saving optimizer state
+        # to avoid OOM during serialization and flattened_range errors in
+        # mcore 0.16.0. Training can resume from model-only checkpoints.
+        save_optimizer = self.optimizer
+        save_scheduler = self.scheduler
+        if getattr(self, "_skip_optimizer_checkpoint", False):
+            save_optimizer = None
+            save_scheduler = None
         self.strategy.save_checkpoint(
             model=self.model,
-            optimizer=self.optimizer,
-            scheduler=self.scheduler,
+            optimizer=save_optimizer,
+            scheduler=save_scheduler,
             ckpt_dir=ckpt_dir,
             node_local_rank=self.get_node_local_rank(),
             tokenizer=tokenizer,
@@ -995,6 +1012,11 @@ class PolicyWorkerBase(Worker):
     def load_checkpoint(
         self, ckpt_dir: Path, load_optimizer_states: bool = True, load_lr_scheduler_states: bool = True
     ):
+        # Skip optimizer loading when checkpoint was saved without optimizer
+        # states (e.g., when _skip_optimizer_checkpoint was set during save).
+        if getattr(self, "_skip_optimizer_checkpoint", False):
+            load_optimizer_states = False
+            load_lr_scheduler_states = False
         _, states = self.strategy.load_checkpoint(
             model=self.model,
             optimizer=self.optimizer if load_optimizer_states else None,
@@ -1230,10 +1252,19 @@ class CriticWorkerBase(Worker):
         )
 
     def save_checkpoint(self, ckpt_dir: str, tokenizer=None):
+        # When optimizer CPU offload is enabled, skip saving optimizer state
+        # to avoid OOM during serialization (optimizer + model weights can
+        # exceed available system memory). Training can resume from model-only
+        # checkpoints by re-initializing the optimizer.
+        save_optimizer = self.optimizer
+        save_scheduler = self.scheduler
+        if getattr(self, "_skip_optimizer_checkpoint", False):
+            save_optimizer = None
+            save_scheduler = None
         self.strategy.save_checkpoint(
             model=self.model,
-            optimizer=self.optimizer,
-            scheduler=self.scheduler,
+            optimizer=save_optimizer,
+            scheduler=save_scheduler,
             ckpt_dir=ckpt_dir,
             node_local_rank=self.get_node_local_rank(),
             tokenizer=tokenizer,


### PR DESCRIPTION
## Summary

Three runtime patches discovered during GPU validation of GLM-4.7-Flash GRPO training on 8x A100-80GB with optimizer CPU offload.

**Depends on:** #1241 (transformers 5.x compatibility) -- GLM-4.7-Flash requires transformers>=5.0.0, and #1241 adds the necessary return_dict=False fixes to all apply_chat_template call sites.

### Changes

- **NUMA memory interleave**: use numa_set_interleave_mask instead of numa_set_membind. With optimizer CPU offload enabled, binding all workers to a single NUMA node causes system OOM during checkpoint serialization. Interleaving spreads memory pressure across all nodes. Falls back to the original membind if unavailable.

- **Skip optimizer state in checkpoint save/load**: when optimizer_cpu_offload is enabled on the Megatron optimizer config, set _skip_optimizer_checkpoint = True. This causes PolicyWorkerBase and CriticWorkerBase to pass None for optimizer/scheduler during checkpoint save, avoiding serialization OOM and mcore 0.16.0 flattened_range errors. On load, optimizer/scheduler states are skipped and re-initialized fresh. Reduces checkpoint size from about 120 GiB to 56 GiB (model-only).

### Files changed (2)

- skyrl/backends/skyrl_train/workers/worker.py -- NUMA fix + save/load checkpoint patches
- skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py -- set skip flag when CPU offload enabled

### Validated on

- 8x A100-SXM4-80GB, CUDA 12.9, mcore 0.16.0, vLLM 0.16.0
- GLM-4.7-Flash (30B MoE, TP=1/EP=8) with optimizer CPU offload (optimizer_offload_fraction=1.0)
- Checkpoint save (56 GiB, 292s) + resume from checkpoint verified end-to-end
