### PR TITLE
[tinker] Propagate all `uv run` args from server startup command to backend workers

### DIFF
--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -45,42 +45,45 @@ API_SERVER_STARTUP_ARGS = ["-m", "skyrl.tinker.api"]
 SHUTDOWN_TIMEOUT_SECONDS = 10
 
 
-def _get_parent_uv_run_args() -> list[str]:
-    """Extract parent `uv run <uv run args>` flags for the engine launch.
+def _get_parent_uv_run_args(parent_cmd: list[str]) -> list[str]:
+    """Extract parent `uv run <uv run args>` flags for the engine launch given the parent process's startup command
 
     `uv run` starts this Python API process as a child. To recover the original
     `uv run <uv run args> ...` flags, we inspect the parent process command line
     and extract all the uv run args before the script argument.
     """
-    tokens = psutil.Process(os.getppid()).cmdline()
     # the API server startup command can be
     # uv run <uv run args> -m skyrl.tinker.api
     # or uv run <uv run args> python -m skyrl.tinker.api
     # or uv run <uv run args> -- python -m skyrl.tinker.api
     stop_strings = ["--", "python"]
     detected = False
-    for i in range(len(tokens) - 1):
-        if tokens[i] in stop_strings or (
-            tokens[i] == API_SERVER_STARTUP_ARGS[0] and tokens[i + 1] == API_SERVER_STARTUP_ARGS[1]
-        ):
+    for i in range(len(parent_cmd) - 1):
+        if parent_cmd[i] in stop_strings or parent_cmd[i : i + len(API_SERVER_STARTUP_ARGS)] == API_SERVER_STARTUP_ARGS:
             detected = True
             break
     if not detected or i < 2:
         raise ValueError(
-            f"Unable to parse tinker API server startup command: {tokens}. "
+            f"Unable to parse tinker API server startup command: {parent_cmd}. "
             "Ensure that the tinker API server was started with `uv run <uv run args> -m skyrl.tinker.api`"
         )
-    tokens = tokens[2:i]  # ignore uv run
-    return tokens
+    parent_cmd = parent_cmd[2:i]  # ignore uv run
+    return parent_cmd
 
 
-def _build_uv_run_cmd_engine(engine_config: BaseModel) -> list[str]:
+def _build_uv_run_cmd_engine(parent_cmd: list[str], engine_config: BaseModel) -> list[str]:
+    """Builds uv run command for the engine
+
+    Args:
+        parent_cmd: The command for the parent process starting the engine
+        engine_config: Engine configuration
+    Returns:
+        cmd: The uv run command for the tinker engine
+    """
     cmd = ["uv", "run"]
-    parent_flags = _get_parent_uv_run_args()
+    parent_flags = _get_parent_uv_run_args(parent_cmd)
     logger.debug(f"Detected API server uv run flags: {parent_flags}")
     cmd.extend(parent_flags)
-    if "--isolated" not in cmd:
-        cmd.extend(["--isolated"])
     # NOTE: uv deduplicates extras so we can unconditionally add the tinker extra
     cmd.extend(["--extra", "tinker", "--extra", engine_config.backend])
     cmd.extend(["-m", "skyrl.tinker.engine"])
@@ -108,7 +111,8 @@ async def lifespan(app: FastAPI):
         logger.info("Using internal engine for inference")
 
     # Build subprocess command with engine config parameters.
-    cmd = _build_uv_run_cmd_engine(app.state.engine_config)
+    parent_cmd = psutil.Process(os.getppid()).cmdline()
+    cmd = _build_uv_run_cmd_engine(parent_cmd, app.state.engine_config)
 
     background_engine = await asyncio.create_subprocess_exec(*cmd)
     app.state.background_engine = background_engine

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -40,23 +40,54 @@ from skyrl.utils.log import logger, get_uvicorn_log_config
 ID_PATTERN = r"^[a-zA-Z0-9_-]+$"
 ID_MAX_LENGTH = 255
 
+API_SERVER_STARTUP_ARGS = ["-m", "skyrl.tinker.api"]
+
 # Timeout for graceful shutdown when engine crashes
 SHUTDOWN_TIMEOUT_SECONDS = 10
 
 
-def _get_parent_uv_accelerator_extras() -> list[str]:
-    """Extract parent `uv --extra` accelerator flags for the engine launch.
+def _get_parent_uv_run_args() -> list[str]:
+    """Extract parent `uv run <uv run args>` flags for the engine launch.
 
     `uv run` starts this Python API process as a child. To recover the original
-    `uv run --extra ...` flags, we inspect the parent process command line and
-    pass through only accelerator extras (`gpu`/`tpu`) to the engine subprocess.
+    `uv run <uv run args> ...` flags, we inspect the parent process command line
+    and extract all the uv run args before the script argument
     """
     tokens = psutil.Process(os.getppid()).cmdline()
+    # the API server startup command can be
+    # uv run <uv run args> -m skyrl.tinker.api
+    # or uv run <uv run args> python -m skyrl.tinker.api
+    # or uv run <uv run args> -- python -m skyrl.tinker.api
+    stop_strings = ["--", "python"]
+    detected = False
+    for i in range(len(tokens) - 1):
+        if tokens[i] in stop_strings or (
+            tokens[i] == API_SERVER_STARTUP_ARGS[0] and tokens[i + 1] == API_SERVER_STARTUP_ARGS[1]
+        ):
+            detected = True
+            break
+    if not detected or i < 2:
+        raise ValueError(
+            "Unable to parse tinker API server startup command: ",
+            tokens,
+            "Ensure that the tinker API server was started with `uv run <uv run args> -m skyrl.tinker.api",
+        )
+    tokens = tokens[2:i]  # ignore uv run
+    return tokens
 
-    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
-    parser.add_argument("--extra", action="append", default=[])
-    parsed, _ = parser.parse_known_args(tokens)
-    return list({extra for extra in parsed.extra if extra in {"gpu", "tpu"}})
+
+def _build_uv_run_cmd_engine(engine_config: BaseModel) -> list[str]:
+    cmd = ["uv", "run"]
+    parent_flags = _get_parent_uv_run_args()
+    logger.debug(f"Detected API server uv run flags: {parent_flags}")
+    cmd.extend(parent_flags)
+    if "--isolated" not in cmd:
+        cmd.extend(["--isolated"])
+    # NOTE: uv deduplicates extras so we can unconditionally add the tinker extra
+    cmd.extend(["--extra", "tinker", "--extra", engine_config.backend])
+    cmd.extend(["-m", "skyrl.tinker.engine"])
+    cmd.extend(config_to_argv(engine_config))
+    return cmd
 
 
 @asynccontextmanager
@@ -79,12 +110,7 @@ async def lifespan(app: FastAPI):
         logger.info("Using internal engine for inference")
 
     # Build subprocess command with engine config parameters.
-    cmd = ["uv", "run", "--isolated", "--extra", "tinker", "--extra", app.state.engine_config.backend]
-    if app.state.engine_config.backend == "jax":
-        for extra in _get_parent_uv_accelerator_extras():
-            cmd.extend(["--extra", extra])
-    cmd.extend(["-m", "skyrl.tinker.engine"])
-    cmd.extend(config_to_argv(app.state.engine_config))
+    cmd = _build_uv_run_cmd_engine(app.state.engine_config)
 
     background_engine = await asyncio.create_subprocess_exec(*cmd)
     app.state.background_engine = background_engine

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -68,8 +68,7 @@ def _get_parent_uv_run_args() -> list[str]:
             break
     if not detected or i < 2:
         raise ValueError(
-            "Unable to parse tinker API server startup command: ",
-            tokens,
+            f"Unable to parse tinker API server startup command: {tokens},"
             "Ensure that the tinker API server was started with `uv run <uv run args> -m skyrl.tinker.api",
         )
     tokens = tokens[2:i]  # ignore uv run

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1,4 +1,3 @@
-import argparse
 import fastapi
 from fastapi import FastAPI, HTTPException, Depends, Request
 from fastapi.responses import StreamingResponse, RedirectResponse
@@ -51,7 +50,7 @@ def _get_parent_uv_run_args() -> list[str]:
 
     `uv run` starts this Python API process as a child. To recover the original
     `uv run <uv run args> ...` flags, we inspect the parent process command line
-    and extract all the uv run args before the script argument
+    and extract all the uv run args before the script argument.
     """
     tokens = psutil.Process(os.getppid()).cmdline()
     # the API server startup command can be
@@ -68,8 +67,8 @@ def _get_parent_uv_run_args() -> list[str]:
             break
     if not detected or i < 2:
         raise ValueError(
-            f"Unable to parse tinker API server startup command: {tokens},"
-            "Ensure that the tinker API server was started with `uv run <uv run args> -m skyrl.tinker.api",
+            f"Unable to parse tinker API server startup command: {tokens}. "
+            "Ensure that the tinker API server was started with `uv run <uv run args> -m skyrl.tinker.api`"
         )
     tokens = tokens[2:i]  # ignore uv run
     return tokens

--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -439,6 +439,13 @@ def test_stale_session_cleanup(api_server_fast_cleanup):
 @pytest.mark.parametrize(
     "engine_config, parent_process_cmd, expected_cmd_start",
     [
+        # jax backend, no args
+        (
+            EngineConfig(backend="jax", base_model="Qwen/Qwen3-0.6B"),
+            ["uv", "run", "-m", "skyrl.tinker.api"],
+            ["uv", "run", "--isolated", "--extra", "tinker", "--extra", "jax", "-m", "skyrl.tinker.engine"],
+        ),
+        # skyrl-train backend, with args
         (
             EngineConfig(backend="skyrl_train", base_model="Qwen/Qwen3-0.6B"),
             ["uv", "run", "--env-file", ".env", "--extra", "tinker", "-m", "skyrl.tinker.api"],
@@ -565,11 +572,6 @@ def test_stale_session_cleanup(api_server_fast_cleanup):
                 "-m",
                 "skyrl.tinker.engine",
             ],
-        ),
-        (
-            EngineConfig(backend="jax", base_model="Qwen/Qwen3-0.6B"),
-            ["uv", "run", "-m", "skyrl.tinker.api"],
-            ["uv", "run", "--isolated", "--extra", "tinker", "--extra", "jax", "-m", "skyrl.tinker.engine"],
         ),
     ],
 )

--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -7,7 +7,6 @@ import tempfile
 import urllib.request
 from contextlib import contextmanager
 from urllib.parse import urlparse
-from unittest.mock import patch
 
 import pytest
 from skyrl.tinker.config import EngineConfig
@@ -435,7 +434,6 @@ def test_stale_session_cleanup(api_server_fast_cleanup):
     assert wait_for_condition(cleanup_logs_found, timeout_sec=10, poll_interval_sec=1), "Cleanup logs not found"
 
 
-@patch("skyrl.tinker.api.psutil.Process")
 @pytest.mark.parametrize(
     "engine_config, parent_process_cmd, expected_cmd_start",
     [
@@ -443,7 +441,7 @@ def test_stale_session_cleanup(api_server_fast_cleanup):
         (
             EngineConfig(backend="jax", base_model="Qwen/Qwen3-0.6B"),
             ["uv", "run", "-m", "skyrl.tinker.api"],
-            ["uv", "run", "--isolated", "--extra", "tinker", "--extra", "jax", "-m", "skyrl.tinker.engine"],
+            ["uv", "run", "--extra", "tinker", "--extra", "jax", "-m", "skyrl.tinker.engine"],
         ),
         # skyrl-train backend, with args
         (
@@ -457,7 +455,6 @@ def test_stale_session_cleanup(api_server_fast_cleanup):
                 ".env",
                 "--extra",
                 "tinker",
-                "--isolated",
                 "--extra",
                 "tinker",
                 "--extra",
@@ -527,7 +524,6 @@ def test_stale_session_cleanup(api_server_fast_cleanup):
                 ".env",
                 "--extra",
                 "tinker",
-                "--isolated",
                 "--extra",
                 "tinker",
                 "--extra",
@@ -564,7 +560,6 @@ def test_stale_session_cleanup(api_server_fast_cleanup):
                 "tinker",
                 "--extra",
                 "gpu",
-                "--isolated",
                 "--extra",
                 "tinker",
                 "--extra",
@@ -575,14 +570,12 @@ def test_stale_session_cleanup(api_server_fast_cleanup):
         ),
     ],
 )
-def test_build_cmd_engine(mock_process, engine_config, parent_process_cmd, expected_cmd_start):
-    mock_process.return_value.cmdline.return_value = parent_process_cmd
+def test_build_cmd_engine(engine_config, parent_process_cmd, expected_cmd_start):
 
-    cmd = " ".join(_build_uv_run_cmd_engine(engine_config))
+    cmd = " ".join(_build_uv_run_cmd_engine(parent_process_cmd, engine_config))
     assert cmd.startswith(" ".join(expected_cmd_start))
 
 
-@patch("skyrl.tinker.api.psutil.Process")
 @pytest.mark.parametrize(
     "engine_config, parent_process_cmd",
     [
@@ -593,8 +586,7 @@ def test_build_cmd_engine(mock_process, engine_config, parent_process_cmd, expec
         ),
     ],
 )
-def test_build_cmd_engine_invalid_arg(mock_process, engine_config, parent_process_cmd):
-    mock_process.return_value.cmdline.return_value = parent_process_cmd
+def test_build_cmd_engine_invalid_arg(engine_config, parent_process_cmd):
 
     with pytest.raises(ValueError, match="Unable to parse tinker API server startup command"):
-        _build_uv_run_cmd_engine(engine_config)
+        _build_uv_run_cmd_engine(parent_process_cmd, engine_config)

--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -7,8 +7,11 @@ import tempfile
 import urllib.request
 from contextlib import contextmanager
 from urllib.parse import urlparse
+from unittest.mock import patch
 
 import pytest
+from skyrl.tinker.config import EngineConfig
+from skyrl.tinker.api import _build_uv_run_cmd_engine
 import tinker
 from tinker import types
 from transformers import AutoTokenizer
@@ -430,3 +433,166 @@ def test_stale_session_cleanup(api_server_fast_cleanup):
         return "Auto-unloaded stale model" in log_output and "Deleted model" in log_output
 
     assert wait_for_condition(cleanup_logs_found, timeout_sec=10, poll_interval_sec=1), "Cleanup logs not found"
+
+
+@patch("skyrl.tinker.api.psutil.Process")
+@pytest.mark.parametrize(
+    "engine_config, parent_process_cmd, expected_cmd_start",
+    [
+        (
+            EngineConfig(backend="skyrl_train", base_model="Qwen/Qwen3-0.6B"),
+            ["uv", "run", "--env-file", ".env", "--extra", "tinker", "-m", "skyrl.tinker.api"],
+            # NOTE: we end up with duplicate tinker extra, but this is fine because uv run with deduplicate extras
+            [
+                "uv",
+                "run",
+                "--env-file",
+                ".env",
+                "--extra",
+                "tinker",
+                "--isolated",
+                "--extra",
+                "tinker",
+                "--extra",
+                "skyrl_train",
+                "-m",
+                "skyrl.tinker.engine",
+            ],
+        ),
+        (
+            # jax backend with `python -m skyrl.tinker.api` in the startup command
+            EngineConfig(backend="jax", base_model="Qwen/Qwen3-0.6B"),
+            [
+                "uv",
+                "run",
+                "--isolated",
+                "--with",
+                "mypackage",
+                "--env-file",
+                ".env",
+                "--extra",
+                "tinker",
+                "python",
+                "-m",
+                "skyrl.tinker.api",
+            ],
+            [
+                "uv",
+                "run",
+                "--isolated",
+                "--with",
+                "mypackage",
+                "--env-file",
+                ".env",
+                "--extra",
+                "tinker",
+                "--extra",
+                "tinker",
+                "--extra",
+                "jax",
+                "-m",
+                "skyrl.tinker.engine",
+            ],
+        ),
+        (
+            # jax backend with -- python in the api server startup commmand
+            EngineConfig(backend="jax", base_model="Qwen/Qwen3-0.6B"),
+            [
+                "uv",
+                "run",
+                "--with",
+                "mypackage",
+                "--env-file",
+                ".env",
+                "--extra",
+                "tinker",
+                "--",
+                "python",
+                "-m",
+                "skyrl.tinker.api",
+            ],
+            [
+                "uv",
+                "run",
+                "--with",
+                "mypackage",
+                "--env-file",
+                ".env",
+                "--extra",
+                "tinker",
+                "--isolated",
+                "--extra",
+                "tinker",
+                "--extra",
+                "jax",
+                "-m",
+                "skyrl.tinker.engine",
+            ],
+        ),
+        (
+            # Jax backend gpu extra
+            EngineConfig(backend="jax", base_model="Qwen/Qwen3-0.6B"),
+            [
+                "uv",
+                "run",
+                "--with",
+                "mypackage",
+                "--env-file",
+                ".env",
+                "--extra",
+                "tinker",
+                "--extra",
+                "gpu",
+                "-m",
+                "skyrl.tinker.api",
+            ],
+            [
+                "uv",
+                "run",
+                "--with",
+                "mypackage",
+                "--env-file",
+                ".env",
+                "--extra",
+                "tinker",
+                "--extra",
+                "gpu",
+                "--isolated",
+                "--extra",
+                "tinker",
+                "--extra",
+                "jax",
+                "-m",
+                "skyrl.tinker.engine",
+            ],
+        ),
+        (
+            EngineConfig(backend="jax", base_model="Qwen/Qwen3-0.6B"),
+            ["uv", "run", "-m", "skyrl.tinker.api"],
+            ["uv", "run", "--isolated", "--extra", "tinker", "--extra", "jax", "-m", "skyrl.tinker.engine"],
+        ),
+    ],
+)
+def test_build_cmd_engine(mock_process, engine_config, parent_process_cmd, expected_cmd_start):
+    mock_process.return_value.cmdline.return_value = parent_process_cmd
+
+    cmd = " ".join(_build_uv_run_cmd_engine(engine_config))
+    assert cmd.startswith(" ".join(expected_cmd_start))
+
+
+@patch("skyrl.tinker.api.psutil.Process")
+@pytest.mark.parametrize(
+    "engine_config, parent_process_cmd",
+    [
+        (
+            EngineConfig(backend="jax", base_model="Qwen/Qwen3-0.6B"),
+            # invalid parent process startup command
+            ["python", "-m", "skyrl.tinker.api"],
+        ),
+    ],
+)
+def test_build_cmd_engine_invalid_arg(mock_process, engine_config, parent_process_cmd):
+    mock_process.return_value.cmdline.return_value = parent_process_cmd
+
+    with pytest.raises(ValueError, match="Unable to parse tinker API server startup command"):
+        _build_uv_run_cmd_engine(engine_config)


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/NovaSky-AI/SkyRL/issues/1234

After the fixes in this PR, I can successfully train with `meta-llama/Llama-3.2-1B` by passing an env-file to the server startup command :

```bash
 uv run --extra tinker --extra fsdp --env-file skyrl-train/.env.example -m skyrl.tinker.api  --base-mod
el meta-llama/Llama-3.2-1B   --backend fsdp 
```

(For context: See #1231 )

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
