### PR TITLE
[train] Fix `There is no current event loop in thread 'MainThread'.`

### DIFF
--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -18,9 +18,9 @@ import httpx
 import pytest
 import ray
 import torch
-import asyncio
 import argparse
 
+import pytest_asyncio
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from transformers import AutoModelForCausalLM
@@ -141,8 +141,8 @@ class Trainer:
         torch.cuda.synchronize()
 
 
-@pytest.fixture(scope="class")
-def weight_update_env(ray_init_fixture):
+@pytest_asyncio.fixture(scope="class")
+async def weight_update_env(ray_init_fixture):
     """
     Create environment for weight update testing.
 
@@ -211,7 +211,7 @@ def weight_update_env(ray_init_fixture):
         "client": client,
     }
 
-    asyncio.get_event_loop().run_until_complete(client.teardown())
+    await client.teardown()
     router.shutdown()
 
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -215,10 +215,10 @@ async def weight_update_env(ray_init_fixture):
     router.shutdown()
 
 
+@pytest.mark.asyncio(loop_scope="class")
 class TestWeightUpdateFlow:
     """Tests for weight synchronization from trainer to inference server (non-colocated)."""
 
-    @pytest.mark.asyncio
     async def test_update_weights_flow(self, weight_update_env):
         """
         Full E2E weight sync test (non-colocated, NCCL broadcast):


### PR DESCRIPTION
# What does this PR do?

Fixes GPU CI failure seen on CI:

```bash
ERROR tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py::TestWeightUpdateFlow::test_update_weights_flow - RuntimeError: There is no current event loop in thread 'MainThread'.
```

```bash
            MODEL,
            tp_size=2,
            load_format="dummy",
            gpu_memory_utilization=0.5,
        )
        start_port = get_open_port()
    
        # 4 bundles: trainer on 0-1, server on 2-3
        pg = placement_group([{"CPU": 1, "GPU": 1} for _ in range(4)])
        ray.get(pg.ready())
    
        # Trainer on bundle 0 (uses GPU 0-1 with TP=2 via the model itself)
        trainer = Trainer.options(
            num_gpus=1.0,
            scheduling_strategy=PlacementGroupSchedulingStrategy(
                placement_group=pg,
                placement_group_bundle_index=0,
            ),
        ).remote(MODEL)
    
        ray.get(trainer.ready.remote())
    
        # Server on bundles 2-3 (separate from trainer)
        group = ServerGroup(
            cli_args=cli_args,
            num_servers=1,
            start_port=start_port,
            placement_group=pg,
            placement_group_bundle_offset=2,
        )
        server_infos = group.start()
        server_urls = [info.url for info in server_infos]
    
        for url in server_urls:
            assert wait_for_url(url), f"Server {url} failed to start"
    
        # Create router
        router_port = get_open_port()
        router = InferenceRouter(server_urls, host="0.0.0.0", port=router_port)
        router_url = router.start()
        assert wait_for_url(router_url), "Router failed to start"
    
        # Create RemoteInferenceClient for control plane operations
        client = RemoteInferenceClient(
            proxy_url=router_url,
            server_urls=server_urls,
            model_name=MODEL,
        )
    
        yield {
            "group": group,
            "server_urls": server_urls,
            "router": router,
            "router_url": router_url,
            "trainer": trainer,
            "client": client,
        }
    
>       asyncio.get_event_loop().run_until_complete(client.teardown())
        ^^^^^^^^^^^^^^^^^^^^^^^^

tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py:214: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <asyncio.unix_events._UnixDefaultEventLoopPolicy object at 0x75a9b87eac60>

    def get_event_loop(self):
        """Get the event loop for the current context.
    
        Returns an instance of EventLoop or raises an exception.
        """
        if (self._local._loop is None and
                not self._local._set_called and
                threading.current_thread() is threading.main_thread()):
            stacklevel = 2
            try:
                f = sys._getframe(1)
            except AttributeError:
                pass
            else:
                # Move up the call stack so that the warning is attached
                # to the line outside asyncio itself.
                while f:
                    module = f.f_globals.get('__name__')
                    if not (module == 'asyncio' or module.startswith('asyncio.')):
                        break
                    f = f.f_back
                    stacklevel += 1
            import warnings
            warnings.warn('There is no current event loop',
                          DeprecationWarning, stacklevel=stacklevel)
            self.set_event_loop(self.new_event_loop())
    
        if self._local._loop is None:
>           raise RuntimeError('There is no current event loop in thread %r.'
                               % threading.current_thread().name)
E           RuntimeError: There is no current event loop in thread 'MainThread'.

/home/ray/anaconda3/lib/python3.12/asyncio/events.py:702: RuntimeError
```

Running the test file individually (`pytest tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py`) doesn't reproduce the issue. However, running all the tests in `inference_servers/` folder together reproduces the issue:

```bash
 uv run --isolated --extra fsdp --extra dev -- pytest -s -vv tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/
 ```

This is likely because while executing all the tests in the same pytest session (i.e the same main thread), a previous test uses `asyncio.run` which is incompatible with `asyncio.get_event_loop`. 

The fix is to just use an async fixture 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
