### PR TITLE
Add remaining ScaleRL recipe features to skyrl-train

### DIFF
--- a/docs/content/docs/algorithms/meta.json
+++ b/docs/content/docs/algorithms/meta.json
@@ -2,6 +2,7 @@
   "title": "Algorithms",
   "pages": [
     "dapo",
+    "scalerl",
     "off_policy_correction",
     "custom_algorithms"
   ]

--- a/docs/content/docs/algorithms/scalerl.mdx
+++ b/docs/content/docs/algorithms/scalerl.mdx
@@ -1,0 +1,63 @@
+---
+title: "ScaleRL"
+---
+
+<Callout type="info">
+The current ScaleRL recipe is supported with the standard `fsdp` trainer path.
+</Callout>
+
+SkyRL now ships the core ingredients requested in Issue #495 as first-class config knobs:
+
+- `trainer.algorithm.policy_loss_type=cispo`
+- `trainer.algorithm.zero_variance_filter=true`
+- `trainer.algorithm.loss_reduction=prompt_mean`
+- `trainer.algorithm.adaptive_prompt_filtering.enabled=true`
+- `trainer.policy.model.upcast_logits_to_fp32=true`
+
+An example GSM8K launch script is available at `examples/train/algorithms/scalerl/run_scalerl_gsm8k.sh`.
+
+## Prompt-Level Aggregation
+
+Set `trainer.algorithm.loss_reduction=prompt_mean` to average token losses at prompt granularity instead of weighting prompts by total token count.
+
+In V1, `prompt_mean`:
+
+- computes a token-mean loss within each prompt group
+- averages those prompt losses across the mini-batch
+- does not support step-wise trajectories
+- is incompatible with `trainer.algorithm.dynamic_sampling.type=replace`
+
+## Adaptive Prompt Filtering
+
+Adaptive prompt filtering removes prompts that have become consistently easy across epochs.
+
+```yaml
+trainer:
+  algorithm:
+    adaptive_prompt_filtering:
+      enabled: true
+      metric: pass_rate
+      threshold: 0.9
+      min_history: 5
+      warmup_epochs: 1
+      min_active_ratio: 0.1
+```
+
+V1 behavior:
+
+- only `metric=pass_rate` is supported
+- a sampled response counts as positive when its scalar reward is greater than `0`
+- filtering happens only at epoch boundaries
+- a prompt floor is enforced through `min_active_prompts` and `min_active_ratio`
+- fully async training is not supported yet
+
+## Fp32 Logits
+
+Set `trainer.policy.model.upcast_logits_to_fp32=true` to upcast logits to fp32 before temperature scaling, logprob computation, and entropy computation in the HF/FSDP policy path. The same flag is also available on `trainer.ref.model`.
+
+## Example
+
+```bash
+export WANDB_API_KEY=your_wandb_api_key
+bash examples/train/algorithms/scalerl/run_scalerl_gsm8k.sh
+```

--- a/docs/content/docs/configuration/config.mdx
+++ b/docs/content/docs/configuration/config.mdx
@@ -243,6 +243,7 @@ This section configures the policy model used for training, including optimizer,
 policy:
   model:
     path: "Qwen/Qwen2.5-1.5B-Instruct"  # Hugging Face model path for the policy model
+    upcast_logits_to_fp32: false  # Upcast logits to fp32 before logprob / entropy computation
     lora:
       rank: 0                    # LoRA rank (0 = disabled)
       alpha: 16                  # LoRA scaling parameter
@@ -276,6 +277,7 @@ policy:
 ```
 
 - `policy.optimizer_config`: Optimizer configuration for the policy model
+- `policy.model.upcast_logits_to_fp32`: Whether to upcast logits to fp32 before temperature scaling, logprob computation, and entropy computation in the HF/FSDP path.
 - `policy.fsdp_config`: FSDP configuration, applicable if `trainer.strategy='fsdp'`.
 - `policy.sequence_parallel_size`: Sequence parallel size. We implement [Ulysses sequence parallelism](https://arxiv.org/abs/2309.14509)
 - `policy.use_torch_compile`: Whether to enable torch compile for entropy calculation
@@ -327,6 +329,7 @@ critic:
 ref:
   model:
     path: null  # defaults to `trainer.policy.model.path`
+    upcast_logits_to_fp32: false
   fsdp_config:
     cpu_offload: false
     reshard_after_forward: true
@@ -337,6 +340,7 @@ ref:
 ```
 
 - `ref.model.path`: Path to the reference model. Defaults to the`trainer.policy.model.path`, but can be separately set (i.e. for distillation based approaches, the reference model can be a different model than the policy model).
+- `ref.model.upcast_logits_to_fp32`: Whether to upcast reference-model logits to fp32 before logprob computation in the HF/FSDP path.
 - `ref.fsdp_config`: FSDP configuration, applicable if `trainer.strategy='fsdp'`.
 - `ref.sequence_parallel_size`: Sequence parallel size. We implement [Ulysses sequence parallelism](https://arxiv.org/abs/2309.14509)
 
@@ -374,7 +378,7 @@ algorithm:
   advantage_batch_normalize: false
   value_head_prefix: "value_head"
   policy_loss_type: "regular" # "regular", "dual_clip", "gspo", "clip_cov", "kl_cov" or customizable with PolicyLossRegistry
-  loss_reduction: "token_mean" # "token_mean", "sequence_mean", "seq_mean_token_sum_norm"
+  loss_reduction: "token_mean" # "token_mean", "token_mean_legacy", "sequence_mean", "prompt_mean", "seq_mean_token_sum_norm"
   grpo_norm_by_std: true # set to false to disable normalization by std in GRPO (used in Dr. GRPO)
   zero_variance_filter: false # set to true to loss mask out prompts with zero variance rewards. only applicable when rewards are response-level.
 
@@ -412,6 +416,15 @@ algorithm:
     type: null # filter (DAPO), replace (POLARIS/WebSailor), or null
     max_sample_batches: 30 # sample at most this many batches before stopping, -1 to sample forever
     min_replace_ratio: 0.3 # minimum proportion of good samples with which to replace bad samples (for replace strategy only)
+
+  adaptive_prompt_filtering:
+    enabled: false
+    metric: "pass_rate"
+    threshold: 0.9
+    min_history: 1
+    warmup_epochs: 1
+    min_active_prompts: 0
+    min_active_ratio: 0.0
 
   # To be deprecated in favor of off_policy_correction.tis_ratio_type = "token"
   # and "token_tis_ratio_clip_high"
@@ -493,7 +506,9 @@ algorithm:
 - `algorithm.loss_reduction`: Type of loss reduction to use. Options include:
 
   - `token_mean`: computes average loss over all valid tokens in the batch. Used in [DAPO](https://dapo-sia.github.io/).
+  - `token_mean_legacy`: computes token means per micro-batch and then averages them across micro-batches.
   - `sequence_mean`: computes per-sequence avg token loss, then averages over the batch.
+  - `prompt_mean`: computes a token-mean loss within each prompt group and then averages those prompt losses across the mini-batch. This is intended for ScaleRL-style prompt-level aggregation.
   - `seq_mean_token_sum_norm`: computes the sum of token losses for each sequence, normalizes by `max_seq_len`, and then averages over the batch. This is used in [Dr. GRPO](https://arxiv.org/abs/2503.20783). If `algorithm.max_seq_len` is not explicitly set, it defaults to `generator.max_input_length + generator.sampling_params.max_generate_length`.
 
 - `algorithm.grpo_norm_by_std`: Whether to normalize advantages by the standard deviation in GRPO. This is set to `false` in [Dr. GRPO](https://arxiv.org/abs/2503.20783).
@@ -508,6 +523,14 @@ algorithm:
   - `algorithm.dynamic_sampling.type`: Type of dynamic sampling to use. Currently, we support `filter` ([DAPO](https://dapo-sia.github.io/)), `replace` ([POLARIS](https://hkunlp.github.io/blog/2025/Polaris/) / [WebSailor](https://arxiv.org/abs/2507.02592)), or `null` for no dynamic sampling.
   - `algorithm.dynamic_sampling.max_sample_batches`: Maximum number of batches to sample before stopping. Set to `-1` to sample forever.
   - `algorithm.dynamic_sampling.min_replace_ratio`: Minimum proportion of good samples with which to replace bad samples for `replace` strategy.
+- `algorithm.adaptive_prompt_filtering`: Epoch-level prompt filtering configuration.
+  - `algorithm.adaptive_prompt_filtering.enabled`: Whether to remove easy prompts across epochs.
+  - `algorithm.adaptive_prompt_filtering.metric`: Filtering metric. V1 currently supports `pass_rate` only.
+  - `algorithm.adaptive_prompt_filtering.threshold`: Filter prompts whose metric is at least this threshold.
+  - `algorithm.adaptive_prompt_filtering.min_history`: Minimum number of sampled responses required before a prompt can be filtered.
+  - `algorithm.adaptive_prompt_filtering.warmup_epochs`: Number of completed epochs to wait before filtering starts.
+  - `algorithm.adaptive_prompt_filtering.min_active_prompts`: Minimum number of prompts to keep active.
+  - `algorithm.adaptive_prompt_filtering.min_active_ratio`: Minimum fraction of the original prompt dataset to keep active.
 - `algorithm.use_tis`: Whether to use Truncated Importance Sampling (TIS) as proposed in [this blog](https://fengyao.notion.site/off-policy-rl). This flag is to be deprecated, use `off_policy_correction.tis_ratio_type = "token"` instead.
 - `max_seq_len`: Used for `seq_mean_token_sum_norm` `loss_reduction`. Users should set this value for multi-turn for that loss. If not set, will be calculated as generator.max_input_length + generator.sampling_params.max_generate_length, which is incorrect for multi-turn.
 - `algorithm.tis_imp_ratio_cap`: Cap parameter for the importance ratio in TIS. This flag is to be deprecated, use `off_policy_correction.token_tis_ratio_clip_high` instead.

--- a/examples/train/README.md
+++ b/examples/train/README.md
@@ -3,7 +3,7 @@ Welcome to the SkyRL-Train examples! In this folder you can find the following e
 
 ## Algorithms
 
-- `algorithms/`: Examples for how to configure and run RL with various algorithms and policy-loss variants (e.g., DAPO, SAPO, GRPO, CISPO, GSPO, or your own custom advantage estimators and custom policy losses).
+- `algorithms/`: Examples for how to configure and run RL with various algorithms and policy-loss variants (e.g., DAPO, ScaleRL, SAPO, GRPO, CISPO, GSPO, or your own custom advantage estimators and custom policy losses).
 - `ppo/`: Vanilla PPO training (with a critic, ref, and policy model)
 - `on_policy_distillation/`: [On-policy distillation recipe](https://novasky-ai.notion.site/on-policy-distillation) that uses a teacher model to provide dense token-level rewards during training, reproducing results from the [Thinking Machines blog](https://thinkingmachines.ai/blog/on-policy-distillation/).
 - `tis_correction/`: Applying [Flash-RL TIS](https://fengyao.notion.site/off-policy-rl) correction to improve off-policy stability.

--- a/examples/train/algorithms/scalerl/README.md
+++ b/examples/train/algorithms/scalerl/README.md
@@ -1,0 +1,27 @@
+# ScaleRL
+
+This recipe packages the remaining Issue #495 ingredients into one standard SkyRL training run:
+
+- `trainer.algorithm.policy_loss_type=cispo`
+- `trainer.algorithm.zero_variance_filter=true`
+- `trainer.algorithm.loss_reduction=prompt_mean`
+- `trainer.algorithm.adaptive_prompt_filtering.enabled=true`
+- `trainer.policy.model.upcast_logits_to_fp32=true`
+
+The example script is:
+
+- `examples/train/algorithms/scalerl/run_scalerl_gsm8k.sh`
+
+## V1 Constraints
+
+- `prompt_mean` is only supported for non-step-wise training.
+- Adaptive prompt filtering is only supported in the standard trainer, not fully async training.
+- Adaptive prompt filtering uses prompt pass rate, where a sampled response counts as positive when its scalar reward is greater than `0`.
+- Filtering happens only at epoch boundaries and keeps a minimum active prompt floor via `min_active_prompts` / `min_active_ratio`.
+
+## Launch
+
+```bash
+export WANDB_API_KEY=your_wandb_api_key
+bash examples/train/algorithms/scalerl/run_scalerl_gsm8k.sh
+```

--- a/examples/train/algorithms/scalerl/run_scalerl_gsm8k.sh
+++ b/examples/train/algorithms/scalerl/run_scalerl_gsm8k.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -x
+
+# Example ScaleRL-style run on GSM8K using the standard SkyRL trainer.
+#
+# Run data preparation first:
+# uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
+# export WANDB_API_KEY=<your_key_here>
+# bash examples/train/algorithms/scalerl/run_scalerl_gsm8k.sh
+
+DATA_DIR="$HOME/data/gsm8k"
+NUM_GPUS=4
+LOGGER="wandb"  # change to "console" to print to stdout
+
+uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
+  data.train_data="['$DATA_DIR/train.parquet']" \
+  data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \
+  trainer.strategy=fsdp2 \
+  trainer.placement.colocate_all=true \
+  trainer.placement.policy_num_gpus_per_node=$NUM_GPUS \
+  generator.inference_engine.num_engines=$NUM_GPUS \
+  generator.inference_engine.tensor_parallel_size=1 \
+  generator.inference_engine.backend=vllm \
+  generator.inference_engine.run_engines_locally=true \
+  generator.inference_engine.weight_sync_backend=nccl \
+  generator.inference_engine.async_engine=true \
+  generator.inference_engine.gpu_memory_utilization=0.8 \
+  trainer.epochs=20 \
+  trainer.eval_batch_size=1024 \
+  trainer.eval_before_train=true \
+  trainer.eval_interval=5 \
+  trainer.update_epochs_per_batch=1 \
+  trainer.train_batch_size=1024 \
+  trainer.policy_mini_batch_size=256 \
+  trainer.micro_forward_batch_size_per_gpu=64 \
+  trainer.micro_train_batch_size_per_gpu=64 \
+  trainer.ckpt_interval=10 \
+  trainer.max_prompt_length=512 \
+  generator.sampling_params.max_generate_length=1024 \
+  trainer.policy.optimizer_config.lr=1.0e-6 \
+  trainer.algorithm.policy_loss_type=cispo \
+  trainer.algorithm.use_kl_loss=false \
+  trainer.algorithm.zero_variance_filter=true \
+  trainer.algorithm.loss_reduction=prompt_mean \
+  trainer.algorithm.advantage_batch_normalize=true \
+  trainer.algorithm.adaptive_prompt_filtering.enabled=true \
+  trainer.algorithm.adaptive_prompt_filtering.metric=pass_rate \
+  trainer.algorithm.adaptive_prompt_filtering.threshold=0.9 \
+  trainer.algorithm.adaptive_prompt_filtering.min_history=5 \
+  trainer.algorithm.adaptive_prompt_filtering.warmup_epochs=1 \
+  trainer.algorithm.adaptive_prompt_filtering.min_active_ratio=0.1 \
+  trainer.policy.model.upcast_logits_to_fp32=true \
+  trainer.ref.model.upcast_logits_to_fp32=true \
+  generator.batched=true \
+  environment.env_class=gsm8k \
+  generator.n_samples_per_prompt=5 \
+  trainer.logger="$LOGGER" \
+  trainer.project_name="scalerl_gsm8k" \
+  trainer.run_name="scalerl_gsm8k_test" \
+  trainer.resume_mode=null \
+  trainer.ckpt_path="$HOME/ckpts/scalerl_gsm8k_1.5B_ckpt" \
+  $@

--- a/skyrl/backends/skyrl_train/utils/ppo_utils.py
+++ b/skyrl/backends/skyrl_train/utils/ppo_utils.py
@@ -1002,15 +1002,18 @@ def apply_loss_reduction_to_advantages_minibatch(
     loss_reduction: str,
     micro_batch_size: int,
     max_seq_len: int,
+    uids: Optional[List[str]] = None,
 ) -> torch.Tensor:
     """Scale advantages so that summing produces the desired loss reduction.
 
     Args:
         advantages: Advantage tensor of shape (minibatch_size, seq_len).
         loss_mask: Mask of shape (minibatch_size, seq_len) indicating valid loss tokens.
-        loss_reduction: One of "token_mean", "token_mean_legacy", "sequence_mean", "seq_mean_token_sum_norm".
+        loss_reduction: One of "token_mean", "token_mean_legacy", "sequence_mean", "prompt_mean",
+            "seq_mean_token_sum_norm".
         micro_batch_size: Number of sequences per micro-batch
         max_seq_len: Maximum sequence length.
+        uids: Prompt ids aligned with the mini-batch rows. Required for ``prompt_mean``.
 
     Returns:
         Scaled advantages tensor.
@@ -1037,6 +1040,24 @@ def apply_loss_reduction_to_advantages_minibatch(
     # Option 2: sequence mean
     elif loss_reduction == "sequence_mean":
         normalized_advantages = advantages / (batch_size * loss_mask.sum(dim=-1, keepdim=True).clamp(min=1))
+
+    # Option 2b: prompt mean
+    elif loss_reduction == "prompt_mean":
+        if uids is None:
+            raise ValueError("uids must be provided for prompt_mean loss reduction")
+        if len(uids) != batch_size:
+            raise ValueError(f"uids length must match batch size, got {len(uids)} and {batch_size}")
+
+        uid_to_indices = defaultdict(list)
+        for idx, uid in enumerate(uids):
+            uid_to_indices[uid].append(idx)
+
+        num_prompts = len(uid_to_indices)
+        for idxs in uid_to_indices.values():
+            group_advantages = advantages[idxs]
+            group_loss_mask = loss_mask[idxs]
+            denom = group_loss_mask.sum().clamp(min=1)
+            normalized_advantages[idxs] = group_advantages / (num_prompts * denom)
 
     # Option 3: Dr. GRPO style loss reduction to avoid length bias by normalizing by a constant
     elif loss_reduction == "seq_mean_token_sum_norm":

--- a/skyrl/backends/skyrl_train/utils/torch_utils.py
+++ b/skyrl/backends/skyrl_train/utils/torch_utils.py
@@ -31,6 +31,25 @@ except ImportError:
 CHUNK_SIZE = 1024
 
 
+def prepare_logits_for_loss(
+    logits: Float[torch.Tensor, "batch_size seqlen vocab_size"],
+    temperature: float = 1.0,
+    upcast_to_fp32: bool = False,
+) -> Float[torch.Tensor, "batch_size seqlen vocab_size"]:
+    """Prepare logits for logprob / entropy computation.
+
+    Args:
+        logits: Raw model logits.
+        temperature: Temperature used during policy loss computation.
+        upcast_to_fp32: Whether to upcast logits to fp32 before scaling.
+    """
+    if upcast_to_fp32 and logits.dtype != torch.float32:
+        logits = logits.to(torch.float32)
+    if temperature != 1.0:
+        logits = logits / temperature
+    return logits
+
+
 def chunked_cross_entropy_from_log_probs(
     logprobs: Float[torch.Tensor, "batch_size seqlen vocab_size"], requires_grad: bool = False
 ) -> Float[torch.Tensor, "batch_size seqlen"]:

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -188,6 +188,7 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
                 rope_scaling=get_rope_scaling_config(self.cfg),
                 rope_theta=get_rope_theta_config(self.cfg),
                 model_config_kwargs=self.cfg.policy.model_config_kwargs,
+                upcast_logits_to_fp32=self.cfg.policy.model.upcast_logits_to_fp32,
             )
             # in-place patch
             self._seq_parallel_monkey_patch(model=wrapped_model.model)
@@ -426,6 +427,7 @@ class FSDPRefWorkerBase(RefWorkerBase):
                 rope_scaling=get_rope_scaling_config(self.cfg),
                 rope_theta=get_rope_theta_config(self.cfg),
                 model_config_kwargs=self.cfg.ref.model_config_kwargs,
+                upcast_logits_to_fp32=self.cfg.ref.model.upcast_logits_to_fp32,
             )
             self._seq_parallel_monkey_patch(model=wrapped_model.model)
 

--- a/skyrl/backends/skyrl_train/workers/model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/model_wrapper.py
@@ -30,6 +30,7 @@ from skyrl.backends.skyrl_train.training_batch import TensorList
 from skyrl.backends.skyrl_train.utils.torch_utils import (
     chunked_entropy_from_logits,
     logprobs_from_logits,
+    prepare_logits_for_loss,
 )
 
 
@@ -78,10 +79,12 @@ class HFModelWrapper(nn.Module):
         rope_scaling: Dict[str, Any] = {},
         rope_theta: float | None = None,
         model_config_kwargs: dict = {},
+        upcast_logits_to_fp32: bool = False,
         **kwargs,
     ) -> None:
         super().__init__()
         self.temperature = temperature
+        self.upcast_logits_to_fp32 = upcast_logits_to_fp32
         self.sequence_parallel_size = sequence_parallel_size
         self.attn_implementation = "flash_attention_2" if use_flash_attention_2 else "sdpa"
         self.use_sample_packing = use_sample_packing
@@ -367,8 +370,11 @@ class HFModelWrapper(nn.Module):
         else:
             output = self.model(sequences_fwd, attention_mask=attention_mask_fwd, position_ids=position_ids_fwd)
 
-        logits_BSV = output["logits"]
-        logits_BSV.div_(temperature)
+        logits_BSV = prepare_logits_for_loss(
+            output["logits"],
+            temperature=temperature,
+            upcast_to_fp32=self.upcast_logits_to_fp32,
+        )
 
         # NOTE: this is slightly inaccurate with sample packing because last token from nth seq -> first token of n+1th seq loss is added.
         log_probs = logprobs_from_logits(

--- a/skyrl/train/config/__init__.py
+++ b/skyrl/train/config/__init__.py
@@ -1,4 +1,5 @@
 from skyrl.train.config.config import (
+    AdaptivePromptFilteringConfig,
     AlgorithmConfig,
     BaseConfig,
     ChatTemplateConfig,
@@ -45,6 +46,7 @@ __all__ = [
     "CriticConfig",
     "RefConfig",
     "AlgorithmConfig",
+    "AdaptivePromptFilteringConfig",
     "GeneratorConfig",
     "InferenceEngineConfig",
     "EnvironmentConfig",

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -65,6 +65,9 @@ class SkyRLLoraConfig(BaseConfig):
 @dataclass
 class ModelConfig(BaseConfig):
     path: Optional[str] = None
+    upcast_logits_to_fp32: bool = False
+    """Upcast logits to fp32 before temperature scaling, logprob computation, and entropy computation.
+    Primarily relevant for HF/FSDP policy and ref models."""
     lora: SkyRLLoraConfig = field(default_factory=SkyRLLoraConfig)
 
 
@@ -266,6 +269,24 @@ class DynamicSamplingConfig(BaseConfig):
 
 
 @dataclass
+class AdaptivePromptFilteringConfig(BaseConfig):
+    enabled: bool = False
+    """Remove prompts that have become consistently easy at epoch boundaries."""
+    metric: str = "pass_rate"
+    """Filtering metric. V1 supports ``"pass_rate"`` only."""
+    threshold: float = 0.9
+    """Filter prompts whose metric is at least this threshold."""
+    min_history: int = 1
+    """Minimum number of sampled responses required before a prompt can be filtered."""
+    warmup_epochs: int = 1
+    """Do not filter prompts until at least this many epochs have completed."""
+    min_active_prompts: int = 0
+    """Keep at least this many prompts active after filtering."""
+    min_active_ratio: float = 0.0
+    """Keep at least this fraction of the original prompt dataset active after filtering."""
+
+
+@dataclass
 class ClipCovConfig(BaseConfig):
 
     clip_ratio: float = 0.0002
@@ -348,7 +369,7 @@ class AlgorithmConfig(BaseConfig):
     policy_loss_type: str = "regular"
     """``"regular"``, ``"dual_clip"``, ``"gspo"``, ``"clip_cov"``, ``"kl_cov"``, or custom via ``PolicyLossRegistry``."""
     loss_reduction: str = "token_mean"
-    """``"token_mean"``, ``"sequence_mean"``, or ``"seq_mean_token_sum_norm"``."""
+    """``"token_mean"``, ``"token_mean_legacy"``, ``"sequence_mean"``, ``"prompt_mean"``, or ``"seq_mean_token_sum_norm"``."""
     grpo_norm_by_std: bool = True
     zero_variance_filter: bool = False
     """Loss-mask prompts with zero-variance rewards. Only applicable when rewards are response-level."""
@@ -366,6 +387,7 @@ class AlgorithmConfig(BaseConfig):
     sapo: SAPOConfig = field(default_factory=SAPOConfig)
     value_clip: float = 0.2
     dynamic_sampling: DynamicSamplingConfig = field(default_factory=DynamicSamplingConfig)
+    adaptive_prompt_filtering: AdaptivePromptFilteringConfig = field(default_factory=AdaptivePromptFilteringConfig)
     clip_cov: ClipCovConfig = field(default_factory=ClipCovConfig)
     """Only used when ``policy_loss_type="clip_cov"``."""
     kl_cov: KLCovConfig = field(default_factory=KLCovConfig)

--- a/skyrl/train/config/ppo_base_config.yaml
+++ b/skyrl/train/config/ppo_base_config.yaml
@@ -27,6 +27,7 @@ trainer:
   policy:
     model:
       path: "Qwen/Qwen2.5-1.5B-Instruct"
+      upcast_logits_to_fp32: false
       lora:
         rank: 0
         alpha: 16
@@ -59,6 +60,7 @@ trainer:
   ref:
     model:
       path: ${trainer.policy.model.path}
+      upcast_logits_to_fp32: false
     sequence_parallel_size: 1
     fsdp_config:
       cpu_offload: false
@@ -110,7 +112,7 @@ trainer:
     advantage_batch_normalize: false
     value_head_prefix: "value_head"
     policy_loss_type: "regular" # "regular", "dual_clip", "gspo", "clip_cov", "kl_cov", or customizable with PolicyLossRegistry
-    loss_reduction: "token_mean" # "token_mean", "sequence_mean", "seq_mean_token_sum_norm"
+    loss_reduction: "token_mean" # "token_mean", "token_mean_legacy", "sequence_mean", "prompt_mean", "seq_mean_token_sum_norm"
     grpo_norm_by_std: true # set to false to disable normalization by std in GRPO
     zero_variance_filter: false # set to true to loss mask out prompts with zero variance rewards. only applicable when rewards are response-level.
     # GAE parameters
@@ -183,6 +185,14 @@ trainer:
       type: null # filter, replace, or null
       max_sample_batches: 30 # sample at most this many batches before stopping, -1 to sample forever
       min_replace_ratio: 0.3 # minimum proportion of good samples with which to replace bad samples (for replace strategy only)
+    adaptive_prompt_filtering:
+      enabled: false
+      metric: "pass_rate" # currently only pass_rate is supported
+      threshold: 0.9 # filter prompts whose pass rate is at least this threshold
+      min_history: 1 # minimum number of sampled responses before a prompt can be filtered
+      warmup_epochs: 1 # wait this many completed epochs before filtering
+      min_active_prompts: 0 # keep at least this many prompts active
+      min_active_ratio: 0.0 # or this fraction of the original dataset, whichever is larger
     
     # clip-cov parameters (only used when policy_loss_type: "clip_cov"
     clip_cov:

--- a/skyrl/train/dataset/__init__.py
+++ b/skyrl/train/dataset/__init__.py
@@ -1,1 +1,2 @@
+from .dataset import FilteredPromptDataset as FilteredPromptDataset
 from .dataset import PromptDataset as PromptDataset

--- a/skyrl/train/dataset/dataset.py
+++ b/skyrl/train/dataset/dataset.py
@@ -1,5 +1,5 @@
 import os
-from typing import List
+from typing import Any, List, Sequence
 
 import datasets
 from loguru import logger
@@ -101,3 +101,20 @@ class PromptDataset:
 
     def __len__(self):
         return len(self.dataframe)
+
+
+class FilteredPromptDataset:
+    """A lightweight view over a prompt dataset that preserves base-row UIDs."""
+
+    def __init__(self, base_dataset: Any, active_indices: Sequence[int]):
+        self.base_dataset = base_dataset
+        self.active_indices = list(active_indices)
+
+    def __getitem__(self, item):
+        return self.base_dataset[self.active_indices[item]]
+
+    def collate_fn(self, item_list):
+        return self.base_dataset.collate_fn(item_list)
+
+    def __len__(self):
+        return len(self.active_indices)

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -296,6 +296,9 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             self.cfg.trainer.algorithm.dynamic_sampling.type is None
         ), "dynamic sampling is not supported for fully async training yet."
         assert (
+            not self.cfg.trainer.algorithm.adaptive_prompt_filtering.enabled
+        ), "adaptive prompt filtering is not supported for fully async training yet."
+        assert (
             not self.cfg.generator.batched
         ), "batched is not supported for fully async training since a batched generate() call does not support pause/continue."
         assert self.cfg.generator.inference_engine.async_engine, "async_engine must be True for fully async training."

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -43,7 +43,7 @@ from skyrl.backends.skyrl_train.workers.worker_dispatch import WorkerDispatch
 from skyrl.backends.skyrl_train.workers.worker_utils import reduce_metrics
 from skyrl.env_vars import SKYRL_RAY_PG_TIMEOUT_IN_S
 from skyrl.train.config import SkyRLTrainConfig
-from skyrl.train.dataset import PromptDataset
+from skyrl.train.dataset import FilteredPromptDataset, PromptDataset
 from skyrl.train.dataset.preprocess import (
     convert_prompts_responses_to_batch_tensors,
 )
@@ -71,7 +71,9 @@ from skyrl.train.utils.trainer_utils import (
     build_dataloader,
     cleanup_old_checkpoints,
     extract_step_from_path,
+    filter_active_prompt_indices,
     run_on_each_node,
+    update_adaptive_prompt_history,
     validate_consistency_for_latest_checkpoint,
     validate_generator_output,
     zero_variance_filter,
@@ -95,12 +97,23 @@ class RayPPOTrainer:
         self.colocate_all = cfg.trainer.placement.colocate_all
         self.tracker = tracker
         self.tokenizer = tokenizer
+        self.base_train_dataset = train_dataset
         self.train_dataset = train_dataset
         self.eval_dataset = eval_dataset
         self.inference_engine_client = inference_engine_client
         self.generator = generator
         self.train_dataloader = None
         self.total_training_steps = None
+        self.global_step = 0
+        self.current_epoch = 0
+        self.steps_completed_in_epoch = 0
+        self.completed_batches = 0
+        self.adaptive_prompt_history: Dict[str, Dict[str, int]] = {}
+        self.active_prompt_indices = (
+            list(range(len(self.base_train_dataset)))
+            if self._adaptive_prompt_filtering_enabled() and self.base_train_dataset is not None
+            else []
+        )
         self._build_train_dataloader_and_compute_training_steps()
 
         self.eval_dataloader = (
@@ -112,7 +125,6 @@ class RayPPOTrainer:
 
         self.all_metrics = {}
         self.all_timings = {}
-        self.global_step = 0
 
         # initialized in `build_models`
         self.policy_model: PPORayActorGroup = None
@@ -132,6 +144,93 @@ class RayPPOTrainer:
         """Check if critic model is configured."""
         return bool(self.cfg.trainer.critic.model.path)
 
+    def _adaptive_prompt_filtering_enabled(self) -> bool:
+        return bool(self.cfg.trainer.algorithm.adaptive_prompt_filtering.enabled and self.base_train_dataset is not None)
+
+    def _get_current_train_dataset(self):
+        if not self._adaptive_prompt_filtering_enabled():
+            return self.base_train_dataset
+        if len(self.active_prompt_indices) == len(self.base_train_dataset):
+            return self.base_train_dataset
+        return FilteredPromptDataset(self.base_train_dataset, self.active_prompt_indices)
+
+    def _estimate_total_batches(self) -> Optional[int]:
+        if self.train_dataloader is None:
+            return None
+        remaining_batches_current_epoch = max(len(self.train_dataloader) - self.steps_completed_in_epoch, 0)
+        remaining_epochs_after_current = max(self.cfg.trainer.epochs - self.current_epoch - 1, 0)
+        return self.completed_batches + remaining_batches_current_epoch + remaining_epochs_after_current * len(
+            self.train_dataloader
+        )
+
+    def _update_progress_bar_total(self, pbar: tqdm) -> None:
+        estimated_total = self._estimate_total_batches()
+        if estimated_total is None:
+            return
+        pbar.total = max(estimated_total, pbar.n)
+        pbar.refresh()
+
+    def _record_adaptive_prompt_history(self, generator_output: GeneratorOutput, uids: List[str]) -> None:
+        if not self._adaptive_prompt_filtering_enabled():
+            return
+        self.adaptive_prompt_history = update_adaptive_prompt_history(
+            prompt_history=self.adaptive_prompt_history,
+            uids=uids,
+            rewards=generator_output["rewards"],
+        )
+        self.all_metrics.update(
+            {
+                "adaptive_prompt_filtering/active_prompt_count": len(self.active_prompt_indices),
+                "adaptive_prompt_filtering/history_size": len(self.adaptive_prompt_history),
+            }
+        )
+
+    def _apply_adaptive_prompt_filtering_for_next_epoch(self) -> None:
+        if not self._adaptive_prompt_filtering_enabled():
+            return
+
+        filter_cfg = self.cfg.trainer.algorithm.adaptive_prompt_filtering
+        if self.current_epoch < filter_cfg.warmup_epochs:
+            logger.info(
+                "Skipping adaptive prompt filtering after epoch "
+                f"{self.current_epoch}: waiting for warmup_epochs={filter_cfg.warmup_epochs}"
+            )
+            self.all_metrics.update(
+                {
+                    "adaptive_prompt_filtering/filtered_prompt_count": 0,
+                    "adaptive_prompt_filtering/easy_prompt_candidate_count": 0,
+                }
+            )
+            return
+
+        next_active_prompt_indices, filter_metrics = filter_active_prompt_indices(
+            num_total_prompts=len(self.base_train_dataset),
+            active_prompt_indices=self.active_prompt_indices,
+            prompt_history=self.adaptive_prompt_history,
+            threshold=filter_cfg.threshold,
+            min_history=filter_cfg.min_history,
+            min_active_prompts=max(filter_cfg.min_active_prompts, self.cfg.trainer.train_batch_size),
+            min_active_ratio=filter_cfg.min_active_ratio,
+        )
+        if not next_active_prompt_indices:
+            logger.warning("Adaptive prompt filtering would remove all prompts; keeping the current active set instead.")
+            filter_metrics["filtered_prompt_count"] = 0
+            filter_metrics["active_prompt_count"] = len(self.active_prompt_indices)
+        else:
+            self.active_prompt_indices = next_active_prompt_indices
+
+        self.all_metrics.update(
+            {
+                f"adaptive_prompt_filtering/{key}": value
+                for key, value in filter_metrics.items()
+            }
+        )
+        logger.info(
+            "Adaptive prompt filtering after epoch "
+            f"{self.current_epoch}: active_prompts={len(self.active_prompt_indices)}, "
+            f"filtered_prompts={filter_metrics['filtered_prompt_count']}"
+        )
+
     def _build_train_dataloader_and_compute_training_steps(self):
         """
         Hook for constructing the training dataloader. Subclasses can override
@@ -141,7 +240,8 @@ class RayPPOTrainer:
         When train_dataset is None (e.g. Tinker backend provides data externally),
         the dataloader is not built.
         """
-        if self.train_dataset is not None:
+        if self.base_train_dataset is not None:
+            self.train_dataset = self._get_current_train_dataset()
             self.train_dataloader = build_dataloader(self.cfg, self.train_dataset, is_train=True)
             self.total_training_steps = len(self.train_dataloader) * self.cfg.trainer.epochs
 
@@ -202,11 +302,18 @@ class RayPPOTrainer:
             self.reward_kl_controller = get_kl_controller(self.cfg.trainer.algorithm)
 
         # main training loop
-        pbar = tqdm(total=self.total_training_steps, initial=self.global_step, desc="Training Batches Processed")
-        start_epoch = self.global_step // len(self.train_dataloader)
-        self.global_step += 1  # start training at global_step 1
+        pbar = tqdm(
+            total=self._estimate_total_batches() or self.total_training_steps,
+            initial=self.completed_batches,
+            desc="Training Batches Processed",
+        )
+        start_epoch = self.current_epoch
+        if self.global_step == 0:
+            self.global_step = 1  # start training at global_step 1
         for epoch in range(start_epoch, self.cfg.trainer.epochs):
-            for iter, rand_prompts in enumerate(self.train_dataloader):
+            self.current_epoch = epoch
+            self._update_progress_bar_total(pbar)
+            for iter, rand_prompts in enumerate(self.train_dataloader, start=self.steps_completed_in_epoch):
                 with Timer("step", self.all_timings):
                     # for colocate_all=true, inference engine is always on GPU when starting the training step
 
@@ -236,6 +343,8 @@ class RayPPOTrainer:
                     if self.cfg.trainer.algorithm.dynamic_sampling.type is not None:
                         generator_output, uids, keep_sampling = self.handle_dynamic_sampling(generator_output, uids)
                         if keep_sampling:  # continue sampling
+                            self.steps_completed_in_epoch += 1
+                            self.completed_batches += 1
                             # update progress bar for current batch (but not global step)
                             pbar.update(1)
                             continue
@@ -247,6 +356,7 @@ class RayPPOTrainer:
                     # 1.2 postprocess rewards
                     with Timer("postprocess_generator_output", self.all_timings):
                         generator_output = self.postprocess_generator_output(generator_output, uids)
+                    self._record_adaptive_prompt_history(generator_output, uids)
 
                     # 2. print example just for debugging
                     vis = self.tokenizer.decode(generator_output["response_ids"][0])
@@ -291,7 +401,7 @@ class RayPPOTrainer:
                     # 8. conditionally save checkpoints and hf model
                     if self.cfg.trainer.ckpt_interval > 0 and self.global_step % self.cfg.trainer.ckpt_interval == 0:
                         with Timer("save_checkpoints", self.all_timings):
-                            self.save_checkpoints()
+                            self.save_checkpoints(post_step_state=True)
                     if (
                         self.cfg.trainer.hf_save_interval > 0
                         and self.global_step % self.cfg.trainer.hf_save_interval == 0
@@ -319,7 +429,7 @@ class RayPPOTrainer:
                 self.all_metrics.update({"trainer/epoch": epoch, "trainer/global_step": self.global_step})
                 if self.cfg.trainer.eval_interval > 0 and (
                     self.global_step % self.cfg.trainer.eval_interval == 0
-                    or self.global_step == self.total_training_steps
+                    or (epoch == self.cfg.trainer.epochs - 1 and iter == len(self.train_dataloader) - 1)
                 ):
                     with Timer("eval", self.all_timings):
                         eval_metrics = await self.eval()
@@ -334,11 +444,20 @@ class RayPPOTrainer:
                 self.all_timings = {}
 
                 # update progress bar after logging
+                self.steps_completed_in_epoch += 1
+                self.completed_batches += 1
                 pbar.update(1)
 
                 self.global_step += 1
 
                 del training_input, generator_output
+
+            self.steps_completed_in_epoch = 0
+            self.current_epoch = epoch + 1
+            if epoch != self.cfg.trainer.epochs - 1 and self._adaptive_prompt_filtering_enabled():
+                self._apply_adaptive_prompt_filtering_for_next_epoch()
+                self._build_train_dataloader_and_compute_training_steps()
+                self._update_progress_bar_total(pbar)
 
         pbar.close()
         if self.colocate_all:
@@ -1080,6 +1199,7 @@ class RayPPOTrainer:
                 loss_reduction=self.cfg.trainer.algorithm.loss_reduction,
                 micro_batch_size=self.cfg.trainer.micro_train_batch_size_per_gpu,
                 max_seq_len=self.cfg.trainer.algorithm.max_seq_len,
+                uids=data.metadata["uids"][start_idx:end_idx],
             )
 
         data["advantages"] = normalized_advantages
@@ -1234,12 +1354,21 @@ class RayPPOTrainer:
         actor_info: ActorInfo = model.actor_infos[rank]
         return actor_info.rank
 
-    def save_checkpoints(self):
+    def save_checkpoints(self, post_step_state: bool = False):
         """
         Save the model, optimizer, and training states to disk.
 
         Dispatch handles offload/backload automatically for all colocation configurations.
+
+        Args:
+            post_step_state: When True, snapshot trainer counters as if the current
+                training batch bookkeeping increment has already happened. This is
+                used for in-loop checkpoint saves that occur after a batch is
+                consumed but before the outer loop updates its counters.
         """
+        saved_steps_completed_in_epoch = self.steps_completed_in_epoch + int(post_step_state)
+        saved_completed_batches = self.completed_batches + int(post_step_state)
+
         # Create global step folder structure
         global_step_folder = os.path.join(self.cfg.trainer.ckpt_path, f"global_step_{self.global_step}")
         policy_save_dir = os.path.join(global_step_folder, "policy")
@@ -1267,6 +1396,11 @@ class RayPPOTrainer:
         # Save additional trainer state
         trainer_state = {
             "global_step": self.global_step,
+            "current_epoch": self.current_epoch,
+            "steps_completed_in_epoch": saved_steps_completed_in_epoch,
+            "completed_batches": saved_completed_batches,
+            "adaptive_prompt_history": self.adaptive_prompt_history,
+            "active_prompt_indices": self.active_prompt_indices,
             "config": asdict(self.cfg),
         }
         trainer_state_path = os.path.join(global_step_folder, "trainer_state.pt")
@@ -1369,6 +1503,15 @@ class RayPPOTrainer:
         with io.open_file(trainer_state_path, "rb") as f:
             trainer_state = torch.load(f, map_location="cpu", weights_only=False)
         saved_global_step = trainer_state.get("global_step", global_step)
+        self.current_epoch = trainer_state.get("current_epoch", 0)
+        self.steps_completed_in_epoch = trainer_state.get("steps_completed_in_epoch", 0)
+        self.completed_batches = trainer_state.get("completed_batches", saved_global_step)
+        if self._adaptive_prompt_filtering_enabled():
+            self.adaptive_prompt_history = trainer_state.get("adaptive_prompt_history", {})
+            self.active_prompt_indices = trainer_state.get(
+                "active_prompt_indices", list(range(len(self.base_train_dataset)))
+            )
+            self._build_train_dataloader_and_compute_training_steps()
         logger.info("Successfully loaded trainer state")
         if saved_global_step != global_step:
             logger.warning(f"Global step mismatch: path={global_step}, saved={saved_global_step}. Using path value.")

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 from collections import defaultdict
 from enum import Enum
@@ -305,6 +306,80 @@ class DynamicSamplingState(TypedDict, total=False):
     collected_generator_output: Optional[GeneratorOutput]
     collected_uids: Optional[List[str]]
     num_prompts_in_batch: Optional[int]
+
+
+class AdaptivePromptStats(TypedDict):
+    positive_count: int
+    total_count: int
+
+
+def extract_sequence_scores(rewards: List[float] | List[List[float]]) -> List[float]:
+    """Convert response-level or token-level rewards into one scalar score per response."""
+    if not rewards:
+        return []
+    if isinstance(rewards[0], list):
+        return [float(sum(response_rewards)) for response_rewards in rewards]
+    return [float(reward) for reward in rewards]
+
+
+def update_adaptive_prompt_history(
+    prompt_history: Dict[str, AdaptivePromptStats],
+    uids: List[str],
+    rewards: List[float] | List[List[float]],
+) -> Dict[str, AdaptivePromptStats]:
+    """Update prompt success counts from a batch of sampled responses.
+
+    V1 uses pass-rate filtering, so a response is counted as positive when its
+    scalar sequence score is strictly greater than zero.
+    """
+    sequence_scores = extract_sequence_scores(rewards)
+    for uid, score in zip(uids, sequence_scores):
+        stats = prompt_history.setdefault(uid, {"positive_count": 0, "total_count": 0})
+        stats["total_count"] += 1
+        stats["positive_count"] += int(score > 0.0)
+    return prompt_history
+
+
+def filter_active_prompt_indices(
+    num_total_prompts: int,
+    active_prompt_indices: List[int],
+    prompt_history: Dict[str, AdaptivePromptStats],
+    threshold: float,
+    min_history: int,
+    min_active_prompts: int = 0,
+    min_active_ratio: float = 0.0,
+) -> Tuple[List[int], Dict[str, BasicType]]:
+    """Filter easy prompts while enforcing a minimum active-set floor."""
+    min_active_by_ratio = math.ceil(num_total_prompts * min_active_ratio)
+    min_active = max(min_active_prompts, min_active_by_ratio)
+    if num_total_prompts > 0:
+        min_active = min(max(min_active, 1), num_total_prompts)
+
+    easy_candidates = []
+    for prompt_idx in active_prompt_indices:
+        prompt_uid = str(prompt_idx)
+        stats = prompt_history.get(prompt_uid)
+        if stats is None or stats["total_count"] < min_history:
+            continue
+        pass_rate = stats["positive_count"] / stats["total_count"]
+        if pass_rate >= threshold:
+            easy_candidates.append((prompt_idx, pass_rate, stats["total_count"]))
+
+    max_filterable = max(0, len(active_prompt_indices) - min_active)
+    easy_candidates.sort(key=lambda item: (-item[1], -item[2], item[0]))
+    filtered_prompt_indices = [prompt_idx for prompt_idx, _, _ in easy_candidates[:max_filterable]]
+    filtered_prompt_indices_set = set(filtered_prompt_indices)
+    next_active_prompt_indices = [
+        prompt_idx for prompt_idx in active_prompt_indices if prompt_idx not in filtered_prompt_indices_set
+    ]
+
+    metrics: Dict[str, BasicType] = {
+        "active_prompt_count": len(next_active_prompt_indices),
+        "filtered_prompt_count": len(filtered_prompt_indices),
+        "easy_prompt_candidate_count": len(easy_candidates),
+        "min_active_prompt_floor": min_active,
+    }
+    return next_active_prompt_indices, metrics
 
 
 def handle_dynamic_sampling(

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -278,11 +278,47 @@ def validate_cfg(cfg: SkyRLTrainConfig):
         "token_mean",
         "token_mean_legacy",
         "sequence_mean",
+        "prompt_mean",
         "seq_mean_token_sum_norm",
     ), (
         f"invalid loss_reduction: {cfg.trainer.algorithm.loss_reduction}. "
-        f"Must be one of `['token_mean', 'sequence_mean', 'seq_mean_token_sum_norm']`"
+        f"Must be one of `['token_mean', 'token_mean_legacy', 'sequence_mean', 'prompt_mean', 'seq_mean_token_sum_norm']`"
     )
+
+    if cfg.trainer.algorithm.loss_reduction == "prompt_mean":
+        assert not cfg.generator.step_wise_trajectories, "`prompt_mean` does not support step-wise trajectories yet"
+        assert cfg.trainer.algorithm.dynamic_sampling.type != "replace", (
+            "`prompt_mean` is incompatible with `dynamic_sampling.type='replace'` because replacement can change "
+            "prompt group semantics within a batch"
+        )
+
+    adaptive_prompt_filtering = cfg.trainer.algorithm.adaptive_prompt_filtering
+    if adaptive_prompt_filtering.enabled:
+        assert adaptive_prompt_filtering.metric == "pass_rate", (
+            "adaptive_prompt_filtering.metric must be 'pass_rate' in V1, "
+            f"got {adaptive_prompt_filtering.metric}"
+        )
+        assert adaptive_prompt_filtering.threshold >= 0.0, (
+            "adaptive_prompt_filtering.threshold must be greater than or equal to 0"
+        )
+        assert adaptive_prompt_filtering.threshold <= 1.0, (
+            "adaptive_prompt_filtering.threshold must be less than or equal to 1"
+        )
+        assert adaptive_prompt_filtering.min_history > 0, (
+            "adaptive_prompt_filtering.min_history must be greater than 0"
+        )
+        assert adaptive_prompt_filtering.warmup_epochs >= 0, (
+            "adaptive_prompt_filtering.warmup_epochs must be greater than or equal to 0"
+        )
+        assert adaptive_prompt_filtering.min_active_prompts >= 0, (
+            "adaptive_prompt_filtering.min_active_prompts must be greater than or equal to 0"
+        )
+        assert 0.0 <= adaptive_prompt_filtering.min_active_ratio <= 1.0, (
+            "adaptive_prompt_filtering.min_active_ratio must be between 0 and 1"
+        )
+        assert not cfg.generator.step_wise_trajectories, (
+            "adaptive prompt filtering does not support step-wise trajectories yet"
+        )
 
     # TODO (erictang000): remove this after deprecation period
     if cfg.trainer.algorithm.use_tis:

--- a/tests/backends/skyrl_train/utils/test_ppo_utils.py
+++ b/tests/backends/skyrl_train/utils/test_ppo_utils.py
@@ -642,6 +642,37 @@ class TestApplyLossReductionToAdvantagesMinibatch:
         loss = reduce_loss(scaled, loss_mask)
         assert torch.allclose(loss, torch.tensor(0.7))
 
+    def test_prompt_mean(self):
+        advantages = torch.tensor(
+            [
+                [1.0, 2.0],
+                [3.0, 4.0],
+                [10.0, 20.0],
+                [30.0, 40.0],
+            ]
+        )
+        loss_mask = torch.tensor(
+            [
+                [1.0, 1.0],
+                [1.0, 0.0],
+                [1.0, 1.0],
+                [1.0, 1.0],
+            ]
+        )
+        # Prompt A token mean = (1 + 2 + 3) / 3 = 2.0
+        # Prompt B token mean = (10 + 20 + 30 + 40) / 4 = 25.0
+        # Prompt mean = (2.0 + 25.0) / 2 = 13.5
+        scaled = apply_loss_reduction_to_advantages_minibatch(
+            advantages=advantages,
+            loss_mask=loss_mask,
+            loss_reduction="prompt_mean",
+            micro_batch_size=1,
+            max_seq_len=2,
+            uids=["a", "a", "b", "b"],
+        )
+        loss = reduce_loss(scaled, loss_mask)
+        assert torch.allclose(loss, torch.tensor(13.5))
+
     def test_token_mean_legacy(self):
         """Legacy token mean: per-microbatch token mean, then averaged across microbatches."""
         # 4 sequences, micro_batch_size=2 -> 2 microbatches
@@ -669,6 +700,18 @@ class TestApplyLossReductionToAdvantagesMinibatch:
                 advantages=advantages,
                 loss_mask=loss_mask,
                 loss_reduction="invalid",
+                micro_batch_size=1,
+                max_seq_len=1,
+            )
+
+    def test_prompt_mean_requires_uids(self):
+        advantages = torch.tensor([[1.0]])
+        loss_mask = torch.tensor([[1.0]])
+        with pytest.raises(ValueError, match="uids must be provided"):
+            apply_loss_reduction_to_advantages_minibatch(
+                advantages=advantages,
+                loss_mask=loss_mask,
+                loss_reduction="prompt_mean",
                 micro_batch_size=1,
                 max_seq_len=1,
             )

--- a/tests/backends/skyrl_train/utils/test_torch_utils.py
+++ b/tests/backends/skyrl_train/utils/test_torch_utils.py
@@ -6,6 +6,7 @@ import torch
 from skyrl.backends.skyrl_train.utils.torch_utils import (
     chunked_cross_entropy_from_log_probs,
     chunked_entropy_from_logits,
+    prepare_logits_for_loss,
 )
 
 
@@ -117,3 +118,22 @@ def test_chunked_entropy_from_logits_attention_mask_shape_validation():
     correct_mask = torch.ones(2, 3, dtype=torch.float32)
     result = chunked_entropy_from_logits(logits, attention_mask=correct_mask)
     assert result.shape == (2, 3)
+
+
+def test_prepare_logits_for_loss_upcasts_and_scales():
+    logits = torch.tensor([[[2.0, 4.0]]], dtype=torch.bfloat16)
+
+    prepared = prepare_logits_for_loss(logits, temperature=2.0, upcast_to_fp32=True)
+
+    assert prepared.dtype == torch.float32
+    expected = torch.tensor([[[1.0, 2.0]]], dtype=torch.float32)
+    torch.testing.assert_close(prepared, expected)
+
+
+def test_prepare_logits_for_loss_leaves_dtype_when_disabled():
+    logits = torch.tensor([[[2.0, 4.0]]], dtype=torch.bfloat16)
+
+    prepared = prepare_logits_for_loss(logits, temperature=1.0, upcast_to_fp32=False)
+
+    assert prepared.dtype == torch.bfloat16
+    torch.testing.assert_close(prepared, logits)

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -16,6 +16,7 @@ from skyrl.train.config.config import (
     build_nested_dataclass,
 )
 from skyrl.train.config.utils import get_legacy_config
+from skyrl.train.utils.utils import validate_cfg
 
 
 # Helper dataclasses for testing
@@ -212,3 +213,79 @@ class TestMaxSeqLenValidation:
         cfg = SkyRLTrainConfig.from_cli_overrides(["trainer.algorithm.max_seq_len=32768"])
 
         assert cfg.trainer.algorithm.max_seq_len == 32768
+
+
+def test_validate_cfg_allows_prompt_mean():
+    cfg = SkyRLTrainConfig.from_cli_overrides(["trainer.algorithm.loss_reduction=prompt_mean"])
+    validate_cfg(cfg)
+
+
+def test_validate_cfg_rejects_prompt_mean_with_step_wise_trajectories():
+    cfg = SkyRLTrainConfig.from_cli_overrides(
+        [
+            "trainer.algorithm.loss_reduction=prompt_mean",
+            "generator.step_wise_trajectories=true",
+        ]
+    )
+
+    with pytest.raises(AssertionError, match="prompt_mean"):
+        validate_cfg(cfg)
+
+
+def test_validate_cfg_rejects_prompt_mean_with_replace_sampling():
+    cfg = SkyRLTrainConfig.from_cli_overrides(
+        [
+            "trainer.algorithm.loss_reduction=prompt_mean",
+            "trainer.algorithm.dynamic_sampling.type=replace",
+        ]
+    )
+
+    with pytest.raises(AssertionError, match="prompt_mean"):
+        validate_cfg(cfg)
+
+
+def test_validate_cfg_allows_adaptive_prompt_filtering():
+    cfg = SkyRLTrainConfig.from_cli_overrides(
+        [
+            "trainer.algorithm.adaptive_prompt_filtering.enabled=true",
+            "trainer.algorithm.adaptive_prompt_filtering.metric=pass_rate",
+            "trainer.algorithm.adaptive_prompt_filtering.threshold=0.9",
+        ]
+    )
+    validate_cfg(cfg)
+
+
+def test_validate_cfg_rejects_adaptive_prompt_filtering_invalid_metric():
+    cfg = SkyRLTrainConfig.from_cli_overrides(
+        [
+            "trainer.algorithm.adaptive_prompt_filtering.enabled=true",
+            "trainer.algorithm.adaptive_prompt_filtering.metric=avg_reward",
+        ]
+    )
+
+    with pytest.raises(AssertionError, match="pass_rate"):
+        validate_cfg(cfg)
+
+
+def test_validate_cfg_rejects_adaptive_prompt_filtering_threshold_above_one():
+    cfg = SkyRLTrainConfig.from_cli_overrides(
+        [
+            "trainer.algorithm.adaptive_prompt_filtering.enabled=true",
+            "trainer.algorithm.adaptive_prompt_filtering.threshold=1.1",
+        ]
+    )
+
+    with pytest.raises(AssertionError, match="less than or equal to 1"):
+        validate_cfg(cfg)
+
+
+def test_validate_cfg_rejects_adaptive_prompt_filtering_with_step_wise():
+    cfg = SkyRLTrainConfig.from_cli_overrides(
+        [
+            "trainer.algorithm.adaptive_prompt_filtering.enabled=true",
+            "generator.step_wise_trajectories=true",
+        ]
+    )
+
+    with pytest.raises(AssertionError, match="adaptive prompt filtering"):
+        validate_cfg(cfg)

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -2,6 +2,8 @@
 uv  run --isolated --extra dev pytest tests/train/test_trainer.py
 """
 
+import os
+import tempfile
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -30,6 +32,20 @@ class DummyDataset:
 
     def __getitem__(self, idx):
         return "dummy"
+
+    def collate_fn(self, batch):
+        return batch
+
+
+class MultiItemDummyDataset:
+    def __init__(self, size=6):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return [{"role": "user", "content": f"prompt-{idx}"}], None, {}, str(idx)
 
     def collate_fn(self, batch):
         return batch
@@ -537,3 +553,105 @@ def test_validate_batch_sizes_lcm_dp_requirement():
     # Pass: ref disabled -> requirement reduces to policy_dp. With policy_dp=2, tbs=2 is valid.
     cfg = create_config(train_batch_size=2, policy_dp=2, ref_dp=3, include_ref=False)
     validate_batch_sizes(cfg)
+
+
+def test_adaptive_prompt_filtering_checkpoint_state_round_trip(dummy_config, dummy_generator):
+    dummy_config.trainer.algorithm.adaptive_prompt_filtering.enabled = True
+    dummy_config.trainer.algorithm.adaptive_prompt_filtering.threshold = 0.9
+    dummy_config.trainer.algorithm.adaptive_prompt_filtering.min_history = 1
+    dummy_config.generator.inference_engine.enable_http_endpoint = True
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dummy_config.trainer.ckpt_path = tmpdir
+        dummy_config.trainer.export_path = tmpdir
+
+        train_dataset = MultiItemDummyDataset(size=6)
+        trainer = RayPPOTrainer(
+            cfg=dummy_config,
+            tracker=None,
+            tokenizer=None,
+            train_dataset=train_dataset,
+            eval_dataset=None,
+            inference_engine_client=None,
+            generator=dummy_generator,
+        )
+        trainer.dispatch = MagicMock()
+        trainer._cleanup_old_checkpoints = MagicMock()
+        trainer.global_step = 3
+        trainer.current_epoch = 1
+        trainer.steps_completed_in_epoch = 0
+        trainer.completed_batches = 2
+        trainer.adaptive_prompt_history = {
+            "1": {"positive_count": 2, "total_count": 2},
+            "4": {"positive_count": 0, "total_count": 2},
+        }
+        trainer.active_prompt_indices = [1, 2, 4, 5]
+        trainer._build_train_dataloader_and_compute_training_steps()
+
+        trainer.save_checkpoints()
+
+        checkpoint_dir = os.path.join(tmpdir, "global_step_3")
+        resumed_cfg = example_dummy_config()
+        resumed_cfg.trainer.algorithm.adaptive_prompt_filtering.enabled = True
+        resumed_cfg.generator.inference_engine.enable_http_endpoint = True
+        resumed_cfg.trainer.resume_mode = "from_path"
+        resumed_cfg.trainer.resume_path = checkpoint_dir
+        resumed_cfg.trainer.ckpt_path = tmpdir
+        resumed_cfg.trainer.export_path = tmpdir
+
+        resumed_trainer = RayPPOTrainer(
+            cfg=resumed_cfg,
+            tracker=None,
+            tokenizer=None,
+            train_dataset=train_dataset,
+            eval_dataset=None,
+            inference_engine_client=None,
+            generator=dummy_generator,
+        )
+        resumed_trainer.dispatch = MagicMock()
+
+        loaded_step, loaded_checkpoint_dir = resumed_trainer.load_checkpoints()
+
+        assert loaded_step == 3
+        assert loaded_checkpoint_dir == checkpoint_dir
+        assert resumed_trainer.current_epoch == 1
+        assert resumed_trainer.steps_completed_in_epoch == 0
+        assert resumed_trainer.completed_batches == 2
+        assert resumed_trainer.active_prompt_indices == [1, 2, 4, 5]
+        assert resumed_trainer.adaptive_prompt_history == {
+            "1": {"positive_count": 2, "total_count": 2},
+            "4": {"positive_count": 0, "total_count": 2},
+        }
+        assert len(resumed_trainer.train_dataset) == 4
+
+
+def test_save_checkpoints_post_step_state_snapshots_advanced_counters(dummy_config, dummy_generator):
+    dummy_config.trainer.algorithm.adaptive_prompt_filtering.enabled = True
+    dummy_config.generator.inference_engine.enable_http_endpoint = True
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dummy_config.trainer.ckpt_path = tmpdir
+        dummy_config.trainer.export_path = tmpdir
+
+        trainer = RayPPOTrainer(
+            cfg=dummy_config,
+            tracker=None,
+            tokenizer=None,
+            train_dataset=MultiItemDummyDataset(size=6),
+            eval_dataset=None,
+            inference_engine_client=None,
+            generator=dummy_generator,
+        )
+        trainer.dispatch = MagicMock()
+        trainer._cleanup_old_checkpoints = MagicMock()
+        trainer.global_step = 3
+        trainer.current_epoch = 1
+        trainer.steps_completed_in_epoch = 1
+        trainer.completed_batches = 4
+
+        trainer.save_checkpoints(post_step_state=True)
+
+        checkpoint_dir = os.path.join(tmpdir, "global_step_3")
+        saved_state = torch.load(os.path.join(checkpoint_dir, "trainer_state.pt"), map_location="cpu", weights_only=False)
+        assert saved_state["steps_completed_in_epoch"] == 2
+        assert saved_state["completed_batches"] == 5

--- a/tests/train/test_trainer_utils.py
+++ b/tests/train/test_trainer_utils.py
@@ -19,12 +19,15 @@ from skyrl.train.utils.trainer_utils import (
     calculate_per_dataset_metrics,
     cleanup_old_checkpoints,
     dump_per_dataset_eval_results,
+    extract_sequence_scores,
+    filter_active_prompt_indices,
     filter_generator_output,
     handle_dynamic_sampling,
     handle_filter_sampling,
     handle_replace_sampling,
     run_on_each_node,
     sanitize_data_source,
+    update_adaptive_prompt_history,
     validate_consistency_for_latest_checkpoint,
     validate_generator_output,
     zero_variance_filter,
@@ -226,6 +229,46 @@ def test_sanitize_data_source_normal_string():
     """Test sanitize_data_source with normal string."""
     result = sanitize_data_source("normal_dataset")
     assert result == "normal_dataset"
+
+
+def test_extract_sequence_scores_supports_token_level_rewards():
+    rewards = [[0.0, 1.0], [0.0, 0.0, 2.0]]
+    assert extract_sequence_scores(rewards) == [1.0, 2.0]
+
+
+def test_update_adaptive_prompt_history_counts_positive_responses():
+    history = {}
+    updated = update_adaptive_prompt_history(
+        prompt_history=history,
+        uids=["0", "0", "1"],
+        rewards=[1.0, 0.0, -1.0],
+    )
+    assert updated == {
+        "0": {"positive_count": 1, "total_count": 2},
+        "1": {"positive_count": 0, "total_count": 1},
+    }
+
+
+def test_filter_active_prompt_indices_applies_floor_and_filters_easiest_prompts():
+    prompt_history = {
+        "0": {"positive_count": 10, "total_count": 10},
+        "1": {"positive_count": 9, "total_count": 10},
+        "2": {"positive_count": 8, "total_count": 10},
+        "3": {"positive_count": 1, "total_count": 10},
+    }
+    next_active_indices, metrics = filter_active_prompt_indices(
+        num_total_prompts=4,
+        active_prompt_indices=[0, 1, 2, 3],
+        prompt_history=prompt_history,
+        threshold=0.8,
+        min_history=1,
+        min_active_prompts=2,
+        min_active_ratio=0.0,
+    )
+    assert next_active_indices == [2, 3]
+    assert metrics["filtered_prompt_count"] == 2
+    assert metrics["easy_prompt_candidate_count"] == 3
+    assert metrics["min_active_prompt_floor"] == 2
 
 
 def test_calculate_per_dataset_metrics_single_source():


### PR DESCRIPTION
## Summary

Addresses #495 by landing the remaining ScaleRL recipe features in the core SkyRL trainer/config/runtime stack and packaging them into a documented example.

This PR adds:
- prompt-level loss aggregation via `trainer.algorithm.loss_reduction=prompt_mean`
- fp32 logits upcasting for the HF/FSDP policy and reference paths
- adaptive prompt filtering across epochs with checkpoint/resume support
- a ScaleRL example recipe and docs

## What Changed

### Core training changes
- Added `prompt_mean` loss reduction and wired it through trainer-side advantage scaling.
- Added `upcast_logits_to_fp32` to `ModelConfig` and applied it to HF/FSDP policy/ref logprob + entropy computation.
- Added adaptive prompt filtering config and trainer logic:
  - prompt pass-rate history tracked across batches
  - filtering applied only at epoch boundaries
  - filtered dataset view that preserves original row-derived UIDs
  - checkpoint persistence for active prompt set and filtering state
  - resume logic that rebuilds the filtered dataloader before loading dataloader state
  - minimum active prompt floor so filtering cannot shrink below one full train batch
- Added a fully-async guard so adaptive prompt filtering is explicitly unsupported there for now.
- Fixed an in-loop checkpointing edge case so trainer counters are snapshotted consistently with the already-consumed dataloader state.

### Docs / examples
- Added a dedicated ScaleRL docs page.
- Added a ScaleRL GSM8K example script and README.
- Updated configuration docs to cover:
  - `prompt_mean`
  - `token_mean_legacy`
  - adaptive prompt filtering knobs
  - fp32 logits upcast flags

### Tests
- Added coverage for:
  - `prompt_mean`
  - fp32 logits preparation
  - adaptive prompt filtering config validation
  - adaptive prompt filtering helper behavior
  - checkpoint round-trip restore of adaptive filtering state
  - post-step checkpoint snapshot semantics

## Validation

Ran:
- `python -m compileall skyrl/train tests/train tests/backends/skyrl_train/utils`
- direct runtime checks for:
  - `prompt_mean` behavior
  - adaptive prompt-history updates
  - adaptive filtering minimum-active floor
  - checkpoint round-trip restore
  - post-step checkpoint counter snapshot behavior

I also attempted focused pytest runs for the touched areas. In this local environment, the repo's session-scoped Ray fixtures emit passing dots and then hang during teardown, so I could not get a clean local pytest exit despite the assertions themselves progressing.

## Notes

This PR is intentionally opened as a draft because the local Ray teardown behavior still makes full pytest verification noisy here, even though the feature-specific checks passed.

Addresses #495.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
