### PR TITLE
[train] Add KL-in-advantages mode

### DIFF
--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -328,6 +328,12 @@ class AlgorithmConfig(BaseConfig):
     use_kl_loss: bool = True
     """Apply KL loss in the policy model. Mutually exclusive with ``use_kl_in_reward``."""
     kl_loss_coef: float = 0.001
+    use_kl_in_advantages: bool = False
+    """Modify advantages with a batch-centered relative KL signal after group normalization.
+    ``advantage += coef * (avg_batch_KL - token_KL)``. Tokens drifting more than
+    the batch average from the reference get penalized; tokens drifting less get a bonus."""
+    kl_advantages_coef: float = 0.01
+    """Coefficient for the KL-in-advantages penalty. Only used when ``use_kl_in_advantages=True``."""
     use_entropy_loss: bool = False
     entropy_loss_coef: float = 0.01
     temperature: Optional[float] = None

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -269,6 +269,10 @@ class RayPPOTrainer:
                     # 3. calculate advantages and returns
                     with Timer("compute_advantages_and_returns", self.all_timings):
                         training_input = self.compute_advantages_and_returns(training_input)
+
+                        if self.cfg.trainer.algorithm.use_kl_in_advantages and training_input.get("base_action_log_probs") is not None:
+                            training_input = self.apply_kl_advantage_penalty(training_input)
+
                         # remove some unwanted keys
                         for key in ["rewards"]:
                             training_input.pop(key)
@@ -866,6 +870,43 @@ class RayPPOTrainer:
                 "loss/avg_raw_advantages_abs": avg_advantages_abs,
             }
         )
+        return data
+
+    def apply_kl_advantage_penalty(
+        self,
+        data: TrainingInputBatch,
+    ) -> TrainingInputBatch:
+        """Modify advantages with a batch-centered relative KL signal.
+
+        For each token the adjustment is:
+
+            advantage += coef * (avg_batch_KL - token_KL) * loss_mask
+
+        Tokens drifting more than the batch average from the reference get
+        penalized; tokens drifting less get a bonus.  Because the adjustment
+        is centered around the batch mean the sum is approximately zero,
+        which is variance-reducing compared to a naive subtraction.
+        """
+        base_action_log_probs = data["base_action_log_probs"]
+        action_log_probs = data["action_log_probs"]
+        loss_mask = data["loss_mask"]
+        advantages = data["advantages"]
+
+        # Per-token KL divergence estimate
+        token_kl = compute_approx_kl(
+            action_log_probs,
+            base_action_log_probs,
+            loss_mask=loss_mask,
+            kl_estimator_type=self.cfg.trainer.algorithm.kl_estimator_type,
+        )
+
+        # Batch-average KL (scalar) -- mean over valid tokens
+        avg_kl = masked_mean(token_kl, loss_mask).item()
+
+        coef = self.cfg.trainer.algorithm.kl_advantages_coef
+        data["advantages"] = advantages + coef * (avg_kl - token_kl) * loss_mask
+
+        self.all_metrics.update({"kl_in_advantages/avg_token_kl": avg_kl})
         return data
 
     def dump_data(self, data: TrainingInputBatch, file_name: str):


### PR DESCRIPTION
## Summary
- New KL penalty mode: batch-centered relative KL applied to advantages after group normalization
- `advantage += coef * (avg_batch_KL - token_KL)`
- Tokens drifting more than average get penalized; tokens drifting less get a bonus
- Configure with `use_kl_in_advantages: true`, `kl_advantages_coef: 0.01`

## Test plan
- [ ] Existing trainer tests pass
- [ ] KL advantage sums to ~0 (batch-centered)


🤖 Generated with [Claude Code](https://claude.com/claude-code)