### PR TITLE
[CI] Make `MultiItemDataset` a global variable after switch to `spawn`

### DIFF
--- a/tests/train/test_trainer_utils.py
+++ b/tests/train/test_trainer_utils.py
@@ -840,22 +840,23 @@ def test_validate_generator_output_element_length_mismatch():
         validate_generator_output(len(input_batch["prompts"]), generator_output)
 
 
+# Create a dataset with multiple distinct items to test shuffling
+class MultiItemDataset:
+    def __init__(self, size=10):
+        self.data = [f"item_{i}" for i in range(size)]
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+    def collate_fn(self, batch):
+        return batch
+
+
 def test_build_dataloader_seeding(dummy_config):
     """Test that build_dataloader correctly seeds the dataloader for reproducible shuffling."""
-
-    # Create a dataset with multiple distinct items to test shuffling
-    class MultiItemDataset:
-        def __init__(self, size=10):
-            self.data = [f"item_{i}" for i in range(size)]
-
-        def __len__(self):
-            return len(self.data)
-
-        def __getitem__(self, idx):
-            return self.data[idx]
-
-        def collate_fn(self, batch):
-            return batch
 
     dataset = MultiItemDataset(size=20)
 


### PR DESCRIPTION
# What does this PR do?

Fixes CI failure on main for the `SkyRL-Train-CPU` workflow: https://github.com/NovaSky-AI/SkyRL/actions/runs/23273262330/job/67670625938

After #1344 , we added `multiprocessing_context='spawn'` to the `build_dataloader` function. It looks like there was one case where the change here affected a test that was not affected by the usage of `worker_process_startup_hook` previously. A CPU test `test_dataloader_seeding` referenced a local dataset class in dataloader map function. After switch to `spawn`, we need to ensure that the dataset class is a global variable. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
