### PR TITLE
[bug] Fix `KeyError` for `pixel_values` in `RefWorkerBase.forward`

### DIFF
--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -1226,8 +1226,8 @@ class RefWorkerBase(Worker):
         sequences = micro_batch["sequences"]
         response_length = micro_batch.metadata["response_length"]
         attention_mask = micro_batch["attention_mask"]
-        pixel_values = micro_batch["pixel_values"]
-        image_grid_thw = micro_batch["image_grid_thw"]
+        pixel_values = micro_batch.get("pixel_values", None)
+        image_grid_thw = micro_batch.get("image_grid_thw", None)
         with torch.no_grad(), torch.autocast(dtype=torch.bfloat16, device_type="cuda"):
             log_probs = self.model(
                 sequences,


### PR DESCRIPTION
# What does this PR do?

Fixes E2E CI failures: https://github.com/NovaSky-AI/SkyRL/actions/runs/23638914395/job/68854463564#step:7:66

```bash
              ^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^
                                  ^^^^^^^^^^^^^^^^^^^
ray.exceptions.RayTaskError(KeyError): ray::FSDPRefWorkerBase.forward() (pid=13109, ip=10.0.64.247, actor_id=ff9e6e3d54cb908a6bd23f3302000000, repr=<skyrl.backends.skyrl_train.workers.fsdp.fsdp_worker.FSDPRefWorkerBase object at 0x7da734b3bce0>)
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
           ^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-03-27_09-15-28_423442_3332/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_5a41786a63245861c45982c5d641ba10/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py", line 443, in forward
    output = super().forward(data)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-03-27_09-15-28_423442_3332/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_5a41786a63245861c45982c5d641ba10/skyrl/backends/skyrl_train/workers/worker.py", line 387, in forward
    outputs.append(self._forward_micro_batch(micro_batch))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-03-27_09-15-28_423442_3332/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_5a41786a63245861c45982c5d641ba10/skyrl/backends/skyrl_train/workers/worker.py", line 1229, in _forward_micro_batch
    pixel_values = micro_batch["pixel_values"]
                   ~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-03-27_09-15-28_423442_3332/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_5a41786a63245861c45982c5d641ba10/skyrl/backends/skyrl_train/training_batch.py", line 177, in __getitem__
    return super().__getitem__(index)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'pixel_values'
```


Uses .get() with `None` default for multi-modal fields (pixel_values, image_grid_thw) in `RefWorkerBase._forward_micro_batch`. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
