### PR TITLE
[megatron][lora] Fix megatron lora weight syncing not initializing buckets correctly

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -237,9 +237,9 @@ class MegatronWeightExtractor(WeightExtractor):
         """Lazily initialize param buckets on first use (model must be on GPU)."""
         if self._buckets_initialized:
             return
-        self._buckets_initialized = True
         if self.enable_bucketing:
             self._init_param_buckets()
+        self._buckets_initialized = True
 
     def extract_weights(self, dtype: torch.dtype):
         """Extract weights from Megatron model.


### PR DESCRIPTION
## Fix OOM during LoRA weight sync by deferring bucket initialization

### Problem

When `colocate_all=True`, `offload_megatron_model_to_cpu` replaces all frozen base parameter data with `torch.empty(0, ...)` to free GPU memory for LoRA params. `MegatronWeightExtractor.__init__` was eagerly computing param buckets at this point, seeing `numel()==0` for all 688 base params and computing `size_in_bytes=0` for each. This collapsed everything into a single bucket, and the subsequent `_send_chunks_legacy` tried to allocate ~30GB in one shot → `torch.OutOfMemoryError`.

### Root Cause

Lifecycle ordering issue:

1. `init_model()` — model created on GPU, all params have data
2. `offload_to_cpu()` — base params replaced with `torch.empty(0, ...)` ← **params now empty**
3. `init_weight_sync_state()` → `MegatronWeightExtractor.__init__` → `_init_param_buckets()` ← **buckets computed here, sees 0-size params**
4. `broadcast_to_inference_engines()` → `prepare_for_weight_sync` → `_ensure_on_gpu` ← params restored, but buckets already wrong

### Fix

Defer `_init_param_buckets` to the first `extract_weights()` call via lazy `_ensure_buckets_initialized()`. By that time, the dispatch has already restored the model to GPU via `prepare_for_weight_sync` → `_ensure_on_gpu`, so `param.numel()` returns correct sizes and bucketing works properly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
