### PR TITLE
WIP: Restore PR changes lost during skyrl-train deprecation

### DIFF
--- a/examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
+++ b/examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
@@ -20,7 +20,8 @@ set -x
 #        bash examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
 
 MODEL_NAME="zai-org/GLM-4.7-Flash"
-DATA_DIR="$HOME/data/gsm8k"
+DATA_DIR=${DATA_DIR:-"$HOME/data/gsm8k"}
+CKPT_DIR=${CKPT_DIR:-"$HOME/ckpts/glm4_7_30b_a3b_grpo_megatron"}
 LOGGER="wandb"  # change to "console" to print to stdout
 
 INFERENCE_BACKEND="vllm"
@@ -112,5 +113,5 @@ uv run --isolated --extra megatron -m skyrl.train.entrypoints.main_base \
   trainer.project_name="glm4_7_30b_grpo" \
   trainer.run_name="glm4_7_30b_a3b_grpo_megatron_tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}_ep${MEGATRON_EP}_etp${MEGATRON_ETP}" \
   trainer.resume_mode=null \
-  trainer.ckpt_path="$HOME/ckpts/glm4_7_30b_a3b_grpo_megatron" \
+  trainer.ckpt_path="$CKPT_DIR" \
   $@


### PR DESCRIPTION
## Summary
Restore GLM-4.7-Flash Megatron GRPO example script (from PR #1215), adapted for the new `skyrl.train` entrypoint and config key format.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
