### PR TITLE
[CI] Fix `test_inference_engines_generation` after vllm 0.16.0 upgrade; Use the correct GSM8k path for  `test_generator_multi_turn_gsm8k_router_replay`

### DIFF
--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py
@@ -25,10 +25,10 @@ MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
 MOE_MODEL = "Qwen/Qwen1.5-MoE-A2.7B"
 
 
-def get_test_actor_config() -> SkyRLTrainConfig:
+def get_test_actor_config(model: str = MODEL) -> SkyRLTrainConfig:
     """Get base config with test-specific overrides."""
     cfg = SkyRLTrainConfig()
-    cfg.trainer.policy.model.path = MODEL
+    cfg.trainer.policy.model.path = model
 
     cfg.generator.sampling_params.temperature = 0.0
     cfg.generator.sampling_params.top_p = 1
@@ -102,7 +102,7 @@ def test_inference_engines_generation(ray_init_fixture, tp_size: int, pp_size: i
     """
     Tests generation with both remote and ray-wrapped engines.
     """
-    cfg = get_test_actor_config()
+    cfg = get_test_actor_config(model)
 
     prompts = get_test_prompts(model)
     tokenizer = AutoTokenizer.from_pretrained(model)
@@ -210,8 +210,7 @@ def test_token_based_generation(
 ):
     """Test generation using prompt_token_ids."""
 
-    cfg = get_test_actor_config()
-    cfg.trainer.policy.model.path = model
+    cfg = get_test_actor_config(model)
 
     prompts = get_test_prompts(model, 3)
     tokenizer = AutoTokenizer.from_pretrained(model)

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py
@@ -90,25 +90,25 @@ async def run_single_generation_with_tokens(client, prompt_token_ids, sampling_p
 
 @pytest.mark.skipif(_SKYRL_USE_NEW_INFERENCE, reason="New inference pathway doesn't support text based generation")
 @pytest.mark.parametrize(
-    "tp_size,pp_size,dp_size",
+    "tp_size,pp_size,dp_size,model",
     [
-        pytest.param(2, 1, 1),
-        pytest.param(2, 1, 2),
-        pytest.param(2, 2, 1),  # TP=2, PP=2
+        pytest.param(2, 1, 1, MODEL),
+        pytest.param(2, 1, 2, MOE_MODEL),
+        pytest.param(2, 2, 1, MODEL),  # TP=2, PP=2
     ],
-    ids=["tp2_pp1_dp1", "tp2_pp1_dp2", "tp2_pp2_dp1"],
+    ids=["tp2_pp1_dp1", "tp2_pp1_dp2_moe", "tp2_pp2_dp1"],
 )
-def test_inference_engines_generation(ray_init_fixture, tp_size: int, pp_size: int, dp_size: int):
+def test_inference_engines_generation(ray_init_fixture, tp_size: int, pp_size: int, dp_size: int, model: str):
     """
     Tests generation with both remote and ray-wrapped engines.
     """
     cfg = get_test_actor_config()
 
-    prompts = get_test_prompts(MODEL)
-    tokenizer = AutoTokenizer.from_pretrained(MODEL)
+    prompts = get_test_prompts(model)
+    tokenizer = AutoTokenizer.from_pretrained(model)
 
     try:
-        llm_client, remote_server_process = init_remote_inference_servers(tp_size, "vllm", tokenizer, cfg, MODEL)
+        llm_client, remote_server_process = init_remote_inference_servers(tp_size, "vllm", tokenizer, cfg, model)
         sampling_params = get_sampling_params_for_backend(
             cfg.generator.inference_engine.backend, cfg.generator.sampling_params
         )

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py
@@ -488,7 +488,7 @@ async def test_generator_multi_turn_gsm8k_router_replay(ray_init_fixture):
         max_prompt_length=2048,
         max_input_length=max_input_length,
         max_generate_length=1000,
-        data_path=os.path.expanduser("/mnt/cluster_storage/data/gsm8k/validation.parquet"),
+        data_path=os.path.expanduser("~/data/gsm8k/validation.parquet"),
         env_class="gsm8k_multi_turn",
         num_prompts=num_prompts,
         max_turns=2,


### PR DESCRIPTION
# What does this PR do?

Fixes CI failures on main right now: https://github.com/NovaSky-AI/SkyRL/actions/runs/23218100038/job/67484003027


1. `tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py::test_generator_multi_turn_gsm8k_router_replay - FileNotFoundError: Unable to find '/mnt/cluster_storage/data/gsm8k/validation.parquet'` -> #1273   added a router replay test but used an incorrect path for the GSM8K dataset on CI 
2. `tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py::TestColocatedIpcWeightUpdateFlow::test_update_weights_ipc` -> Similar fix as in https://github.com/NovaSky-AI/SkyRL/pull/1301 

```bash
=========================== short test summary info ============================
FAILED tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py::test_inference_engines_generation[tp2_pp1_dp2] - ray.exceptions.ActorDiedError: The actor died because of an error raised in its creation task, ray::AsyncVLLMInferenceEngine.__init__() (pid=25165, ip=10.0.25.170, actor_id=7617504c4a769d500d1bc9ef13000000, repr=<skyrl.backends.skyrl_train.inference_engines.vllm.vllm_engine.AsyncVLLMInferenceEngine object at 0x7ea2b748c800>)
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
           ^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-03-17_21-54-20_786615_3475/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_95e2ed2914e100bfad4cccac453e4b5b/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py", line 343, in __init__
    super().__init__(*args, **kwargs)
  File "/tmp/ray/session_2026-03-17_21-54-20_786615_3475/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_95e2ed2914e100bfad4cccac453e4b5b/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py", line 112, in __init__
    self.llm = self._create_engine(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-03-17_21-54-20_786615_3475/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_95e2ed2914e100bfad4cccac453e4b5b/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py", line 364, in _create_engine
    engine = vllm.AsyncLLMEngine.from_engine_args(engine_args, stat_loggers=stat_loggers)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmpuPz58u/lib/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 251, in from_engine_args
    return cls(
           ^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmpuPz58u/lib/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 148, in __init__
    self.engine_core = EngineCoreClient.make_async_mp_client(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmpuPz58u/lib/python3.12/site-packages/vllm/v1/engine/core_client.py", line 121, in make_async_mp_client
    return DPAsyncMPClient(*client_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmpuPz58u/lib/python3.12/site-packages/vllm/v1/engine/core_client.py", line 1082, in __init__
    self._ensure_stats_update_task()
  File "/home/ray/.cache/uv/builds-v0/.tmpuPz58u/lib/python3.12/site-packages/vllm/v1/engine/core_client.py", line 1091, in _ensure_stats_update_task
    assert self.stats_update_address is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
FAILED tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py::test_generator_multi_turn_gsm8k_router_replay - FileNotFoundError: Unable to find '/mnt/cluster_storage/data/gsm8k/validation.parquet'
ERROR tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py::TestColocatedIpcWeightUpdateFlow::test_update_weights_ipc - AssertionError
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
