### PR TITLE
[docs] Fix `examples/` paths in the docs after `skyrl-train` -> `skyrl` migration

### DIFF
--- a/docs/content/docs/algorithms/dapo.mdx
+++ b/docs/content/docs/algorithms/dapo.mdx
@@ -14,7 +14,7 @@ The [DAPO](https://arxiv.org/abs/2503.14476) (Decoupled Clip and Dynamic Samplin
 - **Token-Level Policy Gradient Loss**: Critical in long-CoT RL scenarios;
 - **Overlong Reward Shaping**: Reduces reward noise and stabilizes training.
 
-In this guide, we walk through how to enable each of these components in SkyRL. We provide a simple example script for training DAPO on GSM8K in `examples/algorithms/dapo/`.
+In this guide, we walk through how to enable each of these components in SkyRL. We provide a simple example script for training DAPO on GSM8K in `examples/train/algorithms/dapo/`.
 
 ### Clip-Higher
 
@@ -75,9 +75,9 @@ generator:
 ## Soft Overlong Punishment
 
 To enable soft overlong punishment, you can create a custom trainer class and override the `RayPPOTrainer` `postprocess_generator_output` method to additionally apply soft overlong punishment to rewards.
-We provide an example of this in `examples/algorithms/dapo/main_dapo.py`, and show an overview of the implementation below:
+We provide an example of this in `examples/train/algorithms/dapo/main_dapo.py`, and show an overview of the implementation below:
 
-```python title="examples/algorithms/dapo/main_dapo.py"
+```python title="examples/train/algorithms/dapo/main_dapo.py"
 class DAPOTrainer(RayPPOTrainer):
   @torch.no_grad()
   def postprocess_generator_output(self, generator_output: GeneratorOutput, uids: List[str]) -> GeneratorOutput:
@@ -101,17 +101,17 @@ def skyrl_entrypoint(cfg: SkyRLTrainConfig):
 
 To add the overlong buffer length and penalty factor parameters to the config, you can add the following lines to the `run_dapo_gsm8k.sh` script:
 
-```bash title="examples/algorithms/dapo/run_dapo_gsm8k.sh"
+```bash title="examples/train/algorithms/dapo/run_dapo_gsm8k.sh"
 trainer.algorithm.overlong_buffer.len=512 \
 trainer.algorithm.overlong_buffer.penalty_factor=1.0 \
 ```
 
 ### Launching a DAPO Training Run
 
-An example script with all of the above components enabled for basic GSM8K training can be found at `examples/algorithms/dapo/run_dapo_gsm8k.sh`.
+An example script with all of the above components enabled for basic GSM8K training can be found at `examples/train/algorithms/dapo/run_dapo_gsm8k.sh`.
 
 ```bash
 export WANDB_API_KEY=your_wandb_api_key
-bash examples/algorithms/dapo/run_dapo_gsm8k.sh
+bash examples/train/algorithms/dapo/run_dapo_gsm8k.sh
 
 ```

--- a/docs/content/docs/checkpointing-logging/logging.mdx
+++ b/docs/content/docs/checkpointing-logging/logging.mdx
@@ -37,19 +37,19 @@ With default settings this is e.g. `/tmp/skyrl-logs/infra-260212_143052.log`. Ea
 **Normal run** — clean stdout, infrastructure logs to `/tmp/skyrl-logs/infra-YYMMDD_HHMMSS.log`:
 
 ```bash
-bash examples/gsm8k/run_gsm8k.sh
+bash examples/train/gsm8k/run_gsm8k.sh
 ```
 
 **Custom log directory:**
 
 ```bash
-bash examples/gsm8k/run_gsm8k.sh trainer.log_path=/home/user/logs
+bash examples/train/gsm8k/run_gsm8k.sh trainer.log_path=/home/user/logs
 ```
 
 **Dump infrastructure logs to stdout** (no file redirection):
 
 ```bash
-SKYRL_DUMP_INFRA_LOG_TO_STDOUT=1 bash examples/gsm8k/run_gsm8k.sh
+SKYRL_DUMP_INFRA_LOG_TO_STDOUT=1 bash examples/train/gsm8k/run_gsm8k.sh
 ```
 
 ## How It Works
@@ -77,7 +77,7 @@ By default, `trainer.log_path` is `/tmp/skyrl-logs`, which is a **node-local** p
 To consolidate all nodes' infrastructure logs into a **single file**, point `trainer.log_path` at a shared filesystem that is mounted on all nodes, e.g.:
 
 ```bash
-bash examples/gsm8k/run_gsm8k.sh trainer.log_path=/mnt/shared_storage/skyrl-logs
+bash examples/train/gsm8k/run_gsm8k.sh trainer.log_path=/mnt/shared_storage/skyrl-logs
 ```
 
 With a shared filesystem, all actors across all nodes append to the same timestamped log file. Individual log lines remain intact (POSIX atomic append), but lines from different actors will be interleaved.

--- a/docs/content/docs/examples/flash_rl.mdx
+++ b/docs/content/docs/examples/flash_rl.mdx
@@ -29,7 +29,7 @@ At a high level, we sample generations from the inference engine with quantized 
 
 ## Examples
 
-We provide examples for training with FP8 and Int8 rollouts for DAPO. The FlashRL related files are in the `examples/flash_rl/` folder. 
+We provide examples for training with FP8 and Int8 rollouts for DAPO. The FlashRL related files are in the `examples/train/flash_rl/` folder. 
 
 For FP8, you simply need to specify `FLASHRL_CONFIG=fp8_vllm` in your environment variables. 
 
@@ -45,13 +45,13 @@ First, prepare and save the dataset in a chosen `DATA_DIR` by running:
 ```bash
 # execute from SkyRL root directory
 
-DATA_DIR="$HOME/data/dapo" bash examples/algorithms/dapo/prepare_dapo_data.sh
+DATA_DIR="$HOME/data/dapo" bash examples/train/algorithms/dapo/prepare_dapo_data.sh
 
 ```
 
-We highlight some important training parameters configured for FlashRL from our example configuration at `examples/flash_rl/run_dapo_repro_flashrl_32b_int8.sh`:
+We highlight some important training parameters configured for FlashRL from our example configuration at `examples/train/flash_rl/run_dapo_repro_flashrl_32b_int8.sh`:
 
-```bash title="examples/flash_rl/run_dapo_repro_flashrl_32b_int8.sh"
+```bash title="examples/train/flash_rl/run_dapo_repro_flashrl_32b_int8.sh"
 # path for dataset (.parquet files) containing the prompts and metadata for each question
 DATA_DIR="$HOME/data/dapo"
 
@@ -59,7 +59,7 @@ DATA_DIR="$HOME/data/dapo"
 USE_TIS=true
 TIS_IMP_RATIO_CAP=8.0
 
-uv run --isolated --extra flashrl --env-file examples/flash_rl/.env.int8 -m examples.flash_rl.main_dapo_flashrl \
+uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.int8 -m examples.train.flash_rl.main_dapo_flashrl \
     ...
     trainer.algorithm.use_tis=$USE_TIS \
     trainer.algorithm.tis_imp_ratio_cap=$TIS_IMP_RATIO_CAP \
@@ -68,19 +68,19 @@ uv run --isolated --extra flashrl --env-file examples/flash_rl/.env.int8 -m exam
 
 ```
 
-Here, we've configured training to use TIS with the importance sampling ratio cap of 8.0. `generator.sampling_params.logprobs=1` ensures that logprobs for the chosen tokens are returned by the inference engine, which is required for TIS. Note that for making sure the FlashRL patches are applied for vLLM, we use the `FLASHRL_CONFIG` environment variable in `examples/flash_rl/.env.int8`: 
+Here, we've configured training to use TIS with the importance sampling ratio cap of 8.0. `generator.sampling_params.logprobs=1` ensures that logprobs for the chosen tokens are returned by the inference engine, which is required for TIS. Note that for making sure the FlashRL patches are applied for vLLM, we use the `FLASHRL_CONFIG` environment variable in `examples/train/flash_rl/.env.int8`: 
 
-```bash title="examples/flash_rl/.env.int8"
+```bash title="examples/train/flash_rl/.env.int8"
 FLASHRL_CONFIG=LiyuanLucasLiu/Qwen2.5-32B-quantized.w8a8/flashrl_config.yaml
 # FLASHRL_LOGGING_LEVEL=DEBUG <--- optional
 ...
 ```
 
-For a more lightweight example, we also provide scripts for training on Qwen2.5-0.5B-Instruct with Int8 rollouts at `examples/flash_rl/run_dapo_repro_flashrl_0.5b_int8.sh`.
+For a more lightweight example, we also provide scripts for training on Qwen2.5-0.5B-Instruct with Int8 rollouts at `examples/train/flash_rl/run_dapo_repro_flashrl_0.5b_int8.sh`.
 
 ### Training with FP8
 
-The configuration is similar to the Int8 example. The only difference is the value for `FLASHRL_CONFIG` in `examples/flash_rl/.env.0.5b_fp8`. We provide a script for training Qwen2.5-0.5B-Instruct with FP8 rollouts  at `examples/flash_rl/run_dapo_gsm8k_flashrl_0.5b_fp8.sh`.
+The configuration is similar to the Int8 example. The only difference is the value for `FLASHRL_CONFIG` in `examples/train/flash_rl/.env.0.5b_fp8`. We provide a script for training Qwen2.5-0.5B-Instruct with FP8 rollouts  at `examples/train/flash_rl/run_dapo_gsm8k_flashrl_0.5b_fp8.sh`.
 
 ## What does the `FLASHRL_CONFIG` do?
 

--- a/docs/content/docs/examples/llm_as_a_judge.mdx
+++ b/docs/content/docs/examples/llm_as_a_judge.mdx
@@ -94,7 +94,7 @@ NUM_GPUS=4
 NUM_INFERENCE_ENGINES=4
 TP_SIZE=1
 
-uv run --isolated --extra fsdp --env-file .env.llm_judge -m examples.llm_as_a_judge.main_llm_judge \
+uv run --isolated --extra fsdp --env-file .env.llm_judge -m examples.train.llm_as_a_judge.main_llm_judge \
   # Data configuration
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \

--- a/docs/content/docs/examples/llm_as_a_judge.mdx
+++ b/docs/content/docs/examples/llm_as_a_judge.mdx
@@ -25,7 +25,7 @@ The LLM judge provides a binary reward (0 or 1) based on these criteria.
 To download and prepare the dataset, run the following script:
 
 ```bash
-uv run examples/llm_as_a_judge/gsm8k_dataset_judge.py --output_dir $HOME/data/gsm8k_llm_judge
+uv run examples/train/llm_as_a_judge/gsm8k_dataset_judge.py --output_dir $HOME/data/gsm8k_llm_judge
 
 ```
 
@@ -33,7 +33,7 @@ This script downloads the GSM8K dataset, extracts ground truth answers, and form
 
 ## Environment Implementation
 
-The LLM judge environment is implemented in `examples/llm_as_a_judge/llm_judge_env.py`. We use the OpenAI API to access the LLM judge.
+The LLM judge environment is implemented in `examples/train/llm_as_a_judge/llm_judge_env.py`. We use the OpenAI API to access the LLM judge.
 
 The environment sends the following prompt to the judge:
 
@@ -82,7 +82,7 @@ Do not include any explanation after the final score.
 
 The training configuration uses GRPO with colocated training and generation. Key parameters include:
 
-**Training configuration** (from `examples/llm_as_a_judge/run_llm_judge.sh`):
+**Training configuration** (from `examples/train/llm_as_a_judge/run_llm_judge.sh`):
 
 ```bash
 # Data and model paths
@@ -121,7 +121,7 @@ uv run --isolated --extra fsdp --env-file .env.llm_judge -m examples.llm_as_a_ju
   environment.env_class=llm_as_a_judge \
   environment.skyrl_gym.llm_as_a_judge.model="gpt-4o-mini" \
 
-  # Other parameters (see the `examples/llm_as_a_judge/run_llm_judge.sh` for the full script)
+  # Other parameters (see the `examples/train/llm_as_a_judge/run_llm_judge.sh` for the full script)
   ...
 
 ```
@@ -131,7 +131,7 @@ uv run --isolated --extra fsdp --env-file .env.llm_judge -m examples.llm_as_a_ju
 Now you can launch your training run with the following command:
 
 ```bash
-bash examples/llm_as_a_judge/run_llm_judge.sh
+bash examples/train/llm_as_a_judge/run_llm_judge.sh
 
 ```
 

--- a/docs/content/docs/examples/lora.mdx
+++ b/docs/content/docs/examples/lora.mdx
@@ -59,7 +59,7 @@ Here's a complete example of running LoRA training on GSM8K:
 First, prepare your dataset:
 
 ```bash
-uv run examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
+uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 
 ```
 
@@ -115,7 +115,7 @@ Set up your WandB API key and run the training:
 
 ```bash
 export WANDB_API_KEY=your_wandb_api_key
-bash examples/lora/run_qwen2_5_0.5b_gsm8k_grpo_lora.sh
+bash examples/train/lora/run_qwen2_5_0.5b_gsm8k_grpo_lora.sh
 
 ```
 

--- a/docs/content/docs/examples/mini_swe_agent.mdx
+++ b/docs/content/docs/examples/mini_swe_agent.mdx
@@ -10,7 +10,7 @@ In this example, we walk through a simple example on how to train a SWE-Agent on
 
 ## How does it work?
 
-The Mini-SWE-Agent integration with SkyRL can be found in `examples/mini_swe_agent/`. We implement a custom generator `MiniSweAgentGenerator` to use Mini-SWE-Agent to generate trajectories for the SWE-Bench task. 
+The Mini-SWE-Agent integration with SkyRL can be found in `examples/train/mini_swe_agent/`. We implement a custom generator `MiniSweAgentGenerator` to use Mini-SWE-Agent to generate trajectories for the SWE-Bench task. 
 
 ```python
 class MiniSweAgentGenerator(SkyRLGymGenerator):
@@ -72,7 +72,7 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
 
 ```
 
-Note that the full implementation has some additional logic for configuration and error handling, and can be found in `examples/mini_swe_agent/mini_swe_generator.py`.
+Note that the full implementation has some additional logic for configuration and error handling, and can be found in `examples/train/mini_swe_agent/mini_swe_generator.py`.
 
 ## Dataset preparation
 
@@ -82,21 +82,21 @@ Execute the following command:
 
 ```bash
 # execute from SkyRL root directory
-uv run --isolated examples/mini_swe_agent/preprocess_swegym.py --output_dir ~/data/swe_gym_subset
+uv run --isolated examples/train/mini_swe_agent/preprocess_swegym.py --output_dir ~/data/swe_gym_subset
 
 ```
 
 ## Training
 
-Prerequisites: Ensure that you have the required environment backend installed for generating trajectories with Mini-SWE-Agent. By default, we use [Podman](https://podman.io/docs). This can be modified in `examples/mini_swe_agent/swebench.yaml` 
+Prerequisites: Ensure that you have the required environment backend installed for generating trajectories with Mini-SWE-Agent. By default, we use [Podman](https://podman.io/docs). This can be modified in `examples/train/mini_swe_agent/swebench.yaml` 
 
 We provide two example scripts: One for Qwen3-8B model and another for the [Qwen/Qwen3-Coder-30B-A3B-Instruct](https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct) model. While the first script for Qwen3-8B requires a single 8xH100 node, the script for the 30B model requires 2 8xH100 nodes for training.
 
 ```bash
 # execute from SkyRL root directory
-bash examples/mini_swe_agent/run_mini_swe_8B.sh
+bash examples/train/mini_swe_agent/run_mini_swe_8B.sh
 # or for 30B:
-# bash examples/mini_swe_agent/run_mini_swe_30B.sh
+# bash examples/train/mini_swe_agent/run_mini_swe_30B.sh
 
 ```
 

--- a/docs/content/docs/examples/multi_turn_text2sql.mdx
+++ b/docs/content/docs/examples/multi_turn_text2sql.mdx
@@ -77,7 +77,7 @@ unzip <path_to_file.zip>
 
 Now that we have our dataset and database files, let's walk through the some of the key training configurations.
 
-```bash title="examples/text_to_sql/run_skyrl_sql.sh"
+```bash title="examples/train/text_to_sql/run_skyrl_sql.sh"
 # path for dataset (.parquet files) containing the prompts and metadata for each question
 DATA_DIR="$HOME/data/sql"
 # path for .db files for environment interaction
@@ -142,7 +142,7 @@ uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
     trainer.eval_batch_size=1024 \
     trainer.eval_before_train=true \
     trainer.eval_interval=5 \
-    ... # Other parameters (see `examples/text_to_sql/run_skyrl_sql.sh` for the full script)
+    ... # Other parameters (see `examples/train/text_to_sql/run_skyrl_sql.sh` for the full script)
 
 ```
 
@@ -154,7 +154,7 @@ uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
   - In the above example, we set `use_conversation_multi_turn=false` to enforce that the multi-turn conversation is formatted as a single assistant response.
   - We also set `stop='["</sql>", "</solution>"]'` for both `sampling_params` and `eval_sampling_params` as a part
     of the training recipe.
-  - If you are using `generator.use_conversation_multi_turn=true`, you might want to append an EOS token ID to the end of the response after these stop strings to adhere to the model's behavior (i.e. ending generation with an EOS token ID rather than say `</solution>`). This can be done by setting `generator.append_eos_token_after_stop_str_in_multi_turn=true` in the generator config. The full script is available in `examples/text_to_sql/run_skyrl_sql_conversation_format.sh`.
+  - If you are using `generator.use_conversation_multi_turn=true`, you might want to append an EOS token ID to the end of the response after these stop strings to adhere to the model's behavior (i.e. ending generation with an EOS token ID rather than say `</solution>`). This can be done by setting `generator.append_eos_token_after_stop_str_in_multi_turn=true` in the generator config. The full script is available in `examples/train/text_to_sql/run_skyrl_sql_conversation_format.sh`.
   - If you want to use a conversation-based format, you can set `use_conversation_multi_turn=true` and the model will generate a separate assistant response for each turn. This is supported only with `backend="vllm"` as of now.
   - See `skyrl/train/generators/skyrl_gym_generator.py` for more details on both options!
 
@@ -164,7 +164,7 @@ Let's get our training run started! Make sure to set your WandB API key for logg
 
 ```bash
 export WANDB_API_KEY=your_wandb_api_key
-bash examples/text_to_sql/run_skyrl_sql.sh
+bash examples/train/text_to_sql/run_skyrl_sql.sh
 
 ```
 

--- a/docs/content/docs/examples/ppo.mdx
+++ b/docs/content/docs/examples/ppo.mdx
@@ -13,13 +13,13 @@ This example demonstrates how to run PPO training on GSM8K. See [Quick Start Gui
 To download and prepare the GSM8K dataset, run the following script.
 
 ```bash
-uv run --isolated examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
+uv run --isolated examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 
 ```
 
 ## Training Configuration
 
-Next, let's set up the training configuration. You can find a complete example in `examples/ppo/run_ppo.sh` - we highlight some key parameters here:
+Next, let's set up the training configuration. You can find a complete example in `examples/train/ppo/run_ppo.sh` - we highlight some key parameters here:
 
 ```bash
 uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
@@ -60,7 +60,7 @@ uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
    # Can be specified here to apply to the full dataset, or at the per-prompt level during preprocessing
    environment.env_class=gsm8k \
 
-   ... # Other parameters (see `examples/ppo/run_ppo.sh` for more)
+   ... # Other parameters (see `examples/train/ppo/run_ppo.sh` for more)
 
 ```
 
@@ -86,7 +86,7 @@ export WANDB_API_KEY=your_wandb_api_key
 Then launch your training run:
 
 ```bash
-bash examples/ppo/run_ppo.sh
+bash examples/train/ppo/run_ppo.sh
 
 ```
 

--- a/docs/content/docs/examples/remote_server.mdx
+++ b/docs/content/docs/examples/remote_server.mdx
@@ -25,7 +25,7 @@ In addition to the standard OpenAI-compatible generation endpoints (`/v1/chat/co
 
 That's it! We use a custom `WorkerWrap` class at `skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py` with VLLM's worker extension API to enable efficient NCCL weight updates.
 
-To launch the server, run the following command (the full script is at `examples/remote_inference_engine/run_vllm_server.sh`):
+To launch the server, run the following command (the full script is at `examples/train/remote_inference_engine/run_vllm_server.sh`):
 
 ```bash
 uv run --isolated --extra fsdp -m skyrl.backends.skyrl_train.inference_engines.vllm.vllm_server \
@@ -65,7 +65,7 @@ uv run --isolated --extra fsdp -m skyrl.backends.skyrl_train.inference_engines.v
 
 Now that we've started our remote inference engine (located behind `127.0.0.1:8001`), we can start a training run!
 
-To start training, we need to set up our training script. You can find a complete example in `examples/remote_inference_engine/run_remote.sh`:
+To start training, we need to set up our training script. You can find a complete example in `examples/train/remote_inference_engine/run_remote.sh`:
 
 ```bash
 uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
@@ -106,7 +106,7 @@ uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
     trainer.eval_before_train=true \
     trainer.eval_interval=5 \
 
-    ... # Other parameters (see `examples/remote_inference_engine/run_remote.sh` for more)
+    ... # Other parameters (see `examples/train/remote_inference_engine/run_remote.sh` for more)
 
 ```
 
@@ -120,7 +120,7 @@ You're done setting up! Now let's get our training run started!
 
 ```bash
 export WANDB_API_KEY=your_wandb_api_key
-bash examples/remote_inference_engine/run_remote.sh
+bash examples/train/remote_inference_engine/run_remote.sh
 
 ```
 

--- a/docs/content/docs/examples/search.mdx
+++ b/docs/content/docs/examples/search.mdx
@@ -39,7 +39,7 @@ A reward of 0 is given for incorrect responses, and a reward of 1 is given for c
 
 Let's walk through configuration for running GRPO to train a 4-turn search agent on the SearchR1 dataset
 
-```bash title="examples/search/run_search.sh"
+```bash title="examples/train/search/run_search.sh"
 # path for dataset (.parquet files) containing the prompts and metadata for each question
 DATA_DIR="$HOME/data/searchR1"
 
@@ -116,7 +116,7 @@ uv run --isolated --frozen --extra fsdp -m skyrl.train.entrypoints.main_base \
     generator.eval_sampling_params.temperature=0 \
     generator.eval_sampling_params.stop='["</search>", "</answer>"]' \
     trainer.eval_interval=50 \
-    ... # logging + checkpointing configuration (see `examples/search/run_search.sh` for the full script)
+    ... # logging + checkpointing configuration (see `examples/train/search/run_search.sh` for the full script)
 
 ```
 
@@ -130,7 +130,7 @@ If you are using `generator.use_conversation_multi_turn=true`,
 you might want to append an EOS token ID to the end of the response after these stop strings to adhere
 to the model's behavior (i.e. ending generation with an EOS token ID rather than say `</answer>`).
 This can be done by setting `generator.append_eos_token_after_stop_str_in_multi_turn=true` in the generator config.
-The full script is available in `examples/search/run_search_conversation_format.sh`.
+The full script is available in `examples/train/search/run_search_conversation_format.sh`.
 
 ## Launching Your Training Run
 
@@ -138,7 +138,7 @@ Let's get our training run started! Make sure your WandB API key is set, your da
 
 ```bash
 export WANDB_API_KEY=your_wandb_api_key
-bash examples/search/run_search.sh
+bash examples/train/search/run_search.sh
 
 ```
 

--- a/docs/content/docs/getting-started/development.mdx
+++ b/docs/content/docs/getting-started/development.mdx
@@ -10,16 +10,16 @@ Follow the [installation guide](installation). Make sure that the installation w
 ## Modifying the code
 
 **Adding a new environment or task?**
-Follow the [new task tutorial](../tutorials/new_env). Your custom code can be placed anywhere - building on top of `skyrl` as a package - but we recommend structuring it as a folder similar to `examples/multiply`.
+Follow the [new task tutorial](../tutorials/new_env). Your custom code can be placed anywhere - building on top of `skyrl` as a package - but we recommend structuring it as a folder similar to `examples/train/multiply`.
 
 **Creating a custom Generator (ex: porting an agent harness, implementing custom trajectory generation logic, etc.)?**
-Same as the above: your custom code can be placed anywhere and we typically use `examples/train/` for this. See `examples/mini_swe_agent` for an example of creating a custom `Generator` for [Mini-SWE-Agent](https://github.com/SWE-agent/mini-swe-agent).
+Same as the above: your custom code can be placed anywhere and we typically use `examples/train/` for this. See `examples/train/mini_swe_agent` for an example of creating a custom `Generator` for [Mini-SWE-Agent](https://github.com/SWE-agent/mini-swe-agent).
 
 **Looking to add a new algorithm by changing your advantage estimator or policy loss?**
-Follow the guide for [implementing custom algorithms](../algorithms/custom_algorithms). See `examples/algorithms` for examples of various custom algorithm implementations.
+Follow the guide for [implementing custom algorithms](../algorithms/custom_algorithms). See `examples/train/algorithms` for examples of various custom algorithm implementations.
 
 **Looking to modify the training loop for full control?**
-Follow the guide for [creating a custom trainer](../algorithms/custom_algorithms#creating-a-custom-trainer). See `examples/algorithms/dapo/main_dapo.py` for an example of how to modify the Trainer class for DAPO.
+Follow the guide for [creating a custom trainer](../algorithms/custom_algorithms#creating-a-custom-trainer). See `examples/train/algorithms/dapo/main_dapo.py` for an example of how to modify the Trainer class for DAPO.
 
 **Modifying the existing environment code (ex: adding a custom method for all Env classes, improving the SearchEnv implementation)?**
 You would modify the code in [skyrl-gym](https://github.com/NovaSky-AI/SkyRL/tree/main/skyrl-gym/). Note: you do **not** have to modify the `skyrl-gym` package for adding a new environment or task. 

--- a/docs/content/docs/getting-started/quickstart.mdx
+++ b/docs/content/docs/getting-started/quickstart.mdx
@@ -15,13 +15,13 @@ You'll prepare the dataset, configure your training parameters, and launch your 
 To download and prepare the GSM8K dataset, run the following script. We provide convenience scripts for GSM8K and several other popular datasets, but you can also use your own custom dataset by following the instructions in the [dataset-preparation](#dataset-preparation) section.
 
 ```bash
-uv run --isolated examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
+uv run --isolated examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 
 ```
 
 ## Training Configuration
 
-Next, let's set up the training configuration. You can find a complete example in `examples/gsm8k/run_gsm8k.sh`, and we highlight some key parameters here:
+Next, let's set up the training configuration. You can find a complete example in `examples/train/gsm8k/run_gsm8k.sh`, and we highlight some key parameters here:
 
 ```bash
 uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
@@ -59,7 +59,7 @@ uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
    trainer.project_name="gsm8k" \
    trainer.run_name="gsm8k_test" \
 
-   ... # Other parameters (see `examples/gsm8k/run_gsm8k.sh` for more)
+   ... # Other parameters (see `examples/train/gsm8k/run_gsm8k.sh` for more)
 
 ```
 
@@ -87,7 +87,7 @@ export WANDB_API_KEY=your_wandb_api_key
 Then launch your training run:
 
 ```bash
-bash examples/gsm8k/run_gsm8k.sh
+bash examples/train/gsm8k/run_gsm8k.sh
 
 ```
 

--- a/docs/content/docs/recipes/overview.mdx
+++ b/docs/content/docs/recipes/overview.mdx
@@ -14,7 +14,7 @@ We provide reproduction runs for the following recipes:
 
 ### Simple training on GSM8K
 
-The scripts for training on GSM8K are available at `examples/gsm8k/`.
+The scripts for training on GSM8K are available at `examples/train/gsm8k/`.
 
 <style>{`
   table.skytable {
@@ -70,7 +70,7 @@ The scripts for training on GSM8K are available at `examples/gsm8k/`.
 
 ### DAPO Recipes
 
-The code for the DAPO recipe is available at `examples/algorithms/dapo/`. 
+The code for the DAPO recipe is available at `examples/train/algorithms/dapo/`. 
 
 For evals we report Pass@32 and Mean@32. In the WandB metrics we log "avg_score" - since reward is either -1 or 1 for the AIME task, mean@32 can be computed as mean@32 = (avg_score + 1) / 2. 
 In the table below we report the peak mean@32 and pass@32 over the course of the run. All runs are DAPO but without Dynamic Sampling enabled (just clip-higher, overlong buffer, overlong filtering, and token level loss aggregation).

--- a/docs/content/docs/recipes/searchr1.mdx
+++ b/docs/content/docs/recipes/searchr1.mdx
@@ -15,7 +15,7 @@ Make sure to have followed the installation commands in [Installation Guide](../
 We provide a script to download the dataset from huggingface, and preprocess it to run in SkyRL-Gym.
 
 ```bash
-uv run --isolated examples/search/searchr1_dataset.py --local_dir ~/data/searchR1
+uv run --isolated examples/train/search/searchr1_dataset.py --local_dir ~/data/searchR1
 
 ```
 
@@ -52,7 +52,7 @@ pip install uvicorn fastapi
 conda activate retriever
 
 local_dir=~/data/searchR1
-python examples/search/searchr1_download.py --local_dir $local_dir
+python examples/train/search/searchr1_download.py --local_dir $local_dir
 cat $local_dir/part_* > $local_dir/e5_Flat.index
 gzip -d $local_dir/wiki-18.jsonl.gz
 
@@ -61,7 +61,7 @@ gzip -d $local_dir/wiki-18.jsonl.gz
 ### Prepare Datasets
 
 ```bash
-python examples/search/searchr1_dataset.py --local_dir $local_dir
+python examples/train/search/searchr1_dataset.py --local_dir $local_dir
 
 ```
 
@@ -72,7 +72,7 @@ conda activate retriever
 
 # redirect the output to a file to avoid cluttering the terminal
 # we have observed outputting to the terminal causing spikes in server response times
-bash examples/search/retriever/retrieval_launch.sh > retrieval_server.log 
+bash examples/train/search/retriever/retrieval_launch.sh > retrieval_server.log 
 
 ```
 
@@ -82,7 +82,7 @@ Now from your base environment, you can launch your training run (which will use
 
 ```bash
 export WANDB_API_KEY=your_wandb_api_key
-bash examples/search/run_search.sh
+bash examples/train/search/run_search.sh
 
 ```
 

--- a/docs/content/docs/recipes/skyrl-sql.mdx
+++ b/docs/content/docs/recipes/skyrl-sql.mdx
@@ -45,10 +45,10 @@ unzip <path_to_file.zip>
 
 ## Running the scripts
 
-We provide a script `examples/text_to_sql/run_skyrl_sql.sh` for reproducing the results for SkyRL-SQL-7B. Make sure to substitute the `DB_PATH`  and `DATA_PATH` variables with your own.
+We provide a script `examples/train/text_to_sql/run_skyrl_sql.sh` for reproducing the results for SkyRL-SQL-7B. Make sure to substitute the `DB_PATH`  and `DATA_PATH` variables with your own.
 
 ```bash
 export WANDB_API_KEY=<wandb-api-key>
-bash examples/text_to_sql/run_skyrl_sql.sh
+bash examples/train/text_to_sql/run_skyrl_sql.sh
 
 ```

--- a/docs/content/docs/tutorials/fully_async.mdx
+++ b/docs/content/docs/tutorials/fully_async.mdx
@@ -76,7 +76,7 @@ Following [examples/train/fully_async/main_fully_async.py](https://github.com/No
 Following [examples/train/fully_async/fully_async_run_gsm8k.sh](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/fully_async/fully_async_run_gsm8k.sh), update the training configuration to use your new entrypoint `main_async.py`:
 
 ```bash
-uv run --isolated --extra fsdp -m examples.train.fully_async.main_async \
+uv run --isolated --extra fsdp -m examples.train.fully_async.main_fully_async \
 ...
 
 ```

--- a/docs/content/docs/tutorials/fully_async.mdx
+++ b/docs/content/docs/tutorials/fully_async.mdx
@@ -60,20 +60,20 @@ The fully async trainer class is implemented in `fully_async_trainer.py::FullyAs
 
 This trainer class is generator-agnostic, meaning it can support any generator that implements the `GeneratorInterface` interface, including your arbitrary agent harness.
 
-We provide an example script in `examples/fully_async`, where we train Qwen2.5-1.5B-Instruct on GSM8K with the fully async approach.
+We provide an example script in `examples/train/fully_async`, where we train Qwen2.5-1.5B-Instruct on GSM8K with the fully async approach.
 
 We break down the usage into two simple steps.
 
 ### Step 1: Define your `main_async.py`
 
-Following [examples/fully_async/main_fully_async.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/fully_async/main_fully_async.py), subclass the base entrypoint class `BasePPOExp`:
+Following [examples/train/fully_async/main_fully_async.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/fully_async/main_fully_async.py), subclass the base entrypoint class `BasePPOExp`:
 
 - Override `get_trainer()` to use fully async trainer class `FullyAsyncRayPPOTrainer`
 - Override `get_generator()` to use your custom generator class. Note that currently we only support generators that use `/chat/completions` (hence the `SkyRLGymHTTPGenerator` used in the example).
 
 ### Step 2: Config knobs to tune for fully async training
 
-Following [examples/fully_async/fully_async_run_gsm8k.sh](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/fully_async/fully_async_run_gsm8k.sh), update the training configuration to use your new entrypoint `main_async.py`:
+Following [examples/train/fully_async/fully_async_run_gsm8k.sh](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/fully_async/fully_async_run_gsm8k.sh), update the training configuration to use your new entrypoint `main_async.py`:
 
 ```bash
 uv run --isolated --extra fsdp -m examples.fully_async.main_async \

--- a/docs/content/docs/tutorials/fully_async.mdx
+++ b/docs/content/docs/tutorials/fully_async.mdx
@@ -76,7 +76,7 @@ Following [examples/train/fully_async/main_fully_async.py](https://github.com/No
 Following [examples/train/fully_async/fully_async_run_gsm8k.sh](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/fully_async/fully_async_run_gsm8k.sh), update the training configuration to use your new entrypoint `main_async.py`:
 
 ```bash
-uv run --isolated --extra fsdp -m examples.fully_async.main_async \
+uv run --isolated --extra fsdp -m examples.train.fully_async.main_async \
 ...
 
 ```

--- a/docs/content/docs/tutorials/new_env.mdx
+++ b/docs/content/docs/tutorials/new_env.mdx
@@ -191,7 +191,7 @@ def skyrl_entrypoint(cfg: SkyRLTrainConfig):
    # this needs to be done inside the entrypoint task
    register(
       id="multiply",  # <-- The name of the environment.
-      entry_point="examples.multiply.env:MultiplyEnv",  # <-- The path to the environment class.
+      entry_point="examples.train.multiply.env:MultiplyEnv",  # <-- The path to the environment class.
    )
 
    # make sure that the training loop is not run on the head node.

--- a/docs/content/docs/tutorials/new_env.mdx
+++ b/docs/content/docs/tutorials/new_env.mdx
@@ -7,7 +7,7 @@ To demonstrate how to create custom environments in SkyRL-Gym and train with Sky
 
 We'll walk through the complete process: implementing the environment, registering it, preparing training data, and running your first training session.
 
-**What we're building:** An environment that asks the model to multiply numbers and checks if the answer is correct. The completed code is available at [examples/multiply](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply).
+**What we're building:** An environment that asks the model to multiply numbers and checks if the answer is correct. The completed code is available at [examples/train/multiply](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply).
 
 ## Environment Interface
 
@@ -94,7 +94,7 @@ We will make a few simple extensions to our `step()` method:
   - Incorrect answer, and not in format of `\\boxed{...}`: 0.0.
 - If the model is incorrect and has more turns remaining, we also provide feedback as a new `observation`.
 
-**Multi-turn multiplication environment in [examples/multiply/env.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply/env.py)**:
+**Multi-turn multiplication environment in [examples/train/multiply/env.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply/env.py)**:
 
 ```python
 def step(self, action: str) -> BaseTextEnvStepOutput:
@@ -142,7 +142,7 @@ def step(self, action: str) -> BaseTextEnvStepOutput:
 
 The multi-turn version gives partial credit for formatting the answer correctly, even if it's wrong. This helps the model learn the expected output format.
 
-The final implementation is available in [examples/multiply/env.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply/env.py).
+The final implementation is available in [examples/train/multiply/env.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply/env.py).
 
 ## (Turn-level) Rewards And Metrics
 
@@ -180,9 +180,9 @@ If there is only an outcome reward of `1.0` (i.e. intermediate turns' rewards ar
 
 Finally, we need to `register` the new environment so the training stack can find it by name (which we refer to as `env_class`). We will name this environment `multiply`.
 
-We will create a new entrypoint for training with the `multiply` environment by creating a file at `examples/multiply/main_multiply.py` that looks like this:
+We will create a new entrypoint for training with the `multiply` environment by creating a file at `examples/train/multiply/main_multiply.py` that looks like this:
 
-**Environment registration at [examples/multiply/main_multiply.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply/main_multiply.py)**:
+**Environment registration at [examples/train/multiply/main_multiply.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply/main_multiply.py)**:
 
 ```python
 @ray.remote(num_cpus=1)
@@ -220,7 +220,7 @@ All example code written in this document is *outside* of the `skyrl` and `skyrl
 
 Before we can train, we need a dataset of problems to train on.
 
-We can generate a dataset of multiplication problems using [examples/multiply/multiply_dataset.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply/multiply_dataset.py). See the file for more details, but the core idea is to generate random multiplication problems of n-digit numbers, and ensure the dataset example is in the correct format:
+We can generate a dataset of multiplication problems using [examples/train/multiply/multiply_dataset.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply/multiply_dataset.py). See the file for more details, but the core idea is to generate random multiplication problems of n-digit numbers, and ensure the dataset example is in the correct format:
 
 **Generating a dataset of random multiplication problems.**:
 
@@ -258,7 +258,7 @@ See the doc on [Dataset Preparation](../datasets/dataset-preparation) for more d
 Now we can generate the datsaet:
 
 ```bash title="Generate training data"
-uv run --isolated examples/multiply/multiply_dataset.py \
+uv run --isolated examples/train/multiply/multiply_dataset.py \
   --output_dir $HOME/data/multiply \
   --num_digits 4 \
   --train_size 10000 \
@@ -271,7 +271,7 @@ This creates `train.parquet` and `validation.parquet` files in the `$HOME/data/m
 
 Time to train! 🚀
 
-We will use the `run_multiply.sh` script to train the model. This script is located in [examples/multiply/run_multiply.sh](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply/run_multiply.sh), which sets up the training configuration and calls `main_multiply.py`.
+We will use the `run_multiply.sh` script to train the model. This script is located in [examples/train/multiply/run_multiply.sh](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/multiply/run_multiply.sh), which sets up the training configuration and calls `main_multiply.py`.
 
 **Common Configuration Parameters**
 
@@ -286,7 +286,7 @@ Then, configure how the environment should be executed. For multi-turn environme
 
 ```bash title="Run training"
 export WANDB_API_KEY=your_wandb_api_key  # or set trainer.logger="console" to print to stdout
-bash examples/multiply/run_multiply.sh
+bash examples/train/multiply/run_multiply.sh
 ```
 
 **Next Steps:** Want to make multiplication easier? Try integrating a calculator tool into your environment! Check out the [tools_guide](tools_guide) documentation for details.

--- a/docs/content/docs/tutorials/one_step_off_async.mdx
+++ b/docs/content/docs/tutorials/one_step_off_async.mdx
@@ -107,7 +107,7 @@ uv run --isolated --extra fsdp -m examples.train.async.main_async \
 
 Key configuration changes:
 
-* **examples.async.main_async**: Point the bash script to the new entrypoint
+* **examples.train.async.main_async**: Point the bash script to the new entrypoint
 * **colocate_all=false, colocate_policy_ref=true**: Disables colocation of generation and training models (but keeps the policy and reference models colocated).
 
 Now we can train!

--- a/docs/content/docs/tutorials/one_step_off_async.mdx
+++ b/docs/content/docs/tutorials/one_step_off_async.mdx
@@ -35,7 +35,7 @@ The original `train()` method performs generation and training sequentially, so 
 
 The generation loop passes the training loop completed trajectories via an `asyncio.Queue` and coordinates weight synchronization using asyncio events.
 
-We include a minimal version here, please see [examples/async/async_trainer.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/async/async_trainer.py) for full details:
+We include a minimal version here, please see [examples/train/async/async_trainer.py](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/async/async_trainer.py) for full details:
 
 ```python
 class AsyncRayPPOTrainer(RayPPOTrainer):
@@ -114,10 +114,10 @@ Now we can train!
 
 ```bash
 # Prepare the dataset
-uv run --isolated examples/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
+uv run --isolated examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 
  # Run the training script
 export WANDB_API_KEY=your_wandb_api_key  # or set trainer.logger="console" to print to stdout
-bash examples/async/async_run_gsm8k.sh
+bash examples/train/async/async_run_gsm8k.sh
 
 ```

--- a/docs/content/docs/tutorials/one_step_off_async.mdx
+++ b/docs/content/docs/tutorials/one_step_off_async.mdx
@@ -8,7 +8,7 @@ Async training is supported with the `fsdp` and `megatron` backends.
 
 This example demonstrates how to implement asynchronous training with one-off pipelining, showcasing the flexibility of the training framework to support different execution plans with minimal code changes.
 
-The complete code from this example is available at [examples/async](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/async).
+The complete code from this example is available at [examples/train/async](https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train/async).
 
 ## Overview
 

--- a/docs/content/docs/tutorials/one_step_off_async.mdx
+++ b/docs/content/docs/tutorials/one_step_off_async.mdx
@@ -95,7 +95,7 @@ That's it! The rest of the entrypoint logic for launching the training run remai
 Finally, we modify the training configuration to use our new entrypoint and disable model colocation:
 
 ```bash
-uv run --isolated --extra fsdp -m examples.async.main_async \
+uv run --isolated --extra fsdp -m examples.train.async.main_async \
   trainer.placement.colocate_all=false \
   trainer.placement.colocate_policy_ref=true \
   trainer.placement.policy_num_gpus_per_node=4 \


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
