### PR TITLE
[bug] Fix fork + Ray deadlock in dataset filtering by using spawn

### DIFF
--- a/skyrl/train/dataset/dataset.py
+++ b/skyrl/train/dataset/dataset.py
@@ -1,4 +1,3 @@
-import functools
 import os
 from typing import List
 
@@ -6,16 +5,8 @@ import datasets
 from loguru import logger
 from transformers import PreTrainedTokenizerBase
 
-from skyrl.utils.tok import get_tokenizer
 
-
-@functools.lru_cache(maxsize=4)
-def _get_tokenizer(tokenizer_name: str) -> PreTrainedTokenizerBase:
-    return get_tokenizer(tokenizer_name)
-
-
-def _prompt_not_too_long(doc, tokenizer_name, prompt_key, max_length):
-    tokenizer = _get_tokenizer(tokenizer_name)
+def _prompt_not_too_long(doc, tokenizer, prompt_key, max_length):
     tokens = tokenizer.apply_chat_template(
         doc[prompt_key], add_generation_prompt=True, return_dict=False, tokenize=True
     )
@@ -82,7 +73,7 @@ class PromptDataset:
         self.dataframe = self.dataframe.filter(
             _prompt_not_too_long,
             fn_kwargs={
-                "tokenizer_name": self.tokenizer.name_or_path,
+                "tokenizer": self.tokenizer,
                 "prompt_key": self.prompt_key,
                 "max_length": self.max_prompt_length,
             },

--- a/tests/train/dataset/test_dataset.py
+++ b/tests/train/dataset/test_dataset.py
@@ -13,13 +13,6 @@ class SimpleTokenizer:
         return x
 
 
-@pytest.fixture(autouse=True)
-def _patch_get_tokenizer():
-    """Patch _get_tokenizer so filter workers use SimpleTokenizer instead of AutoTokenizer."""
-    with patch("skyrl.train.dataset.dataset._get_tokenizer", return_value=SimpleTokenizer()):
-        yield
-
-
 @pytest.fixture
 def mock_tokenizer():
     return SimpleTokenizer()


### PR DESCRIPTION
# What does this PR do?

Sometimes we've seen CI hang during dataset preprocessing: 


```
Filtering prompts longer than 512 tokens (num_proc=8): 100%|██████████| 1319/1319 [1:37:35<00:00, 4.44s/examples]
```

The root cause is that HuggingFace dataset `.map` uses `fork` for multiprocessing by default, and SkyRL uses `num_proc=8` by default. Ray + fork needs to be avoided

Also, HuggingFace uses `multiprocess` internally, not `multiprocessing` module, so we need to explicitly set `multiprocess.set_start_method` 

This PR ensures that we use `spawn` for dataset preprocessing and switches to a picklable filter function to be compatible with `spawn`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
