### PR TITLE
[Outdated] PR for R3 CP and PP

### DIFF
--- a/skyrl/backends/skyrl_train/utils/replay_utils.py
+++ b/skyrl/backends/skyrl_train/utils/replay_utils.py
@@ -2,274 +2,341 @@
 Utility functions for MoE Router Replay.
 """
 
-from typing import List
 
 import torch
+from typing import List
 
 
-def patch_topk_router_layer_number():
-    """Monkey-patch TopKRouter.set_layer_number to propagate the global layer
-    number to the RouterReplay instance.
 
-    DeepSeek V3 (and similar) architectures have dense FFN layers before the MoE
-    layers.  vLLM reports routing indices for ALL transformer layers (including
-    dense), but Megatron only creates RouterReplay instances for MoE layers.
-    Storing the global layer_number on each RouterReplay instance lets us map
-    vLLM's per-layer data to the correct MoE router even when dense layers are
-    present.
 
-    Must be called BEFORE model creation (i.e. before make_megatron_module).
-    """
-    try:
-        from megatron.core.transformer.moe.router import TopKRouter
-    except ImportError:
-        return
+def _patch_topk_router_layer_number():
+   """Monkey-patch TopKRouter.set_layer_number to propagate the global layer
+   number to the RouterReplay instance.
 
-    if getattr(TopKRouter, "_set_layer_number_patched", False):
-        return
 
-    original_set_layer_number = TopKRouter.set_layer_number
+   DeepSeek V3 (and similar) architectures have dense FFN layers before the MoE
+   layers.  vLLM reports routing indices for ALL transformer layers (including
+   dense), but Megatron only creates RouterReplay instances for MoE layers.
+   Storing the global layer_number on each RouterReplay instance lets us map
+   vLLM's per-layer data to the correct MoE router even when dense layers are
+   present.
 
-    def patched_set_layer_number(self, layer_number: int):
-        original_set_layer_number(self, layer_number)
-        if self.router_replay is not None:
-            self.router_replay.layer_number = layer_number
 
-    TopKRouter.set_layer_number = patched_set_layer_number
-    TopKRouter._set_layer_number_patched = True
+   Must be called BEFORE model creation (i.e. before make_megatron_module).
+   """
+   try:
+       from megatron.core.transformer.moe.router import TopKRouter
+   except ImportError:
+       return
+
+
+   if getattr(TopKRouter, "_set_layer_number_patched", False):
+       return
+
+
+   original_set_layer_number = TopKRouter.set_layer_number
+
+
+   def patched_set_layer_number(self, layer_number: int):
+       original_set_layer_number(self, layer_number)
+       if self.router_replay is not None:
+           self.router_replay.layer_number = layer_number
+
+
+   TopKRouter.set_layer_number = patched_set_layer_number
+   TopKRouter._set_layer_number_patched = True
+
+
 
 
 def _patch_alltoall_dispatcher_for_replay():
-    """Monkey-patch MoEAlltoAllTokenDispatcher.preprocess to handle router replay.
+   """Monkey-patch MoEAlltoAllTokenDispatcher.preprocess to handle router replay.
 
-    When router replay is enabled, duplicate indices in top_indices can cause
-    routing_map.sum() < num_tokens * topk, leading to a split size mismatch
-    in the alltoall collective.  We fix this by deriving num_out_tokens from
-    the routing map instead of the static num_tokens * topk formula.
 
-    Reference: https://github.com/verl-project/verl/pull/4986
-    """
-    try:
-        from megatron.core.transformer.moe.token_dispatcher import (
-            MoEAlltoAllTokenDispatcher,
-        )
-    except ImportError:
-        return
+   When router replay is enabled, duplicate indices in top_indices can cause
+   routing_map.sum() < num_tokens * topk, leading to a split size mismatch
+   in the alltoall collective.  We fix this by deriving num_out_tokens from
+   the routing map instead of the static num_tokens * topk formula.
 
-    if getattr(MoEAlltoAllTokenDispatcher, "_preprocess_patched", False):
-        return
 
-    original_preprocess = MoEAlltoAllTokenDispatcher.preprocess
+   Reference: https://github.com/verl-project/verl/pull/4986
+   """
+   try:
+       from megatron.core.transformer.moe.token_dispatcher import MoEAlltoAllTokenDispatcher
+   except ImportError:
+       return
 
-    def patched_preprocess(self, routing_map):
-        result = original_preprocess(self, routing_map)
-        if (
-            getattr(self.config, "moe_enable_routing_replay", False)
-            and not self.drop_and_pad
-            and self.config.moe_expert_capacity_factor is None
-            and not self.config.moe_router_padding_for_quantization
-        ):
-            self.num_out_tokens = int(routing_map.sum().item())
-        return result
 
-    MoEAlltoAllTokenDispatcher.preprocess = patched_preprocess
-    MoEAlltoAllTokenDispatcher._preprocess_patched = True
+   if getattr(MoEAlltoAllTokenDispatcher, "_preprocess_patched", False):
+       return
+
+
+   original_preprocess = MoEAlltoAllTokenDispatcher.preprocess
+
+
+   def patched_preprocess(self, routing_map):
+       result = original_preprocess(self, routing_map)
+       if (
+           getattr(self.config, "moe_enable_routing_replay", False)
+           and not self.drop_and_pad
+           and self.config.moe_expert_capacity_factor is None
+           and not self.config.moe_router_padding_for_quantization
+       ):
+           self.num_out_tokens = int(routing_map.sum().item())
+       return result
+
+
+   MoEAlltoAllTokenDispatcher.preprocess = patched_preprocess
+   MoEAlltoAllTokenDispatcher._preprocess_patched = True
+
+
 
 
 def _split_replay_indices(rollout_expert_indices: torch.Tensor) -> List[torch.Tensor]:
-    if rollout_expert_indices is None:
-        return None
-    if rollout_expert_indices.dim() != 4:
-        raise ValueError(f"Expected 4D replay indices, got shape {rollout_expert_indices.shape}")
-    per_layer = rollout_expert_indices.permute(2, 0, 1, 3).contiguous()
-    # flatten [batch, seq, topk] to [batch * seq, topk] for each layer
-    return [per_layer[i].reshape(-1, per_layer.shape[-1]) for i in range(per_layer.shape[0])]
+   if rollout_expert_indices is None:
+       return None
+   if rollout_expert_indices.dim() != 4:
+       raise ValueError(f"Expected 4D replay indices, got shape {rollout_expert_indices.shape}")
+   per_layer = rollout_expert_indices.permute(2, 0, 1, 3).contiguous()
+   # flatten [batch, seq, topk] to [batch * seq, topk] for each layer
+   return [per_layer[i].reshape(-1, per_layer.shape[-1]) for i in range(per_layer.shape[0])]
+
+
 
 
 def _remove_left_padding_from_indices(
-    rollout_expert_indices: torch.Tensor,
-    attention_mask: torch.Tensor,
+   rollout_expert_indices: torch.Tensor,
+   attention_mask: torch.Tensor,
 ) -> torch.Tensor:
-    """Apply the same left-padding removal as remove_left_padding to routing indices.
-
-    Args:
-        rollout_expert_indices: [batch, padded_seq_len, layers, topk]
-        attention_mask: [batch, padded_seq_len] (int or bool)
-
-    Returns:
-        [batch, effective_seq_len, layers, topk] with real tokens packed left.
-    """
-    import megatron.core.parallel_state as mpu
-
-    seq_lens = attention_mask.sum(dim=1)
-    effective_seq_len = seq_lens.max().item()
-    sp_world_size = mpu.get_tensor_model_parallel_world_size()
-    if sp_world_size > 1:
-        pad_size = (sp_world_size - effective_seq_len % sp_world_size) % sp_world_size
-        effective_seq_len += pad_size
-
-    batch_size = rollout_expert_indices.shape[0]
-    new_rii = torch.zeros(
-        batch_size,
-        effective_seq_len,
-        rollout_expert_indices.shape[2],
-        rollout_expert_indices.shape[3],
-        dtype=rollout_expert_indices.dtype,
-        device=rollout_expert_indices.device,
-    )
-    for i in range(batch_size):
-        mask = attention_mask[i].bool()
-        new_rii[i, : seq_lens[i]] = rollout_expert_indices[i, mask]
-    return new_rii
+   """Apply the same left-padding removal as remove_left_padding to routing indices.
 
 
-def _pack_replay_indices(
-    rollout_expert_indices: torch.Tensor,
-    attention_mask: torch.Tensor,
-) -> torch.Tensor:
-    """Pack routing indices to match the token layout produced by preprocess_packed_seqs.
+   Args:
+       rollout_expert_indices: [batch, padded_seq_len, layers, topk]
+       attention_mask: [batch, padded_seq_len] (int or bool)
 
-    With sample packing, Megatron concatenates all sequences into one packed
-    sequence with per-sample alignment padding.  The MoE router sees tokens in
-    this packed order, so replay indices must follow the same layout.
 
-    Returns:
-        [1, total_packed_len, layers, topk] matching the packed model input.
-    """
-    import megatron.core.parallel_state as mpu
+   Returns:
+       [batch, effective_seq_len, layers, topk] with real tokens packed left.
+   """
+   import megatron.core.parallel_state as mpu
 
-    batch_size = rollout_expert_indices.shape[0]
-    num_layers = rollout_expert_indices.shape[2]
-    topk = rollout_expert_indices.shape[3]
 
-    seq_lens = attention_mask.sum(dim=-1, dtype=torch.int32)
-    tp_size = mpu.get_tensor_model_parallel_world_size()
-    cp_size = mpu.get_context_parallel_world_size()
-    align_size = tp_size * cp_size * 2 if cp_size > 1 else tp_size
+   seq_lens = attention_mask.sum(dim=1)
+   effective_seq_len = seq_lens.max().item()
+   tp_size = mpu.get_tensor_model_parallel_world_size()
+   cp_size = mpu.get_context_parallel_world_size()
+   align_size = tp_size * cp_size * 2 if cp_size > 1 else tp_size
+   if align_size > 1:
+       pad_size = (align_size - effective_seq_len % align_size) % align_size
+       effective_seq_len += pad_size
 
-    pad_sizes = (align_size - seq_lens % align_size) % align_size
-    seqlens_padded = seq_lens + pad_sizes
 
-    total_packed_len = int(seqlens_padded.sum().item())
-    if cp_size > 1:
-        total_packed_len = total_packed_len // cp_size
+   batch_size = rollout_expert_indices.shape[0]
+   new_rii = torch.zeros(
+       batch_size,
+       effective_seq_len,
+       rollout_expert_indices.shape[2],
+       rollout_expert_indices.shape[3],
+       dtype=rollout_expert_indices.dtype,
+       device=rollout_expert_indices.device,
+   )
+   for i in range(batch_size):
+       mask = attention_mask[i].bool()
+       new_rii[i, : seq_lens[i]] = rollout_expert_indices[i, mask]
+   return new_rii
 
-    packed = torch.zeros(
-        total_packed_len,
-        num_layers,
-        topk,
-        dtype=rollout_expert_indices.dtype,
-        device=rollout_expert_indices.device,
-    )
 
-    seq_lens_cpu = seq_lens.tolist()
-    seqlens_padded_cpu = seqlens_padded.tolist()
-    if cp_size > 1:
-        cp_rank = mpu.get_context_parallel_rank()
-    offset = 0
-    for i in range(batch_size):
-        n = seq_lens_cpu[i]
-        mask = attention_mask[i].bool()
-        d = rollout_expert_indices[i, mask]
-        if cp_size > 1:
-            chunk_size = seqlens_padded_cpu[i] // cp_size
-            start = cp_rank * chunk_size
-            end = min(start + chunk_size, n)
-            valid_len = max(0, end - start)
-            if valid_len > 0:
-                packed[offset : offset + valid_len] = d[start:end]
-            offset += chunk_size
-        else:
-            packed[offset : offset + n] = d
-            offset += seqlens_padded_cpu[i]
 
-    return packed.unsqueeze(0)  # [1, total_packed_len, layers, topk]
+
+def _get_current_pp_stage_layer_range(model_config) -> tuple[int, int]:
+   """Return the current PP rank's transformer-layer range.
+
+
+   Prefer Megatron's own helpers so replay indexing stays aligned with the
+   actual model partition, including embedding/loss pipeline accounting.
+   """
+   import megatron.core.parallel_state as mpu
+   from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
+   from megatron.core.transformer.transformer_block import get_num_layers_to_build
+
+
+   pp_rank = mpu.get_pipeline_model_parallel_rank()
+
+
+   if get_num_layers_to_build is not None:
+       return get_transformer_layer_offset(model_config), get_num_layers_to_build(model_config, pp_rank=pp_rank)
+
+
+   pp_size = mpu.get_pipeline_model_parallel_world_size()
+
+
+   total_layers = model_config.num_layers
+   first_stage_layers = getattr(model_config, "num_layers_in_first_pipeline_stage", None)
+   last_stage_layers = getattr(model_config, "num_layers_in_last_pipeline_stage", None)
+
+
+   if pp_size <= 1:
+       return 0, total_layers
+
+
+   if first_stage_layers is None and last_stage_layers is None:
+       assert total_layers % pp_size == 0, (
+           "For even pipelineing, num_layers should be divisible by pipeline_model_parallel_size"
+       )
+       pp_layers = total_layers // pp_size
+       return pp_rank * pp_layers, pp_layers
+
+
+   next_n_pp_layers = total_layers
+   next_n_pp_stages = pp_size
+
+
+   if first_stage_layers is not None:
+       next_n_pp_layers -= first_stage_layers
+       next_n_pp_stages -= 1
+
+
+   if last_stage_layers is not None:
+       next_n_pp_layers -= last_stage_layers
+       next_n_pp_stages -= 1
+
+
+   if next_n_pp_stages > 0:
+       assert next_n_pp_layers % next_n_pp_stages == 0, (
+           "Uneven pipelineing, not divisible by remaining pipeline stages"
+       )
+       next_n_pp_layers = next_n_pp_layers // next_n_pp_stages
+   else:
+       next_n_pp_layers = 0
+
+
+   if pp_rank == 0 and first_stage_layers is not None:
+       return 0, first_stage_layers
+
+
+   if pp_rank == pp_size - 1 and last_stage_layers is not None:
+       if first_stage_layers is not None:
+           start = first_stage_layers + (next_n_pp_layers * (pp_size - 2))
+       else:
+           start = next_n_pp_layers * (pp_size - 1)
+       return start, last_stage_layers
+
+
+   if first_stage_layers is not None:
+       return first_stage_layers + (next_n_pp_layers * (pp_rank - 1)), next_n_pp_layers
+   return next_n_pp_layers * pp_rank, next_n_pp_layers
+
+
 
 
 def setup_per_microbatch_replay_forward(
-    rollout_expert_indices: torch.Tensor,
-    attention_mask: torch.Tensor,
-    use_sample_packing: bool = False,
+   rollout_expert_indices: torch.Tensor,
+   attention_mask: torch.Tensor,
+   model_config,
 ) -> None:
-    """Set up RouterReplay for a single micro-batch, aligning indices
-    with the token layout that the MoE layer sees.
-
-    Handles sequence parallelism: when TP > 1, the sequence is split across
-    TP ranks, so each rank's MoE router only sees its local chunk of tokens.
-
-    Handles sample packing: when use_sample_packing is True, sequences are
-    concatenated into one packed sequence with per-sample alignment padding.
-    The replay indices must follow this same packed layout.
-
-    Handles dense-layer mismatch: DeepSeek V3-style models have dense FFN
-    layers before the MoE layers.  vLLM reports routing indices for ALL
-    transformer layers, but Megatron only has RouterReplay instances for MoE
-    layers.  We use each instance's global layer_number (set by the patched
-    TopKRouter.set_layer_number) to index into the correct slice of the data.
-    """
-    import megatron.core.parallel_state as mpu
-    from megatron.core.transformer.moe.router_replay import (
-        RouterReplay,
-        RouterReplayAction,
-    )
-
-    _patch_alltoall_dispatcher_for_replay()
-
-    if use_sample_packing:
-        aligned = _pack_replay_indices(rollout_expert_indices, attention_mask)
-    else:
-        aligned = _remove_left_padding_from_indices(rollout_expert_indices, attention_mask)
-
-    tp_size = mpu.get_tensor_model_parallel_world_size()
-    if tp_size > 1:
-        tp_rank = mpu.get_tensor_model_parallel_rank()
-        seq_len = aligned.shape[1]
-        chunk_size = seq_len // tp_size
-        aligned = aligned[:, tp_rank * chunk_size : (tp_rank + 1) * chunk_size, :, :]
-
-    per_layer_data = _split_replay_indices(aligned)
-    num_layers_in_data = len(per_layer_data)
-    instances = RouterReplay.global_router_replay_instances
-    num_instances = len(instances)
-
-    if num_layers_in_data == num_instances:
-        RouterReplay.set_replay_data(per_layer_data)
-    else:
-        # Dense-layer mismatch: map each MoE router to its global layer index.
-        # Prefer the patched layer_number; fall back to offset-based mapping
-        # (assumes dense layers precede MoE layers).
-        for i, router_instance in enumerate(instances):
-            layer_number = getattr(router_instance, "layer_number", None)
-            if layer_number is not None:
-                layer_idx = layer_number - 1  # layer_number is 1-based
-            else:
-                layer_idx = i + (num_layers_in_data - num_instances)
-            if layer_idx < 0 or layer_idx >= num_layers_in_data:
-                raise ValueError(
-                    f"Router replay layer index {layer_idx} out of range "
-                    f"for data with {num_layers_in_data} layers "
-                    f"({num_instances} router instances)"
-                )
-            router_instance.set_target_indices(per_layer_data[layer_idx])
-    RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+   """Set up RouterReplay for a single micro-batch, aligning indices
+   with the left-padding-removed token layout that the MoE layer sees.
 
 
-def setup_per_microbatch_replay_backward() -> None:
-    """Switch RouterReplay to backward mode so that activation-checkpoint
-    recomputation during the backward pass consumes indices from
-    ``replay_backward_list`` in FIFO order (populated during the forward pass).
-    """
-    from megatron.core.transformer.moe.router_replay import (
-        RouterReplay,
-        RouterReplayAction,
-    )
+   Handles context parallelism: when CP > 1, the sequence is split into
+   2*cp_size chunks with each CP rank receiving a front chunk and a back
+   chunk (for causal-mask load balancing). Replay indices are split using
+   the same pattern so they stay aligned with the tokens each rank sees.
 
-    RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_BACKWARD)
+
+   Handles sequence parallelism: when TP > 1, the sequence is split across
+   TP ranks, so each rank's MoE router only sees its local chunk of tokens.
+
+
+   Handles dense-layer mismatch: DeepSeek V3-style models have dense FFN
+   layers before the MoE layers. vLLM reports routing indices for ALL
+   transformer layers, but Megatron only has RouterReplay instances for MoE
+   layers. We use each instance's global layer_number (set by the patched
+   TopKRouter.set_layer_number) to index into the correct slice of the data.
+
+
+   Handles pipeline parallelism: when PP > 1, the sequence is split across
+   PP ranks, so each rank only sees its local RouterReplay instances. In cases
+   where the number of local RouterReplay instances does not match the local
+   layer count, indicating that the model has dense layers before MoE layers,
+   we use the global layer_number to index into the correct slice of the data.
+
+
+   """
+   import megatron.core.parallel_state as mpu
+   from megatron.core.transformer.moe.router_replay import RouterReplay, RouterReplayAction
+
+
+   _patch_alltoall_dispatcher_for_replay()
+
+
+   aligned = _remove_left_padding_from_indices(rollout_expert_indices, attention_mask)
+
+
+   # CP splitting: mirror the front+back chunking from preprocess_packed_seqs
+   cp_size = mpu.get_context_parallel_world_size()
+   if cp_size > 1:
+       cp_rank = mpu.get_context_parallel_rank()
+       seq_len = aligned.shape[1]
+       seqlen_per_cp = seq_len // cp_size
+       half = seqlen_per_cp // 2 # we do *2 for causal masking, so get half of the sequence length per CP rank
+       front = aligned[:, half * cp_rank : half * (cp_rank + 1), :, :]
+       back_start = seq_len - half * (cp_rank + 1)
+       back_end = seq_len - half * cp_rank
+       back = aligned[:, back_start:back_end, :, :]
+       aligned = torch.cat([front, back], dim=1)
+
+
+   # TP splitting: sequence parallelism across the tensor model parallel region
+   tp_size = mpu.get_tensor_model_parallel_world_size()
+   if tp_size > 1:
+       tp_rank = mpu.get_tensor_model_parallel_rank()
+       seq_len = aligned.shape[1]
+       chunk_size = seq_len // tp_size
+       aligned = aligned[:, tp_rank * chunk_size : (tp_rank + 1) * chunk_size, :, :]
+ 
+   per_layer_data = _split_replay_indices(aligned)
+   global_num_layers_in_data = len(per_layer_data)
+   instances = RouterReplay.global_router_replay_instances
+   num_instances = len(instances)
+
+
+   local_layer_offset, local_num_layers = _get_current_pp_stage_layer_range(model_config)
+
+
+   if local_num_layers == num_instances:
+       local_per_layer_data = per_layer_data[local_layer_offset : local_layer_offset + local_num_layers]
+       RouterReplay.set_replay_data(local_per_layer_data)
+   else:
+       # Dense-layer mismatch: map each MoE router to its global layer index.
+       # Prefer the patched layer_number; fall back to offset-based mapping
+       # (assumes dense layers precede MoE layers).
+       for local_router_idx, router_instance in enumerate(instances):
+           layer_number = getattr(router_instance, "layer_number", None)
+           if layer_number is not None:
+               layer_idx = layer_number - 1  # layer_number is 1-based
+           else:
+               layer_idx = local_layer_offset + local_router_idx
+           if layer_idx < 0 or layer_idx >= global_num_layers_in_data:
+               raise ValueError(
+                   f"Router replay layer index {layer_idx} out of range "
+                   f"for data with {global_num_layers_in_data} layers "
+                   f"({num_instances} router instances)"
+               )
+           router_instance.set_target_indices(per_layer_data[layer_idx])
+   RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+
+
 
 
 def clear_router_replay():
-    """Clear all router replay state."""
-    from megatron.core.transformer.moe.router_replay import RouterReplay
+   """Clear all router replay state."""
+   from megatron.core.transformer.moe.router_replay import RouterReplay
 
-    RouterReplay.clear_global_indices()
-    RouterReplay.clear_global_router_replay_action()
+
+   RouterReplay.clear_global_indices()
+   RouterReplay.clear_global_router_replay_action()
+   RouterReplay.clear_global_router_replay_instances()
+
+

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -1,452 +1,503 @@
-from dataclasses import asdict
+from typing import Optional, Callable, List, Dict, Any
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional
-
-import megatron.core.parallel_state as mpu
 import torch
 import torch.nn as nn
-from megatron.core.distributed import finalize_model_grads
-from megatron.core.pipeline_parallel import get_forward_backward_func
 from omegaconf import OmegaConf
+from dataclasses import asdict
 
-from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
-    get_model_config,
-    make_batch_generator,
-    postprocess_packed_seqs,
-    preprocess_packed_seqs,
-    recover_left_padding,
-    remove_left_padding,
-)
-from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
-    from_parallel_logits_to_logprobs,
-    vocab_parallel_entropy,
-)
-from skyrl.backends.skyrl_train.utils.ppo_utils import (
-    PolicyLossRegistry,
-    compute_approx_kl,
-)
-from skyrl.backends.skyrl_train.utils.replay_utils import (
-    setup_per_microbatch_replay_backward,
-    setup_per_microbatch_replay_forward,
-)
-from skyrl.backends.skyrl_train.utils.torch_utils import masked_mean
+
+from megatron.core.pipeline_parallel import get_forward_backward_func
+import megatron.core.parallel_state as mpu
+from megatron.core.distributed import finalize_model_grads
+
+
 from skyrl.train.config import TrainerConfig
+from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
+   from_parallel_logits_to_logprobs,
+   vocab_parallel_entropy,
+)
+from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import get_model_config
+from skyrl.backends.skyrl_train.utils.ppo_utils import compute_approx_kl, PolicyLossRegistry
+from skyrl.backends.skyrl_train.utils.torch_utils import masked_mean
+from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
+   make_batch_generator,
+   preprocess_packed_seqs,
+   postprocess_packed_seqs,
+   remove_left_padding,
+   recover_left_padding,
+)
+from skyrl.backends.skyrl_train.utils.replay_utils import setup_per_microbatch_replay_forward
+
+
 
 
 class MegatronModelWrapper:
-    def __init__(
-        self,
-        config: TrainerConfig,
-        actor_module: List[nn.Module],
-        actor_optimizer: Optional[torch.optim.Optimizer] = None,
-        policy_loss_fn: Optional[Callable] = None,
-    ):
-        self.cfg = config
-        self.actor_module = actor_module
-        self.actor_optimizer = actor_optimizer
-        self.policy_loss_fn = policy_loss_fn
-        self.use_sample_packing = self.cfg.use_sample_packing
+   def __init__(
+       self,
+       config: TrainerConfig,
+       actor_module: List[nn.Module],
+       actor_optimizer: Optional[torch.optim.Optimizer] = None,
+       policy_loss_fn: Optional[Callable] = None,
+   ):
+       self.cfg = config
+       self.actor_module = actor_module
+       self.actor_optimizer = actor_optimizer
+       self.policy_loss_fn = policy_loss_fn
+       self.use_sample_packing = self.cfg.use_sample_packing
 
-        config = get_model_config(self.actor_module[0])
-        # This is set to None by default: https://github.com/NVIDIA/Megatron-LM/blob/07b22a05136a3cb08ece05f7de38cf6aeeb165fb/megatron/core/model_parallel_config.py#L95
-        # use the build in finalize_model_grads function to all reduce gradients across parallelism dimensions
-        config.finalize_model_grads_func = finalize_model_grads
-        # Wire up the optimizer's loss scaler so Megatron's pipeline schedule can scale
-        # the loss before backward (critical for fp16 dynamic loss scaling, MoE aux loss
-        # scaling, and any explicit loss_scale configuration).
-        if actor_optimizer is not None:
-            config.grad_scale_func = actor_optimizer.scale_loss
 
-    def train(self):
-        [module.train() for module in self.actor_module]
+       config = get_model_config(self.actor_module[0])
+       # This is set to None by default: https://github.com/NVIDIA/Megatron-LM/blob/07b22a05136a3cb08ece05f7de38cf6aeeb165fb/megatron/core/model_parallel_config.py#L95
+       # use the build in finalize_model_grads function to all reduce gradients across parallelism dimensions
+       config.finalize_model_grads_func = finalize_model_grads
+       # Wire up the optimizer's loss scaler so Megatron's pipeline schedule can scale
+       # the loss before backward (critical for fp16 dynamic loss scaling, MoE aux loss
+       # scaling, and any explicit loss_scale configuration).
+       if actor_optimizer is not None:
+           config.grad_scale_func = actor_optimizer.scale_loss
 
-    def eval(self):
-        [module.eval() for module in self.actor_module]
 
-    def __call__(self, *args, **kwargs):
-        return self.forward(*args, **kwargs)
+   def train(self):
+       [module.train() for module in self.actor_module]
 
-    def forward(
-        self,
-        micro_batches: List[dict],
-        seq_len: int,
-        micro_batch_size: int,
-        temperature: float = 1.0,
-    ) -> torch.Tensor:
-        """
-        Forward-only inference to compute log-probs over a full mini-batch consisting of multiple micro-batches.
 
-        Args:
-            micro_batches: List of micro-batch dicts with keys: "sequences", "attention_mask", "position_ids",
-                           and "num_actions".
-            seq_len: Padded sequence length per sample.
-            micro_batch_size: Per-micro-batch size.
-            temperature: Optional temperature scaling for logits.
+   def eval(self):
+       [module.eval() for module in self.actor_module]
 
-        Returns:
-            torch.Tensor of concatenated log-probs across micro-batches (valid on pipeline last stage only).
-        """
-        forward_backward_func = get_forward_backward_func()
 
-        def collection_func(logits, data):
-            sequences = data["sequences"]
-            tp_grp = mpu.get_tensor_model_parallel_group()
-            tp_rank = mpu.get_tensor_model_parallel_rank()
+   def __call__(self, *args, **kwargs):
+       return self.forward(*args, **kwargs)
 
-            if temperature != 1.0:
-                logits.div_(temperature)
 
-            token_logprobs = from_parallel_logits_to_logprobs(
-                logits,
-                sequences,
-                vocab_start_index=tp_rank * logits.shape[-1],
-                vocab_end_index=(tp_rank + 1) * logits.shape[-1],
-                tp_group=tp_grp,
-                inference_only=True,
-                cp_group=None,  # we handle cp gathering in `postprocess_packed_seqs`
-                chunk_size=None,
-            )
-            return torch.tensor(0.0, device=token_logprobs.device), {"log_probs": token_logprobs}
+   def forward(
+       self,
+       micro_batches: List[dict],
+       seq_len: int,
+       micro_batch_size: int,
+       temperature: float = 1.0,
+   ) -> torch.Tensor:
+       """
+       Forward-only inference to compute log-probs over a full mini-batch consisting of multiple micro-batches.
 
-        def forward_step(batch_iter, model):
-            batch = next(batch_iter)
 
-            rollout_expert_indices = batch.pop("rollout_expert_indices", None)
-            if rollout_expert_indices is not None:
-                setup_per_microbatch_replay_forward(
-                    rollout_expert_indices, batch["attention_mask"], use_sample_packing=self.use_sample_packing
-                )
+       Args:
+           micro_batches: List of micro-batch dicts with keys: "sequences", "attention_mask", "position_ids",
+                          and "num_actions".
+           seq_len: Padded sequence length per sample.
+           micro_batch_size: Per-micro-batch size.
+           temperature: Optional temperature scaling for logits.
 
-            sequences = batch["sequences"]
-            attention_mask = batch["attention_mask"].to(bool)
-            position_ids = batch["position_ids"]
 
-            if self.use_sample_packing:
-                new_sequences, packed_seq_params = preprocess_packed_seqs(
-                    sequences,
-                    attention_mask,
-                    pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
-                )
-                new_attention_mask = None
-                new_position_ids = None
-            else:
-                new_sequences, new_attention_mask, new_position_ids = remove_left_padding(
-                    sequences,
-                    attention_mask,
-                    position_ids,
-                    pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
-                )
-                packed_seq_params = None
+       Returns:
+           torch.Tensor of concatenated log-probs across micro-batches (valid on pipeline last stage only).
+       """
+       forward_backward_func = get_forward_backward_func()
 
-            outputs = model(
-                new_sequences,
-                new_position_ids,
-                new_attention_mask,
-                packed_seq_params=packed_seq_params,
-            )
 
-            if self.use_sample_packing:
-                outputs = postprocess_packed_seqs(
-                    outputs,
-                    packed_seq_params,
-                    attention_mask,
-                    micro_batch_size,
-                    seq_len,
-                    post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
-                )
-            else:
-                outputs = recover_left_padding(
-                    outputs,
-                    new_attention_mask,
-                    attention_mask,
-                    seq_len,
-                    post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
-                )
+       def collection_func(logits, data):
+           sequences = data["sequences"]
+           tp_grp = mpu.get_tensor_model_parallel_group()
+           tp_rank = mpu.get_tensor_model_parallel_rank()
 
-            return outputs, partial(collection_func, data=batch)
 
-        batch_generator = make_batch_generator(micro_batches, vpp_size=len(self.actor_module))
+           if temperature != 1.0:
+               logits.div_(temperature)
 
-        output = forward_backward_func(
-            forward_step_func=forward_step,
-            data_iterator=batch_generator,
-            model=self.actor_module,
-            num_microbatches=len(micro_batches),
-            seq_length=seq_len,
-            micro_batch_size=micro_batch_size,
-            forward_only=True,
-        )
 
-        if mpu.is_pipeline_last_stage(ignore_virtual=True):
-            log_probs = [o["log_probs"] for o in output]
-            log_probs = torch.cat(log_probs, dim=0)
-            # take last num_actions tokens per micro; concatenate later
-            # Assume all micros have same num_actions
-            num_actions = micro_batches[0]["num_actions"]
-            log_probs = log_probs[:, -num_actions:]
-        else:
-            # return dummy tensor for non-last pp stages
-            device = micro_batches[0]["sequences"].device
-            log_probs = torch.zeros(size=(1, 1), dtype=torch.bfloat16, device=device)
-        return log_probs
+           token_logprobs = from_parallel_logits_to_logprobs(
+               logits,
+               sequences,
+               vocab_start_index=tp_rank * logits.shape[-1],
+               vocab_end_index=(tp_rank + 1) * logits.shape[-1],
+               tp_group=tp_grp,
+               inference_only=True,
+               cp_group=None,  # we handle cp gathering in `postprocess_packed_seqs`
+               chunk_size=None,
+           )
+           return torch.tensor(0.0, device=token_logprobs.device), {"log_probs": token_logprobs}
 
-    def forward_backward_mini_batch(
-        self,
-        micro_batches: List[dict],
-        seq_len: int,
-        micro_batch_size: int,
-        temperature: float = 1.0,
-        loss_fn: Optional[str] = None,
-        loss_fn_config: Optional[Dict[str, Any]] = None,
-    ) -> List[dict]:
-        """
-        Run forward-backward over a full mini-batch consisting of multiple micro-batches.
 
-        Args:
-            micro_batches: A list of micro-batch dicts. Each dict must contain keys:
-                "sequences", "attention_mask", "position_ids", "num_actions",
-                "old_action_log_probs", "base_action_log_probs", "advantages",
-                "loss_mask", "rollout_action_logprobs".
-            seq_len: Sequence length (tokens) per sample (assumed same across micros after padding).
-            micro_batch_size: Micro-batch size per forward pass.
-            temperature: Optional temperature for logits scaling.
-            loss_fn: Optional loss function name (e.g., "cross_entropy", "ppo").
-                     If provided, overrides the config's policy_loss_type.
-            loss_fn_config: Optional config overrides for the loss function.
+       def forward_step(batch_iter, model):
+           batch = next(batch_iter)
 
-        Returns:
-            List[dict]: one metrics dict per micro-batch in order.
-        """
-        forward_backward_func = get_forward_backward_func()
 
-        # Resolve loss function
-        resolved_loss_name = loss_fn if loss_fn is not None else self.cfg.algorithm.policy_loss_type
-        if loss_fn is not None:
-            current_loss_fn = PolicyLossRegistry.get(loss_fn)
-        else:
-            current_loss_fn = self.policy_loss_fn
+           rollout_expert_indices = batch.pop("rollout_expert_indices", None)
+           if rollout_expert_indices is not None:
+               setup_per_microbatch_replay_forward(
+                   rollout_expert_indices, batch["attention_mask"], get_model_config(model)
+               )
 
-        # Build config for loss function, applying any overrides
-        loss_config = self.cfg.algorithm
-        if loss_fn_config is not None:
 
-            new_loss_config = OmegaConf.merge(OmegaConf.create(asdict(loss_config)), OmegaConf.create(loss_fn_config))
-            # NOTE: users can provide a custom loss config class, so we need to use the same class after applying overrides
-            loss_config = type(loss_config).from_dict_config(new_loss_config)
+           sequences = batch["sequences"]
+           attention_mask = batch["attention_mask"].to(bool)
+           position_ids = batch["position_ids"]
 
-        def loss_func(logits, data):
-            sequences = data["sequences"]
-            num_actions = data["num_actions"]
-            old_action_log_probs = data["old_action_log_probs"]
-            base_action_log_probs = data["base_action_log_probs"]
-            advantages = data["advantages"]
-            loss_mask = data["loss_mask"]
-            rollout_action_logprobs = data["rollout_action_logprobs"]
-            action_mask = data.get("action_mask")
 
-            tp_grp = mpu.get_tensor_model_parallel_group()
-            tp_rank = mpu.get_tensor_model_parallel_rank()
+           if self.use_sample_packing:
+               new_sequences, packed_seq_params = preprocess_packed_seqs(
+                   sequences,
+                   attention_mask,
+                   pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
+               )
+               new_attention_mask = None
+               new_position_ids = None
+           else:
+               new_sequences, new_attention_mask, new_position_ids = remove_left_padding(
+                   sequences,
+                   attention_mask,
+                   position_ids,
+                   pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
+               )
+               packed_seq_params = None
 
-            # temperature normalization
-            if temperature != 1.0:
-                logits.div_(temperature)
 
-            token_logprobs = from_parallel_logits_to_logprobs(
-                logits,
-                sequences,
-                vocab_start_index=tp_rank * logits.shape[-1],
-                vocab_end_index=(tp_rank + 1) * logits.shape[-1],
-                tp_group=tp_grp,
-                inference_only=False,
-                cp_group=None,  # we handle cp gathering in `postprocess_packed_seqs`
-                chunk_size=None,
-            )
+           outputs = model(
+               new_sequences,
+               new_position_ids,
+               new_attention_mask,
+               packed_seq_params=packed_seq_params,
+           )
 
-            action_log_probs = token_logprobs[:, -num_actions:]
 
-            # policy loss should be calculated based on the selected token logprobs
-            policy_loss, loss_metrics = current_loss_fn(
-                action_log_probs,
-                old_action_log_probs,
-                advantages,
-                config=loss_config,
-                loss_mask=loss_mask,
-                rollout_logprobs=rollout_action_logprobs,
-            )
+           if self.use_sample_packing:
+               outputs = postprocess_packed_seqs(
+                   outputs,
+                   packed_seq_params,
+                   attention_mask,
+                   micro_batch_size,
+                   seq_len,
+                   post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
+               )
+           else:
+               outputs = recover_left_padding(
+                   outputs,
+                   new_attention_mask,
+                   attention_mask,
+                   seq_len,
+                   post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
+               )
 
-            # SFT path: cross_entropy loss (negative log likelihood)
-            if resolved_loss_name == "cross_entropy":
-                loss = policy_loss
 
-                # Compute elementwise loss for Tinker API (per-token NLL)
-                with torch.no_grad():
-                    elementwise_loss = -action_log_probs
-                    if loss_mask is not None:
-                        elementwise_loss = elementwise_loss * loss_mask
+           return outputs, partial(collection_func, data=batch)
 
-                # Build per-sequence loss_fn_outputs
-                batch_size = action_log_probs.shape[0]
-                loss_fn_outputs = []
-                for i in range(batch_size):
-                    if action_mask is not None:
-                        valid_len = int(action_mask[i].sum().item())
-                    elif loss_mask is not None:
-                        valid_len = int(loss_mask[i].sum().item())
-                    else:
-                        valid_len = action_log_probs.shape[1]
 
-                    loss_fn_outputs.append(
-                        {
-                            "logprobs": action_log_probs[i, :valid_len].detach().cpu().tolist(),
-                            "elementwise_loss": elementwise_loss[i, :valid_len].detach().cpu().tolist(),
-                        }
-                    )
+       batch_generator = make_batch_generator(micro_batches, vpp_size=len(self.actor_module))
 
-                metrics = {
-                    "loss": loss.detach().item(),
-                    "response_length": num_actions,
-                    "loss_fn_outputs": loss_fn_outputs,
-                }
-                return loss, metrics
 
-            # RL path: add optional KL/entropy terms
-            # entropy loss
-            with torch.set_grad_enabled(loss_config.use_entropy_loss):
-                action_logits = logits[:, -num_actions - 1 : -1, :]
-                entropy_BS = vocab_parallel_entropy(action_logits)
-                entropy = masked_mean(entropy_BS, loss_mask)
+       output = forward_backward_func(
+           forward_step_func=forward_step,
+           data_iterator=batch_generator,
+           model=self.actor_module,
+           num_microbatches=len(micro_batches),
+           seq_length=seq_len,
+           micro_batch_size=micro_batch_size,
+           forward_only=True,
+       )
 
-            if loss_config.use_entropy_loss:
-                entropy_loss_term = entropy * loss_config.entropy_loss_coef
-            else:
-                entropy_loss_term = torch.tensor(0.0)
 
-            if loss_config.use_kl_loss:
-                kl_loss = compute_approx_kl(
-                    action_log_probs,
-                    base_action_log_probs,
-                    loss_mask=loss_mask,
-                    kl_estimator_type=loss_config.kl_estimator_type,
-                )
-                kl_loss = masked_mean(kl_loss, loss_mask, dim=-1).mean()
-            else:
-                kl_loss = torch.tensor(0.0)
-            kl_loss_term = kl_loss * loss_config.kl_loss_coef
+       if mpu.is_pipeline_last_stage(ignore_virtual=True):
+           log_probs = [o["log_probs"] for o in output]
+           log_probs = torch.cat(log_probs, dim=0)
+           # take last num_actions tokens per micro; concatenate later
+           # Assume all micros have same num_actions
+           num_actions = micro_batches[0]["num_actions"]
+           log_probs = log_probs[:, -num_actions:]
+       else:
+           # return dummy tensor for non-last pp stages
+           device = micro_batches[0]["sequences"].device
+           log_probs = torch.zeros(size=(1, 1), dtype=torch.bfloat16, device=device)
+       return log_probs
 
-            loss = policy_loss + kl_loss_term - entropy_loss_term
 
-            # Build per-sequence loss_fn_outputs with logprobs.
-            batch_size = action_log_probs.shape[0]
-            seq_len = action_log_probs.shape[1]
+   def forward_backward_mini_batch(
+       self,
+       micro_batches: List[dict],
+       seq_len: int,
+       micro_batch_size: int,
+       temperature: float = 1.0,
+       loss_fn: Optional[str] = None,
+       loss_fn_config: Optional[Dict[str, Any]] = None,
+   ) -> List[dict]:
+       """
+       Run forward-backward over a full mini-batch consisting of multiple micro-batches.
 
-            if action_mask is not None:
-                valid_lens = action_mask.sum(dim=1).int().tolist()
-            elif loss_mask is not None:
-                valid_lens = loss_mask.sum(dim=1).int().tolist()
-            else:
-                valid_lens = [seq_len] * batch_size
 
-            detached_log_probs = action_log_probs.detach().cpu()
-            loss_fn_outputs = []
-            for i, valid_len in enumerate(valid_lens):
-                loss_fn_outputs.append(
-                    {
-                        "logprobs": detached_log_probs[i, :valid_len].tolist(),
-                    }
-                )
+       Args:
+           micro_batches: A list of micro-batch dicts. Each dict must contain keys:
+               "sequences", "attention_mask", "position_ids", "num_actions",
+               "old_action_log_probs", "base_action_log_probs", "advantages",
+               "loss_mask", "rollout_action_logprobs".
+           seq_len: Sequence length (tokens) per sample (assumed same across micros after padding).
+           micro_batch_size: Micro-batch size per forward pass.
+           temperature: Optional temperature for logits scaling.
+           loss_fn: Optional loss function name (e.g., "cross_entropy", "ppo").
+                    If provided, overrides the config's policy_loss_type.
+           loss_fn_config: Optional config overrides for the loss function.
 
-            metrics = {
-                "final_loss": loss.detach().item(),
-                "policy_loss": policy_loss.detach().item(),
-                "policy_entropy": entropy.detach().item(),
-                "policy_kl": kl_loss.detach().item(),
-                "loss_fn_outputs": loss_fn_outputs,
-            }
-            for k, v in loss_metrics.items():
-                metrics["loss_metrics/" + k] = v
-            return loss, metrics
 
-        def forward_step(batch_iter, model):
-            batch = next(batch_iter)
+       Returns:
+           List[dict]: one metrics dict per micro-batch in order.
+       """
+       forward_backward_func = get_forward_backward_func()
 
-            rollout_expert_indices = batch.pop("rollout_expert_indices", None)
-            if rollout_expert_indices is not None:
-                setup_per_microbatch_replay_forward(
-                    rollout_expert_indices, batch["attention_mask"], use_sample_packing=self.use_sample_packing
-                )
 
-            sequences = batch["sequences"]
-            attention_mask = batch["attention_mask"].to(bool)
-            position_ids = batch["position_ids"]
+       # Resolve loss function
+       resolved_loss_name = loss_fn if loss_fn is not None else self.cfg.algorithm.policy_loss_type
+       if loss_fn is not None:
+           current_loss_fn = PolicyLossRegistry.get(loss_fn)
+       else:
+           current_loss_fn = self.policy_loss_fn
 
-            if self.use_sample_packing:
-                new_sequences, packed_seq_params = preprocess_packed_seqs(
-                    sequences,
-                    attention_mask,
-                    pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
-                )
-                new_attention_mask = None
-                new_position_ids = None
-            else:
-                new_sequences, new_attention_mask, new_position_ids = remove_left_padding(
-                    sequences,
-                    attention_mask,
-                    position_ids,
-                    pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
-                )
-                packed_seq_params = None
 
-            outputs = model(
-                new_sequences,
-                new_position_ids,
-                new_attention_mask,
-                packed_seq_params=packed_seq_params,
-            )
+       # Build config for loss function, applying any overrides
+       loss_config = self.cfg.algorithm
+       if loss_fn_config is not None:
 
-            if self.use_sample_packing:
-                outputs = postprocess_packed_seqs(
-                    outputs,
-                    packed_seq_params,
-                    attention_mask,
-                    micro_batch_size,
-                    seq_len,
-                    post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
-                )
-            else:
-                outputs = recover_left_padding(
-                    outputs,
-                    new_attention_mask,
-                    attention_mask,
-                    seq_len,
-                    post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
-                )
 
-            if rollout_expert_indices is not None:
-                setup_per_microbatch_replay_backward()
+           new_loss_config = OmegaConf.merge(OmegaConf.create(asdict(loss_config)), OmegaConf.create(loss_fn_config))
+           # NOTE: users can provide a custom loss config class, so we need to use the same class after applying overrides
+           loss_config = type(loss_config).from_dict_config(new_loss_config)
 
-            return outputs, partial(loss_func, data=batch)
 
-        # batch should be a list of micro-batches
-        batch_generator = make_batch_generator(micro_batches, vpp_size=len(self.actor_module))
+       def loss_func(logits, data):
+           sequences = data["sequences"]
+           num_actions = data["num_actions"]
+           old_action_log_probs = data["old_action_log_probs"]
+           base_action_log_probs = data["base_action_log_probs"]
+           advantages = data["advantages"]
+           loss_mask = data["loss_mask"]
+           rollout_action_logprobs = data["rollout_action_logprobs"]
+           action_mask = data.get("action_mask")
 
-        metrics_list = forward_backward_func(
-            forward_step_func=forward_step,
-            data_iterator=batch_generator,
-            model=self.actor_module,
-            num_microbatches=len(micro_batches),
-            seq_length=seq_len,
-            micro_batch_size=micro_batch_size,
-            forward_only=False,
-        )
 
-        # broadcast metrics to all pp ranks
-        if not mpu.is_pipeline_last_stage(ignore_virtual=True):
-            metrics_list = [None] * len(micro_batches)
-        with torch.no_grad():
-            torch.distributed.broadcast_object_list(
-                metrics_list,
-                src=mpu.get_pipeline_model_parallel_last_rank(),
-                group=mpu.get_pipeline_model_parallel_group(),
-            )
+           tp_grp = mpu.get_tensor_model_parallel_group()
+           tp_rank = mpu.get_tensor_model_parallel_rank()
 
-        return metrics_list
+
+           # temperature normalization
+           if temperature != 1.0:
+               logits.div_(temperature)
+
+
+           token_logprobs = from_parallel_logits_to_logprobs(
+               logits,
+               sequences,
+               vocab_start_index=tp_rank * logits.shape[-1],
+               vocab_end_index=(tp_rank + 1) * logits.shape[-1],
+               tp_group=tp_grp,
+               inference_only=False,
+               cp_group=None,  # we handle cp gathering in `postprocess_packed_seqs`
+               chunk_size=None,
+           )
+
+
+           action_log_probs = token_logprobs[:, -num_actions:]
+
+
+           # policy loss should be calculated based on the selected token logprobs
+           policy_loss, loss_metrics = current_loss_fn(
+               action_log_probs,
+               old_action_log_probs,
+               advantages,
+               config=loss_config,
+               loss_mask=loss_mask,
+               rollout_logprobs=rollout_action_logprobs,
+           )
+
+
+           # SFT path: cross_entropy loss (negative log likelihood)
+           if resolved_loss_name == "cross_entropy":
+               loss = policy_loss
+
+
+               # Compute elementwise loss for Tinker API (per-token NLL)
+               with torch.no_grad():
+                   elementwise_loss = -action_log_probs
+                   if loss_mask is not None:
+                       elementwise_loss = elementwise_loss * loss_mask
+
+
+               # Build per-sequence loss_fn_outputs
+               batch_size = action_log_probs.shape[0]
+               loss_fn_outputs = []
+               for i in range(batch_size):
+                   if action_mask is not None:
+                       valid_len = int(action_mask[i].sum().item())
+                   elif loss_mask is not None:
+                       valid_len = int(loss_mask[i].sum().item())
+                   else:
+                       valid_len = action_log_probs.shape[1]
+
+
+                   loss_fn_outputs.append(
+                       {
+                           "logprobs": action_log_probs[i, :valid_len].detach().cpu().tolist(),
+                           "elementwise_loss": elementwise_loss[i, :valid_len].detach().cpu().tolist(),
+                       }
+                   )
+
+
+               metrics = {
+                   "loss": loss.detach().item(),
+                   "response_length": num_actions,
+                   "loss_fn_outputs": loss_fn_outputs,
+               }
+               return loss, metrics
+
+
+           # RL path: add optional KL/entropy terms
+           # entropy loss
+           with torch.set_grad_enabled(loss_config.use_entropy_loss):
+               action_logits = logits[:, -num_actions - 1 : -1, :]
+               entropy_BS = vocab_parallel_entropy(action_logits)
+               entropy = masked_mean(entropy_BS, loss_mask)
+
+
+           if loss_config.use_entropy_loss:
+               entropy_loss_term = entropy * loss_config.entropy_loss_coef
+           else:
+               entropy_loss_term = torch.tensor(0.0)
+
+
+           if loss_config.use_kl_loss:
+               kl_loss = compute_approx_kl(
+                   action_log_probs,
+                   base_action_log_probs,
+                   loss_mask=loss_mask,
+                   kl_estimator_type=loss_config.kl_estimator_type,
+               )
+               kl_loss = masked_mean(kl_loss, loss_mask, dim=-1).mean()
+           else:
+               kl_loss = torch.tensor(0.0)
+           kl_loss_term = kl_loss * loss_config.kl_loss_coef
+
+
+           loss = policy_loss + kl_loss_term - entropy_loss_term
+
+
+           # Build per-sequence loss_fn_outputs with logprobs.
+           batch_size = action_log_probs.shape[0]
+           seq_len = action_log_probs.shape[1]
+
+
+           if action_mask is not None:
+               valid_lens = action_mask.sum(dim=1).int().tolist()
+           elif loss_mask is not None:
+               valid_lens = loss_mask.sum(dim=1).int().tolist()
+           else:
+               valid_lens = [seq_len] * batch_size
+
+
+           detached_log_probs = action_log_probs.detach().cpu()
+           loss_fn_outputs = []
+           for i, valid_len in enumerate(valid_lens):
+               loss_fn_outputs.append(
+                   {
+                       "logprobs": detached_log_probs[i, :valid_len].tolist(),
+                   }
+               )
+
+
+           metrics = {
+               "final_loss": loss.detach().item(),
+               "policy_loss": policy_loss.detach().item(),
+               "policy_entropy": entropy.detach().item(),
+               "policy_kl": kl_loss.detach().item(),
+               "loss_fn_outputs": loss_fn_outputs,
+           }
+           for k, v in loss_metrics.items():
+               metrics["loss_metrics/" + k] = v
+           return loss, metrics
+
+
+       def forward_step(batch_iter, model):
+           batch = next(batch_iter)
+
+
+           rollout_expert_indices = batch.pop("rollout_expert_indices", None)
+           if rollout_expert_indices is not None:
+               setup_per_microbatch_replay_forward(
+                   rollout_expert_indices, batch["attention_mask"], get_model_config(model)
+               )
+
+
+           sequences = batch["sequences"]
+           attention_mask = batch["attention_mask"].to(bool)
+           position_ids = batch["position_ids"]
+
+
+           if self.use_sample_packing:
+               new_sequences, packed_seq_params = preprocess_packed_seqs(
+                   sequences,
+                   attention_mask,
+                   pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
+               )
+               new_attention_mask = None
+               new_position_ids = None
+           else:
+               new_sequences, new_attention_mask, new_position_ids = remove_left_padding(
+                   sequences,
+                   attention_mask,
+                   position_ids,
+                   pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
+               )
+               packed_seq_params = None
+
+
+           outputs = model(
+               new_sequences,
+               new_position_ids,
+               new_attention_mask,
+               packed_seq_params=packed_seq_params,
+           )
+
+
+           if self.use_sample_packing:
+               outputs = postprocess_packed_seqs(
+                   outputs,
+                   packed_seq_params,
+                   attention_mask,
+                   micro_batch_size,
+                   seq_len,
+                   post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
+               )
+           else:
+               outputs = recover_left_padding(
+                   outputs,
+                   new_attention_mask,
+                   attention_mask,
+                   seq_len,
+                   post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
+               )
+
+
+           return outputs, partial(loss_func, data=batch)
+
+
+       # batch should be a list of micro-batches
+       batch_generator = make_batch_generator(micro_batches, vpp_size=len(self.actor_module))
+
+
+       metrics_list = forward_backward_func(
+           forward_step_func=forward_step,
+           data_iterator=batch_generator,
+           model=self.actor_module,
+           num_microbatches=len(micro_batches),
+           seq_length=seq_len,
+           micro_batch_size=micro_batch_size,
+           forward_only=False,
+       )
+
+
+       # broadcast metrics to all pp ranks
+       if not mpu.is_pipeline_last_stage(ignore_virtual=True):
+           metrics_list = [None] * len(micro_batches)
+       with torch.no_grad():
+           torch.distributed.broadcast_object_list(
+               metrics_list,
+               src=mpu.get_pipeline_model_parallel_last_rank(),
+               group=mpu.get_pipeline_model_parallel_group(),
+           )
+
+
+       return metrics_list

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_router_replay.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_router_replay.py
@@ -3,369 +3,571 @@ Run with:
 uv run --isolated --extra dev --extra megatron -- pytest -s tests/backends/skyrl_train/gpu/gpu_ci/test_router_replay.py
 """
 
-import asyncio
 
-import pytest
 import ray
+import pytest
+import asyncio
 import torch
 from transformers import AutoTokenizer
-
-from skyrl.backends.skyrl_train.distributed.dispatch import (
-    concatenate_outputs_after_mesh_dispatch,
-)
-from skyrl.backends.skyrl_train.inference_engines.utils import (
-    get_sampling_params_for_backend,
-)
-from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
-from skyrl.train.config import SamplingParams, SkyRLTrainConfig
-from skyrl.train.dataset.preprocess import convert_prompts_responses_to_batch_tensors
-from skyrl.train.generators.base import GeneratorInput
-from skyrl.train.generators.skyrl_gym_generator import SkyRLGymGenerator
-from skyrl.train.utils.utils import validate_cfg
 from tests.backends.skyrl_train.gpu.utils import (
-    InferenceEngineState,
-    Timer,
-    get_test_generator_input,
-    init_worker_with_type,
+   InferenceEngineState,
+   get_test_generator_input,
+   Timer,
+   init_worker_with_type,
 )
+from skyrl.backends.skyrl_train.distributed.dispatch import concatenate_outputs_after_mesh_dispatch
+from skyrl.train.utils.utils import validate_cfg
+from skyrl.train.config import SkyRLTrainConfig, SamplingParams
+from skyrl.train.generators.skyrl_gym_generator import SkyRLGymGenerator
+from skyrl.train.generators.base import GeneratorInput
+from skyrl.backends.skyrl_train.inference_engines.utils import get_sampling_params_for_backend
+from skyrl.train.dataset.preprocess import convert_prompts_responses_to_batch_tensors
+from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 
-MOE_MODEL_NAME = "moonshotai/Moonlight-16B-A3B-Instruct"
-NUM_PROMPTS = 5
+
+# MOE_MODEL_NAME = "/home/ray/moonlight16b"
+# MOE_MODEL_NAME = "Qwen/Qwen3-30B-A3B"
+MOE_MODEL_NAME = "moonshotai/Moonlight-16B-A3B"
+REPLAY_NUM_LAYERS = 2
+NUM_PROMPTS = 2
 N_SAMPLES_PER_PROMPT = 2
 MAX_GENERATE_LENGTH = 128
 
 
+
+
 def get_test_actor_config(model_name=MOE_MODEL_NAME) -> SkyRLTrainConfig:
-    cfg = SkyRLTrainConfig()
-    cfg.trainer.policy.model.path = model_name
-    cfg.trainer.micro_forward_batch_size_per_gpu = 2
-    cfg.trainer.micro_train_batch_size_per_gpu = 2
-    cfg.trainer.use_sample_packing = True
-    cfg.generator.inference_engine.distributed_executor_backend = "mp"
-    # flash attn + mla works without sample packing, logprobs are crazy/wrong
-    # but flash-attn correctly throws error with sample packing
-    # we should add an assert that if you set use_sample_packing=False flash attn can accidentally be used
-    cfg.trainer.logger = "console"
-    if "moonlight" in model_name:
-        if cfg.trainer.policy.megatron_config.transformer_config_kwargs is None:
-            cfg.trainer.policy.megatron_config.transformer_config_kwargs = {}
-        cfg.trainer.flash_attn = False
-    validate_cfg(cfg)
-    return cfg
+   cfg = SkyRLTrainConfig()
+   cfg.trainer.policy.model.path = model_name
+   cfg.trainer.micro_forward_batch_size_per_gpu = 2
+   cfg.trainer.micro_train_batch_size_per_gpu = 2
+   cfg.trainer.use_sample_packing = True
+   # flash attn + mla works without sample packing, logprobs are crazy/wrong
+   # but flash-attn correctly throws error with sample packing
+   # we should add an assert that if you set use_sample_packing=False flash attn can accidentally be used
+   cfg.trainer.logger = "console"
+   if "moonlight" in model_name:
+       if cfg.trainer.policy.megatron_config.transformer_config_kwargs is None:
+           cfg.trainer.policy.megatron_config.transformer_config_kwargs = {}
+       # flash attn not supported for moonlight16b
+       # cfg.trainer.policy.megatron_config.moe_token_dispatcher_type = "alltoall"
+       # cfg.trainer.policy.megatron_config.moe_router_load_balancing_type = "seq_aux_loss"
+       # cfg.trainer.policy.megatron_config.transformer_config_kwargs["moe_aux_loss_coeff"] = 0
+       # cfg.trainer.policy.megatron_config.moe_router_score_function = "sigmoid"
+       # cfg.trainer.policy.megatron_config.moe_router_enable_expert_bias = True
+       # cfg.trainer.policy.megatron_config.transformer_config_kwargs["moe_router_bias_update_rate"] = 0
+       # cfg.trainer.policy.megatron_config.transformer_config_kwargs["moe_router_dtype"] = "fp32"
+       # cfg.trainer.policy.megatron_config.transformer_config_kwargs["moe_router_topk"] = 6
+       # cfg.trainer.policy.megatron_config.transformer_config_kwargs["moe_router_pre_softmax"] = True
+       # cfg.trainer.policy.megatron_config.transformer_config_kwargs["moe_router_group_topk"] = 1
+       # cfg.trainer.policy.megatron_config.transformer_config_kwargs["moe_router_num_groups"] = 1
+       # cfg.trainer.policy.megatron_config.transformer_config_kwargs["num_layers_in_last_pipeline_stage"] = 13
+       cfg.trainer.flash_attn = False
+   validate_cfg(cfg)
+   return cfg
+
+
 
 
 def build_training_input_from_text_samples(
-    tokenizer: AutoTokenizer, prompt_response_pairs: list[tuple[str, str]]
+   tokenizer: AutoTokenizer, prompt_response_pairs: list[tuple[str, str]]
 ) -> TrainingInputBatch:
-    prompts = []
-    responses = []
-    rewards = []
-    loss_masks = []
-
-    if tokenizer.pad_token_id is None:
-        tokenizer.pad_token = tokenizer.eos_token
-
-    for prompt_text, response_text in prompt_response_pairs:
-        prompt_ids = tokenizer.encode(prompt_text, add_special_tokens=False)
-        response_ids = tokenizer.encode(response_text, add_special_tokens=False)
-        if tokenizer.eos_token_id is not None and (not response_ids or response_ids[-1] != tokenizer.eos_token_id):
-            response_ids.append(tokenizer.eos_token_id)
-
-        prompts.append(prompt_ids)
-        responses.append(response_ids)
-        rewards.append([0.0] * len(response_ids))
-        loss_masks.append([1] * len(response_ids))
-
-    sequences, attention_mask, response_mask, rewards_t, loss_mask_t, _, _ = convert_prompts_responses_to_batch_tensors(
-        tokenizer=tokenizer,
-        prompts=prompts,
-        responses=responses,
-        rewards=rewards,
-        loss_masks=loss_masks,
-    )
-
-    num_actions = response_mask.shape[1]
-    batch_size = sequences.shape[0]
-    training_input = TrainingInputBatch(
-        {
-            "sequences": sequences,
-            "attention_mask": attention_mask,
-            "response_mask": response_mask,
-            "rewards": rewards_t,
-            "loss_mask": loss_mask_t,
-            "rollout_logprobs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
-            "action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
-            "base_action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
-            "advantages": torch.zeros((batch_size, num_actions), dtype=torch.float32),
-            "action_mask": response_mask.to(dtype=torch.int64),
-        }
-    )
-    training_input.metadata = {"response_length": num_actions}
-    return training_input
+   prompts = []
+   responses = []
+   rewards = []
+   loss_masks = []
 
 
-@pytest.mark.megatron
-@pytest.mark.skip(reason="Skipping router replay test for now due to size constraints")
-def test_logprobs(ray_init_fixture):
-    """
-    Check that logprob diff is lower when using router replay. Requires full 8xH100 setup to do full forward pass.
-    """
-    try:
-        cfg = get_test_actor_config(model_name=MOE_MODEL_NAME)
-        cfg.trainer.strategy = "megatron"
-        cfg.generator.inference_engine.enable_return_routed_experts = True
-        cfg.generator.inference_engine.tensor_parallel_size = 8
-        cfg.generator.sampling_params = SamplingParams(
-            max_generate_length=MAX_GENERATE_LENGTH,
-            logprobs=1,
-            temperature=1.0,
-        )
-        cfg.generator.batched = True
-        cfg.generator.async_engine = False
-        cfg.generator.max_turns = 1
+   if tokenizer.pad_token_id is None:
+       tokenizer.pad_token = tokenizer.eos_token
 
-        tokenizer = AutoTokenizer.from_pretrained(MOE_MODEL_NAME, trust_remote_code=True)
 
-        with InferenceEngineState.create(
-            cfg=cfg,
-            model=MOE_MODEL_NAME,
-            use_local=True,
-            colocate_all=True,
-            backend="vllm",
-            sleep_level=1,
-            gpu_memory_utilization=0.9,
-        ) as engines:
-            client, pg = engines.client, engines.pg
-            asyncio.run(client.wake_up())
+   for prompt_text, response_text in prompt_response_pairs:
+       prompt_ids = tokenizer.encode(prompt_text, add_special_tokens=False)
+       response_ids = tokenizer.encode(response_text, add_special_tokens=False)
+       if tokenizer.eos_token_id is not None and (not response_ids or response_ids[-1] != tokenizer.eos_token_id):
+           response_ids.append(tokenizer.eos_token_id)
 
-            generator = SkyRLGymGenerator(
-                generator_cfg=cfg.generator,
-                skyrl_gym_cfg=cfg.environment.skyrl_gym,
-                inference_engine_client=client,
-                tokenizer=tokenizer,
-            )
 
-            input_batch: GeneratorInput = get_test_generator_input(
-                model=MOE_MODEL_NAME,
-                num_prompts=NUM_PROMPTS,
-                n_samples_per_prompt=N_SAMPLES_PER_PROMPT,
-                max_prompt_length=512,
-                env_class="gsm8k",
-            )
-            input_batch["sampling_params"] = get_sampling_params_for_backend(
-                "vllm",
-                SamplingParams(
-                    temperature=1.0,
-                    top_p=1.0,
-                    top_k=-1,
-                    max_generate_length=MAX_GENERATE_LENGTH,
-                    min_p=0.0,
-                    logprobs=1,
-                ),
-            )
+       prompts.append(prompt_ids)
+       responses.append(response_ids)
+       rewards.append([0.0] * len(response_ids))
+       loss_masks.append([1] * len(response_ids))
 
-            with Timer("generate_with_router_replay"):
-                generator_output = asyncio.run(generator.generate(input_batch))
 
-            indices = generator_output["rollout_expert_indices"]
-            responses = generator_output["response_ids"]
-            assert (
-                indices is not None
-            ), "rollout_expert_indices should not be None when enable_return_routed_experts=True"
-            assert len(indices) == len(
-                responses
-            ), f"Batch size mismatch: {len(indices)} indices vs {len(responses)} responses"
-            asyncio.run(client.sleep())
+   sequences, attention_mask, response_mask, rewards_t, loss_mask_t, _, _ = convert_prompts_responses_to_batch_tensors(
+       tokenizer=tokenizer,
+       prompts=prompts,
+       responses=responses,
+       rewards=rewards,
+       loss_masks=loss_masks,
+   )
 
-        rewards = generator_output["rewards"]
-        if rewards and not isinstance(rewards[0], list):
-            rewards = [[r] * len(resp) for r, resp in zip(rewards, responses)]
-        (sequences, attention_mask, response_mask, rewards_t, loss_mask_t, logprobs_t, rii_tensor) = (
-            convert_prompts_responses_to_batch_tensors(
-                tokenizer=tokenizer,
-                prompts=generator_output["prompt_token_ids"],
-                responses=responses,
-                rewards=rewards,
-                loss_masks=generator_output["loss_masks"],
-                logprobs=generator_output.get("rollout_logprobs"),
-                rollout_expert_indices=indices,
-            )
-        )
 
-        assert rii_tensor is not None
-        num_actions = response_mask.shape[1]
-        batch_size = sequences.shape[0]
-        training_input = TrainingInputBatch(
-            {
-                "sequences": sequences,
-                "attention_mask": attention_mask,
-                "response_mask": response_mask,
-                "rewards": rewards_t,
-                "loss_mask": loss_mask_t,
-                "rollout_logprobs": (
-                    logprobs_t
-                    if logprobs_t is not None
-                    else torch.zeros((batch_size, num_actions), dtype=torch.float32)
-                ),
-                "rollout_expert_indices": rii_tensor,
-                "action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
-                "base_action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
-                "advantages": torch.zeros((batch_size, num_actions), dtype=torch.float32),
-                "action_mask": response_mask.to(dtype=torch.int64),
-            }
-        )
-        training_input.metadata = {"response_length": num_actions}
+   num_actions = response_mask.shape[1]
+   batch_size = sequences.shape[0]
+   training_input = TrainingInputBatch(
+       {
+           "sequences": sequences,
+           "attention_mask": attention_mask,
+           "response_mask": response_mask,
+           "rewards": rewards_t,
+           "loss_mask": loss_mask_t,
+           "rollout_logprobs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
+           "action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
+           "base_action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
+           "advantages": torch.zeros((batch_size, num_actions), dtype=torch.float32),
+           "action_mask": response_mask.to(dtype=torch.int64),
+       }
+   )
+   training_input.metadata = {"response_length": num_actions}
+   return training_input
 
-        cfg.trainer.placement.policy_num_gpus_per_node = 8
-        cfg.trainer.policy.megatron_config.tensor_model_parallel_size = 2
-        cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = 1
-        cfg.trainer.policy.megatron_config.context_parallel_size = 1
-        cfg.trainer.policy.megatron_config.expert_model_parallel_size = 8
-        cfg.trainer.policy.megatron_config.expert_tensor_parallel_size = 1
-        cfg.trainer.micro_forward_batch_size_per_gpu = 2
-        cfg.trainer.micro_train_batch_size_per_gpu = 2
 
-        def run_megatron_forward(enable_replay: bool) -> torch.Tensor:
-            cfg.trainer.policy.megatron_config.moe_enable_routing_replay = enable_replay
-            actor_group = init_worker_with_type(
-                "policy",
-                shared_pg=pg,
-                colocate_all=True,
-                num_gpus_per_node=8,
-                cfg=cfg,
-            )
 
-            refs = actor_group.async_run_ray_method("mesh", "forward", data=training_input)
-            results = ray.get(refs)
-            outputs = concatenate_outputs_after_mesh_dispatch(actor_group.actor_infos, results)["output"]
 
-            for actor in actor_group._actor_handlers:
-                ray.kill(actor)
-            return outputs
+def test_generate_with_router_replay(ray_init_fixture):
+   """
+   Check that generate with router replay produces the correct rollout inference indices.
+   """
+   try:
+       cfg = get_test_actor_config(model_name=MOE_MODEL_NAME)
+       cfg.trainer.strategy = "megatron"
+       cfg.generator.inference_engine.enable_return_routed_experts = True
+       cfg.generator.inference_engine.tensor_parallel_size = 8
+       cfg.generator.sampling_params = SamplingParams(
+           max_generate_length=MAX_GENERATE_LENGTH,
+           logprobs=1,
+           temperature=1.0,
+       )
+       cfg.generator.batched = False
+       cfg.generator.max_turns = 2
+       cfg.generator.use_conversation_multi_turn = True
+       env_class = "gsm8k_multi_turn"
 
-        r3_logprobs = run_megatron_forward(enable_replay=True)
-        no_r3_logprobs = run_megatron_forward(enable_replay=False)
 
-        mask = response_mask.bool()
-        vllm_valid = logprobs_t[mask]
-        r3_valid = r3_logprobs[mask]
-        no_r3_valid = no_r3_logprobs[mask]
-        r3_diff = (vllm_valid - r3_valid).abs()
-        no_r3_diff = (vllm_valid - no_r3_valid).abs()
-        print(f"vLLM logprobs     - mean: {vllm_valid.mean().item():.6f}, std: {vllm_valid.std().item():.6f}")
-        print(f"Megatron (replay) - mean: {r3_valid.mean().item():.6f}, std: {r3_valid.std().item():.6f}")
-        print(f"Megatron (no rep) - mean: {no_r3_valid.mean().item():.6f}, std: {no_r3_valid.std().item():.6f}")
-        print(f"With replay    - logprob diff mean: {r3_diff.mean().item():.6f}, std: {r3_diff.std().item():.6f}")
-        print(f"Without replay - logprob diff mean: {no_r3_diff.mean().item():.6f}, std: {no_r3_diff.std().item():.6f}")
+       tokenizer = AutoTokenizer.from_pretrained(MOE_MODEL_NAME, trust_remote_code=True)
 
-        assert r3_diff.mean().item() < no_r3_diff.mean().item(), (
-            f"Router replay should reduce logprob diff vs rollout, "
-            f"but with_replay={r3_diff.mean().item():.6f} >= without_replay={no_r3_diff.mean().item():.6f}"
-        )
-    finally:
-        ray.shutdown()
+
+       with InferenceEngineState.create(
+           cfg=cfg,
+           model=MOE_MODEL_NAME,
+           use_local=True,
+           colocate_all=True,
+           backend="vllm",
+           sleep_level=1,
+           gpu_memory_utilization=0.9,
+       ) as engines:
+           client = engines.client
+           asyncio.run(client.wake_up())
+
+
+           generator = SkyRLGymGenerator(
+               generator_cfg=cfg.generator,
+               skyrl_gym_cfg=cfg.environment.skyrl_gym,
+               inference_engine_client=client,
+               tokenizer=tokenizer,
+           )
+
+
+           input_batch: GeneratorInput = get_test_generator_input(
+               model=MOE_MODEL_NAME,
+               num_prompts=NUM_PROMPTS,
+               n_samples_per_prompt=N_SAMPLES_PER_PROMPT,
+               max_prompt_length=512,
+               env_class=env_class,
+           )
+           input_batch["sampling_params"] = get_sampling_params_for_backend(
+               "vllm",
+               SamplingParams(
+                   temperature=1.0,
+                   top_p=1.0,
+                   top_k=-1,
+                   max_generate_length=MAX_GENERATE_LENGTH,
+                   min_p=0.0,
+                   logprobs=1,
+               ),
+           )
+
+
+           with Timer("generate_with_router_replay"):
+               generator_output = asyncio.run(generator.generate(input_batch))
+
+
+           indices = generator_output["rollout_expert_indices"]
+           responses = generator_output["response_ids"]
+           assert (
+               indices is not None
+           ), "rollout_expert_indices should not be None when enable_return_routed_experts=True"
+           assert len(indices) == len(
+               responses
+           ), f"Batch size mismatch: {len(indices)} indices vs {len(responses)} responses"
+           asyncio.run(client.sleep())
+   finally:
+       ray.shutdown()
+
+
 
 
 @pytest.mark.megatron
-@pytest.mark.skip(reason="Skipping router replay test for now due to size constraints")
-def test_forward_backward(ray_init_fixture):
-    """
-    Check that forward_backward with router replay completes without error.
-    Uses dummy expert routing indices (no vLLM engine needed).
-    Non-zero advantages / action_log_probs verify the loss is actually computed.
-    """
-    try:
-        cfg = get_test_actor_config(model_name=MOE_MODEL_NAME)
-        cfg.trainer.strategy = "megatron"
+@pytest.mark.parametrize(
+   "tp,pp,cp,ep,etp,extra_tf_kwargs",
+   [
+       pytest.param(2, 1, 1, 2, 1, {}, id="baseline"),
+       pytest.param(2, 2, 1, 2, 1, {"num_layers_in_last_pipeline_stage": 13}, id="pp2"),
+       pytest.param(4, 1, 2, 8, 1, {}, id="cp2"),
+       pytest.param(2, 2, 2, 4, 1, {"num_layers_in_last_pipeline_stage": 13}, id="cp2_pp2"),
+   ],
+)
+def test_logprobs(ray_init_fixture, tp, pp, cp, ep, etp, extra_tf_kwargs):
+   """
+   Check that logprob diff is lower when using router replay. Requires full 8xH100 setup to do full forward pass.
+   """
+   try:
+       cfg = get_test_actor_config(model_name=MOE_MODEL_NAME)
+       cfg.trainer.strategy = "megatron"
+       cfg.generator.inference_engine.enable_return_routed_experts = True
+       cfg.generator.inference_engine.tensor_parallel_size = 8
+       cfg.generator.sampling_params = SamplingParams(
+           max_generate_length=MAX_GENERATE_LENGTH,
+           logprobs=1,
+           temperature=1.0,
+       )
+       cfg.generator.batched = False
+       cfg.generator.max_turns = 1
 
-        tokenizer = AutoTokenizer.from_pretrained(MOE_MODEL_NAME, trust_remote_code=True)
-        if tokenizer.pad_token_id is None:
-            tokenizer.pad_token = tokenizer.eos_token
 
-        num_samples = NUM_PROMPTS * N_SAMPLES_PER_PROMPT
-        prompts = []
-        responses = []
-        rewards = []
-        loss_masks = []
-        for i in range(num_samples):
-            prompt_ids = tokenizer.encode(f"What is {i} + {i}?", add_special_tokens=False)
-            response_ids = tokenizer.encode(f"The answer is {i + i}.", add_special_tokens=False)
-            if tokenizer.eos_token_id is not None and (not response_ids or response_ids[-1] != tokenizer.eos_token_id):
-                response_ids.append(tokenizer.eos_token_id)
-            prompts.append(prompt_ids)
-            responses.append(response_ids)
-            rewards.append([1.0] * len(response_ids))
-            loss_masks.append([1] * len(response_ids))
+       tokenizer = AutoTokenizer.from_pretrained(MOE_MODEL_NAME, trust_remote_code=True)
 
-        sequences, attention_mask, response_mask, rewards_t, loss_mask_t, _, _ = (
-            convert_prompts_responses_to_batch_tensors(
-                tokenizer=tokenizer,
-                prompts=prompts,
-                responses=responses,
-                rewards=rewards,
-                loss_masks=loss_masks,
-            )
-        )
 
-        batch_size = sequences.shape[0]
-        seq_len = sequences.shape[1]
-        num_actions = response_mask.shape[1]
+       with InferenceEngineState.create(
+           cfg=cfg,
+           model=MOE_MODEL_NAME,
+           use_local=True,
+           colocate_all=True,
+           backend="vllm",
+           sleep_level=1,
+           gpu_memory_utilization=0.9,
+       ) as engines:
+           client, pg = engines.client, engines.pg
+           asyncio.run(client.wake_up())
 
-        # Moonlight 16B: 27 MoE layers, top_k=6, 64 routed experts
-        MOONLIGHT_NUM_LAYERS = 27
-        MOONLIGHT_TOPK = 6
-        MOONLIGHT_NUM_EXPERTS = 64
-        rollout_expert_indices = torch.randint(
-            0, MOONLIGHT_NUM_EXPERTS, (batch_size, seq_len, MOONLIGHT_NUM_LAYERS, MOONLIGHT_TOPK), dtype=torch.int32
-        )
-        rollout_expert_indices[attention_mask == 0] = 0
 
-        gen = torch.Generator().manual_seed(42)
-        training_input = TrainingInputBatch(
-            {
-                "sequences": sequences,
-                "attention_mask": attention_mask,
-                "response_mask": response_mask,
-                "rewards": rewards_t,
-                "loss_mask": loss_mask_t,
-                "rollout_logprobs": -torch.rand((batch_size, num_actions), generator=gen) * 2.0,
-                "rollout_expert_indices": rollout_expert_indices,
-                "action_log_probs": -torch.rand((batch_size, num_actions), generator=gen) * 2.0,
-                "base_action_log_probs": -torch.rand((batch_size, num_actions), generator=gen) * 2.0,
-                "advantages": torch.randn((batch_size, num_actions), generator=gen),
-                "action_mask": response_mask.to(dtype=torch.int64),
-            }
-        )
-        training_input.metadata = {"response_length": num_actions}
+           generator = SkyRLGymGenerator(
+               generator_cfg=cfg.generator,
+               skyrl_gym_cfg=cfg.environment.skyrl_gym,
+               inference_engine_client=client,
+               tokenizer=tokenizer,
+           )
 
-        cfg.trainer.placement.policy_num_gpus_per_node = 8
-        cfg.trainer.policy.megatron_config.tensor_model_parallel_size = 4
-        cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = 1
-        cfg.trainer.policy.megatron_config.context_parallel_size = 1
-        cfg.trainer.policy.megatron_config.expert_model_parallel_size = 8
-        cfg.trainer.policy.megatron_config.expert_tensor_parallel_size = 1
-        cfg.trainer.micro_forward_batch_size_per_gpu = 2
-        cfg.trainer.micro_train_batch_size_per_gpu = 2
-        cfg.trainer.policy.megatron_config.moe_enable_routing_replay = True
 
-        actor_group = init_worker_with_type(
-            "policy",
-            num_gpus_per_node=8,
-            cfg=cfg,
-        )
+           input_batch: GeneratorInput = get_test_generator_input(
+               model=MOE_MODEL_NAME,
+               num_prompts=NUM_PROMPTS,
+               n_samples_per_prompt=N_SAMPLES_PER_PROMPT,
+               max_prompt_length=512,
+               env_class="gsm8k",
+           )
+           input_batch["sampling_params"] = get_sampling_params_for_backend(
+               "vllm",
+               SamplingParams(
+                   temperature=1.0,
+                   top_p=1.0,
+                   top_k=-1,
+                   max_generate_length=MAX_GENERATE_LENGTH,
+                   min_p=0.0,
+                   logprobs=1,
+               ),
+           )
 
-        ray.get(actor_group.async_run_ray_method("pass_through", "setup_per_microbatch_replay_backward"))
-        ray.get(actor_group.async_run_ray_method("mesh", "forward_backward", data=training_input))
-        ray.get(actor_group.async_run_ray_method("pass_through", "optim_step"))
-        results = ray.get(actor_group.async_run_ray_method("mesh", "forward_backward", data=training_input))
 
-        metrics = results[0]
-        loss = metrics["policy_loss"]
-        print(f"Router replay forward_backward - loss: {loss:.6f}")
-        assert loss is not None and not torch.isnan(torch.tensor(loss)), "Loss should be valid (not NaN)"
-        assert loss != 0.0, "Loss should be non-zero with non-zero advantages"
+           with Timer("generate_with_router_replay"):
+               generator_output = asyncio.run(generator.generate(input_batch))
 
-        for actor in actor_group._actor_handlers:
-            ray.kill(actor)
-    finally:
-        ray.shutdown()
+
+           indices = generator_output["rollout_expert_indices"]
+           responses = generator_output["response_ids"]
+           assert (
+               indices is not None
+           ), "rollout_expert_indices should not be None when enable_return_routed_experts=True"
+           assert len(indices) == len(
+               responses
+           ), f"Batch size mismatch: {len(indices)} indices vs {len(responses)} responses"
+           asyncio.run(client.sleep())
+
+
+       rewards = generator_output["rewards"]
+       if rewards and not isinstance(rewards[0], list):
+           rewards = [[r] * len(resp) for r, resp in zip(rewards, responses)]
+       (sequences, attention_mask, response_mask, rewards_t, loss_mask_t, logprobs_t, rii_tensor) = (
+           convert_prompts_responses_to_batch_tensors(
+               tokenizer=tokenizer,
+               prompts=generator_output["prompt_token_ids"],
+               responses=responses,
+               rewards=rewards,
+               loss_masks=generator_output["loss_masks"],
+               logprobs=generator_output.get("rollout_logprobs"),
+               rollout_expert_indices=indices,
+           )
+       )
+
+
+       assert rii_tensor is not None
+       num_actions = response_mask.shape[1]
+       batch_size = sequences.shape[0]
+       training_input = TrainingInputBatch(
+           {
+               "sequences": sequences,
+               "attention_mask": attention_mask,
+               "response_mask": response_mask,
+               "rewards": rewards_t,
+               "loss_mask": loss_mask_t,
+               "rollout_logprobs": (
+                   logprobs_t
+                   if logprobs_t is not None
+                   else torch.zeros((batch_size, num_actions), dtype=torch.float32)
+               ),
+               "rollout_expert_indices": rii_tensor,
+               "action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
+               "base_action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
+               "advantages": torch.zeros((batch_size, num_actions), dtype=torch.float32),
+               "action_mask": response_mask.to(dtype=torch.int64),
+           }
+       )
+       training_input.metadata = {"response_length": num_actions}
+
+
+       cfg.trainer.placement.policy_num_gpus_per_node = 8
+       cfg.trainer.policy.megatron_config.tensor_model_parallel_size = tp
+       cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = pp
+       cfg.trainer.policy.megatron_config.context_parallel_size = cp
+       cfg.trainer.policy.megatron_config.expert_model_parallel_size = ep
+       cfg.trainer.policy.megatron_config.expert_tensor_parallel_size = etp
+       cfg.trainer.micro_forward_batch_size_per_gpu = 1
+       cfg.trainer.micro_train_batch_size_per_gpu = 1
+
+
+       def run_megatron_forward(enable_replay: bool) -> torch.Tensor:
+           cfg.trainer.policy.megatron_config.transformer_config_kwargs = {
+               "moe_enable_routing_replay": enable_replay,
+               **extra_tf_kwargs,
+           }
+           actor_group = init_worker_with_type(
+               "policy",
+               shared_pg=pg,
+               colocate_all=True,
+               num_gpus_per_node=8,
+               cfg=cfg,
+           )
+
+
+           refs = actor_group.async_run_ray_method("mesh", "forward", data=training_input)
+           results = ray.get(refs)
+           outputs = concatenate_outputs_after_mesh_dispatch(actor_group.actor_infos, results)["output"]
+
+
+           for actor in actor_group._actor_handlers:
+               ray.kill(actor)
+           return outputs
+
+
+       r3_logprobs = run_megatron_forward(enable_replay=True)
+       no_r3_logprobs = run_megatron_forward(enable_replay=False)
+
+
+       r3_diff = (logprobs_t - r3_logprobs).abs()
+       no_r3_diff = (logprobs_t - no_r3_logprobs).abs()
+       print(f"vLLM logprobs     - mean: {logprobs_t.mean().item():.6f}, std: {logprobs_t.std().item():.6f}")
+       print(f"Megatron (replay) - mean: {r3_logprobs.mean().item():.6f}, std: {r3_logprobs.std().item():.6f}")
+       print(f"Megatron (no rep) - mean: {no_r3_logprobs.mean().item():.6f}, std: {no_r3_logprobs.std().item():.6f}")
+       print(f"With replay    - logprob diff mean: {r3_diff.mean().item():.6f}, std: {r3_diff.std().item():.6f}")
+       print(f"Without replay - logprob diff mean: {no_r3_diff.mean().item():.6f}, std: {no_r3_diff.std().item():.6f}")
+
+
+       assert r3_diff.mean().item() < no_r3_diff.mean().item(), (
+           f"Router replay should reduce logprob diff vs rollout, "
+           f"but with_replay={r3_diff.mean().item():.6f} >= without_replay={no_r3_diff.mean().item():.6f}"
+       )
+   finally:
+       ray.shutdown()
+
+
+
+
+@pytest.mark.megatron
+@pytest.mark.parametrize(
+   "tp,pp,cp,ep,etp,extra_tf_kwargs",
+   [
+       pytest.param(4, 1, 1, 8, 1, {}, id="baseline"),
+       pytest.param(2, 2, 1, 2, 1, {"num_layers_in_last_pipeline_stage": 13}, id="pp2"),
+   ],
+)
+def test_forward_backward(ray_init_fixture, tp, pp, cp, ep, etp, extra_tf_kwargs):
+   """
+   Check that forward_backward produces similar losses with and without
+   router replay (same weights, so routing decisions should nearly match).
+   Requires full 8xH100 setup.
+   """
+   try:
+       cfg = get_test_actor_config(model_name=MOE_MODEL_NAME)
+       cfg.trainer.strategy = "megatron"
+       cfg.generator.inference_engine.enable_return_routed_experts = True
+       cfg.generator.inference_engine.tensor_parallel_size = 8
+       cfg.generator.sampling_params = SamplingParams(
+           max_generate_length=MAX_GENERATE_LENGTH,
+           logprobs=1,
+           temperature=1.0,
+       )
+       cfg.generator.batched = False
+       cfg.generator.max_turns = 1
+
+
+       tokenizer = AutoTokenizer.from_pretrained(MOE_MODEL_NAME, trust_remote_code=True)
+
+
+       with InferenceEngineState.create(
+           cfg=cfg,
+           model=MOE_MODEL_NAME,
+           use_local=True,
+           colocate_all=True,
+           backend="vllm",
+           sleep_level=1,
+           gpu_memory_utilization=0.9,
+       ) as engines:
+           client, pg = engines.client, engines.pg
+           asyncio.run(client.wake_up())
+
+
+           generator = SkyRLGymGenerator(
+               generator_cfg=cfg.generator,
+               skyrl_gym_cfg=cfg.environment.skyrl_gym,
+               inference_engine_client=client,
+               tokenizer=tokenizer,
+           )
+
+
+           input_batch: GeneratorInput = get_test_generator_input(
+               model=MOE_MODEL_NAME,
+               num_prompts=NUM_PROMPTS,
+               n_samples_per_prompt=N_SAMPLES_PER_PROMPT,
+               max_prompt_length=512,
+               env_class="gsm8k",
+           )
+           input_batch["sampling_params"] = get_sampling_params_for_backend(
+               "vllm",
+               SamplingParams(
+                   temperature=1.0,
+                   top_p=1.0,
+                   top_k=-1,
+                   max_generate_length=MAX_GENERATE_LENGTH,
+                   min_p=0.0,
+                   logprobs=1,
+               ),
+           )
+
+
+           with Timer("generate_with_router_replay"):
+               generator_output = asyncio.run(generator.generate(input_batch))
+
+
+           indices = generator_output["rollout_expert_indices"]
+           responses = generator_output["response_ids"]
+           assert (
+               indices is not None
+           ), "rollout_expert_indices should not be None when enable_return_routed_experts=True"
+           assert len(indices) == len(
+               responses
+           ), f"Batch size mismatch: {len(indices)} indices vs {len(responses)} responses"
+           asyncio.run(client.sleep())
+
+
+       rewards = generator_output["rewards"]
+       if rewards and not isinstance(rewards[0], list):
+           rewards = [[r] * len(resp) for r, resp in zip(rewards, responses)]
+       (sequences, attention_mask, response_mask, rewards_t, loss_mask_t, logprobs_t, rii_tensor) = (
+           convert_prompts_responses_to_batch_tensors(
+               tokenizer=tokenizer,
+               prompts=generator_output["prompt_token_ids"],
+               responses=responses,
+               rewards=rewards,
+               loss_masks=generator_output["loss_masks"],
+               logprobs=generator_output.get("rollout_logprobs"),
+               rollout_expert_indices=indices,
+           )
+       )
+
+
+       assert rii_tensor is not None
+       num_actions = response_mask.shape[1]
+       batch_size = sequences.shape[0]
+       training_input = TrainingInputBatch(
+           {
+               "sequences": sequences,
+               "attention_mask": attention_mask,
+               "response_mask": response_mask,
+               "rewards": rewards_t,
+               "loss_mask": loss_mask_t,
+               "rollout_logprobs": (
+                   logprobs_t
+                   if logprobs_t is not None
+                   else torch.zeros((batch_size, num_actions), dtype=torch.float32)
+               ),
+               "rollout_expert_indices": rii_tensor,
+               "action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
+               "base_action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
+               "advantages": torch.zeros((batch_size, num_actions), dtype=torch.float32),
+               "action_mask": response_mask.to(dtype=torch.int64),
+           }
+       )
+       training_input.metadata = {"response_length": num_actions}
+
+
+       cfg.trainer.placement.policy_num_gpus_per_node = 8
+       cfg.trainer.policy.megatron_config.tensor_model_parallel_size = tp
+       cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = pp
+       cfg.trainer.policy.megatron_config.context_parallel_size = cp
+       cfg.trainer.policy.megatron_config.expert_model_parallel_size = ep
+       cfg.trainer.policy.megatron_config.expert_tensor_parallel_size = etp
+       cfg.trainer.micro_forward_batch_size_per_gpu = 1
+       cfg.trainer.micro_train_batch_size_per_gpu = 1
+
+
+       def run_megatron_forward_backward(enable_replay: bool) -> dict:
+           cfg.trainer.policy.megatron_config.transformer_config_kwargs = {
+               "moe_enable_routing_replay": enable_replay,
+               **extra_tf_kwargs,
+           }
+           actor_group = init_worker_with_type(
+               "policy",
+               shared_pg=pg,
+               colocate_all=True,
+               num_gpus_per_node=8,
+               cfg=cfg,
+           )
+           results = ray.get(actor_group.async_run_ray_method("mesh", "forward_backward", data=training_input))
+           for actor in actor_group._actor_handlers:
+               ray.kill(actor)
+           return results[0]
+
+
+       metrics_replay = run_megatron_forward_backward(enable_replay=True)
+       metrics_no_replay = run_megatron_forward_backward(enable_replay=False)
+
+
+       loss_replay = metrics_replay["policy_loss"]
+       loss_no_replay = metrics_no_replay["policy_loss"]
+       print(f"With replay    - loss: {loss_replay:.6f}")
+       print(f"Without replay - loss: {loss_no_replay:.6f}")
+       print(f"With replay metrics: {metrics_replay}")
+       print(f"Without replay metrics: {metrics_no_replay}")
+
+
+       diff = abs(loss_replay - loss_no_replay)
+       threshold = 0.5
+       print(f"Loss diff: {diff:.6f} (threshold: {threshold})")
+       assert diff < threshold, (
+           f"Losses with/without replay should be similar (same weights), "
+           f"but diff={diff:.6f} >= threshold={threshold}"
+       )
+   finally:
+       ray.shutdown()


### PR DESCRIPTION
# Summary
Extending #1273, this PR provides support for pipeline parallelism and context parallelism for R3. See #815 for tracking of future tasks to fully support routing replay in all settings.

# Implementation

**Pipeline Parallelism**
For pipeline parallelism, we create a helper function `_get_current_pp_stage_layer_range(model_config)` which maps the current PP rank and its layers to the global layer offset across all the model layers so that we can use this offset to correctly select the corresponding replay instances from a `RouterReplay.global_router_replay_instances`. 

First, we get the number of pipeline stages from PP world size along with the total number of model layers. For models containing dense layers / unequal pipeline stages, megatron supports setting a customer number of layers for the first and last PP rank. Then, we capture these values from the model config and check to see if the remaining number of layers can be evenly distributed across the remaining PP ranks. Finally, we return the transformer-layer range owned by the current PP rank as s_p, n_p, where:
- s_p is the global starting layer index for rank p
- n_p is the number of transformer layers assigned to that stage

For an even partition with L total layers and P pipeline stages:
- next_n_pp_layers = L // P, start_index = next_n_pp_layers * pp_rank
- the offset should thus span (next_n_pp_layers * pp_rank) : (next_n_pp_layers * (pp_rank+1)

For uneven partitioning, if the first and/or last stages are assigned custom layer counts, we subtract those from $L$, split the remaining layers evenly among the remaining stages, and then shift the start index accordingly. This means we can support cases like Moonlight-16B models which have 27 layers, where we can pass `num_layers_in_first_pipeline_stage` as 13 for PP=2.  

**Context Parallelism**

When using sample_packing, our megatron worker pre-processes and post-processes packed sequences. When CP is enabled, it is split into CP*2 chunks, so each effective GPU gets 2 CP chunks of half the size. See https://github.com/NVIDIA/TransformerEngine/issues/1368. To account for this extra chunking, the `setup_per_microbatch_replay_forward` method is updated to so that the effective_seq_len accounts for cp_size * 2 (same as the alignment in preprocess_packed_seqs in megatron_utils.py) along with the seqlen_per_cp as seqlen_per_cp // 2. We then index the front and back halves of these CP chunks from the aligned indices across the CP ranks and then concatenate them. This ensures that the router replay indices see the correct tokens from this CP chunking for megatron.

**Testing**

You can test with CP and/or PP configs from the test_router_replay file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
