### PR TITLE
Skip output_router_logits for granitemoehybrid models

### DIFF
--- a/skyrl/backends/skyrl_train/workers/model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/model_wrapper.py
@@ -169,7 +169,9 @@ class HFModelWrapper(nn.Module):
                 # logits, so enabling this flag causes an IndexError in
                 # load_balancing_loss_func when it tries to access empty gate_logits.
                 if model_config.get("model_type") == "granitemoehybrid":
-                    logger.info("[MoE] granitemoehybrid detected, skipping output_router_logits (decoder layers don't return router logits)")
+                    logger.info(
+                        "[MoE] granitemoehybrid detected, skipping output_router_logits (decoder layers don't return router logits)"
+                    )
                 else:
                     logger.info("[MoE] set output_router_logits as True")
                     self.model.config.output_router_logits = True
@@ -604,7 +606,9 @@ def get_llm_for_sequence_regression(
     model_config = model.config.to_dict()
     if "output_router_logits" in model_config:
         if model_config.get("model_type") == "granitemoehybrid":
-            logger.info("[MoE] granitemoehybrid detected, skipping output_router_logits (decoder layers don't return router logits)")
+            logger.info(
+                "[MoE] granitemoehybrid detected, skipping output_router_logits (decoder layers don't return router logits)"
+            )
         else:
             logger.info("[MoE] set output_router_logits as True")
             model.config.output_router_logits = True


### PR DESCRIPTION
Hi!!
I was trying to use SkyRL to do RL alignment for the Granite 4.0 models (e.g., [granite-4.0-micro](https://huggingface.co/ibm-granite/granite-4.0-micro)). These models use a hybrid Mamba + Attention +  MoE architecture where the decoder layers don't return router logits in their output tuples.

This causes an `IndexError` during training because SkyRL unconditionally sets `output_router_logits=True` for any model that has this field in its config (`model_wrapper.py`). When the ForCausalLM wrapper then calls load_balancing_loss_func with the empty gate_logits tuple, it crashes:

```python
transformers/models/granitemoehybrid/modeling_granitemoehybrid.py, line 1752, in forward
      aux_loss = load_balancing_loss_func(
  transformers/models/granitemoehybrid/modeling_granitemoehybrid.py, line 1598, in load_balancing_loss_func
      compute_device = gate_logits[0].device
  IndexError: tuple index out of range
```

This PR skips setting `output_router_logits=True` when `model_type == "granitemoehybrid"`, fixing training for Granite hybrid MoE models.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
