### PR TITLE
feat: make max_logprobs configurable for inference engines

### DIFF
--- a/skyrl/backends/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -115,6 +115,7 @@ def create_ray_wrapped_inference_engines(
     enable_return_routed_experts: bool = False,
     served_model_name: str | None = None,
     distributed_executor_backend: str = "ray",
+    max_logprobs: int = 1,
 ) -> List[InferenceEngineInterface]:
     """
     Create a list of RayWrappedInferenceEngine instances wrapping Ray actor handles to InferenceEngineInterface
@@ -301,7 +302,7 @@ def create_ray_wrapped_inference_engines(
                     noset_visible_devices=noset_visible_devices,
                     max_num_batched_tokens=max_num_batched_tokens,
                     max_num_seqs=max_num_seqs,
-                    max_logprobs=1,  # only need chosen-token logprobs
+                    max_logprobs=max_logprobs,
                     enable_ray_prometheus_stats=enable_ray_prometheus_stats,
                     enable_return_routed_experts=enable_return_routed_experts,
                     **dp_kwargs,


### PR DESCRIPTION
## Summary
- The `max_logprobs` parameter in `create_ray_wrapped_inference_engines()` was hardcoded to 1 (chosen-token only)
- Makes it configurable so callers like teacher distillation can request top-K logprobs from vLLM
- Default remains 1 for backward compatibility — no behavior change for existing users

## Test plan
- [ ] Verify default behavior unchanged (max_logprobs=1)
- [ ] Verify passing max_logprobs>1 propagates to vLLM engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
