### PR TITLE
[CI] Skip FlashRL integration test in CI and fix failing generation test for new inference codepath

### DIFF
--- a/ci/gpu_ci_run_skyrl_train.sh
+++ b/ci/gpu_ci_run_skyrl_train.sh
@@ -20,14 +20,15 @@ uv run --directory . --isolated --extra dev --extra fsdp pytest -s tests/backend
 #     echo "$add_integrations"
 # fi
 
+# TODO (sumanthrh): Migrate flashrl to vllm 0.16.0 and renable integration test
 # Run tests for vllm 0.9.2
 # TODO (sumanthrh): We should have a better way to override without pinning a flash-attn wheel
-uv run --isolated --extra fsdp --extra dev \
-    --with vllm==0.9.2 \
-    --with transformers==4.53.0 \
-    --with torch==2.7.0 \
-    --with "flash-attn@https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.7cxx11abiTRUE-cp312-cp312-linux_x86_64.whl" \
-    -- pytest -s -vvv tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py::test_token_based_generation
+# uv run --isolated --extra fsdp --extra dev \
+#     --with vllm==0.9.2 \
+#     --with transformers==4.53.0 \
+#     --with torch==2.7.0 \
+#     --with "flash-attn@https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.7cxx11abiTRUE-cp312-cp312-linux_x86_64.whl" \
+#     -- pytest -s -vvv tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py::test_token_based_generation
 
 # Run tests for new inference layer
 # TODO (sumanthrh): Migrate the remaining tests: test_verifiers_generator.py , test_pause_and_continue_generation.py

--- a/ci/gpu_ci_run_skyrl_train.sh
+++ b/ci/gpu_ci_run_skyrl_train.sh
@@ -20,7 +20,7 @@ uv run --directory . --isolated --extra dev --extra fsdp pytest -s tests/backend
 #     echo "$add_integrations"
 # fi
 
-# TODO (sumanthrh): Migrate flashrl to vllm 0.16.0 and renable integration test
+# TODO (sumanthrh): Migrate flashrl to vllm 0.16.0 and re-enable integration test
 # Run tests for vllm 0.9.2
 # TODO (sumanthrh): We should have a better way to override without pinning a flash-attn wheel
 # uv run --isolated --extra fsdp --extra dev \

--- a/skyrl-gym/skyrl_gym/envs/search/env.py
+++ b/skyrl-gym/skyrl_gym/envs/search/env.py
@@ -65,18 +65,6 @@ class SearchEnv(BaseTextEnv):
             return True
         return "<answer>" in action and "</answer>" in action
 
-    def _validate_action(self, action: str):
-        stop_tags = ["</search>", "</answer>"]
-        # TODO (sumanthrh): This assertion should really be that the *last token* generated contains <answer>.
-        # The last token generated can have additional punctuation characters like periods, etc.
-        action = action.rstrip("\n").rstrip(".")  # strip out any trailing newlines and periods
-        for tag in stop_tags:
-            if tag in action:
-                assert action.split(tag, 1)[1] == "", (
-                    f"{tag} detected in the response but it is not the last string generated. "
-                    f"Use {stop_tags} as stop strings in the configuration."
-                )
-
     def _execute_tool(self, tool_group_name: str, tool_name: str, tool_input: Any) -> str:
         tool_output = super()._execute_tool(tool_group_name, tool_name, tool_input)
 
@@ -84,7 +72,6 @@ class SearchEnv(BaseTextEnv):
 
     def step(self, action: str) -> BaseTextEnvStepOutput:
         self.turns += 1
-        self._validate_action(action)
         self.chat_history.append({"role": "assistant", "content": action})
 
         error = None

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py
@@ -19,6 +19,7 @@ from skyrl.train.config import SkyRLTrainConfig
 from skyrl.backends.skyrl_train.inference_engines.base import InferenceEngineInput
 
 MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+MOE_MODEL = "Qwen/Qwen1.5-MoE-A2.7B"
 
 
 def get_test_actor_config() -> SkyRLTrainConfig:
@@ -192,21 +193,22 @@ def test_inference_engines_generation(ray_init_fixture, tp_size: int, pp_size: i
 
 
 @pytest.mark.parametrize(
-    "tp_size,pp_size,dp_size",
+    "tp_size,pp_size,dp_size,model",
     [
-        pytest.param(2, 1, 1),
-        pytest.param(2, 2, 1),
-        pytest.param(2, 1, 2),
+        pytest.param(2, 1, 1, MODEL),
+        pytest.param(2, 2, 1, MODEL),
+        pytest.param(2, 1, 2, MOE_MODEL),
     ],
     ids=["tp2_pp1_dp1", "tp2_pp2_dp1", "tp2_pp1_dp2"],
 )
-def test_token_based_generation(ray_init_fixture, tp_size: int, pp_size: int, dp_size: int):
+def test_token_based_generation(ray_init_fixture, tp_size: int, pp_size: int, dp_size: int, model: str):
     """Test generation using prompt_token_ids."""
 
     cfg = get_test_actor_config()
+    cfg.trainer.policy.model.path = model
 
-    prompts = get_test_prompts(MODEL, 3)
-    tokenizer = AutoTokenizer.from_pretrained(MODEL)
+    prompts = get_test_prompts(model, 3)
+    tokenizer = AutoTokenizer.from_pretrained(model)
     prompt_token_ids = tokenizer.apply_chat_template(
         prompts, add_generation_prompt=True, tokenize=True, return_dict=True
     )["input_ids"]

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py
@@ -199,7 +199,7 @@ def test_inference_engines_generation(ray_init_fixture, tp_size: int, pp_size: i
         pytest.param(2, 2, 1, MODEL),
         pytest.param(2, 1, 2, MOE_MODEL),
     ],
-    ids=["tp2_pp1_dp1", "tp2_pp2_dp1", "tp2_pp1_dp2"],
+    ids=["tp2_pp1_dp1", "tp2_pp2_dp1", "tp2_pp1_dp2_moe"],
 )
 def test_token_based_generation(ray_init_fixture, tp_size: int, pp_size: int, dp_size: int, model: str):
     """Test generation using prompt_token_ids."""


### PR DESCRIPTION
# What does this PR do?

Fixes outstanding CI failures. 

1. FlashRL integration test is failing on CI after the vllm 0.16.0 upgrade. The correct fix is to migrate the flashRL fork: https://github.com/SumanthRH/vllm/tree/flashrl to the latest version. (We currently only support one vllm version in SkyRL)
2. `tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py::test_token_based_generation` is failing for the new inference codepath (Note that the corresponding text based generation - `test_text_based_generation` is not enabled for the new path yet) 
The error is as follows:

```bash
>       with InferenceEngineState.create(cfg, sleep_level=1) as engines:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py:218: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/backends/skyrl_train/gpu/utils.py:484: in create
    server_infos = server_group.start()
                   ^^^^^^^^^^^^^^^^^^^^
skyrl/backends/skyrl_train/inference_servers/server_group.py:166: in start
    server_infos = self._pool.start()
                   ^^^^^^^^^^^^^^^^^^
skyrl/backends/skyrl_train/inference_servers/server_pool.py:39: in start
    self._server_infos = ray.get(start_refs)
                         ^^^^^^^^^^^^^^^^^^^
../../.cache/uv/builds-v0/.tmprBPQeX/lib/python3.12/site-packages/ray/_private/auto_init_hook.py:22: in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
../../.cache/uv/builds-v0/.tmprBPQeX/lib/python3.12/site-packages/ray/_private/client_mode_hook.py:104: in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
../../.cache/uv/builds-v0/.tmprBPQeX/lib/python3.12/site-packages/ray/_private/worker.py:2961: in get
    values, debugger_breakpoint = worker.get_objects(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ray._private.worker.Worker object at 0x7d598c0f89b0>
object_refs = [ObjectRef(637d71cfd8c3d0934199ab468c294a5876a09f88c803000001000000), ObjectRef(4ff1d0239b93c6f55967e35303f114e59f3eddd7c803000001000000)]
timeout = None, return_exceptions = False, skip_deserialization = False
_tensor_transport = None

    def get_objects(
        self,
        object_refs: list,
        timeout: Optional[float] = None,
        return_exceptions: bool = False,
        skip_deserialization: bool = False,
        _tensor_transport: Optional[str] = None,
    ) -> Tuple[List[serialization.SerializedRayObject], bytes]:
        """Get the values in the object store associated with the IDs.
    
        Return the values from the local object store for object_refs. This
        will block until all the values for object_refs have been written to
        the local object store.
    
        Args:
            object_refs: A list of the object refs
                whose values should be retrieved.
            timeout: The maximum amount of time in
                seconds to wait before returning.
            return_exceptions: If any of the objects deserialize to an
                Exception object, whether to return them as values in the
                returned list. If False, then the first found exception will be
                raised.
            skip_deserialization: If true, only the buffer will be released and
                the object associated with the buffer will not be deserialized.
            _tensor_transport: [Alpha] The tensor transport to use to fetch `torch.Tensors` found in the Ray Direct Transport object. Currently, this supports "object_store" and "nixl".
        Returns:
            list: List of deserialized objects or None if skip_deserialization is True.
            bytes: UUID of the debugger breakpoint we should drop
                into or b"" if there is no breakpoint.
        """
        # Make sure that the values are object refs.
        for object_ref in object_refs:
            if not isinstance(object_ref, ObjectRef):
                raise TypeError(
                    f"Attempting to call `get` on the value {object_ref}, "
                    "which is not an ray.ObjectRef."
                )
        tensor_transport: TensorTransportEnum = (
            TensorTransportEnum.from_str(_tensor_transport)
            if _tensor_transport is not None
            else None
        )
        assert tensor_transport in [
            TensorTransportEnum.OBJECT_STORE,
            TensorTransportEnum.NIXL,
            None,
        ], "Currently, RDT only supports 'object_store' and 'nixl' for tensor transport in ray.get()."
        timeout_ms = (
            int(timeout * 1000) if timeout is not None and timeout != -1 else -1
        )
        serialized_objects: List[
            serialization.SerializedRayObject
        ] = self.core_worker.get_objects(
            object_refs,
            timeout_ms,
        )
    
        debugger_breakpoint = b""
        for data, metadata, _ in serialized_objects:
            if metadata:
                metadata_fields = metadata.split(b",")
                if len(metadata_fields) >= 2 and metadata_fields[1].startswith(
                    ray_constants.OBJECT_METADATA_DEBUG_PREFIX
                ):
                    debugger_breakpoint = metadata_fields[1][
                        len(ray_constants.OBJECT_METADATA_DEBUG_PREFIX) :
                    ]
        if skip_deserialization:
            return None, debugger_breakpoint
    
        values = self.deserialize_objects(
            serialized_objects, object_refs, tensor_transport_hint=tensor_transport
        )
        if not return_exceptions:
            # Raise exceptions instead of returning them to the user.
            for i, value in enumerate(values):
                if isinstance(value, RayError):
                    if isinstance(value, ray.exceptions.ObjectLostError):
                        global_worker.core_worker.log_plasma_usage()
                    if isinstance(value, RayTaskError):
>                       raise value.as_instanceof_cause()
E                       ray.exceptions.RayTaskError(AssertionError): [36mray::VLLMServerActor.start()[39m (pid=2304492, ip=10.0.143.202, actor_id=4199ab468c294a5876a09f88c8030000, repr=<skyrl.backends.skyrl_train.inference_servers.vllm_server_actor.VLLMServerActor object at 0x73f1e5133950>)
E                         File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 449, in result
E                           return self.__get_result()
E                                  ^^^^^^^^^^^^^^^^^^^
E                         File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
E                           raise self._exception
E                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                         File "/tmp/ray/session_2026-02-19_20-32-05_605637_5843/runtime_resources/working_dir_files/_ray_pkg_92c1802cabc39cf5/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py", line 209, in start
E                           await self._wait_until_healthy()
E                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                         File "/tmp/ray/session_2026-02-19_20-32-05_605637_5843/runtime_resources/working_dir_files/_ray_pkg_92c1802cabc39cf5/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py", line 224, in _wait_until_healthy
E                           raise exc
E                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                         File "/tmp/ray/session_2026-02-19_20-32-05_605637_5843/runtime_resources/working_dir_files/_ray_pkg_92c1802cabc39cf5/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py", line 248, in _run_server
E                           self._engine = AsyncLLMEngine.from_engine_args(
E                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                         File "/home/ray/.cache/uv/builds-v0/.tmpjRRfSQ/lib/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 251, in from_engine_args
E                           return cls(
E                                  ^^^^
E                         File "/home/ray/.cache/uv/builds-v0/.tmpjRRfSQ/lib/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 148, in __init__
E                           self.engine_core = EngineCoreClient.make_async_mp_client(
E                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                         File "/home/ray/.cache/uv/builds-v0/.tmpjRRfSQ/lib/python3.12/site-packages/vllm/v1/engine/core_client.py", line 121, in make_async_mp_client
E                           return DPAsyncMPClient(*client_args)
E                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                         File "/home/ray/.cache/uv/builds-v0/.tmpjRRfSQ/lib/python3.12/site-packages/vllm/v1/engine/core_client.py", line 1082, in __init__
E                           self._ensure_stats_update_task()
E                         File "/home/ray/.cache/uv/builds-v0/.tmpjRRfSQ/lib/python3.12/site-packages/vllm/v1/engine/core_client.py", line 1091, in _ensure_stats_update_task
E                           assert self.stats_update_address is not None
E                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                       AssertionError

```

The issue is that we are using a dense model and testing DP > 1 setting in external load balancer mode. However, in vLLM, the DPCoordinator is configured only for MoE models in this setting. For a dense model with external load balancing, DP > 1 simply means that we are handling all the routing ourselves. So vLLM really expects us to not pass any DP arguments. See https://github.com/vllm-project/vllm/issues/32252 for discussion. The right fix here is to test an MoE model - The PR switches to use the `Qwen/Qwen1.5-moe-a2.7b`
3. Flakiness in `tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py::test_generator_multi_turn_search ` -> I again saw some flakiness for this test because of the strict validation. The issue is that the Env expects the stop string to be the ending *text*, but in reality vllm will stop when the stop string is a *part* of the ending *token*. So the trailing character can be comma, period, etc. I have removed this validation - it doesn't affect correctness. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
