### PR TITLE
[tx] Fuse the projection matrices for Qwen 3.5

### DIFF
--- a/skyrl/tx/models/qwen3_5.py
+++ b/skyrl/tx/models/qwen3_5.py
@@ -8,7 +8,7 @@ from jax import numpy as jnp
 from jax.sharding import get_abstract_mesh
 
 from skyrl.tx.layers.attention import dot_product_attention
-from skyrl.tx.layers.lora import LoRAEmbed, LoRALinear
+from skyrl.tx.layers.lora import FusedLoRALinear, LoRAEmbed, LoRALinear
 from skyrl.tx.layers.rotary_embedding import apply_rope
 from skyrl.tx.layers.util import Param
 from skyrl.tx.models.configs import Qwen3_5Config
@@ -297,40 +297,18 @@ class Qwen3_5Attention(nnx.Module):
         self.rotary_dim = rotary_dim - (rotary_dim % 2)
         self.rope_theta = rope_theta
 
-        self.q_proj = LoRALinear(
+        q_per_kv = self.num_heads // self.num_kv_heads
+        self.qkv_proj = FusedLoRALinear(
             in_features=config.hidden_size,
-            out_features=self.num_heads * self.head_dim * 2,
+            out_features=(self.num_heads * 2 + 2 * self.num_kv_heads) * self.head_dim,
+            components=("q_proj", "k_proj", "v_proj"),
+            group_sizes=(q_per_kv * 2 * self.head_dim, self.head_dim, self.head_dim),
             sharding=("fsdp", tp_shard),
             max_lora_adapters=config.max_lora_adapters,
             max_lora_rank=config.max_lora_rank,
+            use_bias=config.attention_bias,
             dtype=dtype,
             param_dtype=dtype,
-            use_bias=config.attention_bias,
-            kernel_init=nnx.initializers.lecun_normal(),
-            rngs=rngs,
-        )
-        self.k_proj = LoRALinear(
-            in_features=config.hidden_size,
-            out_features=self.num_kv_heads * self.head_dim,
-            sharding=("fsdp", tp_shard),
-            max_lora_adapters=config.max_lora_adapters,
-            max_lora_rank=config.max_lora_rank,
-            dtype=dtype,
-            param_dtype=dtype,
-            use_bias=config.attention_bias,
-            kernel_init=nnx.initializers.lecun_normal(),
-            rngs=rngs,
-        )
-        self.v_proj = LoRALinear(
-            in_features=config.hidden_size,
-            out_features=self.num_kv_heads * self.head_dim,
-            sharding=("fsdp", tp_shard),
-            max_lora_adapters=config.max_lora_adapters,
-            max_lora_rank=config.max_lora_rank,
-            dtype=dtype,
-            param_dtype=dtype,
-            use_bias=config.attention_bias,
-            kernel_init=nnx.initializers.lecun_normal(),
             rngs=rngs,
         )
         self.o_proj = LoRALinear(
@@ -359,15 +337,14 @@ class Qwen3_5Attention(nnx.Module):
     ) -> tuple[jax.Array, tuple[jax.Array, jax.Array]]:
         bsz, seq_len, _ = x.shape
 
-        q_all = self.q_proj(x, adapter_indices=adapter_indices).reshape(bsz, seq_len, self.num_heads, self.head_dim * 2)
+        q_raw, k_raw, v_raw = self.qkv_proj(x, adapter_indices=adapter_indices)
+        q_all = q_raw.reshape(bsz, seq_len, self.num_heads, self.head_dim * 2)
         q, gate = jnp.split(q_all, 2, axis=-1)
         gate = gate.reshape(bsz, seq_len, self.num_heads * self.head_dim)
 
         q = self.q_norm(q)
-        k = self.k_norm(
-            self.k_proj(x, adapter_indices=adapter_indices).reshape(bsz, seq_len, self.num_kv_heads, self.head_dim)
-        )
-        v = self.v_proj(x, adapter_indices=adapter_indices).reshape(bsz, seq_len, self.num_kv_heads, self.head_dim)
+        k = self.k_norm(k_raw.reshape(bsz, seq_len, self.num_kv_heads, self.head_dim))
+        v = v_raw.reshape(bsz, seq_len, self.num_kv_heads, self.head_dim)
 
         q, k = apply_partial_rope(q, k, positions, self.rotary_dim, self.rope_theta)
 
@@ -584,28 +561,17 @@ class Qwen3_5MLP(nnx.Module):
         hidden_size = config.hidden_size
         intermediate_size = intermediate_size or config.intermediate_size
 
-        self.gate_proj = LoRALinear(
+        self.gate_up_proj = FusedLoRALinear(
             hidden_size,
-            intermediate_size,
+            2 * intermediate_size,
+            components=("gate_proj", "up_proj"),
+            group_sizes=(1, 1),
             sharding=("fsdp", "tp"),
+            max_lora_adapters=config.max_lora_adapters,
+            max_lora_rank=config.max_lora_rank,
             use_bias=False,
             dtype=dtype,
             param_dtype=dtype,
-            kernel_init=nnx.initializers.lecun_normal(),
-            max_lora_adapters=config.max_lora_adapters,
-            max_lora_rank=config.max_lora_rank,
-            rngs=rngs,
-        )
-        self.up_proj = LoRALinear(
-            hidden_size,
-            intermediate_size,
-            sharding=("fsdp", "tp"),
-            use_bias=False,
-            dtype=dtype,
-            param_dtype=dtype,
-            kernel_init=nnx.initializers.lecun_normal(),
-            max_lora_adapters=config.max_lora_adapters,
-            max_lora_rank=config.max_lora_rank,
             rngs=rngs,
         )
         self.down_proj = LoRALinear(
@@ -622,9 +588,8 @@ class Qwen3_5MLP(nnx.Module):
         )
 
     def __call__(self, x: jax.Array, adapter_indices: jax.Array | None = None) -> jax.Array:
-        return self.down_proj(
-            nnx.silu(self.gate_proj(x, adapter_indices)) * self.up_proj(x, adapter_indices), adapter_indices
-        )
+        gate_out, up_out = self.gate_up_proj(x, adapter_indices=adapter_indices)
+        return self.down_proj(nnx.silu(gate_out) * up_out, adapter_indices=adapter_indices)
 
 
 class Qwen3_5DecoderLayer(nnx.Module):


### PR DESCRIPTION
Implement https://github.com/NovaSky-AI/SkyRL/pull/1341 for the Qwen 3.5 model

Before the PR:
```
02:38:30  ============================================================
02:38:30  Connecting to http://localhost:8000  [jax]
02:38:30    model=Qwen/Qwen3.5-4B  lora_rank=32
02:38:30    data: 32 prompts × 8 rollouts = 256 datums, seq_len=1063 (prompt=586 + response=477)
02:38:30    total tokens/step = 272128
02:38:30  ============================================================
02:38:30  ServiceClient initialized for session session_5a0bec12
02:38:30  Creating LoRA training client (blocks until server is ready)...
02:38:55  TrainingClient initialized for model model_8e1203de
02:38:55  Training client ready.
02:38:57  Batch ready: 256 datums (dummy paragraphs tokenized to prompt/response lengths).
02:38:57  [warmup 1/1] running step (may trigger JIT compile) ...
02:44:28  [warmup 1/1]  fwd_bwd=276.2s  optim=55.5s  total=331.7s
02:44:28  --- measuring 3 step(s) ---
02:47:05  [iter 1/3]  fwd_bwd=151.32s  optim=4.95s  total=156.27s  tok/s=1,741
02:49:36  [iter 2/3]  fwd_bwd=151.11s  optim=0.00s  total=151.11s  tok/s=1,801
02:52:08  [iter 3/3]  fwd_bwd=151.87s  optim=0.00s  total=151.87s  tok/s=1,792

==============================================================
  Benchmark result: jax
==============================================================
  Server            : http://localhost:8000
  Model             : Qwen/Qwen3.5-4B
  Datums            : 256  (32 prompts × 8 rollouts)
  Seq length        : 1063  (prompt=586 + response=477)
  Total tokens/step : 272,128
  Warmup steps      : 1
  Measure steps     : 3

  fwd_bwd times     : 151.32s  151.11s  151.87s
  optim times       : 4.95s  0.00s  0.00s

  avg fwd_bwd       : 151.43 s
  avg optim_step    : 1.65 s
  avg total step    : 153.08 s
  throughput        : 1,778 tok/s
==============================================================
```

After the PR:
```
02:53:46  ============================================================
02:53:46  Connecting to http://localhost:8000  [jax]
02:53:46    model=Qwen/Qwen3.5-4B  lora_rank=32
02:53:46    data: 32 prompts × 8 rollouts = 256 datums, seq_len=1063 (prompt=586 + response=477)
02:53:46    total tokens/step = 272128
02:53:46  ============================================================
02:53:46  ServiceClient initialized for session session_8d833693
02:53:46  Creating LoRA training client (blocks until server is ready)...
02:54:28  TrainingClient initialized for model model_181f7acb
02:54:28  Training client ready.
02:54:31  Batch ready: 256 datums (dummy paragraphs tokenized to prompt/response lengths).
02:54:31  [warmup 1/1] running step (may trigger JIT compile) ...
02:58:47  [warmup 1/1]  fwd_bwd=226.2s  optim=30.5s  total=256.7s
02:58:47  --- measuring 3 step(s) ---
03:00:53  [iter 1/3]  fwd_bwd=122.58s  optim=3.41s  total=125.99s  tok/s=2,160
03:02:56  [iter 2/3]  fwd_bwd=122.26s  optim=0.00s  total=122.26s  tok/s=2,226
03:04:58  [iter 3/3]  fwd_bwd=122.73s  optim=0.00s  total=122.73s  tok/s=2,217

==============================================================
  Benchmark result: jax
==============================================================
  Server            : http://localhost:8000
  Model             : Qwen/Qwen3.5-4B
  Datums            : 256  (32 prompts × 8 rollouts)
  Seq length        : 1063  (prompt=586 + response=477)
  Total tokens/step : 272,128
  Warmup steps      : 1
  Measure steps     : 3

  fwd_bwd times     : 122.58s  122.26s  122.73s
  optim times       : 3.41s  0.00s  0.00s

  avg fwd_bwd       : 122.52 s
  avg optim_step    : 1.14 s
  avg total step    : 123.66 s
  throughput        : 2,201 tok/s
==============================================================
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
