### PR TITLE
[bug][examples] Fix lcb dataset issue in examples dir

### DIFF
--- a/examples/train/livecodebench/lcb_dataset.py
+++ b/examples/train/livecodebench/lcb_dataset.py
@@ -11,7 +11,7 @@ import json
 import os
 from typing import Any, Dict, List, Optional
 
-import pandas as pd
+import datasets as hf_datasets
 
 """Utility functions for loading and processing datasets."""
 
@@ -145,17 +145,11 @@ def process_dataset(dataset_name: str, split: str, dataset_dir: str, local_dir: 
     if max_rows:
         processed_data = processed_data[:max_rows]
 
-    # Save individual dataset files
-    df = pd.DataFrame(processed_data)
+    ds = hf_datasets.Dataset.from_list(processed_data)
     parquet_path = os.path.join(local_dir, f"{split}_{dataset_name}.parquet")
-    json_path = os.path.join(local_dir, f"{split}_{dataset_name}.json")
 
-    print(f"Writing {len(df)} rows to {split}_{dataset_name}.parquet")
-    df.to_parquet(parquet_path)
-
-    if split == "test":
-        print(f"Writing {len(df)} rows to {split}_{dataset_name}.json")
-        df.to_json(json_path, orient="records")
+    print(f"Writing {len(ds)} rows to {split}_{dataset_name}.parquet")
+    ds.to_parquet(parquet_path)
 
     return processed_data
 
@@ -194,7 +188,6 @@ if __name__ == "__main__":
     val_data = process_dataset(LIVECODEBENCH, "test", args.dataset_dir, local_dir, args.max_rows)
 
     # Save combined train dataset
-    all_train_df = pd.DataFrame(train_data)
-    all_train_df.to_parquet(os.path.join(local_dir, "deepcoder_train.parquet"))
-    all_train_df.to_json(os.path.join(local_dir, "deepcoder_train.json"), orient="records")
-    print(f"Writing {len(all_train_df)} rows to deepcoder_train.parquet and deepcoder_train.json")
+    all_train_ds = hf_datasets.Dataset.from_list(train_data)
+    all_train_ds.to_parquet(os.path.join(local_dir, "deepcoder_train.parquet"))
+    print(f"Writing {len(all_train_ds)} rows to deepcoder_train.parquet")

--- a/examples/train/livecodebench/run_lcb.sh
+++ b/examples/train/livecodebench/run_lcb.sh
@@ -5,8 +5,8 @@ set -x
 # bash examples/livecodebench/run_lcb.sh
 
 DATA_DIR="$HOME/data/lcb"
-train_data="['${DATA_DIR}/deepcoder_train.json']"
-val_data="['${DATA_DIR}/test_livecodebench.json']"
+train_data="['${DATA_DIR}/deepcoder_train.parquet']"
+val_data="['${DATA_DIR}/test_livecodebench.parquet']"
 
 # NOTE (sumanthrh): micro_train_batch_size and micro_forward_batch_size can be tuned
 uv run --isolated --frozen --extra fsdp -m skyrl.train.entrypoints.main_base \


### PR DESCRIPTION
Fixes #542

The original `deepcoder_train.json` is a 5.2 GB JSON array. When `datasets.load_dataset("json", ...)` reads it, PyArrow's JSON reader sets a block_size based on the file size, but block_size is an `int32_t` — so any file over ~2 GB overflows and crashes with `OverflowError: value too large to convert to int32_t`.
                                                                                                                                                                          
Changed lcb_dataset.py to output parquet files directly via `Dataset.from_list()` instead of writing large JSON arrays. Updated data paths to reference the new `.parquet` files.                                                                         
                                                                                                                                                                          
Confirmed by training on the resulting parquet files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
