### PR TITLE
[train] Use a shared semaphore for all generate requests with `RemoteInferenceClient`; Move tokenization to client

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -811,7 +811,6 @@ def _force_close_connector(connector: Optional[aiohttp.TCPConnector]) -> None:
             if tsock is not None:
                 fd = tsock.fileno()
                 if fd != -1:
-                if fd != -1:
                     try:
                         tsock.close()
                     except OSError:

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -811,8 +811,9 @@ def _force_close_connector(connector: Optional[aiohttp.TCPConnector]) -> None:
             if tsock is not None:
                 fd = tsock.fileno()
                 if fd != -1:
+                if fd != -1:
                     try:
-                        os.close(fd)
+                        tsock.close()
                     except OSError:
                         pass
 

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -128,6 +128,9 @@ class RemoteInferenceClient:
     active_lora_name: Optional[str] = None
     """Name of the active LoRA adapter. If set, generation requests use this adapter instead of the base model."""
 
+    tokenizer: Optional[Any] = None
+    """Optional HF tokenizer for local tokenize/detokenize (avoids HTTP round-trips)."""
+
     # Private fields excluded from repr for cleaner output
     _session: Optional[aiohttp.ClientSession] = field(default=None, repr=False)
     _world_size: Optional[Tuple[int, int]] = field(default=None, repr=False)
@@ -407,7 +410,9 @@ class RemoteInferenceClient:
         add_special_tokens: bool = True,
     ) -> List[List[int]]:
         """
-        Tokenize texts via /tokenize.
+        Tokenize texts.
+
+        Uses the local tokenizer if available, otherwise falls back to HTTP /tokenize.
 
         Args:
             texts: List of texts to tokenize.
@@ -416,6 +421,9 @@ class RemoteInferenceClient:
         Returns:
             List of token ID lists.
         """
+        if self.tokenizer is not None:
+            return [self.tokenizer.encode(text, add_special_tokens=add_special_tokens) for text in texts]
+
         url = f"{self.proxy_url}/tokenize"
 
         # vLLM /tokenize expects individual requests, batch them
@@ -436,7 +444,9 @@ class RemoteInferenceClient:
         token_ids: List[List[int]],
     ) -> List[str]:
         """
-        Detokenize token IDs via /detokenize.
+        Detokenize token IDs.
+
+        Uses the local tokenizer if available, otherwise falls back to HTTP /detokenize.
 
         Args:
             token_ids: List of token ID lists.
@@ -444,6 +454,9 @@ class RemoteInferenceClient:
         Returns:
             List of decoded texts.
         """
+        if self.tokenizer is not None:
+            return [self.tokenizer.decode(ids) for ids in token_ids]
+
         url = f"{self.proxy_url}/detokenize"
 
         # vLLM /detokenize expects individual requests, batch them

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -593,9 +593,6 @@ class RemoteInferenceClient:
             tags: Optional list of tags to wake up specific resources.
                 Common tags: ["weights"], ["kv_cache"], or None for all.
         """
-        # if self._session and not self._session.closed:
-        #     await self._session.close()
-        #     self._session = None
         body = {"tags": tags} if tags else {}
         return await self._call_all_servers("/wake_up", body)
 

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -182,7 +182,7 @@ class RemoteInferenceClient:
             )
             self._session = aiohttp.ClientSession(connector=connector, timeout=aiohttp.ClientTimeout(total=None))
         logger.info(
-            f"Number of connections for session: {self._session.connector._conns=}, {self._session.connector._acquired=}"
+            f"Number of connections for session: conns={len(self._session.connector._conns)}, acquired={len(self._session.connector._acquired)}"
         )
         return self._session
 

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -64,7 +64,7 @@ from skyrl.env_vars import (
     SKYRL_HTTP_CONNECTION_LIMIT,
 )
 
-_DATA_PLANE_RETRIES = 3
+_DATA_PLANE_RETRIES = 30
 
 if TYPE_CHECKING:
     from skyrl.backends.skyrl_train.weight_sync.transfer_strategy import (
@@ -206,9 +206,7 @@ class RemoteInferenceClient:
             except (aiohttp.ServerDisconnectedError, aiohttp.ClientOSError) as e:
                 last_exc = e
                 logger.warning(f"POST retry {attempt + 1}/{_DATA_PLANE_RETRIES} for {url=}: {e}")
-                # Back off so the connector can purge stale connections before
-                # the next attempt grabs another dead socket from the pool.
-                await asyncio.sleep(0.1 * 2**attempt)  # 0.1s, 0.2s, 0.4s
+                await asyncio.sleep(1)
                 continue
         raise last_exc  # type: ignore[misc]
 

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -422,7 +422,7 @@ class RemoteInferenceClient:
             List of token ID lists.
         """
         if self.tokenizer is not None:
-            return [self.tokenizer.encode(text, add_special_tokens=add_special_tokens) for text in texts]
+            return self.tokenizer(texts, add_special_tokens=add_special_tokens)["input_ids"]
 
         url = f"{self.proxy_url}/tokenize"
 
@@ -455,7 +455,7 @@ class RemoteInferenceClient:
             List of decoded texts.
         """
         if self.tokenizer is not None:
-            return [self.tokenizer.decode(ids) for ids in token_ids]
+            return self.tokenizer.batch_decode(token_ids)
 
         url = f"{self.proxy_url}/detokenize"
 

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -152,7 +152,7 @@ class RemoteInferenceClient:
         SKYRL_GENERATE_CONCURRENCY_PER_ENGINE × num_engines.
         """
         current_loop = asyncio.get_running_loop()
-        if self._gen_sem is None or self._sem_loop is not current_loop:
+        if self._sem_loop is not current_loop:
             if SKYRL_GENERATE_CONCURRENCY_PER_ENGINE > 0:
                 concurrency = SKYRL_GENERATE_CONCURRENCY_PER_ENGINE * len(self.server_urls)
                 self._gen_sem = asyncio.Semaphore(concurrency)

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -260,7 +260,9 @@ class RemoteInferenceClient:
         # TODO (sumanthrh) (RemoteInferenceClient data-plane-deprecation): We should move this outside of the client to a runner abstraction that will also parallelize client requests across processes.
         gen_sem, detok_sem = self._get_semaphores()
         batch_size = len(prompt_token_ids)
-        concurrency = self._gen_sem._value if self._gen_sem is not None else "unlimited"
+        concurrency = (
+            SKYRL_GENERATE_CONCURRENCY_PER_ENGINE * len(self.server_urls) if self._gen_sem is not None else "unlimited"
+        )
         logger.info(
             f"generate: batch_size={batch_size}, concurrency_limit={concurrency} "
             f"(shared across all concurrent generate() calls)"
@@ -581,9 +583,6 @@ class RemoteInferenceClient:
     async def wake_up(self, tags: Optional[List[str]] = None) -> Dict[str, Any]:
         """
         Wake up all backends (load weights back to GPU).
-
-        Recreates the HTTP session to discard stale keep-alive connections
-        that the server may have closed during sleep.
 
         Args:
             tags: Optional list of tags to wake up specific resources.

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -183,9 +183,6 @@ class RemoteInferenceClient:
                 keepalive_timeout=2,
             )
             self._session = aiohttp.ClientSession(connector=connector, timeout=aiohttp.ClientTimeout(total=None))
-        logger.info(
-            f"Number of connections for session: conns={len(self._session.connector._conns)}, acquired={len(self._session.connector._acquired)}"
-        )
         return self._session
 
     async def _post(self, url: str, json: Dict[str, Any], headers: Optional[Dict[str, str]] = None) -> Any:

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
@@ -130,10 +131,35 @@ class RemoteInferenceClient:
     # Private fields excluded from repr for cleaner output
     _session: Optional[aiohttp.ClientSession] = field(default=None, repr=False)
     _world_size: Optional[Tuple[int, int]] = field(default=None, repr=False)
+    _gen_sem: Optional[asyncio.Semaphore] = field(default=None, repr=False)
+    _detok_sem: Optional[asyncio.Semaphore] = field(default=None, repr=False)
+    _sem_loop: Optional[asyncio.AbstractEventLoop] = field(default=None, repr=False)
 
     # ---------------------------
     # Session Management
     # ---------------------------
+
+    def _get_semaphores(self) -> Tuple[Optional[asyncio.Semaphore], Optional[asyncio.Semaphore]]:
+        """Get or create the shared generate/detokenize semaphores for this client.
+
+        Semaphores are event-loop-bound (Python 3.10+). If the running loop has
+        changed since they were created, recreate them.
+
+        All concurrent generate() calls on the same client instance share these
+        semaphores, capping total in-flight requests at
+        SKYRL_GENERATE_CONCURRENCY_PER_ENGINE × num_engines.
+        """
+        current_loop = asyncio.get_running_loop()
+        if self._gen_sem is None or self._sem_loop is not current_loop:
+            if SKYRL_GENERATE_CONCURRENCY_PER_ENGINE > 0:
+                concurrency = SKYRL_GENERATE_CONCURRENCY_PER_ENGINE * len(self.server_urls)
+                self._gen_sem = asyncio.Semaphore(concurrency)
+                self._detok_sem = asyncio.Semaphore(concurrency)
+            else:
+                self._gen_sem = None
+                self._detok_sem = None
+            self._sem_loop = current_loop
+        return self._gen_sem, self._detok_sem
 
     async def _get_session(self) -> aiohttp.ClientSession:
         """Get or create the aiohttp session."""
@@ -143,9 +169,8 @@ class RemoteInferenceClient:
         current_loop = asyncio.get_running_loop()
         if self._session is not None and not self._session.closed and self._session.loop != current_loop:
             # Event loop changed - the old session is unusable (bound to a dead loop).
-            # Force-close the connector to tear down TCP connections synchronously.
-            if self._session.connector is not None:
-                self._session.connector.close()
+            # Force-close the connector to release socket FDs immediately.
+            _force_close_connector(self._session.connector)
             self._session = None
         if self._session is None or self._session.closed:
             # keepalive_timeout must be shorter than the server's timeout_keep_alive
@@ -156,6 +181,9 @@ class RemoteInferenceClient:
                 keepalive_timeout=2,
             )
             self._session = aiohttp.ClientSession(connector=connector, timeout=aiohttp.ClientTimeout(total=None))
+        logger.info(
+            f"Number of connections for session: {self._session.connector._conns=}, {self._session.connector._acquired=}"
+        )
         return self._session
 
     async def _post(self, url: str, json: Dict[str, Any], headers: Optional[Dict[str, str]] = None) -> Any:
@@ -228,16 +256,17 @@ class RemoteInferenceClient:
         #              generation finishes, so the GPU slot is freed immediately.
         #   detok_sem: limits concurrent detokenize calls independently.  Uses the
         #              same concurrency limit so detokenize never starves generate.
-        # Scales with number of engines so the limit fits the cluster size.
+        # Semaphores are shared across all concurrent generate() calls on this client
+        # instance, so total in-flight requests are capped at
+        # SKYRL_GENERATE_CONCURRENCY_PER_ENGINE × num_engines regardless of how many
+        # callers invoke generate() simultaneously.
         # TODO (sumanthrh) (RemoteInferenceClient data-plane-deprecation): We should move this outside of the client to a runner abstraction that will also parallelize client requests across processes.
-        num_engines = len(self.server_urls)
-        concurrency = SKYRL_GENERATE_CONCURRENCY_PER_ENGINE * num_engines
-        gen_sem = asyncio.Semaphore(concurrency) if SKYRL_GENERATE_CONCURRENCY_PER_ENGINE > 0 else None
-        detok_sem = asyncio.Semaphore(concurrency) if SKYRL_GENERATE_CONCURRENCY_PER_ENGINE > 0 else None
+        gen_sem, detok_sem = self._get_semaphores()
         batch_size = len(prompt_token_ids)
+        concurrency = self._gen_sem._value if self._gen_sem is not None else "unlimited"
         logger.info(
             f"generate: batch_size={batch_size}, concurrency_limit={concurrency} "
-            f"({SKYRL_GENERATE_CONCURRENCY_PER_ENGINE}/engine × {num_engines} engines)"
+            f"(shared across all concurrent generate() calls)"
         )
 
         async def _throttled_generate(idx: int) -> Dict[str, Any]:
@@ -553,9 +582,9 @@ class RemoteInferenceClient:
             tags: Optional list of tags to wake up specific resources.
                 Common tags: ["weights"], ["kv_cache"], or None for all.
         """
-        if self._session and not self._session.closed:
-            await self._session.close()
-            self._session = None
+        # if self._session and not self._session.closed:
+        #     await self._session.close()
+        #     self._session = None
         body = {"tags": tags} if tags else {}
         return await self._call_all_servers("/wake_up", body)
 
@@ -740,12 +769,54 @@ class RemoteInferenceClient:
         """Exclude non-serializable fields from pickle."""
         state = self.__dict__.copy()
         state["_session"] = None
+        state["_gen_sem"] = None
+        state["_detok_sem"] = None
+        state["_sem_loop"] = None
         return state
 
     def __setstate__(self, state: dict) -> None:
         """Restore state after unpickling."""
         self.__dict__.update(state)
         self._session = None
+        self._gen_sem = None
+        self._detok_sem = None
+        self._sem_loop = None
+
+
+def _force_close_connector(connector: Optional[aiohttp.TCPConnector]) -> None:
+    """Release socket FDs held by a connector whose event loop is already closed.
+
+    asyncio's normal transport.close() schedules a connection_lost() callback
+    on the loop, which raises RuntimeError when the loop is closed. We instead
+    close the raw file descriptors via os.close(fileno()) and then manually
+    clear aiohttp's internal connection pools.
+
+    Note: this uses aiohttp internals (_conns, _acquired, _closed). These are
+    stable across aiohttp 3.x but may change in 4.x.
+    """
+    if connector is None or connector.closed:
+        return
+
+    def _release(proto: aiohttp.client_proto.ResponseHandler) -> None:
+        if proto.transport is not None:
+            tsock = proto.transport.get_extra_info("socket")
+            if tsock is not None:
+                fd = tsock.fileno()
+                if fd != -1:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+
+    for proto_list in connector._conns.values():
+        for proto, _ in proto_list:
+            _release(proto)
+    for proto in list(connector._acquired):
+        _release(proto)
+
+    connector._conns.clear()
+    connector._acquired.clear()
+    connector._closed = True
 
 
 def raise_for_status(resp: aiohttp.ClientResponse, body: Optional[Any] = None) -> None:

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -48,7 +48,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union

--- a/skyrl/backends/skyrl_train/inference_servers/router.py
+++ b/skyrl/backends/skyrl_train/inference_servers/router.py
@@ -168,6 +168,11 @@ class InferenceRouter:
                     headers=headers,
                     content=body,
                 )
+                if attempt > 0:
+                    logger.warning(
+                        f"Proxy retry {attempt}/{_PROXY_RETRIES - 1} succeeded for {path} "
+                        f"(stale keepalive connection on attempt 0: {last_exc})"
+                    )
                 return Response(
                     content=response.content,
                     status_code=response.status_code,
@@ -175,7 +180,7 @@ class InferenceRouter:
                 )
             except (httpx.ReadError, httpx.ConnectError) as e:
                 last_exc = e
-                logger.warning(f"Proxy retry {attempt + 1}/{_PROXY_RETRIES} for {path}: {e}")
+                logger.warning(f"Proxy retry {attempt + 1}/{_PROXY_RETRIES} for {path}: {type(e).__name__}: {e}")
                 continue
             except Exception as e:
                 logger.info(f"Encountered an exception while proxying a request to path {path}: {e}")

--- a/skyrl/benchmarks/load_test_concurrency.py
+++ b/skyrl/benchmarks/load_test_concurrency.py
@@ -95,10 +95,9 @@ def start_servers(cfg: SkyRLTrainConfig) -> Tuple[RemoteInferenceClient, Inferen
     proxy_url = router.start()
 
     # Client
+    tokenizer = AutoTokenizer.from_pretrained(cfg.trainer.policy.model.path)
     client = RemoteInferenceClient(
-        proxy_url=proxy_url,
-        server_urls=server_urls,
-        model_name=SERVED_MODEL_NAME,
+        proxy_url=proxy_url, server_urls=server_urls, model_name=SERVED_MODEL_NAME, tokenizer=tokenizer
     )
 
     return client, router, server_group

--- a/skyrl/benchmarks/load_test_concurrency.py
+++ b/skyrl/benchmarks/load_test_concurrency.py
@@ -44,13 +44,13 @@ from skyrl.backends.skyrl_train.inference_servers.router import InferenceRouter
 from skyrl.backends.skyrl_train.inference_servers.server_group import ServerGroup
 from skyrl.backends.skyrl_train.inference_servers.utils import build_vllm_cli_args
 from skyrl.train.config import SkyRLTrainConfig
-from skyrl.train.utils.utils import initialize_ray
+from skyrl.train.utils.utils import ResolvedPlacementGroup, initialize_ray
 
 logger = logging.getLogger(__name__)
 
 MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
 SERVED_MODEL_NAME = "load_test_model"
-VALID_MODES = ["direct", "router", "e2e"]
+VALID_MODES = ["direct", "router", "e2e", "fully_async"]
 
 
 def get_config() -> SkyRLTrainConfig:
@@ -76,8 +76,9 @@ def start_servers(cfg: SkyRLTrainConfig) -> Tuple[RemoteInferenceClient, Inferen
 
     # Placement group
     num_gpus = ie_cfg.tensor_parallel_size * ie_cfg.num_engines
-    pg = placement_group([{"GPU": 1, "CPU": 1}] * num_gpus, strategy="PACK")
-    ray.get(pg.ready())
+    raw_pg = placement_group([{"GPU": 1, "CPU": 1}] * num_gpus, strategy="PACK")
+    ray.get(raw_pg.ready())
+    pg = ResolvedPlacementGroup(raw_pg)
 
     # Server group
     server_group = ServerGroup(
@@ -196,6 +197,86 @@ async def fire_client_generate(
     return {"n": n, "ok": ok, "errors": len(errors), "elapsed_s": elapsed, "first_errors": errors[:3]}
 
 
+async def fire_fully_async_generate(
+    client: RemoteInferenceClient,
+    tokenizer,
+    n_workers: int,
+    batch_size: int,
+    max_tokens: int,
+    pause_resume: bool = False,
+) -> dict:
+    """Simulate fully-async RL: n_workers concurrent generate() calls, each with batch_size prompts.
+
+    This mirrors the production scenario where num_parallel_generation_workers concurrent
+    asyncio Tasks all call generate() on the same client instance simultaneously.
+
+    With the buggy local semaphore: each generate() creates its own Semaphore(512), so
+    n_workers × batch_size requests fire simultaneously with no cross-call throttling.
+    With the fix: all calls share one Semaphore(512 × num_engines) on the client instance.
+
+    If pause_resume=True, simulates a training-step weight-sync cycle before the burst:
+      1. Warmup burst (builds the connection pool)
+      2. pause(KEEP) - freezes the server
+      3. Sleep until all keep-alive connections go stale on both sides
+      4. resume() - unfreezes the server
+      5. Immediately fire n_workers concurrent generate() calls
+    This is the exact trigger for ServerDisconnectedError in production async RL.
+    """
+    token_ids = tokenizer.apply_chat_template(
+        [[{"role": "user", "content": "Say hi"}]],
+        add_generation_prompt=True,
+        tokenize=True,
+    )
+    single_token_ids = token_ids[0]
+    sampling_params = {"max_tokens": max_tokens}
+    input_batch = {
+        "prompt_token_ids": [single_token_ids] * batch_size,
+        "sampling_params": sampling_params,
+    }
+
+    async def _worker(idx: int):
+        try:
+            return await client.generate(input_batch)
+        except Exception as e:
+            raise RuntimeError(f"worker {idx}: {type(e).__name__}: {e}") from e
+
+    async def _run_burst(label: str) -> dict:
+        t0 = time.monotonic()
+        tasks = [_worker(i) for i in range(n_workers)]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        elapsed = time.monotonic() - t0
+        errors = [r for r in results if isinstance(r, Exception)]
+        ok = sum(1 for r in results if not isinstance(r, Exception))
+        return {"n": n_workers, "ok": ok, "errors": len(errors), "elapsed_s": elapsed, "first_errors": errors[:3]}
+
+    if pause_resume:
+        # Step 1: warmup burst to fill the connection pool
+        print("  [pause_resume] Step 1: warmup burst to build connection pool...")
+        warmup = await _run_burst("warmup")
+        print(f"  [pause_resume] Warmup: ok={warmup['ok']} errors={warmup['errors']}")
+
+        # Step 2: pause (keep mode - like weight sync)
+        print("  [pause_resume] Step 2: pausing server (KEEP mode)...")
+        await client.pause()
+
+        # Step 3: sleep until connections go stale
+        # uvicorn default timeout_keep_alive=5s; aiohttp keepalive_timeout=2s.
+        # Sleep 8s to ensure both sides have closed keep-alive connections.
+        stale_sleep = 8
+        print(f"  [pause_resume] Step 3: sleeping {stale_sleep}s to stale all keep-alive connections...")
+        await asyncio.sleep(stale_sleep)
+
+        # Step 4: resume (like after weight sync completes)
+        print("  [pause_resume] Step 4: resuming server...")
+        await client.resume()
+
+        # Step 5: immediately fire the burst into stale connections
+        print(f"  [pause_resume] Step 5: firing {n_workers} concurrent generate() calls into stale pool...")
+        return await _run_burst("post-resume")
+    else:
+        return await _run_burst("burst")
+
+
 def print_result(result: dict):
     elapsed = result["elapsed_s"]
     throughput = result["n"] / elapsed if elapsed > 0 else float("inf")
@@ -284,6 +365,18 @@ def parse_args():
         default=math.inf,
         help="Submit requests at a steady rate (requests/sec). " "Default: inf (all requests fired at time 0).",
     )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=8,
+        help="Prompts per generate() call in fully_async mode (default: 8)",
+    )
+    parser.add_argument(
+        "--pause-resume",
+        action="store_true",
+        default=False,
+        help="In fully_async mode: do a pause/sleep/resume cycle before the burst to stale connections (default: False)",
+    )
 
     args = parser.parse_args()
 
@@ -295,12 +388,12 @@ def parse_args():
     if args.max_workers > 1 and "e2e" in modes and len(modes) == 1:
         parser.error("--max-workers is not supported for e2e mode")
 
-    return args.num_prompts, modes, args.max_tokens, args.qps, args.max_workers
+    return args.num_prompts, modes, args.max_tokens, args.qps, args.max_workers, args.batch_size, args.pause_resume
 
 
 def main():
     logging.basicConfig(level=logging.WARNING, format="%(name)s: %(message)s")
-    num_prompts, modes, max_tokens, qps, max_workers = parse_args()
+    num_prompts, modes, max_tokens, qps, max_workers, batch_size, pause_resume = parse_args()
 
     print("Load test config:")
     print(f"  model={MODEL}")
@@ -309,6 +402,7 @@ def main():
     print(f"  modes={modes}")
     print(f"  qps={qps}")
     print(f"  max_workers={max_workers}")
+    print(f"  batch_size={batch_size} (fully_async mode)")
     print()
     print("Starting servers...")
 
@@ -353,6 +447,32 @@ def main():
                 await client.teardown()
 
             asyncio.run(_run_e2e())
+            print()
+
+        if "fully_async" in modes:
+            n_workers = num_prompts // batch_size
+            pr_label = " + pause/resume" if pause_resume else ""
+            print("=" * 60)
+            print(f"Mode: fully_async{pr_label} - {n_workers} concurrent generate() calls × batch_size={batch_size}")
+            print(f"  = {n_workers * batch_size} total simultaneous requests (no cross-call throttle on baseline)")
+            print("=" * 60)
+
+            async def _run_fully_async():
+                result = await fire_fully_async_generate(
+                    client, tokenizer, n_workers, batch_size, max_tokens, pause_resume=pause_resume
+                )
+                elapsed = result["elapsed_s"]
+                throughput = result["n"] / elapsed if elapsed > 0 else float("inf")
+                status = "PASS" if result["errors"] == 0 else "FAIL"
+                print(
+                    f"  [{status}] workers={result['n']:>6}  ok={result['ok']:>6}  "
+                    f"errors={result['errors']:>4}  time={elapsed:.2f}s  throughput={throughput:.1f} workers/s"
+                )
+                for e in result["first_errors"]:
+                    print(f"         err: {str(e)[:200]}")
+                await client.teardown()
+
+            asyncio.run(_run_fully_async())
             print()
 
     finally:

--- a/skyrl/benchmarks/load_test_concurrency.py
+++ b/skyrl/benchmarks/load_test_concurrency.py
@@ -2,7 +2,7 @@
 """
 Load test for concurrency limits across the inference stack.
 
-NOTE: This is not a full fledged serving benchmark script. This is primarily 
+NOTE: This is not a full fledged serving benchmark script. This is primarily
 aimed to testing bottlenecks in client/ API server code in handling
 concurrent requests before they are handed off to the inference engine.
 
@@ -13,7 +13,8 @@ pipeline handles high concurrency without dropping connections.
 Three modes:
   direct  - Direct to vLLM server (bypasses router)
   router  - Through the InferenceRouter (tests httpx pool + uvicorn backlog)
-  e2e     - Via RemoteInferenceClient.generate() (tests aiohttp connector)
+  e2e     - Via RemoteInferenceClient.generate() (tests aiohttp connector +
+            shared semaphore throttling)
 
 Usage:
   # Requires at least 1 GPU
@@ -50,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
 SERVED_MODEL_NAME = "load_test_model"
-VALID_MODES = ["direct", "router", "e2e", "fully_async"]
+VALID_MODES = ["direct", "router", "e2e"]
 
 
 def get_config() -> SkyRLTrainConfig:
@@ -158,11 +159,12 @@ async def fire_chat_completions(base_url: str, n: int, model_name: str, max_toke
 async def fire_client_generate(
     client: RemoteInferenceClient, tokenizer, n: int, max_tokens: int, qps: float = math.inf
 ) -> dict:
-    """Send *n* concurrent prompts through RemoteInferenceClient._generate_single().
+    """Send *n* concurrent single-prompt generate() calls through RemoteInferenceClient.
 
-    Calls _generate_single directly (generate stage only, no detokenize) so we
-    can use return_exceptions=True and get per-request error counts instead of
-    one failure killing the whole batch.
+    Each of the n calls is a separate client.generate() with batch_size=1, simulating
+    num_parallel_generation_workers concurrent async RL workers all sharing one client.
+    Concurrency is throttled by the shared semaphore inside RemoteInferenceClient
+    (SKYRL_GENERATE_CONCURRENCY_PER_ENGINE × num_engines), not by this function.
     """
     token_ids = tokenizer.apply_chat_template(
         [[{"role": "user", "content": "Say hi"}]],
@@ -170,111 +172,29 @@ async def fire_client_generate(
         tokenize=True,
     )
     sampling_params = {"max_tokens": max_tokens}
+    input_batch = {
+        "prompt_token_ids": [token_ids[0]],
+        "sampling_params": sampling_params,
+    }
 
-    async def _single(idx: int) -> dict:
-        """Wrap _generate_single to tag errors with the phase that failed."""
+    async def _call(idx: int):
         try:
-            return await client._generate_single(
-                prompt_token_ids=token_ids[0],
-                sampling_params=sampling_params,
-                session_id=None,
-            )
+            return await client.generate(input_batch)
         except Exception as e:
-            # Re-raise with context about which request and what type
             raise RuntimeError(f"request {idx}: {type(e).__name__}: {e}") from e
 
     t0 = time.monotonic()
     if math.isinf(qps):
-        tasks = [_single(i) for i in range(n)]
+        tasks = [_call(i) for i in range(n)]
         results = await asyncio.gather(*tasks, return_exceptions=True)
     else:
-        coro_fns = [lambda i=i: _single(i) for i in range(n)]
+        coro_fns = [lambda i=i: _call(i) for i in range(n)]
         results = await _rate_limited_gather(coro_fns, qps)
     elapsed = time.monotonic() - t0
 
     ok = sum(1 for r in results if not isinstance(r, Exception))
     errors = [r for r in results if isinstance(r, Exception)]
     return {"n": n, "ok": ok, "errors": len(errors), "elapsed_s": elapsed, "first_errors": errors[:3]}
-
-
-async def fire_fully_async_generate(
-    client: RemoteInferenceClient,
-    tokenizer,
-    n_workers: int,
-    batch_size: int,
-    max_tokens: int,
-    pause_resume: bool = False,
-) -> dict:
-    """Simulate fully-async RL: n_workers concurrent generate() calls, each with batch_size prompts.
-
-    This mirrors the production scenario where num_parallel_generation_workers concurrent
-    asyncio Tasks all call generate() on the same client instance simultaneously.
-
-    With the buggy local semaphore: each generate() creates its own Semaphore(512), so
-    n_workers × batch_size requests fire simultaneously with no cross-call throttling.
-    With the fix: all calls share one Semaphore(512 × num_engines) on the client instance.
-
-    If pause_resume=True, simulates a training-step weight-sync cycle before the burst:
-      1. Warmup burst (builds the connection pool)
-      2. pause(KEEP) - freezes the server
-      3. Sleep until all keep-alive connections go stale on both sides
-      4. resume() - unfreezes the server
-      5. Immediately fire n_workers concurrent generate() calls
-    This is the exact trigger for ServerDisconnectedError in production async RL.
-    """
-    token_ids = tokenizer.apply_chat_template(
-        [[{"role": "user", "content": "Say hi"}]],
-        add_generation_prompt=True,
-        tokenize=True,
-    )
-    single_token_ids = token_ids[0]
-    sampling_params = {"max_tokens": max_tokens}
-    input_batch = {
-        "prompt_token_ids": [single_token_ids] * batch_size,
-        "sampling_params": sampling_params,
-    }
-
-    async def _worker(idx: int):
-        try:
-            return await client.generate(input_batch)
-        except Exception as e:
-            raise RuntimeError(f"worker {idx}: {type(e).__name__}: {e}") from e
-
-    async def _run_burst(label: str) -> dict:
-        t0 = time.monotonic()
-        tasks = [_worker(i) for i in range(n_workers)]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        elapsed = time.monotonic() - t0
-        errors = [r for r in results if isinstance(r, Exception)]
-        ok = sum(1 for r in results if not isinstance(r, Exception))
-        return {"n": n_workers, "ok": ok, "errors": len(errors), "elapsed_s": elapsed, "first_errors": errors[:3]}
-
-    if pause_resume:
-        # Step 1: warmup burst to fill the connection pool
-        print("  [pause_resume] Step 1: warmup burst to build connection pool...")
-        warmup = await _run_burst("warmup")
-        print(f"  [pause_resume] Warmup: ok={warmup['ok']} errors={warmup['errors']}")
-
-        # Step 2: pause (keep mode - like weight sync)
-        print("  [pause_resume] Step 2: pausing server (KEEP mode)...")
-        await client.pause()
-
-        # Step 3: sleep until connections go stale
-        # uvicorn default timeout_keep_alive=5s; aiohttp keepalive_timeout=2s.
-        # Sleep 8s to ensure both sides have closed keep-alive connections.
-        stale_sleep = 8
-        print(f"  [pause_resume] Step 3: sleeping {stale_sleep}s to stale all keep-alive connections...")
-        await asyncio.sleep(stale_sleep)
-
-        # Step 4: resume (like after weight sync completes)
-        print("  [pause_resume] Step 4: resuming server...")
-        await client.resume()
-
-        # Step 5: immediately fire the burst into stale connections
-        print(f"  [pause_resume] Step 5: firing {n_workers} concurrent generate() calls into stale pool...")
-        return await _run_burst("post-resume")
-    else:
-        return await _run_burst("burst")
 
 
 def print_result(result: dict):
@@ -358,24 +278,11 @@ def parse_args():
         default=1,
         help="Number of worker processes for direct/router modes (default: 1)",
     )
-
     parser.add_argument(
         "--qps",
         type=float,
         default=math.inf,
-        help="Submit requests at a steady rate (requests/sec). " "Default: inf (all requests fired at time 0).",
-    )
-    parser.add_argument(
-        "--batch-size",
-        type=int,
-        default=8,
-        help="Prompts per generate() call in fully_async mode (default: 8)",
-    )
-    parser.add_argument(
-        "--pause-resume",
-        action="store_true",
-        default=False,
-        help="In fully_async mode: do a pause/sleep/resume cycle before the burst to stale connections (default: False)",
+        help="Submit requests at a steady rate (requests/sec). Default: inf (all requests fired at time 0).",
     )
 
     args = parser.parse_args()
@@ -388,12 +295,12 @@ def parse_args():
     if args.max_workers > 1 and "e2e" in modes and len(modes) == 1:
         parser.error("--max-workers is not supported for e2e mode")
 
-    return args.num_prompts, modes, args.max_tokens, args.qps, args.max_workers, args.batch_size, args.pause_resume
+    return args.num_prompts, modes, args.max_tokens, args.qps, args.max_workers
 
 
 def main():
     logging.basicConfig(level=logging.WARNING, format="%(name)s: %(message)s")
-    num_prompts, modes, max_tokens, qps, max_workers, batch_size, pause_resume = parse_args()
+    num_prompts, modes, max_tokens, qps, max_workers = parse_args()
 
     print("Load test config:")
     print(f"  model={MODEL}")
@@ -402,7 +309,6 @@ def main():
     print(f"  modes={modes}")
     print(f"  qps={qps}")
     print(f"  max_workers={max_workers}")
-    print(f"  batch_size={batch_size} (fully_async mode)")
     print()
     print("Starting servers...")
 
@@ -447,32 +353,6 @@ def main():
                 await client.teardown()
 
             asyncio.run(_run_e2e())
-            print()
-
-        if "fully_async" in modes:
-            n_workers = num_prompts // batch_size
-            pr_label = " + pause/resume" if pause_resume else ""
-            print("=" * 60)
-            print(f"Mode: fully_async{pr_label} - {n_workers} concurrent generate() calls × batch_size={batch_size}")
-            print(f"  = {n_workers * batch_size} total simultaneous requests (no cross-call throttle on baseline)")
-            print("=" * 60)
-
-            async def _run_fully_async():
-                result = await fire_fully_async_generate(
-                    client, tokenizer, n_workers, batch_size, max_tokens, pause_resume=pause_resume
-                )
-                elapsed = result["elapsed_s"]
-                throughput = result["n"] / elapsed if elapsed > 0 else float("inf")
-                status = "PASS" if result["errors"] == 0 else "FAIL"
-                print(
-                    f"  [{status}] workers={result['n']:>6}  ok={result['ok']:>6}  "
-                    f"errors={result['errors']:>4}  time={elapsed:.2f}s  throughput={throughput:.1f} workers/s"
-                )
-                for e in result["first_errors"]:
-                    print(f"         err: {str(e)[:200]}")
-                await client.teardown()
-
-            asyncio.run(_run_fully_async())
             print()
 
     finally:

--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -386,6 +386,7 @@ class BasePPOExp:
             server_urls=server_urls,
             model_name=self.cfg.trainer.policy.model.path,
             active_lora_name=active_lora_name,
+            tokenizer=self.tokenizer,
         )
 
     def _setup_trainer(self):

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_inference_server_group.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_inference_server_group.py
@@ -24,6 +24,7 @@ from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import
 )
 from skyrl.backends.skyrl_train.inference_servers.router import InferenceRouter
 from skyrl.backends.skyrl_train.inference_servers.server_group import ServerGroup
+from skyrl.utils.tok import get_tokenizer
 
 MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
 
@@ -99,6 +100,7 @@ def server_group_and_router(ray_init_fixture):
         proxy_url=router_url,
         server_urls=server_urls,
         model_name=MODEL,
+        tokenizer=get_tokenizer(MODEL),
     )
 
     yield {

--- a/tests/backends/skyrl_train/gpu/utils.py
+++ b/tests/backends/skyrl_train/gpu/utils.py
@@ -540,6 +540,7 @@ class InferenceEngineState:
                 server_urls=server_urls,
                 model_name=served_model_name if served_model_name else cfg.trainer.policy.model.path,
                 active_lora_name=active_lora_name,
+                tokenizer=get_tokenizer(cfg.trainer.policy.model.path),
             )
         else:
             eps = create_ray_wrapped_inference_engines(


### PR DESCRIPTION
# What does this PR do?

- Improves concurrency handling in`RemoteInferenceClient` by making a shared semaphore for all generation requests. Previously, individual `.generate` requests had their own semaphore. With Async RL, different samples make different `.generate` calls, and thus the number of concurrent `.generate` calls can get huge. Making the generation and detokenization semaphore an attribute of `RemoteInferenceClient` solves the issue.  This fixes #1350 .
- Increases data plane retries 3-> 30. With async RL, there are more cases of transient connection errors.
- Adds support for tokenization in the client. Adds an optional `tokenizer` argument to `RemoteInferenceClient` to support tokenization and detokenization in the client and avoid making HTTP calls. 


## Performance benchmarking
Ran `examples/train/fully_async/fully_async_run_gsm8k.sh` with num gpus 2 each for trainer and generator.

Four runs: 

1. Old inference -> fully async RL with the old inference codepath (InferenceEngineClient + RayWrappedInferenceEngine)
2. New inference baseline -> New inference run at commit https://github.com/NovaSky-AI/SkyRL/commit/50ebff5a01b8750cf670e948ded945cd3a956232
3. New inference shared sem -> New inference + shared semaphore
4. New inference shared sem local tok -> New inference + shared semaphore + local tokenization

Training proceeds to completion now in the new inference codepath (ran until 580 steps). Note that training would also hang randomly with new inference codepath in `main`. 



Timing metrics for `step` and `generate`:

Overall times are closer with local tokenization fix and the spikes at weight sync are also reduced. (131s -> 85 s -> 28 s )

<img width="648" height="1090" alt="image" src="https://github.com/user-attachments/assets/5437bd4b-47a2-4ef2-9bd9-cad13e581ee6" />



Report: https://wandb.ai/sky-posttraining-uc-berkeley/gsm8k-async/reports/SkyRL-New-Inference-Fully-Async-RL-3-24--VmlldzoxNjMwODQwMw
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
