### PR TITLE
[train][asyncRL] Add fully async in-flight KV cache update policy

### DIFF
--- a/docs/content/docs/configuration/config.mdx
+++ b/docs/content/docs/configuration/config.mdx
@@ -600,11 +600,13 @@ def ppo_policy_loss(
 fully_async:
   max_staleness_steps: 4
   num_parallel_generation_workers: 768
+  preserve_inflight_kv_cache_on_weight_update: true
 
 ```
 
 - `fully_async.max_staleness_steps`: Maximum off-policy steps allowed. If a trajectory group is scheduled at step *i* and trained at step *j*, then `j - i <= max_staleness_steps`. Larger values increase throughput but also off-policy-ness.
 - `fully_async.num_parallel_generation_workers`: Number of generation workers to spawn. Should be \>= `policy_mini_batch_size` and \<= `policy_mini_batch_size * (max_staleness_steps + 1)`.
+- `fully_async.preserve_inflight_kv_cache_on_weight_update`: Whether fully async training should preserve in-flight KV cache entries during keep-mode pause/resume. Leave this at `true` for the current fast no-reprefill behavior. Set it to `false` to reset running requests' KV state while paused so they re-prefill after resume.
 
 ## Generator Configuration
 

--- a/docs/content/docs/tutorials/fully_async.mdx
+++ b/docs/content/docs/tutorials/fully_async.mdx
@@ -91,6 +91,7 @@ For fully async specifically, the following are the main knobs to tune:
   each worker works on a group of trajectories. It should be `&gt;= trainer.policy_mini_batch_size` to avoid wasted throughput,
   and `&lt;= trainer.policy_mini_batch_size * (trainer.fully_async.max_staleness_steps + 1)` since it would be wasted due to capacity control.
   The larger the number, the more throughput, and likely more staleness (and hence off-policy-ness).
+- `trainer.fully_async.preserve_inflight_kv_cache_on_weight_update`: Whether to preserve in-flight KV cache entries across keep-mode pause/resume during weight sync. Keep this at `true` for the fastest PipelineRL-style behavior. Set it to `false` if you want in-flight requests to re-prefill after each weight update.
 
 On GPU placement: first disable colocation of training and generation, then configure how many GPUs to dedicate to training and generation respectively. The following snippet dedicates 4 GPUs to each.
 
@@ -158,7 +159,7 @@ It follows the following steps in a for-loop over the number of steps per epoch:
 2. Train on the generated groups.
 3. Mark the data that we used to train as "consumed" to the `AsyncDataloader`, so that when we resume
    training from a checkpoint, we know what data has been trained on and hence can be skipped.
-4. Make `AnyGenerator` (really the `InferenceEngineClient` in the back): pause generation, sync weights, resume generation. Note that this operation is agnostic to what the generator is doing. It can either be in the middle of a `/chat/completions` generation, or interacting with the environment.
+4. Make `AnyGenerator` (really the `InferenceEngineClient` in the back): pause generation, optionally reset in-flight KV state based on config, sync weights, then resume generation. Note that this operation is agnostic to what the generator is doing. It can either be in the middle of a `/chat/completions` generation, or interacting with the environment.
 5. Update the global step and hence the capacity controlled by the `AsyncStalenessManager`, potentially unblocking
    generation workers stuck on step 1 -- as they can now generate new data that will not be as stale as before.
 6. Repeat from step 1 until the epoch is done.
@@ -271,14 +272,31 @@ underlyingly as the `/chat/completions` endpoint is simply blocked and not retur
 This design makes the implementation of fully async training agnostic to the generator / agent harness as
 the trajectory could be doing anything when weight update is happening -- in the middle of a output generation or in the middle of an interaction with the environment (where the next output generation will simply be blocked until the weight update is finished).
 
-We implement this semantics by implementing SkyRL's `InferenceEngineClient` to keep calling the underlying
-inference engine's `/chat/completions` endpoint in a while loop, until the finish reason is not an `abort`.
+SkyRL now relies on vLLM's keep-mode pause/resume semantics for this. Upon
+`InferenceEngineClient.pause_generation()`, in-flight requests are frozen inside the inference engine
+rather than aborted, so the generator / agent harness does not need retry logic.
 
-Upon `InferenceEngineClient.pause_generation()`, we abort all the in-flight `/chat/completions` requests,
-and save the partial results, waiting to be re-fed into the underlying inference engine as a new
-`/chat/completions` request when `InferenceEngineClient.resume_generation()` is called.
+The default fully async behavior is:
 
-See the following two PRs for more details:
+1. pause generation in keep mode
+2. sync the updated policy weights into the inference engines
+3. resume generation
+
+With this default, in-flight requests preserve their KV state and continue without a clean re-prefill.
+This is the fastest option and is the recommended setting for most async RL runs.
+
+If you set `trainer.fully_async.preserve_inflight_kv_cache_on_weight_update=false`, SkyRL will:
+
+1. pause generation in keep mode
+2. reset running requests' KV state while paused
+3. sync the updated policy weights
+4. resume generation
+
+This forces in-flight requests to re-prefill on resume, which gives cleaner boundaries at the cost of
+additional latency.
+
+See the following PRs for historical context:
+- https://github.com/NovaSky-AI/SkyRL/pull/1179
 - https://github.com/NovaSky-AI/SkyRL/pull/537
 - https://github.com/NovaSky-AI/SkyRL/pull/557
 

--- a/examples/train/fully_async/fully_async_run_gsm8k.sh
+++ b/examples/train/fully_async/fully_async_run_gsm8k.sh
@@ -26,6 +26,7 @@ set -x
 : "${MINI_BATCH_SIZE:=256}"
 : "${MAX_STALENESS_STEPS:=4}"
 : "${NUM_PARALLEL_GENERATION_WORKERS:=$(( MINI_BATCH_SIZE * (MAX_STALENESS_STEPS + 1) ))}"
+: "${PRESERVE_INFLIGHT_KV_CACHE_ON_WEIGHT_UPDATE:=true}"
 
 TIS_TYPE=token
 TIS_IMP_RATIO_CAP=2.0
@@ -37,6 +38,7 @@ uv run --isolated --extra fsdp -m examples.train.fully_async.main_fully_async \
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
+  trainer.fully_async.preserve_inflight_kv_cache_on_weight_update=${PRESERVE_INFLIGHT_KV_CACHE_ON_WEIGHT_UPDATE} \
   trainer.algorithm.advantage_estimator="grpo" \
   trainer.algorithm.off_policy_correction.tis_ratio_type=$TIS_TYPE \
   trainer.algorithm.off_policy_correction.token_tis_ratio_clip_high=$TIS_IMP_RATIO_CAP \

--- a/skyrl/backends/skyrl_train/inference_engines/base.py
+++ b/skyrl/backends/skyrl_train/inference_engines/base.py
@@ -145,7 +145,8 @@ class InferenceEngineInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def reset_prefix_cache(self):
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
+        """Reset prefix/KV cache state on the inference engine."""
         raise NotImplementedError
 
     @abstractmethod

--- a/skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py
@@ -343,8 +343,11 @@ class InferenceEngineClient(InferenceEngineInterface):
     async def update_named_weights(self, request: WeightUpdateRequest):
         return await self._run_on_all_engines("update_named_weights", request=request)
 
-    async def reset_prefix_cache(self):
-        return await self._run_on_all_engines("reset_prefix_cache")
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
+        return await self._run_on_all_engines(
+            "reset_prefix_cache",
+            reset_running_requests=reset_running_requests,
+        )
 
     async def teardown(self):
         return await self._run_on_all_engines("teardown")

--- a/skyrl/backends/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -67,8 +67,8 @@ class RayWrappedInferenceEngine(InferenceEngineInterface):
     async def teardown(self):
         return await self.inference_engine_actor.teardown.remote()
 
-    async def reset_prefix_cache(self):
-        return await self.inference_engine_actor.reset_prefix_cache.remote()
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
+        return await self.inference_engine_actor.reset_prefix_cache.remote(reset_running_requests)
 
     async def chat_completion(self, request_payload: Dict[str, Any]) -> Dict[str, Any]:
         return await self.inference_engine_actor.chat_completion.remote(request_payload)

--- a/skyrl/backends/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/remote_inference_engine.py
@@ -257,14 +257,17 @@ class RemoteInferenceEngine(InferenceEngineInterface):
         return await self._weight_loader.load_weights(request)
 
     # TODO(tgriggs): Come up with a (more) elegant way to handle text or json responses, and test it and handle errors.
-    async def reset_prefix_cache(self):
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
         if self.engine_backend == "vllm":
             reset_prefix_cache_method = "reset_prefix_cache"
         else:
             raise ValueError(f"Invalid engine backend: {self.engine_backend}")
 
         async with aiohttp.ClientSession() as session:
-            resp = await session.post(f"{self.url}/{reset_prefix_cache_method}")
+            resp = await session.post(
+                f"{self.url}/{reset_prefix_cache_method}",
+                params={"reset_running_requests": str(reset_running_requests).lower()},
+            )
             text = await resp.text()
 
         # First try to parse it as JSON

--- a/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -212,9 +212,9 @@ class BaseVLLMInferenceEngine(InferenceEngineInterface):
             return list(output_processor.external_req_ids.keys())
         return list(output_processor.request_states.keys())
 
-    def reset_prefix_cache(self):
+    def reset_prefix_cache(self, reset_running_requests: bool = False):
         """Reset the prefix cache. Subclasses override for async version."""
-        return self.llm.llm_engine.reset_prefix_cache()
+        return self.llm.llm_engine.reset_prefix_cache(reset_running_requests=reset_running_requests)
 
     async def pause_generation(self, clear_cache: bool = False) -> None:
         raise NotImplementedError("pause_generation is only supported for AsyncVLLMInferenceEngine.")
@@ -331,8 +331,11 @@ class VLLMInferenceEngine(BaseVLLMInferenceEngine):
     async def teardown(self):
         await self._teardown_weight_receiver()
 
-    async def reset_prefix_cache(self):
-        return await asyncio.to_thread(self.llm.llm_engine.reset_prefix_cache)
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
+        return await asyncio.to_thread(
+            self.llm.llm_engine.reset_prefix_cache,
+            reset_running_requests=reset_running_requests,
+        )
 
     async def _teardown_weight_receiver(self):
         engine = self._get_engine()
@@ -550,9 +553,9 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
     async def teardown(self):
         await self._teardown_weight_receiver()
 
-    async def reset_prefix_cache(self):
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
         engine = self._get_engine()
-        await engine.reset_prefix_cache()
+        await engine.reset_prefix_cache(reset_running_requests=reset_running_requests)
 
     async def _teardown_weight_receiver(self):
         engine = self._get_engine()

--- a/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_server.py
+++ b/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_server.py
@@ -89,8 +89,8 @@ class VllmServer:
             return {"status": "ok"}
 
         @app.post("/reset_prefix_cache")
-        async def _reset_prefix_cache(request: Request):
-            await engine.reset_prefix_cache()
+        async def _reset_prefix_cache(reset_running_requests: bool = False):
+            await engine.reset_prefix_cache(reset_running_requests=reset_running_requests)
             return {"status": "ok"}
 
         # NOTE (sumanthrh): We use the _skyrl suffix to differentiate this from the native /update_weights endpoint

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -731,7 +731,10 @@ class RemoteInferenceClient:
         Returns:
             Dict mapping server_url to response.
         """
-        return await self._call_all_servers("/reset_prefix_cache", {"reset_running_requests": reset_running_requests})
+        return await self._call_all_servers(
+            "/reset_prefix_cache",
+            params={"reset_running_requests": str(reset_running_requests).lower()},
+        )
 
     # ---------------------------
     # Weight Sync (control plane - fan-out)

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -12,7 +12,6 @@ from typing import List, Optional, Tuple
 import httpx
 import uvicorn
 import vllm.envs as envs
-from fastapi import Request
 from ray.util.placement_group import PlacementGroup
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
@@ -335,9 +334,9 @@ class VLLMServerActor(ServerActorProtocol):
         # VLLM_SERVER_DEV_MODE=1.
 
         @app.post("/reset_prefix_cache")
-        async def _reset_prefix_cache(request: Request):
+        async def _reset_prefix_cache(reset_running_requests: bool = False):
             """Reset the prefix cache."""
-            await engine.reset_prefix_cache()
+            await engine.reset_prefix_cache(reset_running_requests=reset_running_requests)
             return {"status": "ok"}
 
     async def shutdown(self) -> None:

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -393,6 +393,14 @@ class FullyAsyncConfig(BaseConfig):
     num_parallel_generation_workers: int = 768
     """Number of generation workers to spawn. Should be >= ``policy_mini_batch_size`` and
     <= ``policy_mini_batch_size * (max_staleness_steps + 1)``."""
+    preserve_inflight_kv_cache_on_weight_update: bool = True
+    """Whether to preserve in-flight KV cache entries during fully async weight updates.
+
+    If ``True`` (default), keep-mode pause/resume preserves in-flight request state, so requests
+    continue without a clean re-prefill after the policy weights are updated. This is faster.
+    If ``False``, SkyRL resets running requests' KV state while paused so they re-prefill on resume,
+    giving cleaner boundaries at the cost of extra latency.
+    """
 
 
 # ---------------------------------------------------------------------------

--- a/skyrl/train/config/ppo_base_config.yaml
+++ b/skyrl/train/config/ppo_base_config.yaml
@@ -214,6 +214,9 @@ trainer:
     # The larger the number, the more throughput, and likely more staleness (and hence off-policy-ness).
     # Default value is: policy_mini_batch_size * (max_staleness_steps / 2 + 1) = 256 * (4 / 2 + 1) = 768
     num_parallel_generation_workers: 768
+    # If true, preserve in-flight KV cache entries across keep-mode pause/resume during weight sync.
+    # If false, reset running requests' KV state while paused so they re-prefill on resume.
+    preserve_inflight_kv_cache_on_weight_update: true
 
   gradient_checkpointing: true
   gradient_checkpointing_use_reentrant: false

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -418,11 +418,10 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                             [g.uid for g in cur_generation_group_mini_batch]
                         )
 
-                    # 4. After training: pause generation, sync weights, resume.
+                    # 4. After training: pause generation, apply the configured
+                    # in-flight update policy, sync weights, and resume.
                     with Timer("sync_weights", self.all_timings):
-                        await self.inference_engine_client.pause_generation()
-                        await self.async_sync_policy_weights_to_inference_engines()
-                        await self.inference_engine_client.resume_generation()
+                        await self._sync_policy_weights_with_inflight_update_policy()
 
                 # 5. Set logs for this training step.
                 logger.info(status)
@@ -605,6 +604,16 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             self.inference_engine_client,
             self.cfg.generator.inference_engine,
         )
+
+    async def _sync_policy_weights_with_inflight_update_policy(self) -> None:
+        """Pause generation, apply the configured in-flight update policy, sync weights, then resume."""
+        await self.inference_engine_client.pause_generation()
+        try:
+            if not self.cfg.trainer.fully_async.preserve_inflight_kv_cache_on_weight_update:
+                await self.inference_engine_client.reset_prefix_cache(reset_running_requests=True)
+            await self.async_sync_policy_weights_to_inference_engines()
+        finally:
+            await self.inference_engine_client.resume_generation()
 
     def convert_generation_group_mini_batch_to_training_input(
         self, cur_generation_group_mini_batch: List[GeneratedOutputGroup]

--- a/tests/backends/skyrl_train/inference_engines/test_inference_engine_client.py
+++ b/tests/backends/skyrl_train/inference_engines/test_inference_engine_client.py
@@ -431,3 +431,28 @@ def test_route_prompts_to_engines_validation_errors():
     route_prompts_to_engines(num_prompts=2, num_inference_engines=1, session_ids=[1, 2])
     route_prompts_to_engines(num_prompts=2, num_inference_engines=1, session_ids=None)
     route_prompts_to_engines(num_prompts=1, num_inference_engines=1, session_ids=None)
+
+
+@pytest.mark.asyncio
+async def test_reset_prefix_cache_forwards_reset_running_requests():
+    class MockEngine:
+        def dp_size(self):
+            return 1
+
+        async def reset_prefix_cache(self, reset_running_requests: bool = False):
+            return {"reset_running_requests": reset_running_requests}
+
+    cfg = _make_min_cfg()
+    client = InferenceEngineClient(
+        engines=[MockEngine(), MockEngine()],
+        tokenizer=object(),
+        model_path=cfg.trainer.policy.model.path,
+        lora_cfg=cfg.trainer.policy.model.lora,
+        inference_engine_cfg=cfg.generator.inference_engine,
+    )
+
+    result = await client.reset_prefix_cache(reset_running_requests=True)
+    assert result == [
+        {"reset_running_requests": True},
+        {"reset_running_requests": True},
+    ]

--- a/tests/backends/skyrl_train/inference_engines/test_remote_inference_engine.py
+++ b/tests/backends/skyrl_train/inference_engines/test_remote_inference_engine.py
@@ -1,0 +1,84 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skyrl.backends.skyrl_train.inference_engines.remote_inference_engine import (
+    RemoteInferenceEngine,
+)
+
+
+class AsyncContextManagerMock:
+    """Helper to mock async context managers (for `async with ... as ...`)."""
+
+    def __init__(self, return_value):
+        self.return_value = return_value
+
+    async def __aenter__(self):
+        return self.return_value
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def create_mock_session(mock_response):
+    """Create a mock aiohttp.ClientSession with proper async behavior."""
+    mock_session = MagicMock()
+
+    class MockPostReturn:
+        def __init__(self, response):
+            self.response = response
+
+        async def __aenter__(self):
+            return self.response
+
+        async def __aexit__(self, *args):
+            pass
+
+        def __await__(self):
+            async def _await():
+                return self.response
+
+            return _await().__await__()
+
+    mock_session.post = MagicMock(return_value=MockPostReturn(mock_response))
+    return mock_session
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reset_running_requests", "expected_param"),
+    [(False, "false"), (True, "true")],
+)
+async def test_reset_prefix_cache_forwards_reset_running_requests(reset_running_requests, expected_param):
+    engine = RemoteInferenceEngine(
+        url="localhost:8000",
+        model_name="test-model",
+        engine_backend="vllm",
+        tokenizer=MagicMock(),
+    )
+
+    mock_response = MagicMock()
+    mock_response.text = AsyncMock(
+        return_value=json.dumps(
+            {
+                "status": "cache_reset",
+                "reset_running_requests": reset_running_requests,
+            }
+        )
+    )
+
+    with patch("aiohttp.ClientSession") as mock_session_class:
+        mock_session = create_mock_session(mock_response)
+        mock_session_class.return_value = AsyncContextManagerMock(mock_session)
+
+        result = await engine.reset_prefix_cache(reset_running_requests=reset_running_requests)
+
+        mock_session.post.assert_called_once_with(
+            "http://localhost:8000/reset_prefix_cache",
+            params={"reset_running_requests": expected_param},
+        )
+        assert result == {
+            "status": "cache_reset",
+            "reset_running_requests": reset_running_requests,
+        }

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -129,8 +129,12 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
         return {"status": "awake", "server_id": server_id, "tags": tags}
 
     @app.post("/reset_prefix_cache")
-    async def reset_prefix_cache(request: Request):
-        return {"status": "cache_reset", "server_id": server_id}
+    async def reset_prefix_cache(reset_running_requests: bool = False):
+        return {
+            "status": "cache_reset",
+            "server_id": server_id,
+            "reset_running_requests": reset_running_requests,
+        }
 
     @app.post("/init_weight_transfer_engine")
     async def init_weight_transfer_engine(request: Request):
@@ -382,6 +386,16 @@ class TestControlPlane:
         """Test reset_prefix_cache fans out to all servers."""
         result = await client.reset_prefix_cache()
         assert len(result) == 2
+        for _, response in result.items():
+            assert response["body"]["reset_running_requests"] is False
+
+    @pytest.mark.asyncio
+    async def test_reset_prefix_cache_with_running_requests(self, client):
+        """Test reset_prefix_cache forwards reset_running_requests to all servers."""
+        result = await client.reset_prefix_cache(reset_running_requests=True)
+        assert len(result) == 2
+        for _, response in result.items():
+            assert response["body"]["reset_running_requests"] is True
 
 
 class TestWeightSync:

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -104,6 +104,14 @@ def test_cli_overrides_empty_args():
     cfg = SkyRLTrainConfig.from_cli_overrides([])
     assert cfg.trainer.policy.model.path == "Qwen/Qwen2.5-1.5B-Instruct"
     assert cfg.trainer.seed == 42
+    assert cfg.trainer.fully_async.preserve_inflight_kv_cache_on_weight_update is True
+
+
+def test_fully_async_preserve_inflight_kv_cache_override():
+    cfg = SkyRLTrainConfig.from_cli_overrides(
+        ["trainer.fully_async.preserve_inflight_kv_cache_on_weight_update=false"]
+    )
+    assert cfg.trainer.fully_async.preserve_inflight_kv_cache_on_weight_update is False
 
 
 def test_cli_overrides_plus_prefix_rejected():

--- a/tests/train/test_fully_async_trainer.py
+++ b/tests/train/test_fully_async_trainer.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from skyrl.train.fully_async_trainer import FullyAsyncRayPPOTrainer
+
+
+def _make_trainer(preserve_inflight_kv_cache_on_weight_update: bool):
+    trainer = FullyAsyncRayPPOTrainer.__new__(FullyAsyncRayPPOTrainer)
+    trainer.cfg = SimpleNamespace(
+        trainer=SimpleNamespace(
+            fully_async=SimpleNamespace(
+                preserve_inflight_kv_cache_on_weight_update=preserve_inflight_kv_cache_on_weight_update
+            )
+        )
+    )
+    trainer.inference_engine_client = AsyncMock()
+    trainer.async_sync_policy_weights_to_inference_engines = AsyncMock()
+    return trainer
+
+
+@pytest.mark.asyncio
+async def test_sync_policy_weights_preserves_inflight_kv_cache_by_default():
+    call_order = []
+    trainer = _make_trainer(True)
+    trainer.inference_engine_client.pause_generation.side_effect = lambda: call_order.append("pause")
+    trainer.async_sync_policy_weights_to_inference_engines.side_effect = lambda: call_order.append("sync")
+    trainer.inference_engine_client.resume_generation.side_effect = lambda: call_order.append("resume")
+
+    await trainer._sync_policy_weights_with_inflight_update_policy()
+
+    assert call_order == ["pause", "sync", "resume"]
+    trainer.inference_engine_client.reset_prefix_cache.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_policy_weights_can_reset_running_requests_before_sync():
+    call_order = []
+    trainer = _make_trainer(False)
+    trainer.inference_engine_client.pause_generation.side_effect = lambda: call_order.append("pause")
+    trainer.inference_engine_client.reset_prefix_cache.side_effect = lambda **kwargs: call_order.append(
+        f"reset:{kwargs['reset_running_requests']}"
+    )
+    trainer.async_sync_policy_weights_to_inference_engines.side_effect = lambda: call_order.append("sync")
+    trainer.inference_engine_client.resume_generation.side_effect = lambda: call_order.append("resume")
+
+    await trainer._sync_policy_weights_with_inflight_update_policy()
+
+    assert call_order == ["pause", "reset:True", "sync", "resume"]
+
+
+@pytest.mark.asyncio
+async def test_sync_policy_weights_resumes_generation_if_sync_fails():
+    trainer = _make_trainer(True)
+    trainer.async_sync_policy_weights_to_inference_engines.side_effect = RuntimeError("sync failed")
+
+    with pytest.raises(RuntimeError, match="sync failed"):
+        await trainer._sync_policy_weights_with_inflight_update_policy()
+
+    trainer.inference_engine_client.pause_generation.assert_awaited_once()
+    trainer.inference_engine_client.resume_generation.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sync_policy_weights_resumes_generation_if_reset_fails():
+    trainer = _make_trainer(False)
+    trainer.inference_engine_client.reset_prefix_cache.side_effect = RuntimeError("reset failed")
+
+    with pytest.raises(RuntimeError, match="reset failed"):
+        await trainer._sync_policy_weights_with_inflight_update_policy()
+
+    trainer.inference_engine_client.pause_generation.assert_awaited_once()
+    trainer.inference_engine_client.resume_generation.assert_awaited_once()


### PR DESCRIPTION
## Summary
This draft PR implements the remaining user-facing fully async policy requested in #979.

SkyRL already supports keep-mode in-flight weight updates, but there was no config surface for choosing whether in-flight requests should preserve KV state or be reset before resuming. This PR adds that choice while keeping the current fast behavior as the default.

## What Changed
- add `trainer.fully_async.preserve_inflight_kv_cache_on_weight_update` with default `true`
- route fully async weight sync through a dedicated helper that always:
  1. pauses generation
  2. optionally resets running requests' KV cache state
  3. syncs updated weights
  4. resumes generation in a `finally` block
- thread `reset_running_requests` through the inference engine client stack, remote inference engine/client, and vLLM HTTP/server actor endpoints
- update fully async docs and example config to explain the default preserve-KV path and the optional clean re-prefill path
- add targeted tests for config defaults/override, fully async trainer sequencing and failure handling, inference client forwarding, direct remote engine HTTP forwarding, and remote inference control-plane forwarding

## Issue
Addresses #979.

## Testing
- `/Users/vuductai/Documents/Projects/SkyRL/.venv/bin/python -m pytest --noconftest tests/train/test_config.py tests/train/test_fully_async_trainer.py tests/backends/skyrl_train/inference_engines/test_inference_engine_client.py tests/backends/skyrl_train/inference_engines/test_remote_inference_engine.py tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py -q`
- `131 passed`
