### PR TITLE
[train] Add sampler-as-reference KL option

### DIFF
--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -328,6 +328,10 @@ class AlgorithmConfig(BaseConfig):
     use_kl_loss: bool = True
     """Apply KL loss in the policy model. Mutually exclusive with ``use_kl_in_reward``."""
     kl_loss_coef: float = 0.001
+    kl_reference_source: str = "ref_model"
+    """Source of base logprobs for KL computation: ``"ref_model"`` uses a frozen
+    reference model; ``"rollout"`` (or ``"old_policy"``) uses the rollout
+    (sampling) logprobs, eliminating the reference-model memory and compute."""
     use_entropy_loss: bool = False
     entropy_loss_coef: float = 0.01
     temperature: Optional[float] = None

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -384,7 +384,10 @@ class RayPPOTrainer:
         cfg = self.cfg
         pg = None
 
-        use_ref_model = cfg.trainer.algorithm.use_kl_loss or cfg.trainer.algorithm.use_kl_in_reward
+        use_ref_model = (
+            (cfg.trainer.algorithm.use_kl_loss or cfg.trainer.algorithm.use_kl_in_reward)
+            and getattr(cfg.trainer.algorithm, "kl_reference_source", "ref_model") == "ref_model"
+        )
 
         if cfg.trainer.placement.colocate_all:
             num_policy_gpus = cfg.trainer.placement.policy_num_gpus_per_node * cfg.trainer.placement.policy_num_nodes
@@ -949,6 +952,17 @@ class RayPPOTrainer:
             ref_output = self.dispatch.forward("ref", data_fwd_pass)
             base_log_probs = ref_output["output"]
             self.dispatch.empty_cache("ref")
+        elif getattr(self.cfg.trainer.algorithm, "kl_reference_source", "ref_model") in ("rollout", "old_policy"):
+            # Use rollout (sampling) logprobs as reference instead of a frozen ref model.
+            # This eliminates the reference model memory and forward pass compute.
+            base_log_probs = training_input.get("rollout_logprobs", None)
+            if base_log_probs is None:
+                raise ValueError(
+                    "kl_reference_source is set to "
+                    f"'{self.cfg.trainer.algorithm.kl_reference_source}' but "
+                    "rollout_logprobs is not available in the training input. "
+                    "Ensure generator.sampling_params.logprobs is set to 1."
+                )
 
         # Policy forward
         policy_output = self.dispatch.forward("policy", data_fwd_pass)

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -162,7 +162,10 @@ def validate_batch_sizes(cfg: SkyRLTrainConfig):
     # Validate training batch size is larger than the least common multiple of the DP sizes of policy (and ref if used).
     lcm_dp_size = policy_dp_size
 
-    use_ref_model = cfg.trainer.algorithm.use_kl_loss or cfg.trainer.algorithm.use_kl_in_reward
+    use_ref_model = (
+        (cfg.trainer.algorithm.use_kl_loss or cfg.trainer.algorithm.use_kl_in_reward)
+        and getattr(cfg.trainer.algorithm, "kl_reference_source", "ref_model") == "ref_model"
+    )
     if use_ref_model:
         ref_world_size = cfg.trainer.placement.ref_num_nodes * cfg.trainer.placement.ref_num_gpus_per_node
         if cfg.trainer.strategy == "megatron":
@@ -343,7 +346,10 @@ def validate_cfg(cfg: SkyRLTrainConfig):
             "must be the same when colocating all models"
         )
     else:
-        use_ref_model = cfg.trainer.algorithm.use_kl_loss or cfg.trainer.algorithm.use_kl_in_reward
+        use_ref_model = (
+            (cfg.trainer.algorithm.use_kl_loss or cfg.trainer.algorithm.use_kl_in_reward)
+            and getattr(cfg.trainer.algorithm, "kl_reference_source", "ref_model") == "ref_model"
+        )
         if cfg.trainer.placement.colocate_policy_ref and use_ref_model:
             assert cfg.trainer.placement.policy_num_nodes == cfg.trainer.placement.ref_num_nodes, (
                 f"policy_num_nodes ({cfg.trainer.placement.policy_num_nodes}) and ref_num_nodes "


### PR DESCRIPTION
## Summary
- Allow `kl_reference_source: "rollout"` to use rollout logprobs as KL reference
- Eliminates reference model memory and forward pass compute
- KL constrains per-step drift rather than cumulative drift from initialization
- Validation checks updated to skip ref model allocation when not needed

## Test plan
- [ ] Existing trainer tests pass
- [ ] With `kl_reference_source: "rollout"`, no ref model actors are created


🤖 Generated with [Claude Code](https://claude.com/claude-code)