### PR TITLE
[bug] Fix logprobs handling and error status codes for vllm-router compatibility

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -226,6 +226,17 @@ class RemoteInferenceClient:
                     try:
                         body = await resp.json(content_type=None)
                     except Exception as e:
+                        if 400 <= resp.status < 500:
+                            # Non-JSON client error (e.g. plain text 422 from vllm-router).
+                            # Raise immediately — client errors won't succeed on retry.
+                            text = await resp.text()
+                            raise aiohttp.ClientResponseError(
+                                resp.request_info,
+                                resp.history,
+                                status=resp.status,
+                                message=text or resp.reason,
+                                headers=resp.headers,
+                            )
                         last_exc = e
                         logger.debug(f"retry {attempt + 1}/{_DATA_PLANE_RETRIES} for {url=}: {e}")
                         await asyncio.sleep(1)

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_new_inference_generation.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_new_inference_generation.py
@@ -45,9 +45,12 @@ TP_SIZE = 1
 def _get_test_sampling_params(backend: str, cfg: SkyRLTrainConfig, endpoint: str) -> Dict[str, Any]:
     assert endpoint in ["chat_completions", "completions"]
     sampling_params = get_sampling_params_for_backend(backend, cfg.generator.sampling_params)
-    sampling_params["logprobs"] = True
     if endpoint == "chat_completions":
+        sampling_params["logprobs"] = True
         sampling_params["top_logprobs"] = 1
+    else:
+        # /v1/completions expects logprobs as an integer (number of top logprobs)
+        sampling_params["logprobs"] = 1
     sampling_params["return_tokens_as_token_ids"] = True
     return sampling_params
 
@@ -312,7 +315,10 @@ def test_error_handling(vllm_server: InferenceEngineState):
 
     # Missing required field (messages)
     response = requests.post(f"{base_url}/chat/completions", json={"model": SERVED_MODEL_NAME})
-    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.status_code in (
+        HTTPStatus.BAD_REQUEST,
+        HTTPStatus.UNPROCESSABLE_ENTITY,
+    )
 
     # Wrong model name
     response = requests.post(


### PR DESCRIPTION
# What does this PR do?

`vllm-router` has stricter request validation than the previous Python `InferenceRouter`:

- `/v1/completions` expects logprobs as integer, not boolean
- Missing required fields return 422 (Unprocessable Entity) instead of 400
- Error responses may be plain text instead of JSON

This PR updates tests to handle these differences and fix `_post()` to raise immediately on non-JSON 4xx error responses instead of retrying.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
