### PR TITLE
[train] Add Virtual Pipeline Parallelism support to Megatron

### DIFF
--- a/examples/train_integrations/modal/vpp_vs_pp_benchmark.py
+++ b/examples/train_integrations/modal/vpp_vs_pp_benchmark.py
@@ -1,0 +1,602 @@
+"""
+Single-file Modal benchmark for comparing basic pipeline parallelism (PP)
+against virtual pipeline parallelism (VPP) on a small SkyRL Megatron
+train-step workload.
+
+The Modal wrapper launches this same file in an internal benchmark mode under:
+    uv run --isolated --extra megatron python ...
+
+That keeps the benchmark self-contained while still using the repo's locked
+Megatron environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import re
+import shlex
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+try:
+    import modal
+except ImportError:
+    modal = None
+
+
+INTERNAL_STEP_BENCHMARK_FLAG = "--internal-step-benchmark"
+APP_NAME = os.getenv("MODAL_APP_NAME", "skyrl-vpp-benchmark")
+DATA_ROOT = Path("/root/data/vpp_benchmark")
+HF_CACHE_DIR = Path("/root/data/hf-cache")
+DEFAULT_BENCHMARK_MODEL = "Qwen/Qwen3-0.6B"
+LEGACY_QWEN2_BENCHMARK_MODEL = "Qwen/Qwen2.5-1.5B-Instruct"
+
+
+def _find_local_repo_root() -> Path:
+    if "SKYRL_REPO_ROOT" in os.environ:
+        return Path(os.environ["SKYRL_REPO_ROOT"])
+
+    candidates = [Path(__file__).resolve(), Path.cwd()]
+    for start in candidates:
+        for base in [start] + list(start.parents):
+            if base.exists() and (base / "skyrl-gym").exists():
+                return base
+    raise RuntimeError("SkyRL root repo path not found")
+
+
+def create_modal_image():
+    if modal is None:
+        raise RuntimeError("modal is required to build the Modal benchmark image")
+
+    local_repo_path = _find_local_repo_root()
+    print(f"Root path: {local_repo_path}")
+
+    envs = {
+        "SKYRL_REPO_ROOT": "/root/SkyRL",
+    }
+
+    return (
+        modal.Image.from_registry("novaskyai/skyrl-train-ray-2.51.1-py3.12-cu12.8-megatron")
+        .pip_install("huggingface_hub")
+        .env(envs)
+        .add_local_dir(
+            local_path=str(local_repo_path),
+            remote_path="/root/SkyRL",
+            ignore=[
+                ".venv",
+                "*.pyc",
+                "__pycache__",
+                ".git",
+                "*.egg-info",
+                ".pytest_cache",
+                "node_modules",
+                ".DS_Store",
+            ],
+        )
+    )
+
+
+def create_modal_volume(volume_name: str = "skyrl-data"):
+    if modal is None:
+        raise RuntimeError("modal is required to create the Modal volume")
+    data_volume = modal.Volume.from_name(volume_name, create_if_missing=True)
+    return {"/root/data": data_volume}
+
+
+def _run_command(
+    args: list[str],
+    *,
+    cwd: str,
+    env: dict[str, str],
+    check: bool = True,
+) -> tuple[str, float]:
+    print(f"$ {shlex.join(args)}")
+    start = time.perf_counter()
+    process = subprocess.Popen(
+        args,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        universal_newlines=True,
+    )
+
+    output_lines: list[str] = []
+    assert process.stdout is not None
+    for line in process.stdout:
+        print(line, end="")
+        output_lines.append(line)
+
+    returncode = process.wait()
+    elapsed = time.perf_counter() - start
+    output = "".join(output_lines)
+    if check and returncode != 0:
+        tail = "".join(output_lines[-200:]).strip()
+        message = f"Command failed with exit code {returncode}: {shlex.join(args)}"
+        if tail:
+            message = f"{message}\n--- command output tail ---\n{tail}"
+        raise RuntimeError(message)
+    return output, elapsed
+
+
+def _extract_result_json(output: str) -> dict[str, Any]:
+    matches = re.findall(r"^RESULT_JSON=(\{.*\})$", output, flags=re.MULTILINE)
+    if not matches:
+        raise RuntimeError("Internal benchmark runner did not emit RESULT_JSON output")
+    return json.loads(matches[-1])
+
+
+def _print_summary(results: dict[str, dict[str, Any]]) -> None:
+    pp = results["pp"]
+    vpp = results["vpp"]
+
+    def _speedup(metric: str) -> float | None:
+        pp_value = pp.get(metric)
+        vpp_value = vpp.get(metric)
+        if not pp_value or not vpp_value:
+            return None
+        return pp_value / vpp_value
+
+    summary = {
+        "wall_clock_speedup": _speedup("elapsed_s"),
+        "avg_step_speedup": _speedup("avg_step_s"),
+        "avg_train_phase_speedup": _speedup("avg_train_phase_s"),
+        "avg_policy_train_speedup": _speedup("avg_policy_train_s"),
+    }
+
+    print("\n=== PP vs VPP Summary ===")
+    for label in ("pp", "vpp"):
+        run = results[label]
+        print(
+            f"{label.upper():>3} | elapsed={run['elapsed_s']:.2f}s | "
+            f"steps={run['steps']} | "
+            f"avg_step={run['avg_step_s'] if run['avg_step_s'] is not None else 'n/a'} | "
+            f"avg_train_phase={run['avg_train_phase_s'] if run['avg_train_phase_s'] is not None else 'n/a'} | "
+            f"avg_policy_train={run['avg_policy_train_s'] if run['avg_policy_train_s'] is not None else 'n/a'}"
+        )
+
+    print("Speedups (PP / VPP):")
+    for key, value in summary.items():
+        pretty = f"{value:.3f}x" if value is not None else "n/a"
+        print(f"  {key}: {pretty}")
+
+
+def _build_internal_subprocess_args(
+    *,
+    model_name: str,
+    num_gpus: int,
+    pp_size: int,
+    vpp_size: int | None,
+    policy_mini_batch_size: int,
+    micro_batch_size: int,
+    measure_steps: int,
+    warmup_steps: int,
+) -> list[str]:
+    args = [
+        "uv",
+        "run",
+        "--isolated",
+        "--extra",
+        "megatron",
+        "python",
+        "examples/train_integrations/modal/vpp_vs_pp_benchmark.py",
+        INTERNAL_STEP_BENCHMARK_FLAG,
+        "--model-name",
+        model_name,
+        "--num-gpus",
+        str(num_gpus),
+        "--pp-size",
+        str(pp_size),
+        "--policy-mini-batch-size",
+        str(policy_mini_batch_size),
+        "--micro-batch-size",
+        str(micro_batch_size),
+        "--measure-steps",
+        str(measure_steps),
+        "--warmup-steps",
+        str(warmup_steps),
+    ]
+    if vpp_size is not None:
+        args.extend(["--vpp-size", str(vpp_size)])
+    return args
+
+
+def _build_cfg(
+    *,
+    model_name: str,
+    num_gpus: int,
+    pp_size: int,
+    vpp_size: int | None,
+    policy_mini_batch_size: int,
+    micro_batch_size: int,
+):
+    from skyrl.train.config import SkyRLTrainConfig
+    from skyrl.train.utils.utils import validate_cfg
+
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.strategy = "megatron"
+    cfg.trainer.logger = "console"
+    cfg.trainer.flash_attn = False
+    cfg.trainer.use_sample_packing = False
+    cfg.trainer.placement.colocate_all = False
+    cfg.trainer.algorithm.use_kl_loss = False
+    cfg.trainer.ref.model.path = None
+    cfg.trainer.policy.model.path = model_name
+    cfg.trainer.train_batch_size = policy_mini_batch_size
+    cfg.trainer.policy_mini_batch_size = policy_mini_batch_size
+    cfg.trainer.micro_forward_batch_size_per_gpu = micro_batch_size
+    cfg.trainer.micro_train_batch_size_per_gpu = micro_batch_size
+    cfg.generator.n_samples_per_prompt = 1
+    cfg.trainer.placement.policy_num_nodes = 1
+    cfg.trainer.placement.policy_num_gpus_per_node = num_gpus
+    cfg.trainer.policy.megatron_config.tensor_model_parallel_size = 1
+    cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = pp_size
+    cfg.trainer.policy.megatron_config.virtual_pipeline_model_parallel_size = vpp_size
+    cfg.trainer.policy.megatron_config.transformer_config_kwargs["share_embeddings_and_output_weights"] = False
+    validate_cfg(cfg)
+    return cfg
+
+
+def _make_dummy_training_batch(batch_size: int, seq_len: int = 128, num_actions: int = 32):
+    import torch
+    from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
+
+    torch.manual_seed(42)
+    data = TrainingInputBatch(
+        {
+            "sequences": torch.randint(0, 100, (batch_size, seq_len), device="cpu"),
+            "attention_mask": torch.ones((batch_size, seq_len), dtype=int, device="cpu"),
+            "action_log_probs": 0.4 * torch.ones((batch_size, num_actions), device="cpu"),
+            "base_action_log_probs": 0.3 * torch.ones((batch_size, num_actions), device="cpu"),
+            "values": 0.5 * torch.ones((batch_size, num_actions), device="cpu"),
+            "returns": 0.5 * torch.ones((batch_size, num_actions), device="cpu"),
+            "advantages": 0.6 * torch.ones((batch_size, num_actions), device="cpu"),
+            "loss_mask": torch.ones((batch_size, num_actions), dtype=int, device="cpu"),
+            "response_mask": torch.ones((batch_size, num_actions), dtype=int, device="cpu"),
+            "rollout_logprobs": 0.2 * torch.ones((batch_size, num_actions), device="cpu"),
+        }
+    )
+    data.metadata = {"response_length": num_actions}
+    return data
+
+
+def _import_worker(strategy: str, worker_type: str):
+    if strategy in ("fsdp", "fsdp2"):
+        module_path = "skyrl.backends.skyrl_train.workers.fsdp.fsdp_worker"
+    elif strategy == "megatron":
+        module_path = "skyrl.backends.skyrl_train.workers.megatron.megatron_worker"
+    else:
+        raise ValueError(f"Unknown strategy type for {worker_type}: {strategy}")
+    module = importlib.import_module(module_path)
+    return getattr(module, f"{worker_type.capitalize()}Worker")
+
+
+def _init_ray_internal() -> None:
+    import ray
+
+    if ray.is_initialized():
+        ray.shutdown()
+
+    env_vars = {
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+        "NVTE_FUSED_ATTN": "0",
+    }
+    if os.environ.get("PYTHONPATH"):
+        env_vars["PYTHONPATH"] = os.environ["PYTHONPATH"]
+    if os.environ.get("LD_LIBRARY_PATH"):
+        env_vars["LD_LIBRARY_PATH"] = os.environ["LD_LIBRARY_PATH"]
+    ray.init(runtime_env={"env_vars": env_vars}, log_to_driver=True)
+
+
+def _init_policy_actor_group(cfg, num_gpus: int):
+    import ray
+    from ray.util.placement_group import placement_group
+
+    from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
+    from skyrl.train.utils.utils import ResolvedPlacementGroup, get_ray_pg_ready_with_timeout
+
+    raw_pg = placement_group([{"GPU": num_gpus, "CPU": num_gpus}], strategy="PACK")
+    get_ray_pg_ready_with_timeout(raw_pg, timeout=60)
+    pg = ResolvedPlacementGroup(raw_pg)
+    worker_cls = _import_worker(cfg.trainer.strategy, "policy")
+    actor_group = PPORayActorGroup(
+        cfg.trainer,
+        num_nodes=1,
+        num_gpus_per_node=num_gpus,
+        ray_actor_type=worker_cls,
+        pg=pg,
+        num_gpus_per_actor=0.75,
+        colocate_all=False,
+        sequence_parallel_size=cfg.trainer.policy.sequence_parallel_size,
+        record_memory=cfg.trainer.policy.record_memory,
+    )
+    ray.get(actor_group.async_init_model(cfg.trainer.policy.model.path))
+    return actor_group
+
+
+def _run_single_case(
+    *,
+    model_name: str,
+    num_gpus: int,
+    pp_size: int,
+    vpp_size: int | None,
+    policy_mini_batch_size: int,
+    micro_batch_size: int,
+    warmup_steps: int,
+    measure_steps: int,
+) -> dict[str, Any]:
+    import ray
+
+    cfg = _build_cfg(
+        model_name=model_name,
+        num_gpus=num_gpus,
+        pp_size=pp_size,
+        vpp_size=vpp_size,
+        policy_mini_batch_size=policy_mini_batch_size,
+        micro_batch_size=micro_batch_size,
+    )
+    _init_ray_internal()
+    actor_group = _init_policy_actor_group(cfg, num_gpus=num_gpus)
+    batch = _make_dummy_training_batch(batch_size=policy_mini_batch_size)
+
+    warmup_times = []
+    step_times = []
+    forward_backward_times = []
+    optim_step_times = []
+    last_result = None
+
+    try:
+        total_steps = warmup_steps + measure_steps
+        for step_idx in range(total_steps):
+            batch.metadata["global_step"] = step_idx
+
+            forward_start = time.perf_counter()
+            results = ray.get(actor_group.async_run_ray_method("mesh", "forward_backward", batch))
+            forward_elapsed = time.perf_counter() - forward_start
+
+            optim_start = time.perf_counter()
+            ray.get(actor_group.async_run_ray_method("pass_through", "optim_step"))
+            optim_elapsed = time.perf_counter() - optim_start
+
+            step_elapsed = forward_elapsed + optim_elapsed
+            if step_idx < warmup_steps:
+                warmup_times.append(step_elapsed)
+            else:
+                step_times.append(step_elapsed)
+                forward_backward_times.append(forward_elapsed)
+                optim_step_times.append(optim_elapsed)
+                last_result = results[0] if results else None
+    finally:
+        ray.shutdown()
+
+    return {
+        "steps": measure_steps,
+        "warmup_steps": warmup_steps,
+        "avg_step_s": statistics.fmean(step_times),
+        "avg_forward_backward_s": statistics.fmean(forward_backward_times),
+        "avg_optim_step_s": statistics.fmean(optim_step_times),
+        "avg_warmup_step_s": statistics.fmean(warmup_times) if warmup_times else None,
+        "sample_policy_loss": None if last_result is None else last_result.get("policy_loss"),
+    }
+
+
+def _run_internal_benchmark_from_cli() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(INTERNAL_STEP_BENCHMARK_FLAG, action="store_true")
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--num-gpus", type=int, required=True)
+    parser.add_argument("--pp-size", type=int, required=True)
+    parser.add_argument("--vpp-size", type=int, default=None)
+    parser.add_argument("--policy-mini-batch-size", type=int, required=True)
+    parser.add_argument("--micro-batch-size", type=int, required=True)
+    parser.add_argument("--warmup-steps", type=int, default=1)
+    parser.add_argument("--measure-steps", type=int, default=4)
+    args = parser.parse_args()
+
+    result = _run_single_case(
+        model_name=args.model_name,
+        num_gpus=args.num_gpus,
+        pp_size=args.pp_size,
+        vpp_size=args.vpp_size,
+        policy_mini_batch_size=args.policy_mini_batch_size,
+        micro_batch_size=args.micro_batch_size,
+        warmup_steps=args.warmup_steps,
+        measure_steps=args.measure_steps,
+    )
+    print(f"RESULT_JSON={json.dumps(result, sort_keys=True)}")
+
+
+if modal is not None:
+    app = modal.App(APP_NAME)
+    image = create_modal_image()
+    volume = create_modal_volume()
+
+    @app.function(
+        image=image,
+        gpu=os.environ.get("MODAL_GPU", "A100:4"),
+        volumes=volume,
+        timeout=4 * 60 * 60,
+    )
+    def run_vpp_benchmark(
+        model_name: str = DEFAULT_BENCHMARK_MODEL,
+        num_gpus: int = 4,
+        pp_size: int = 2,
+        vpp_size: int = 2,
+        train_examples: int = 64,
+        val_examples: int = 16,
+        train_batch_size: int = 16,
+        policy_mini_batch_size: int = 16,
+        micro_batch_size: int = 4,
+        n_samples_per_prompt: int = 1,
+        max_generate_length: int = 32,
+    ) -> dict[str, Any]:
+        from huggingface_hub import snapshot_download
+
+        del val_examples
+        del max_generate_length
+
+        assert pp_size > 1, "pp_size must be greater than 1 for a PP vs VPP comparison"
+        assert vpp_size > 1, "vpp_size must be greater than 1"
+        assert num_gpus % pp_size == 0, "num_gpus must be divisible by pp_size"
+
+        if model_name == LEGACY_QWEN2_BENCHMARK_MODEL:
+            print(
+                "Switching benchmark model from "
+                f"{LEGACY_QWEN2_BENCHMARK_MODEL} to {DEFAULT_BENCHMARK_MODEL} "
+                "because the current Megatron/VPP path in SkyRL is validated with Qwen3-0.6B."
+            )
+            model_name = DEFAULT_BENCHMARK_MODEL
+
+        policy_dp_size = num_gpus // pp_size
+        effective_policy_mini_batch_size = policy_mini_batch_size * n_samples_per_prompt
+        policy_mini_batch_size_per_gpu = effective_policy_mini_batch_size // policy_dp_size
+        assert policy_mini_batch_size_per_gpu % micro_batch_size == 0, (
+            "policy_mini_batch_size_per_gpu must be divisible by micro_batch_size"
+        )
+        assert (policy_mini_batch_size_per_gpu // micro_batch_size) % pp_size == 0, (
+            "num_microbatches must be divisible by pp_size for interleaved VPP"
+        )
+
+        repo_root = Path(os.environ.get("SKYRL_REPO_ROOT", "/root/SkyRL"))
+        gym_root = repo_root / "skyrl-gym"
+        results_dir = DATA_ROOT / "results"
+        results_dir.mkdir(parents=True, exist_ok=True)
+
+        env = os.environ.copy()
+        env["SKYRL_REPO_ROOT"] = str(repo_root)
+        env["HF_HOME"] = str(HF_CACHE_DIR)
+        env["HF_HUB_CACHE"] = str(HF_CACHE_DIR / "hub")
+        env["TRANSFORMERS_CACHE"] = str(HF_CACHE_DIR / "transformers")
+        env["TOKENIZERS_PARALLELISM"] = "false"
+        env["SKYRL_PYTHONPATH_EXPORT"] = "1"
+        pythonpath_entries = [str(repo_root), str(gym_root)]
+        if env.get("PYTHONPATH"):
+            pythonpath_entries.append(env["PYTHONPATH"])
+        env["PYTHONPATH"] = ":".join(pythonpath_entries)
+        os.environ.update(
+            {
+                "HF_HOME": env["HF_HOME"],
+                "HF_HUB_CACHE": env["HF_HUB_CACHE"],
+                "TRANSFORMERS_CACHE": env["TRANSFORMERS_CACHE"],
+                "TOKENIZERS_PARALLELISM": env["TOKENIZERS_PARALLELISM"],
+                "SKYRL_PYTHONPATH_EXPORT": env["SKYRL_PYTHONPATH_EXPORT"],
+                "PYTHONPATH": env["PYTHONPATH"],
+            }
+        )
+
+        os.chdir(repo_root)
+
+        print(f"Pre-downloading model to cache: {model_name}")
+        snapshot_download(model_name, local_files_only=False)
+        measure_steps = max(1, train_examples // max(1, effective_policy_mini_batch_size))
+        if measure_steps < train_examples // max(1, train_batch_size):
+            measure_steps = max(1, train_examples // max(1, train_batch_size))
+        warmup_steps = 1
+
+        configs = {
+            "pp": _build_internal_subprocess_args(
+                model_name=model_name,
+                num_gpus=num_gpus,
+                pp_size=pp_size,
+                vpp_size=None,
+                policy_mini_batch_size=effective_policy_mini_batch_size,
+                micro_batch_size=micro_batch_size,
+                measure_steps=measure_steps,
+                warmup_steps=warmup_steps,
+            ),
+            "vpp": _build_internal_subprocess_args(
+                model_name=model_name,
+                num_gpus=num_gpus,
+                pp_size=pp_size,
+                vpp_size=vpp_size,
+                policy_mini_batch_size=effective_policy_mini_batch_size,
+                micro_batch_size=micro_batch_size,
+                measure_steps=measure_steps,
+                warmup_steps=warmup_steps,
+            ),
+        }
+
+        results: dict[str, dict[str, Any]] = {}
+        for label, args in configs.items():
+            print(f"\n=== Running {label.upper()} benchmark ===")
+            output, elapsed_s = _run_command(args, cwd=str(repo_root), env=env)
+            (results_dir / label).mkdir(parents=True, exist_ok=True)
+            (results_dir / label / "stdout.log").write_text(output)
+            run_result = _extract_result_json(output)
+            results[label] = {
+                "label": label,
+                "elapsed_s": elapsed_s,
+                "steps": run_result["steps"],
+                "avg_step_s": run_result["avg_step_s"],
+                "avg_train_phase_s": run_result["avg_forward_backward_s"],
+                "avg_policy_train_s": run_result["avg_forward_backward_s"],
+                "avg_optim_step_s": run_result["avg_optim_step_s"],
+                "warmup_steps": run_result["warmup_steps"],
+            }
+
+        pp_run = results["pp"]
+        vpp_run = results["vpp"]
+        results["speedups"] = {
+            "wall_clock_pp_over_vpp": (
+                pp_run["elapsed_s"] / vpp_run["elapsed_s"] if vpp_run["elapsed_s"] else None
+            ),
+            "avg_step_pp_over_vpp": (
+                pp_run["avg_step_s"] / vpp_run["avg_step_s"]
+                if pp_run["avg_step_s"] is not None and vpp_run["avg_step_s"] not in (None, 0)
+                else None
+            ),
+            "avg_policy_train_pp_over_vpp": (
+                pp_run["avg_policy_train_s"] / vpp_run["avg_policy_train_s"]
+                if pp_run["avg_policy_train_s"] is not None and vpp_run["avg_policy_train_s"] not in (None, 0)
+                else None
+            ),
+        }
+
+        _print_summary(results)
+
+        output_path = results_dir / "benchmark_results.json"
+        output_path.write_text(json.dumps(results, indent=2))
+        print(f"\nSaved benchmark results to {output_path}")
+        return results
+
+    @app.local_entrypoint()
+    def main(
+        model_name: str = DEFAULT_BENCHMARK_MODEL,
+        num_gpus: int = 4,
+        pp_size: int = 2,
+        vpp_size: int = 2,
+        train_examples: int = 64,
+        val_examples: int = 16,
+        train_batch_size: int = 16,
+        policy_mini_batch_size: int = 16,
+        micro_batch_size: int = 4,
+        n_samples_per_prompt: int = 1,
+        max_generate_length: int = 32,
+    ) -> None:
+        results = run_vpp_benchmark.remote(
+            model_name=model_name,
+            num_gpus=num_gpus,
+            pp_size=pp_size,
+            vpp_size=vpp_size,
+            train_examples=train_examples,
+            val_examples=val_examples,
+            train_batch_size=train_batch_size,
+            policy_mini_batch_size=policy_mini_batch_size,
+            micro_batch_size=micro_batch_size,
+            n_samples_per_prompt=n_samples_per_prompt,
+            max_generate_length=max_generate_length,
+        )
+        print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__" and INTERNAL_STEP_BENCHMARK_FLAG in sys.argv:
+    _run_internal_benchmark_from_cli()

--- a/examples/train_integrations/modal/vpp_vs_pp_benchmark.py
+++ b/examples/train_integrations/modal/vpp_vs_pp_benchmark.py
@@ -459,12 +459,12 @@ if modal is not None:
         policy_dp_size = num_gpus // pp_size
         effective_policy_mini_batch_size = policy_mini_batch_size * n_samples_per_prompt
         policy_mini_batch_size_per_gpu = effective_policy_mini_batch_size // policy_dp_size
-        assert policy_mini_batch_size_per_gpu % micro_batch_size == 0, (
-            "policy_mini_batch_size_per_gpu must be divisible by micro_batch_size"
-        )
-        assert (policy_mini_batch_size_per_gpu // micro_batch_size) % pp_size == 0, (
-            "num_microbatches must be divisible by pp_size for interleaved VPP"
-        )
+        assert (
+            policy_mini_batch_size_per_gpu % micro_batch_size == 0
+        ), "policy_mini_batch_size_per_gpu must be divisible by micro_batch_size"
+        assert (
+            policy_mini_batch_size_per_gpu // micro_batch_size
+        ) % pp_size == 0, "num_microbatches must be divisible by pp_size for interleaved VPP"
 
         repo_root = Path(os.environ.get("SKYRL_REPO_ROOT", "/root/SkyRL"))
         gym_root = repo_root / "skyrl-gym"
@@ -546,9 +546,7 @@ if modal is not None:
         pp_run = results["pp"]
         vpp_run = results["vpp"]
         results["speedups"] = {
-            "wall_clock_pp_over_vpp": (
-                pp_run["elapsed_s"] / vpp_run["elapsed_s"] if vpp_run["elapsed_s"] else None
-            ),
+            "wall_clock_pp_over_vpp": (pp_run["elapsed_s"] / vpp_run["elapsed_s"] if vpp_run["elapsed_s"] else None),
             "avg_step_pp_over_vpp": (
                 pp_run["avg_step_s"] / vpp_run["avg_step_s"]
                 if pp_run["avg_step_s"] is not None and vpp_run["avg_step_s"] not in (None, 0)

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -86,9 +86,15 @@ class MegatronStrategy(DistributedStrategy):
         if local_rank != -1:
             torch.cuda.set_device(local_rank)
 
+        vpp_size = self.megatron_config.virtual_pipeline_model_parallel_size
+        assert (
+            vpp_size is None or vpp_size > 1
+        ), f"virtual_pipeline_model_parallel_size must be greater than 1 when set (got {vpp_size})"
+
         mpu.initialize_model_parallel(
             tensor_model_parallel_size=self.megatron_config.tensor_model_parallel_size,
             pipeline_model_parallel_size=self.megatron_config.pipeline_model_parallel_size,
+            virtual_pipeline_model_parallel_size=vpp_size,
             expert_model_parallel_size=self.megatron_config.expert_model_parallel_size,
             expert_tensor_parallel_size=self.megatron_config.expert_tensor_parallel_size,
             use_sharp=False,
@@ -166,6 +172,29 @@ class MegatronStrategy(DistributedStrategy):
             if init_fn is not None and inner_opt is not None and cfg is not None and len(inner_opt.state) == 0:
                 init_fn(inner_opt, cfg)
 
+    def _get_unwrapped_model_chunks(self, model: List[nn.Module]) -> List[nn.Module]:
+        unwrapped_models = []
+        for chunk in model:
+            while hasattr(chunk, "module"):
+                chunk = chunk.module
+            unwrapped_models.append(chunk)
+        if self.is_lora and len(unwrapped_models) > 1:
+            raise NotImplementedError("Checkpointing with VPP + LoRA is not yet supported")
+        return unwrapped_models
+
+    def _get_sharded_model_state_dicts(self, model: List[nn.Module]) -> tuple[List[nn.Module], List[dict], dict]:
+        unwrapped_models = self._get_unwrapped_model_chunks(model)
+        model_sharded_state_dicts = [chunk.sharded_state_dict() for chunk in unwrapped_models]
+        if self.is_lora:
+            return unwrapped_models, model_sharded_state_dicts, {}
+        if len(model_sharded_state_dicts) == 1:
+            return unwrapped_models, model_sharded_state_dicts, {"model": model_sharded_state_dicts[0]}
+        return (
+            unwrapped_models,
+            model_sharded_state_dicts,
+            {f"model{i}": state_dict for i, state_dict in enumerate(model_sharded_state_dicts)},
+        )
+
     def save_checkpoint(
         self,
         model: MegatronModelWrapper,
@@ -177,10 +206,7 @@ class MegatronStrategy(DistributedStrategy):
     ):
         # Extract base model.
         model: List[nn.Module] = model.actor_module
-        assert len(model) == 1, "Megatron virtual pipeline parallel is not yet supported"
-        unwrapped_model = model[0]
-        while hasattr(unwrapped_model, "module"):
-            unwrapped_model = unwrapped_model.module
+        unwrapped_models, model_sharded_state_dicts, sharded_state_dict = self._get_sharded_model_state_dicts(model)
 
         # Create checkpoint directory if it doesn't exist.
         if node_local_rank == 0:
@@ -190,14 +216,10 @@ class MegatronStrategy(DistributedStrategy):
         dist.barrier()
 
         # Collect the sharded state dicts for model and optimizer, and full state dict for the scheduler.
-        sharded_state_dict = {}
-        model_sharded_state_dict = unwrapped_model.sharded_state_dict()
-        if not self.is_lora:
-            sharded_state_dict["model"] = model_sharded_state_dict
         if optimizer:
             self._ensure_optimizer_state_initialized(optimizer)
             sharded_state_dict["optimizer"] = optimizer.sharded_state_dict(
-                model_sharded_state_dict,
+                model_sharded_state_dicts[0] if len(model_sharded_state_dicts) == 1 else model_sharded_state_dicts,
                 is_loading=False,
                 metadata=self._dist_ckpt_optim_metadata,
             )
@@ -230,7 +252,7 @@ class MegatronStrategy(DistributedStrategy):
                 self.save_hf_configs(self.hf_config, hf_dir, tokenizer)
 
         if self.is_lora:
-            self._save_lora_adapters(unwrapped_model, ckpt_dir)
+            self._save_lora_adapters(unwrapped_models[0], ckpt_dir)
 
         dist.barrier()
         ckpt_base.async_calls.close()
@@ -281,19 +303,12 @@ class MegatronStrategy(DistributedStrategy):
 
         # Extract base model.
         model: List[nn.Module] = model.actor_module
-        assert len(model) == 1, "Megatron virtual pipeline parallel is not yet supported"
-        unwrapped_model = model[0]
-        while hasattr(unwrapped_model, "module"):
-            unwrapped_model = unwrapped_model.module
+        unwrapped_models, model_sharded_state_dicts, sharded_state_dict = self._get_sharded_model_state_dicts(model)
 
         # Extract sharded state dicts.
-        sharded_state_dict = {}
-        model_sharded_state_dict = unwrapped_model.sharded_state_dict()
-        if not self.is_lora:
-            sharded_state_dict["model"] = model_sharded_state_dict
         if optimizer and load_optimizer_states:
             sharded_state_dict["optimizer"] = optimizer.sharded_state_dict(
-                model_sharded_state_dict,
+                model_sharded_state_dicts[0] if len(model_sharded_state_dicts) == 1 else model_sharded_state_dicts,
                 is_loading=True,
                 metadata=self._dist_ckpt_optim_metadata,
             )
@@ -310,14 +325,17 @@ class MegatronStrategy(DistributedStrategy):
                 sharded_state_dict=sharded_state_dict, checkpoint_dir=read_dir, sharded_strategy=load_strategy
             )
         if not self.is_lora:
-            # Load the model, optimizer, and scheduler state dicts.
-            assert (
-                "model" in state_dict
-            ), f"Model state dict not found in checkpoint loaded from {ckpt_dir}. Available keys: {state_dict.keys()}"
-            model[0].load_state_dict(state_dict["model"], strict=load_module_strict)
+            model_keys = ["model"] if len(model) == 1 else [f"model{i}" for i in range(len(model))]
+            missing = [key for key in model_keys if key not in state_dict]
+            assert not missing, (
+                f"Model state dict keys {missing} not found in checkpoint loaded from {ckpt_dir}. "
+                f"Available keys: {state_dict.keys()}"
+            )
+            for key, chunk in zip(model_keys, model):
+                chunk.load_state_dict(state_dict[key], strict=load_module_strict)
             self.print("Loaded model state dict.")
         else:
-            self._load_lora_adapters(unwrapped_model, ckpt_dir)
+            self._load_lora_adapters(unwrapped_models[0], ckpt_dir)
 
         if optimizer and load_optimizer_states:
             assert (

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 from megatron.core.distributed import finalize_model_grads
 from megatron.core.pipeline_parallel import get_forward_backward_func
+from megatron.core.utils import get_attr_wrapped_model
 from omegaconf import OmegaConf
 
 from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
@@ -31,6 +32,33 @@ from skyrl.backends.skyrl_train.utils.replay_utils import (
 )
 from skyrl.backends.skyrl_train.utils.torch_utils import masked_mean
 from skyrl.train.config import TrainerConfig
+
+
+def _get_model_chunk_attr(model: nn.Module, attr_name: str) -> Any:
+    try:
+        return get_attr_wrapped_model(model, attr_name, allow_none=True)
+    except RuntimeError:
+        return None
+
+
+def _get_model_chunk_stage_flags(model: nn.Module) -> tuple[bool, bool]:
+    pre_process = _get_model_chunk_attr(model, "pre_process")
+    post_process = _get_model_chunk_attr(model, "post_process")
+    vp_stage = _get_model_chunk_attr(model, "vp_stage")
+
+    if pre_process is None:
+        if vp_stage is not None:
+            pre_process = mpu.is_pipeline_first_stage(ignore_virtual=False, vp_stage=vp_stage)
+        else:
+            pre_process = mpu.is_pipeline_first_stage(ignore_virtual=True)
+
+    if post_process is None:
+        if vp_stage is not None:
+            post_process = mpu.is_pipeline_last_stage(ignore_virtual=False, vp_stage=vp_stage)
+        else:
+            post_process = mpu.is_pipeline_last_stage(ignore_virtual=True)
+
+    return bool(pre_process), bool(post_process)
 
 
 class MegatronModelWrapper:
@@ -110,6 +138,7 @@ class MegatronModelWrapper:
 
         def forward_step(batch_iter, model):
             batch = next(batch_iter)
+            pre_process, post_process = _get_model_chunk_stage_flags(model)
 
             rollout_expert_indices = batch.pop("rollout_expert_indices", None)
             if rollout_expert_indices is not None:
@@ -128,7 +157,7 @@ class MegatronModelWrapper:
                 new_sequences, packed_seq_params = preprocess_packed_seqs(
                     sequences,
                     attention_mask,
-                    pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
+                    pre_process=pre_process,
                 )
                 new_attention_mask = None
                 new_position_ids = None
@@ -137,7 +166,7 @@ class MegatronModelWrapper:
                     sequences,
                     attention_mask,
                     position_ids,
-                    pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
+                    pre_process=pre_process,
                 )
                 packed_seq_params = None
 
@@ -155,7 +184,7 @@ class MegatronModelWrapper:
                     attention_mask,
                     micro_batch_size,
                     seq_len,
-                    post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
+                    post_process=post_process,
                 )
             else:
                 outputs = recover_left_padding(
@@ -163,7 +192,7 @@ class MegatronModelWrapper:
                     new_attention_mask,
                     attention_mask,
                     seq_len,
-                    post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
+                    post_process=post_process,
                 )
 
             return outputs, partial(collection_func, data=batch)
@@ -379,6 +408,7 @@ class MegatronModelWrapper:
             # for recover_left_padding and setup_per_microbatch_replay_forward. Especially relevant
             # after this PR https://github.com/NovaSky-AI/SkyRL/pull/1285.
             batch = next(batch_iter)
+            pre_process, post_process = _get_model_chunk_stage_flags(model)
 
             rollout_expert_indices = batch.pop("rollout_expert_indices", None)
             if rollout_expert_indices is not None:
@@ -397,7 +427,7 @@ class MegatronModelWrapper:
                 new_sequences, packed_seq_params = preprocess_packed_seqs(
                     sequences,
                     attention_mask,
-                    pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
+                    pre_process=pre_process,
                 )
                 new_attention_mask = None
                 new_position_ids = None
@@ -406,7 +436,7 @@ class MegatronModelWrapper:
                     sequences,
                     attention_mask,
                     position_ids,
-                    pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
+                    pre_process=pre_process,
                 )
                 packed_seq_params = None
 
@@ -424,7 +454,7 @@ class MegatronModelWrapper:
                     attention_mask,
                     micro_batch_size,
                     seq_len,
-                    post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
+                    post_process=post_process,
                 )
             else:
                 outputs = recover_left_padding(
@@ -432,7 +462,7 @@ class MegatronModelWrapper:
                     new_attention_mask,
                     attention_mask,
                     seq_len,
-                    post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
+                    post_process=post_process,
                 )
 
             if rollout_expert_indices is not None:

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -140,7 +140,7 @@ class MegatronModelWrapper:
             batch = next(batch_iter)
             pre_process, post_process = _get_model_chunk_stage_flags(model)
 
-            rollout_expert_indices = batch.pop("rollout_expert_indices", None)
+            rollout_expert_indices = batch.get("rollout_expert_indices")
             if rollout_expert_indices is not None:
                 setup_per_microbatch_replay_forward(
                     rollout_expert_indices,
@@ -410,7 +410,7 @@ class MegatronModelWrapper:
             batch = next(batch_iter)
             pre_process, post_process = _get_model_chunk_stage_flags(model)
 
-            rollout_expert_indices = batch.pop("rollout_expert_indices", None)
+            rollout_expert_indices = batch.get("rollout_expert_indices")
             if rollout_expert_indices is not None:
                 setup_per_microbatch_replay_forward(
                     rollout_expert_indices,

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -45,16 +45,17 @@ def _get_model_chunk_stage_flags(model: nn.Module) -> tuple[bool, bool]:
     pre_process = _get_model_chunk_attr(model, "pre_process")
     post_process = _get_model_chunk_attr(model, "post_process")
     vp_stage = _get_model_chunk_attr(model, "vp_stage")
-
     if pre_process is None:
         if vp_stage is not None:
-            pre_process = mpu.is_pipeline_first_stage(ignore_virtual=False, vp_stage=vp_stage)
+            pre_process = mpu.is_pipeline_first_stage(ignore_virtual=False) and vp_stage == 0
         else:
             pre_process = mpu.is_pipeline_first_stage(ignore_virtual=True)
-
     if post_process is None:
         if vp_stage is not None:
-            post_process = mpu.is_pipeline_last_stage(ignore_virtual=False, vp_stage=vp_stage)
+            vpp_world_size = mpu.get_virtual_pipeline_model_parallel_world_size()
+            post_process = mpu.is_pipeline_last_stage(ignore_virtual=False) and vp_stage == (
+                vpp_world_size - 1 if vpp_world_size else 0
+            )
         else:
             post_process = mpu.is_pipeline_last_stage(ignore_virtual=True)
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -304,6 +304,28 @@ class MegatronWeightExtractor(WeightExtractor):
 
 
 class MegatronWorker:
+    def _validate_virtual_pipeline_parallelism(self, megatron_config):
+        vpp_size = megatron_config.virtual_pipeline_model_parallel_size
+        if vpp_size is None:
+            return
+        assert vpp_size > 1, f"virtual_pipeline_model_parallel_size must be greater than 1 when set (got {vpp_size})"
+        pp_size = megatron_config.pipeline_model_parallel_size
+        assert pp_size > 1, (
+            f"virtual_pipeline_model_parallel_size={vpp_size} requires "
+            f"pipeline_model_parallel_size > 1 (got {pp_size})"
+        )
+        transformer_config_kwargs = megatron_config.transformer_config_kwargs
+        if not isinstance(transformer_config_kwargs, dict):
+            transformer_config_kwargs = OmegaConf.to_container(transformer_config_kwargs, resolve=True)
+        num_layers = transformer_config_kwargs.get(
+            "num_layers", getattr(self.strategy.hf_config, "num_hidden_layers", None)
+        )
+        total_chunks = pp_size * vpp_size
+        assert num_layers is not None and num_layers % total_chunks == 0, (
+            f"num_hidden_layers ({num_layers}) must be divisible by "
+            f"PP x VPP = {pp_size} x {vpp_size} = {total_chunks}"
+        )
+
     def init_configs(
         self,
         model_path,
@@ -342,6 +364,8 @@ class MegatronWorker:
         provider = bridge.to_megatron_provider()
         provider.tensor_model_parallel_size = megatron_config.tensor_model_parallel_size
         provider.pipeline_model_parallel_size = megatron_config.pipeline_model_parallel_size
+        if megatron_config.virtual_pipeline_model_parallel_size is not None:
+            provider.virtual_pipeline_model_parallel_size = megatron_config.virtual_pipeline_model_parallel_size
         provider.pipeline_dtype = torch.bfloat16 if bf16 else torch.float32
         provider.context_parallel_size = megatron_config.context_parallel_size
         provider.expert_model_parallel_size = megatron_config.expert_model_parallel_size
@@ -586,6 +610,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             bf16=self.cfg.bf16,
             flash_attn=self.cfg.flash_attn,
         )
+        self._validate_virtual_pipeline_parallelism(self.cfg.policy.megatron_config)
 
         if self.enable_router_replay:
             from skyrl.backends.skyrl_train.utils.replay_utils import (
@@ -892,6 +917,7 @@ class MegatronRefWorkerBase(MegatronWorker, RefWorkerBase):
             bf16=self.cfg.bf16,
             flash_attn=self.cfg.flash_attn,
         )
+        self._validate_virtual_pipeline_parallelism(self.cfg.ref.megatron_config)
 
         self.actor_module = self.make_megatron_module(
             wrap_with_ddp=False,

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -149,6 +149,7 @@ DEFAULT_TRANSFORMER_CONFIG_KWARGS = {
 class MegatronConfig(BaseConfig):
     tensor_model_parallel_size: int = 1
     pipeline_model_parallel_size: int = 1
+    virtual_pipeline_model_parallel_size: Optional[int] = None
     context_parallel_size: int = 1
     expert_model_parallel_size: int = 1
     expert_tensor_parallel_size: Optional[int] = None

--- a/skyrl/train/config/megatron_config/policy.yaml
+++ b/skyrl/train/config/megatron_config/policy.yaml
@@ -1,6 +1,7 @@
 # @package megatron_config.policy
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+virtual_pipeline_model_parallel_size: null
 context_parallel_size: 1
 expert_model_parallel_size: 1
 expert_tensor_parallel_size: null

--- a/skyrl/train/config/megatron_config/ref.yaml
+++ b/skyrl/train/config/megatron_config/ref.yaml
@@ -1,6 +1,7 @@
 # @package megatron_config.ref
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+virtual_pipeline_model_parallel_size: null
 context_parallel_size: 1
 expert_model_parallel_size: 1
 expert_tensor_parallel_size: 1

--- a/skyrl/train/utils/Untitled
+++ b/skyrl/train/utils/Untitled
@@ -1,1 +1,0 @@
-policy_fwd_num_microbatches

--- a/skyrl/train/utils/Untitled
+++ b/skyrl/train/utils/Untitled
@@ -1,0 +1,1 @@
+policy_fwd_num_microbatches

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -114,6 +114,15 @@ def validate_batch_sizes(cfg: SkyRLTrainConfig):
         f"normalized policy_mini_batch_size_per_gpu {policy_mini_batch_size_per_gpu} should be larger than "
         f"micro_train_batch_size_per_gpu {cfg.trainer.micro_train_batch_size_per_gpu}"
     )
+    if cfg.trainer.strategy == "megatron":
+        vpp_size = cfg.trainer.policy.megatron_config.virtual_pipeline_model_parallel_size
+        if vpp_size is not None and vpp_size > 1:
+            policy_num_microbatches = policy_mini_batch_size_per_gpu // cfg.trainer.micro_train_batch_size_per_gpu
+            assert policy_num_microbatches % pp == 0, (
+                f"normalized policy num_microbatches {policy_num_microbatches} should be divisible by "
+                f"pipeline_model_parallel_size {pp} when "
+                f"virtual_pipeline_model_parallel_size={vpp_size}"
+            )
     policy_train_batch_size_per_gpu = (
         cfg.trainer.train_batch_size * cfg.generator.n_samples_per_prompt // policy_dp_size
     )
@@ -209,6 +218,11 @@ def validate_megatron_cfg(cfg: SkyRLTrainConfig):
 
     worker_configs = [(cfg.trainer.policy, "policy"), (cfg.trainer.ref, "ref")]
     for config, worker_type in worker_configs:
+        vpp_size = config.megatron_config.virtual_pipeline_model_parallel_size
+        assert vpp_size is None or vpp_size > 1, (
+            f"{worker_type}.megatron_config.virtual_pipeline_model_parallel_size must be greater than 1 when set, "
+            f"got {vpp_size}"
+        )
         # context, expert, and expert tensor parallel are not yet supported for megatron
         if config.megatron_config.context_parallel_size > 1:
             assert cfg.trainer.use_sample_packing, "context parallel is only supported with sample packing"

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -117,10 +117,23 @@ def validate_batch_sizes(cfg: SkyRLTrainConfig):
     if cfg.trainer.strategy == "megatron":
         vpp_size = cfg.trainer.policy.megatron_config.virtual_pipeline_model_parallel_size
         if vpp_size is not None and vpp_size > 1:
-            policy_num_microbatches = policy_mini_batch_size_per_gpu // cfg.trainer.micro_train_batch_size_per_gpu
-            assert policy_num_microbatches % pp == 0, (
-                f"normalized policy num_microbatches {policy_num_microbatches} should be divisible by "
+            policy_train_num_microbatches = policy_mini_batch_size_per_gpu // cfg.trainer.micro_train_batch_size_per_gpu
+            assert policy_train_num_microbatches % pp == 0, (
+                f"normalized policy training num_microbatches {policy_train_num_microbatches} should be divisible by "
                 f"pipeline_model_parallel_size {pp} when "
+                f"virtual_pipeline_model_parallel_size={vpp_size}"
+            )
+            assert policy_mini_batch_size_per_gpu % cfg.trainer.micro_forward_batch_size_per_gpu == 0, (
+                f"normalized policy_mini_batch_size_per_gpu {policy_mini_batch_size_per_gpu} should be divisible "
+                f"by micro_forward_batch_size_per_gpu {cfg.trainer.micro_forward_batch_size_per_gpu} when "
+                f"virtual_pipeline_model_parallel_size={vpp_size}"
+            )
+            policy_forward_num_microbatches = (
+                policy_mini_batch_size_per_gpu // cfg.trainer.micro_forward_batch_size_per_gpu
+            )
+            assert policy_forward_num_microbatches % pp == 0, (
+                f"normalized policy forward num_microbatches {policy_forward_num_microbatches} should be divisible "
+                f"by pipeline_model_parallel_size {pp} when "
                 f"virtual_pipeline_model_parallel_size={vpp_size}"
             )
     policy_train_batch_size_per_gpu = (

--- a/tests/backends/skyrl_train/distributed/test_megatron_correctness.py
+++ b/tests/backends/skyrl_train/distributed/test_megatron_correctness.py
@@ -5,6 +5,7 @@ installed.
 """
 
 import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -108,6 +109,89 @@ class TestSeedVariation:
             with patch("random.seed", side_effect=lambda s: captured.append(s)):
                 strategy.set_seed(42)
             assert captured[0] == expected_seed
+
+
+# ---------------------------------------------------------------------------
+# C6: VPP checkpoint layout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_megatron, reason="megatron-core not installed")
+class TestVPPCheckpointLayout:
+    """Verify VPP checkpoint helpers preserve legacy single-chunk layout."""
+
+    def test_single_chunk_keeps_legacy_model_key(self):
+        from skyrl.backends.skyrl_train.distributed.megatron.megatron_strategy import (
+            MegatronStrategy,
+        )
+        from skyrl.train.config.config import MegatronConfig
+
+        class _Chunk:
+            def sharded_state_dict(self):
+                return {"chunk0": "chunk0_state"}
+
+        strategy = MegatronStrategy(megatron_config=MegatronConfig(), seed=42)
+        _, model_sharded_state_dicts, sharded_state_dict = strategy._get_sharded_model_state_dicts([_Chunk()])
+
+        assert model_sharded_state_dicts == [{"chunk0": "chunk0_state"}]
+        assert sharded_state_dict == {"model": {"chunk0": "chunk0_state"}}
+
+    def test_multi_chunk_uses_per_chunk_keys(self):
+        from skyrl.backends.skyrl_train.distributed.megatron.megatron_strategy import (
+            MegatronStrategy,
+        )
+        from skyrl.train.config.config import MegatronConfig
+
+        class _Chunk:
+            def __init__(self, name):
+                self.name = name
+
+            def sharded_state_dict(self):
+                return {self.name: f"{self.name}_state"}
+
+        chunk0 = _Chunk("chunk0")
+        chunk1 = _Chunk("chunk1")
+        wrapper1 = type("_Wrapper", (), {"module": chunk1})()
+
+        strategy = MegatronStrategy(megatron_config=MegatronConfig(), seed=42)
+        unwrapped, model_sharded_state_dicts, sharded_state_dict = strategy._get_sharded_model_state_dicts(
+            [chunk0, wrapper1]
+        )
+
+        assert unwrapped == [chunk0, chunk1]
+        assert model_sharded_state_dicts == [{"chunk0": "chunk0_state"}, {"chunk1": "chunk1_state"}]
+        assert sharded_state_dict == {"model0": {"chunk0": "chunk0_state"}, "model1": {"chunk1": "chunk1_state"}}
+
+    def test_vpp_lora_checkpointing_not_supported(self):
+        from skyrl.backends.skyrl_train.distributed.megatron.megatron_strategy import (
+            MegatronStrategy,
+        )
+        from skyrl.train.config.config import MegatronConfig
+
+        strategy = MegatronStrategy(megatron_config=MegatronConfig(), seed=42, is_lora=True)
+
+        with pytest.raises(NotImplementedError, match="VPP \\+ LoRA"):
+            strategy._get_sharded_model_state_dicts([object(), object()])
+
+
+@pytest.mark.skipif(not _has_megatron, reason="megatron-core not installed")
+class TestVPPValidation:
+    def test_rejects_vpp_sizes_lte_one(self):
+        from skyrl.backends.skyrl_train.workers.megatron.megatron_worker import (
+            MegatronWorker,
+        )
+        from skyrl.train.config.config import MegatronConfig
+
+        worker = MegatronWorker.__new__(MegatronWorker)
+        worker.strategy = SimpleNamespace(hf_config=SimpleNamespace(num_hidden_layers=32))
+
+        for vpp_size in (0, 1):
+            megatron_config = MegatronConfig(
+                pipeline_model_parallel_size=4,
+                virtual_pipeline_model_parallel_size=vpp_size,
+            )
+            with pytest.raises(AssertionError, match="virtual_pipeline_model_parallel_size must be greater than 1"):
+                worker._validate_virtual_pipeline_parallelism(megatron_config)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -89,12 +89,14 @@ def test_cli_overrides():
         "trainer.seed=123",
         "generator.inference_engine.engine_init_kwargs.field=value",
         "generator.sampling_params.temperature=0.7",
+        "trainer.policy.megatron_config.virtual_pipeline_model_parallel_size=2",
     ]
     cfg = SkyRLTrainConfig.from_cli_overrides(overrides)
     assert cfg.trainer.policy.model.path == "path/to/model"
     assert cfg.trainer.seed == 123
     assert cfg.generator.inference_engine.engine_init_kwargs["field"] == "value"
     assert cfg.generator.sampling_params.temperature == 0.7
+    assert cfg.trainer.policy.megatron_config.virtual_pipeline_model_parallel_size == 2
 
     # check that temperature is propagated to algorithm config
     assert cfg.trainer.algorithm.temperature == 0.7
@@ -104,6 +106,7 @@ def test_cli_overrides_empty_args():
     cfg = SkyRLTrainConfig.from_cli_overrides([])
     assert cfg.trainer.policy.model.path == "Qwen/Qwen2.5-1.5B-Instruct"
     assert cfg.trainer.seed == 42
+    assert cfg.trainer.policy.megatron_config.virtual_pipeline_model_parallel_size is None
 
 
 def test_cli_overrides_plus_prefix_rejected():

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -15,7 +15,10 @@ from skyrl.backends.skyrl_train.workers.worker import CriticWorkerBase, PolicyWo
 from skyrl.backends.skyrl_train.workers.worker_utils import BatchIterator
 from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.trainer import RayPPOTrainer
-from skyrl.train.utils.utils import validate_batch_sizes
+from skyrl.train.utils.utils import (
+    validate_batch_sizes,
+    validate_megatron_cfg,
+)
 from tests.train.util import example_dummy_config
 
 
@@ -396,6 +399,39 @@ def test_validate_batch_sizes():
         AssertionError, match="critic_train_batch_size_per_gpu .* should be divisible by critic_mini_batch_size_per_gpu"
     ):
         validate_batch_sizes(cfg)
+
+    # Test Case 17: Valid Megatron VPP configuration - num microbatches divisible by PP
+    cfg = create_test_config(train_batch_size=96, policy_mini_batch_size=24, micro_train_batch_size_per_gpu=2)
+    cfg.trainer.strategy = "megatron"
+    cfg.generator.n_samples_per_prompt = 1
+    cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = 4
+    cfg.trainer.policy.megatron_config.virtual_pipeline_model_parallel_size = 2
+    validate_batch_sizes(cfg)
+
+    # Test Case 18: Error case - VPP requires num microbatches divisible by PP
+    cfg = create_test_config(train_batch_size=120, policy_mini_batch_size=20, micro_train_batch_size_per_gpu=2)
+    cfg.trainer.strategy = "megatron"
+    cfg.generator.n_samples_per_prompt = 1
+    cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = 4
+    cfg.trainer.policy.megatron_config.virtual_pipeline_model_parallel_size = 2
+    with pytest.raises(
+        AssertionError,
+        match="normalized policy num_microbatches .* should be divisible by pipeline_model_parallel_size",
+    ):
+        validate_batch_sizes(cfg)
+
+
+@pytest.mark.parametrize("vpp_size", [0, 1])
+def test_validate_megatron_cfg_rejects_vpp_size_lte_one(vpp_size):
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.strategy = "megatron"
+    cfg.trainer.policy.megatron_config.virtual_pipeline_model_parallel_size = vpp_size
+
+    with pytest.raises(
+        AssertionError,
+        match="policy\\.megatron_config\\.virtual_pipeline_model_parallel_size must be greater than 1",
+    ):
+        validate_megatron_cfg(cfg)
 
 
 def test_forward_backward_batch_calculations():

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -401,7 +401,12 @@ def test_validate_batch_sizes():
         validate_batch_sizes(cfg)
 
     # Test Case 17: Valid Megatron VPP configuration - num microbatches divisible by PP
-    cfg = create_test_config(train_batch_size=96, policy_mini_batch_size=24, micro_train_batch_size_per_gpu=2)
+    cfg = create_test_config(
+        train_batch_size=96,
+        policy_mini_batch_size=24,
+        micro_train_batch_size_per_gpu=2,
+        micro_forward_batch_size_per_gpu=6,
+    )
     cfg.trainer.strategy = "megatron"
     cfg.generator.n_samples_per_prompt = 1
     cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = 4
@@ -409,14 +414,36 @@ def test_validate_batch_sizes():
     validate_batch_sizes(cfg)
 
     # Test Case 18: Error case - VPP requires num microbatches divisible by PP
-    cfg = create_test_config(train_batch_size=120, policy_mini_batch_size=20, micro_train_batch_size_per_gpu=2)
+    cfg = create_test_config(
+        train_batch_size=120,
+        policy_mini_batch_size=20,
+        micro_train_batch_size_per_gpu=2,
+        micro_forward_batch_size_per_gpu=5,
+    )
     cfg.trainer.strategy = "megatron"
     cfg.generator.n_samples_per_prompt = 1
     cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = 4
     cfg.trainer.policy.megatron_config.virtual_pipeline_model_parallel_size = 2
     with pytest.raises(
         AssertionError,
-        match="normalized policy num_microbatches .* should be divisible by pipeline_model_parallel_size",
+        match="normalized policy training num_microbatches .* should be divisible by pipeline_model_parallel_size",
+    ):
+        validate_batch_sizes(cfg)
+
+    # Test Case 19: Error case - VPP forward path requires num microbatches divisible by PP
+    cfg = create_test_config(
+        train_batch_size=96,
+        policy_mini_batch_size=24,
+        micro_train_batch_size_per_gpu=2,
+        micro_forward_batch_size_per_gpu=8,
+    )
+    cfg.trainer.strategy = "megatron"
+    cfg.generator.n_samples_per_prompt = 1
+    cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = 4
+    cfg.trainer.policy.megatron_config.virtual_pipeline_model_parallel_size = 2
+    with pytest.raises(
+        AssertionError,
+        match="normalized policy forward num_microbatches .* should be divisible by pipeline_model_parallel_size",
     ):
         validate_batch_sizes(cfg)
 


### PR DESCRIPTION
Fixes #1392.
## Summary

This PR adds Virtual Pipeline Parallelism (VPP) support to the SkyRL Megatron backend.

VPP is exposed through config, wired into Megatron distributed/model initialization, and supported in checkpoint save/load for multi-chunk models. The change also adds fail-fast validation for invalid VPP configurations and preserves backward compatibility for existing non-VPP checkpoints.

## What Changed

- Added `virtual_pipeline_model_parallel_size: Optional[int] = None` to `MegatronConfig`
- Added VPP defaults to Megatron policy/ref YAML configs
- Added CLI/config parsing coverage for the new field

- Passed `virtual_pipeline_model_parallel_size` into `mpu.initialize_model_parallel(...)`
- Set `provider.virtual_pipeline_model_parallel_size` on the Megatron-Bridge provider when VPP is enabled

- Added worker-side VPP validation to ensure:
  - `virtual_pipeline_model_parallel_size > 1` when set
  - `pipeline_model_parallel_size > 1` when VPP is enabled
  - `num_hidden_layers % (PP * VPP) == 0`

- Added trainer/config validation for interleaved pipeline scheduling:
  - Reject `virtual_pipeline_model_parallel_size <= 1`
  - Enforce `num_microbatches % pipeline_model_parallel_size == 0` for VPP runs

- Updated Megatron checkpoint save/load to support multi-chunk models:
  - Unwrap and iterate over all model chunks instead of assuming a single module
  - Preserve the legacy `"model"` checkpoint key for single-chunk models
  - Use `"model0"`, `"model1"`, etc. for VPP chunk checkpoints
  - Pass per-chunk sharded model state dicts into optimizer checkpoint save/load
  - Keep `VPP + LoRA` checkpointing explicitly unsupported with a clear error

## Backward Compatibility

- Existing non-VPP configs continue to work unchanged
- Single-chunk checkpoints still use the legacy `"model"` key
- Invalid VPP configs now fail earlier with clearer error messages instead of surfacing deeper Megatron runtime errors

## Tests

Added coverage for:

- Config/CLI parsing of `virtual_pipeline_model_parallel_size`
- Valid and invalid VPP batch-size layouts
- Rejection of invalid VPP sizes (`0` and `1`)
- VPP checkpoint layout behavior
- Preservation of the legacy single-chunk checkpoint format
- Explicit rejection of `VPP + LoRA` checkpointing

## Notes

This PR enables the core VPP plumbing for Megatron training and checkpointing while keeping the unsupported `VPP + LoRA` checkpoint path guarded.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
