### PR TITLE
[fix] Fix cuda ipc weight sync after #1271

### DIFF
--- a/skyrl/backends/skyrl_train/weight_sync/cuda_ipc_strategy.py
+++ b/skyrl/backends/skyrl_train/weight_sync/cuda_ipc_strategy.py
@@ -128,7 +128,11 @@ class CudaIpcWeightTransferSender(WeightTransferSender):
         self._init_info = init_info
         self._inference_client = inference_client
 
-    async def send_chunks(self, chunks: Iterable[WeightChunk]) -> None:
+    async def send_chunks(
+        self,
+        chunks: Iterable[WeightChunk],
+        weight_metadata: Optional[Dict[str, list]] = None,
+    ) -> None:
         """Send chunks via CUDA IPC with packed tensors.
 
         Each chunk can contain multiple parameters. All tensors in a chunk are
@@ -138,6 +142,8 @@ class CudaIpcWeightTransferSender(WeightTransferSender):
 
         Args:
             chunks: Iterable of WeightChunk objects to send.
+            weight_metadata: Pre-computed metadata (unused by CUDA IPC path,
+                accepted for interface compatibility).
         """
         rank = torch.distributed.get_rank()
         world_size = torch.distributed.get_world_size()


### PR DESCRIPTION
Fixes the following error encountered after #1271 when running colocated training w/ cuda ipc weight sync


```bash
                                  ^^^^^^^^^^^^^^^^^^^
ray.exceptions.RayTaskError(TypeError): ray::FSDPPolicyWorkerBase.broadcast_to_inference_engines() (pid=238850, ip=10.0.135.49, actor_id=17e6181c4a6c57b58e04aee108000000, repr=<skyrl.backends.skyrl_train.workers.fsdp.fsdp_worker.FSDPPolicyWorkerBase object at 0x7d820dd11df0>)
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-03-06_17-46-17_343270_6070/runtime_resources/working_dir_files/_ray_pkg_3a51306235ee6269/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py", line 256, in broadcast_to_inference_engines
    await self._weight_transfer_sender.send_chunks(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: CudaIpcWeightTransferSender.send_chunks() got an unexpected keyword argument 'weight_metadata'
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
