### PR TITLE
[megatron] rebuild weight conversion tasks per sync to prevent stale PP-collective caches with bucketing

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -815,11 +815,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         torch.cuda.empty_cache()
 
         # Extract and send weights using the sender created at init time
-        # from skyrl.env_vars import _SKYRL_USE_NEW_INFERENCE
-        # if _SKYRL_USE_NEW_INFERENCE:
         weight_metadata = self.weight_extractor.get_weight_metadata(generator_dtype)
-        # else:
-        #     weight_metadata = None
         await self._weight_transfer_sender.send_chunks(
             self.weight_extractor.extract_weights(generator_dtype),
             weight_metadata=weight_metadata,


### PR DESCRIPTION
## Summary
- Bucketed weight sync reused `WeightConversionTask` objects (and their mapping caches) across sync cycles, causing incorrect vLLM weight updates for DeepSeek-V3 style models (like Moonlight-16B-A3B, or GLM-4.7-Flash) with PP > 1 (for both LoRA and full finetuning). The mapping objects cache PP-collective metadata that becomes stale across train/offload/reload cycles.
- Fix: store only the bucket index structure (which task indices go in which bucket) once, and rebuild fresh tasks with clean mapping objects on each `extract_weights()` call. This preserves packed-broadcast performance while ensuring correct PP collectives every sync.

This manifested in extremely unstable training + reward collapsing for Deepseek-v3 style models with megatron.

## Test plan
- [x] Moonlight-16B with PP=2: reward increases without significant weight sync time regression

## Results

### Moonlight-16B-A3B GSM8k
Before in purple, after the fix in blue:
<img width="315" height="246" alt="image" src="https://github.com/user-attachments/assets/9a7119af-aea8-4b81-888f-f05cd3865c99" />
<img width="318" height="242" alt="image" src="https://github.com/user-attachments/assets/b899766f-9a7e-43fc-98f9-2f856dc04c3c" />

Weight sync timing (~10s after, ~8s before):
<img width="317" height="246" alt="image" src="https://github.com/user-attachments/assets/ed46cdbc-9b95-4533-bb5f-416db56a2847" />

### GLM-4.7-Flash GSM8k

Before in red, after the fix in tan (GLM with LoRA)
<img width="337" height="525" alt="image" src="https://github.com/user-attachments/assets/e647d6f4-42a9-4317-99d4-e3d1d940b038" />

Weight sync timing (~15 after, ~12 before):
<img width="331" height="239" alt="image" src="https://github.com/user-attachments/assets/cc98f4e9-314c-462c-ab7f-80b29bc96f70" />



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
