### PR TITLE
[ckpt] Fix Megatron checkpoint loading with optimizer CPU offloading

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -166,6 +166,29 @@ class MegatronStrategy(DistributedStrategy):
             if init_fn is not None and inner_opt is not None and cfg is not None and len(inner_opt.state) == 0:
                 init_fn(inner_opt, cfg)
 
+    @staticmethod
+    def _disable_inner_optimizer_post_load_hooks(optimizer):
+        """Temporarily disable post-load hooks on inner optimizers.
+
+        When CPU offloading is enabled, the HybridDeviceOptimizer registers a
+        post_load_state_dict_hook that can fail during DistributedOptimizer's
+        internal state normalization roundtrip in sharded_state_dict(is_loading=True).
+        """
+        saved = {}
+        for opt in getattr(optimizer, "chained_optimizers", [optimizer]):
+            inner = getattr(opt, "optimizer", None)
+            if inner is not None and hasattr(inner, "_optimizer_load_state_dict_post_hooks"):
+                hooks = inner._optimizer_load_state_dict_post_hooks
+                saved[id(inner)] = (inner, dict(hooks))
+                hooks.clear()
+        return saved
+
+    @staticmethod
+    def _restore_inner_optimizer_post_load_hooks(optimizer, saved_hooks):
+        """Restore previously disabled post-load hooks."""
+        for inner, hooks in saved_hooks.values():
+            inner._optimizer_load_state_dict_post_hooks.update(hooks)
+
     def save_checkpoint(
         self,
         model: MegatronModelWrapper,
@@ -292,11 +315,18 @@ class MegatronStrategy(DistributedStrategy):
         if not self.is_lora:
             sharded_state_dict["model"] = model_sharded_state_dict
         if optimizer and load_optimizer_states:
+            # When CPU offloading is enabled, the inner HybridDeviceOptimizer has a
+            # post_load_state_dict_hook that fails during sharded_state_dict's internal
+            # state normalization roundtrip (self.load_state_dict(self.state_dict())).
+            # Temporarily disable these hooks since the roundtrip is just for normalization;
+            # the actual optimizer state loading happens later via optimizer.load_state_dict().
+            saved_hooks = self._disable_inner_optimizer_post_load_hooks(optimizer)
             sharded_state_dict["optimizer"] = optimizer.sharded_state_dict(
                 model_sharded_state_dict,
                 is_loading=True,
                 metadata=self._dist_ckpt_optim_metadata,
             )
+            self._restore_inner_optimizer_post_load_hooks(optimizer, saved_hooks)
         if scheduler and load_lr_scheduler_states:
             sharded_state_dict["lr_scheduler"] = scheduler.state_dict()
 
@@ -323,7 +353,9 @@ class MegatronStrategy(DistributedStrategy):
             assert (
                 "optimizer" in state_dict
             ), f"Optimizer state dict not found in checkpoint loaded from {ckpt_dir}. Available keys: {state_dict.keys()}"
+            saved_hooks = self._disable_inner_optimizer_post_load_hooks(optimizer)
             optimizer.load_state_dict(state_dict["optimizer"])
+            self._restore_inner_optimizer_post_load_hooks(optimizer, saved_hooks)
             self.print("Loaded optimizer state dict.")
 
         if scheduler and load_lr_scheduler_states:

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py
@@ -59,13 +59,14 @@ def get_test_actor_config(strategy: str) -> SkyRLTrainConfig:
 
 
 @pytest.mark.parametrize(
-    ("strategy", "lora", "fully_reshardable"),
+    ("strategy", "lora", "fully_reshardable", "optimizer_cpu_offload"),
     [
-        ("fsdp", False, False),
-        ("fsdp2", False, False),
-        pytest.param("megatron", False, False, marks=pytest.mark.megatron),
-        pytest.param("megatron", True, False, marks=[pytest.mark.megatron, pytest.mark.lora]),
-        pytest.param("megatron", False, True, marks=pytest.mark.megatron),
+        ("fsdp", False, False, False),
+        ("fsdp2", False, False, False),
+        pytest.param("megatron", False, False, False, marks=pytest.mark.megatron),
+        pytest.param("megatron", True, False, False, marks=[pytest.mark.megatron, pytest.mark.lora]),
+        pytest.param("megatron", False, True, False, marks=pytest.mark.megatron),
+        pytest.param("megatron", False, False, True, marks=pytest.mark.megatron),
     ],
     ids=[
         "fsdp",
@@ -73,9 +74,10 @@ def get_test_actor_config(strategy: str) -> SkyRLTrainConfig:
         "megatron",
         "megatron_lora",
         "megatron_fully_reshardable",
+        "megatron_optimizer_cpu_offload",
     ],
 )
-def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardable):
+def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardable, optimizer_cpu_offload):
     """
     Test checkpointing logic by:
     1. Creating model and doing one training step
@@ -91,6 +93,9 @@ def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardabl
         cfg.trainer.policy.model.lora = SkyRLLoraConfig(rank=32, alpha=32)
     if fully_reshardable:
         cfg.trainer.policy.megatron_config.dist_ckpt_optim_fully_reshardable = True
+    if optimizer_cpu_offload:
+        cfg.trainer.policy.megatron_config.optimizer_config_kwargs["optimizer_cpu_offload"] = True
+        cfg.trainer.policy.megatron_config.optimizer_config_kwargs["optimizer_offload_fraction"] = 1.0
 
     checkpoint_dir = None
     try:


### PR DESCRIPTION
## Summary
- Fix `KeyError` when loading Megatron checkpoints with `optimizer_cpu_offload=True`
- Temporarily disable `HybridDeviceOptimizer`'s `post_load_state_dict_hook` during checkpoint loading to avoid stale `param_to_fp32_param` mapping after offload/backload cycles
- Add `megatron_optimizer_cpu_offload` test case to checkpoint save/load tests

## Root Cause
When `optimizer_cpu_offload` is enabled, Megatron uses a `HybridDeviceOptimizer` that registers a `post_load_state_dict_hook`. During `load_checkpoint`, `DistributedOptimizer.sharded_state_dict(is_loading=True)` internally calls `self.load_state_dict(self.state_dict())` as a normalization roundtrip, which triggers the hook. The hook calls `_update_fp32_params_by_new_state()` which looks up model params in `param_to_fp32_param` — a mapping that becomes stale after the offload/backload cycle, causing a `KeyError`.

## Fix
Temporarily disable the `HybridDeviceOptimizer`'s post-load hooks during:
1. `optimizer.sharded_state_dict(is_loading=True)` — the normalization roundtrip only builds a template
2. `optimizer.load_state_dict(state_dict)` — the actual loading is handled by `DistributedOptimizer` internally

When CPU offloading is not enabled, `_optimizer_load_state_dict_post_hooks` is empty, so this is a no-op for existing code paths.

## Test plan
- [ ] Run `pytest tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py -m "megatron"` — all 4 cases should pass (base, lora, fully_reshardable, optimizer_cpu_offload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
