### PR TITLE
fix: stagger vLLM engine startup to avoid EADDRINUSE

### DIFF
--- a/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -361,6 +361,16 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
         if enable_ray_prometheus_stats:
             stat_loggers = self._create_ray_prometheus_stat_loggers()
 
+        # Stagger engine startup to avoid TOCTOU port collisions (EADDRINUSE).
+        # vLLM's get_open_port() queries a free port then releases the socket;
+        # if multiple engines on the same node call it simultaneously, they can
+        # get the same port. A random delay desynchronises the calls.
+        import random
+
+        _stagger = random.uniform(1.5, 3.0)
+        logger.info(f"Engine startup stagger: sleeping {_stagger:.2f}s to avoid port collisions")
+        time.sleep(_stagger)
+
         engine = vllm.AsyncLLMEngine.from_engine_args(engine_args, stat_loggers=stat_loggers)
 
         # Adapted from https://github.com/volcengine/verl/blob/e90f18c40aa639cd25092b78a5ff7e2d2508c088/verl/workers/rollout/vllm_rollout/vllm_async_server.py#L327


### PR DESCRIPTION
## Summary
- When multiple inference engines start on the same node simultaneously, vLLM's `get_open_port()` can return the same port to different engines (TOCTOU race), causing `EADDRINUSE` failures during engine init
- Adds a random 1.5-3.0s delay before `AsyncLLMEngine.from_engine_args()` to desynchronise port allocation across engines on the same node

## Test plan
- [ ] Verify multi-engine startup on a single node no longer hits EADDRINUSE
- [ ] Verify single-engine startup is unaffected (just a brief delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
