### PR TITLE
[fix] Forward SKYRL_RAY_PG_TIMEOUT_IN_S to workers via runtime_env

### DIFF
--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -660,6 +660,10 @@ def prepare_runtime_environment(cfg: SkyRLTrainConfig) -> dict[str, str]:
         logger.info(f"Exporting `PYTHONPATH` to ray runtime env: {os.environ['PYTHONPATH']}")
         env_vars["PYTHONPATH"] = os.environ["PYTHONPATH"]
 
+    if pg_timeout := os.environ.get("SKYRL_RAY_PG_TIMEOUT_IN_S"):
+        logger.info(f"Exporting `SKYRL_RAY_PG_TIMEOUT_IN_S` to ray runtime env: {pg_timeout}")
+        env_vars["SKYRL_RAY_PG_TIMEOUT_IN_S"] = pg_timeout
+
     return env_vars
 
 


### PR DESCRIPTION
## Summary
- `SKYRL_RAY_PG_TIMEOUT_IN_S` set on the head node doesn't reach worker nodes because `skyrl_entrypoint` runs as a `@ray.remote` function in a separate Python process on a worker
- This adds `SKYRL_RAY_PG_TIMEOUT_IN_S` to the `prepare_runtime_environment()` exports so Ray forwards it to all workers via `runtime_env`
- Users can now control the PG timeout from launch scripts with `export SKYRL_RAY_PG_TIMEOUT_IN_S=xxx` and it will propagate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
