### PR TITLE
[tx] Enable MPS backend for Apple Silicon on Jax backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,8 @@ jax = [
     "jax>=0.8,<1.0",
     "flax>=0.12.2",
     "optax>=0.2.5",
+    "ml_dtypes>=0.5.0",
+    "jax-mps>=0.0.6; sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 
 skyrl-train = [
@@ -208,7 +210,7 @@ override-dependencies = [
     "causal-conv1d; sys_platform == 'never'",
     "transformer-engine[pytorch]==2.10.0; sys_platform == 'linux'",
     "megatron-core==0.16.0; sys_platform == 'linux'",
-    "ml_dtypes>=0.5.0; sys_platform == 'linux'",
+    "ml_dtypes>=0.5.0",
 ]
 
 [tool.uv.extra-build-dependencies]

--- a/skyrl/backends/jax.py
+++ b/skyrl/backends/jax.py
@@ -787,12 +787,13 @@ class JaxBackendImpl(AbstractBackend):
             logger.warning(f"No accumulated gradients for model {model_id}; applying step with zero gradients")
 
         # Update hyperparameters from the request
+        # Use direct .value assignment instead of [...] indexing to avoid MPS zero-sized tensor issues
         hp = optimizer.opt_state.hyperparams
-        hp["learning_rate"][...] = learning_rate
-        hp["b1"][...] = request_data.adam_params.beta1
-        hp["b2"][...] = request_data.adam_params.beta2
-        hp["eps"][...] = request_data.adam_params.eps
-        hp["weight_decay"][...] = request_data.adam_params.weight_decay
+        hp["learning_rate"].value = jnp.asarray(learning_rate, dtype=hp["learning_rate"].value.dtype)
+        hp["b1"].value = jnp.asarray(request_data.adam_params.beta1, dtype=hp["b1"].value.dtype)
+        hp["b2"].value = jnp.asarray(request_data.adam_params.beta2, dtype=hp["b2"].value.dtype)
+        hp["eps"].value = jnp.asarray(request_data.adam_params.eps, dtype=hp["eps"].value.dtype)
+        hp["weight_decay"].value = jnp.asarray(request_data.adam_params.weight_decay, dtype=hp["weight_decay"].value.dtype)
 
         # JIT-compiled: compute full gradients, apply optimizer update, and reset accumulated grads
         with jax.set_mesh(self.mesh):

--- a/skyrl/tx/layers/lora.py
+++ b/skyrl/tx/layers/lora.py
@@ -361,7 +361,10 @@ def init_lora_adapter(model: ModelForCausalLM, adapter_index: int, lora_config: 
         if key_name == "lora_A":
             # Reinitialize with he_uniform, then zero columns beyond rank
             new_A = nnx.initializers.he_uniform()(rngs.params(), value[idx].shape, value.dtype)
-            new_A = new_A.at[..., effective_rank:].set(0.0)
+            # Zero columns beyond rank using multiplication (avoids MPS zero-sized tensor issues)
+            if new_A.shape[-1] > 0:
+                mask = jnp.arange(new_A.shape[-1]) < effective_rank
+                new_A = new_A * mask.astype(new_A.dtype)
             return value.at[idx].set(new_A)
         if key_name == "lora_B":
             # Explicitly zero lora_B

--- a/skyrl/tx/utils/models.py
+++ b/skyrl/tx/utils/models.py
@@ -194,7 +194,8 @@ def load_safetensors(
                 tensor = tensor.reshape(param.shape)
             assert param.shape == tensor.shape, f"shape mismatch for {key}"
             # ArrayRef.set_raw_value writes through to the stacked parent variable
-            param.set_raw_value(jax.device_put(tensor.astype(param.dtype), param.sharding))
+            # Use np.ascontiguousarray to ensure data is contiguous (required by jax-mps backend)
+            param.set_raw_value(jax.device_put(np.ascontiguousarray(tensor.astype(param.dtype)), param.sharding))
 
 
 def save_safetensors(

--- a/tests/tx/models/test_qwen3.py
+++ b/tests/tx/models/test_qwen3.py
@@ -55,11 +55,11 @@ def test_qwen3(tp: int):
 
 def load_moe_base_weights(jax_moe_layer: Qwen3MoeSparseMoeBlock, hf_moe_layer: HFQwen3MoeSparseMoeBlock) -> None:
     """Load base weights from HF MoE layer to JAX MoE layer."""
-    jax_moe_layer.gate.kernel[:] = hf_moe_layer.gate.weight.detach().numpy().T
+    jax_moe_layer.gate.kernel[:] = np.ascontiguousarray(hf_moe_layer.gate.weight.detach().numpy().T)
     for i, expert in enumerate(hf_moe_layer.experts):
-        jax_moe_layer.experts.gate_proj.weight[i, :, :] = expert.gate_proj.weight.detach().numpy().T
-        jax_moe_layer.experts.up_proj.weight[i, :, :] = expert.up_proj.weight.detach().numpy().T
-        jax_moe_layer.experts.down_proj.weight[i, :, :] = expert.down_proj.weight.detach().numpy().T
+        jax_moe_layer.experts.gate_proj.weight[i, :, :] = np.ascontiguousarray(expert.gate_proj.weight.detach().numpy().T)
+        jax_moe_layer.experts.up_proj.weight[i, :, :] = np.ascontiguousarray(expert.up_proj.weight.detach().numpy().T)
+        jax_moe_layer.experts.down_proj.weight[i, :, :] = np.ascontiguousarray(expert.down_proj.weight.detach().numpy().T)
 
 
 @pytest.mark.parametrize("ep,tp", [(1, 1), (1, 2), (2, 1)])
@@ -100,8 +100,9 @@ def load_lora_weights(
         and jax_module.lora_scaling is not None
         and jax_module.lora_ranks is not None
     )
-    jax_module.lora_A[...] = jax_module.lora_A[...].at[adapter_idx].set(jnp.array(lora_A_weights))
-    jax_module.lora_B[...] = jax_module.lora_B[...].at[adapter_idx].set(jnp.array(lora_B_weights))
+    # Use np.ascontiguousarray to ensure data is contiguous (required by jax-mps backend)
+    jax_module.lora_A[...] = jax_module.lora_A[...].at[adapter_idx].set(jnp.array(np.ascontiguousarray(lora_A_weights)))
+    jax_module.lora_B[...] = jax_module.lora_B[...].at[adapter_idx].set(jnp.array(np.ascontiguousarray(lora_B_weights)))
     jax_module.lora_scaling[...] = jax_module.lora_scaling[...].at[adapter_idx].set(scaling)
     jax_module.lora_ranks[...] = jax_module.lora_ranks[...].at[adapter_idx].set(rank)
 


### PR DESCRIPTION
This uses the OSS MPS pjrt / StableHLO backend https://github.com/tillahoffmann/jax-mps

This will only be really interesting once the M5 Ultra or similar hardware gets released (to have the larger prefill performance of the M5), but it is very nice to see it works, on my puny mac book pro, it already gets a huge speedup over CPU and is useful for local development. It also proves the point that the Jax backend is very portable.

It can be run with
```
JAX_PLATFORMS=mps uv run --extra gpu --extra tinker -m skyrl.tinker.api --base-model Qwen/Qwen3-0.6B --backend-config '{"max_lora_adapters": 2, "max_lora_rank": 1, "train_micro_batch_size": 1}'
```

The timings for
```
export TINKER_API_KEY="tml-dummy"
uv run --with wandb --with tinker sl_loop.py \
    base_url=http://localhost:8000 \
    model_name=Qwen/Qwen3-0.6B lora_rank=1 train_on_what=LAST_ASSISTANT_MESSAGE
```
are:

```
Step 0                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Metric                         ┃ Value      ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ learning_rate                  │ 0.000100   │
│ num_sequences                  │ 128        │
│ num_tokens                     │ 37834      │
│ progress                       │ 0.000000   │
│ skyrl.ai/grad_norm             │ 3.765625   │
│ skyrl.ai/learning_rate         │ 0.000100   │
│ time_total                     │ 331.295395 │
│ train_mean_nll                 │ 2.795922   │
└────────────────────────────────┴────────────┘
tinker_cookbook.utils.ml_log:147 [INFO] Wrote metrics to /tmp/tinker-examples/sl-loop/metrics.jsonl
tinker_cookbook.utils.ml_log:199 [INFO] 
                    Step 1                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Metric                         ┃ Value      ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ learning_rate                  │ 0.000099   │
│ num_sequences                  │ 128        │
│ num_tokens                     │ 35654      │
│ progress                       │ 0.013514   │
│ skyrl.ai/grad_norm             │ 4.781250   │
│ skyrl.ai/learning_rate         │ 0.000099   │
│ time_total                     │ 331.346420 │
│ train_mean_nll                 │ 2.779400   │
└────────────────────────────────┴────────────┘
tinker_cookbook.utils.ml_log:147 [INFO] Wrote metrics to /tmp/tinker-examples/sl-loop/metrics.jsonl
tinker_cookbook.utils.ml_log:199 [INFO] 
                     Step 2                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Metric                         ┃ Value       ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ learning_rate                  │ 0.000097    │
│ num_sequences                  │ 128         │
│ num_tokens                     │ 38474       │
│ progress                       │ 0.027027    │
│ skyrl.ai/grad_norm             │ 4.125000    │
│ skyrl.ai/learning_rate         │ 0.000097    │
│ time_total                     │ 1306.594704 │
│ train_mean_nll                 │ 2.617733    │
└────────────────────────────────┴─────────────┘
tinker_cookbook.utils.ml_log:147 [INFO] Wrote metrics to /tmp/tinker-examples/sl-loop/metrics.jsonl
tinker_cookbook.utils.ml_log:199 [INFO] 
                    Step 3                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Metric                         ┃ Value      ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ learning_rate                  │ 0.000096   │
│ num_sequences                  │ 128        │
│ num_tokens                     │ 39781      │
│ progress                       │ 0.040541   │
│ skyrl.ai/grad_norm             │ 4.281250   │
│ skyrl.ai/learning_rate         │ 0.000096   │
│ time_total                     │ 285.588389 │
│ train_mean_nll                 │ 2.693189   │
└────────────────────────────────┴────────────┘
tinker_cookbook.utils.ml_log:147 [INFO] Wrote metrics to /tmp/tinker-examples/sl-loop/metrics.jsonl
tinker_cookbook.utils.ml_log:199 [INFO] 
                    Step 4                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Metric                         ┃ Value      ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ learning_rate                  │ 0.000095   │
│ num_sequences                  │ 128        │
│ num_tokens                     │ 37346      │
│ progress                       │ 0.054054   │
│ skyrl.ai/grad_norm             │ 3.828125   │
│ skyrl.ai/learning_rate         │ 0.000094   │
│ time_total                     │ 151.503146 │
│ train_mean_nll                 │ 2.667086   │
└────────────────────────────────┴────────────┘
```

Compared on the CPU which is
```
Step 0                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Metric                         ┃ Value       ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ learning_rate                  │ 0.000100    │
│ num_sequences                  │ 128         │
│ num_tokens                     │ 37834       │
│ progress                       │ 0.000000    │
│ skyrl.ai/grad_norm             │ 3.859375    │
│ skyrl.ai/learning_rate         │ 0.000100    │
│ time_total                     │ 2165.875092 │
│ train_mean_nll                 │ 2.794540    │
└────────────────────────────────┴─────────────┘
tinker_cookbook.utils.ml_log:147 [INFO] Wrote metrics to /tmp/tinker-examples/sl-loop/metrics.jsonl
tinker_cookbook.utils.ml_log:199 [INFO] 
                     Step 1                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Metric                         ┃ Value       ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ learning_rate                  │ 0.000099    │
│ num_sequences                  │ 128         │
│ num_tokens                     │ 35654       │
│ progress                       │ 0.013514    │
│ skyrl.ai/grad_norm             │ 5.000000    │
│ skyrl.ai/learning_rate         │ 0.000099    │
│ time_total                     │ 2148.938093 │
│ train_mean_nll                 │ 2.775640    │
└────────────────────────────────┴─────────────┘
tinker_cookbook.utils.ml_log:147 [INFO] Wrote metrics to /tmp/tinker-examples/sl-loop/metrics.jsonl
tinker_cookbook.utils.ml_log:199 [INFO] 
                     Step 2                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Metric                         ┃ Value       ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ learning_rate                  │ 0.000097    │
│ num_sequences                  │ 128         │
│ num_tokens                     │ 38474       │
│ progress                       │ 0.027027    │
│ skyrl.ai/grad_norm             │ 4.343750    │
│ skyrl.ai/learning_rate         │ 0.000097    │
│ time_total                     │ 4486.724472 │
│ train_mean_nll                 │ 2.611415    │
└────────────────────────────────┴─────────────┘
tinker_cookbook.utils.ml_log:147 [INFO] Wrote metrics to /tmp/tinker-examples/sl-loop/metrics.jsonl
tinker_cookbook.utils.ml_log:199 [INFO] 
                     Step 3                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Metric                         ┃ Value       ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ learning_rate                  │ 0.000096    │
│ num_sequences                  │ 128         │
│ num_tokens                     │ 39781       │
│ progress                       │ 0.040541    │
│ skyrl.ai/grad_norm             │ 4.187500    │
│ skyrl.ai/learning_rate         │ 0.000096    │
│ time_total                     │ 2290.050567 │
│ train_mean_nll                 │ 2.682926    │
└────────────────────────────────┴─────────────┘
tinker_cookbook.utils.ml_log:147 [INFO] Wrote metrics to /tmp/tinker-examples/sl-loop/metrics.jsonl
tinker_cookbook.utils.ml_log:199 [INFO] 
                     Step 4                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Metric                         ┃ Value       ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ learning_rate                  │ 0.000095    │
│ num_sequences                  │ 128         │
│ num_tokens                     │ 37346       │
│ progress                       │ 0.054054    │
│ skyrl.ai/grad_norm             │ 3.796875    │
│ skyrl.ai/learning_rate         │ 0.000094    │
│ time_total                     │ 1484.751887 │
│ train_mean_nll                 │ 2.659317    │
└────────────────────────────────┴─────────────┘
```

It runs with the fully OSS backend https://github.com/tillahoffmann/jax-mps

A couple of limitations:

- [ ] Currently sometimes crashes with
```
libc++abi: terminating due to uncaught exception of type std::runtime_error: [METAL] Command buffer execution failed: Internal Error (0000000e:Internal Error)
/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/multiprocessing/resource_tracker.py:276: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown: {'/mp-dam64i5u'}
```
This might be a bug in metal, maybe it is already fixed in a later version, mine is a little outdated currently.
- [ ] Needs tensors to be contiguous
- [ ] Doesn't support zero dimensions

Maybe we can fix them by fixing the jax-mps backend, so it can run without modifications.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
