### PR TITLE
[megatron] refactor megatron param/grad offload to directly use new megatron built in functions

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -111,6 +111,8 @@ def freeze_moe_router(model):
 def offload_megatron_grads_to_cpu(models):
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
+            # use megatron DDP built in function to offload grads to cpu
+            # https://github.com/NVIDIA/Megatron-LM/blob/core_v0.16.0/megatron/core/distributed/distributed_data_parallel.py#L575
             model_chunk.offload_grad_buffers(synchronize=False, empty_cache=False)
         else:
             for _, param in model_chunk.named_parameters():
@@ -145,6 +147,8 @@ def offload_megatron_model_to_cpu(models):
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
             for buffer in model_chunk.buffers + model_chunk.expert_parallel_buffers:
+                # use megatron buffer built in function to offload to cpu
+                # https://github.com/NVIDIA/Megatron-LM/blob/core_v0.16.0/megatron/core/distributed/param_and_grad_buffer.py#L964
                 buffer.offload_to_cpu(move_params=True, move_grads=False)
 
             # LoRA-aware offloading: offload non-lora base weights that live


### PR DESCRIPTION
upgrading to megatron-core==0.16.0 temporarily broke grad offloading code in specific cases due to new grad/param buffer offloading logic built in to megatron-core. Refactors our param/grad offload logic to use megatron builtins from: https://github.com/NVIDIA/Megatron-LM/pull/3112

Fixes `tests/backends/skyrl_train/gpu/gpu_ci/test_worker_dispatch_offload.py::test_dispatch_set_lr` test which previously was encountering an error when offloading grad.
 
<img width="913" height="46" alt="image" src="https://github.com/user-attachments/assets/fc2ac528-1f20-4d1f-ba23-52c1624b0911" />


Offloading test still passes

#### Before
<img width="911" height="112" alt="image" src="https://github.com/user-attachments/assets/781e0550-916b-4620-9e2b-cbac46e4e195" />


#### After
<img width="918" height="140" alt="image" src="https://github.com/user-attachments/assets/fa1a533b-3602-447e-9ba6-11c6e3f74f89" />



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
