### PR TITLE
[skyrl-train] Add step-wise trainer guardrails and trainer-side parity fixes

### DIFF
--- a/docs/content/docs/tutorials/step-wise-training.mdx
+++ b/docs/content/docs/tutorials/step-wise-training.mdx
@@ -39,6 +39,22 @@ Some algorithms have their behavior altered by step-wise decomposition, since ea
 
 That said, some research suggests that treating each turn as a separate sequence may actually be beneficial. See the section on [Modelling Multi-Turn Agentic Task as Chunked MDP](https://faithful-almanac-add.notion.site/The-Bitter-Lesson-Behind-Building-Agentic-RL-in-Terminal-Environments-2eaddd45837f80c9ad2ed6a15ef3c1a1#305ddd45837f80af9807ead712e8d343).
 
+### Current support matrix
+
+With `generator.step_wise_trajectories=true`, SkyRL currently supports:
+
+- regular GRPO/PPO-style training with last-step reward broadcast
+- token-level TIS (`trainer.algorithm.off_policy_correction.tis_ratio_type="token"`)
+- dynamic sampling and zero-variance filtering using final-step trajectory outcomes
+
+SkyRL currently does **not** support the following combinations in step-wise mode and will fail fast during config validation:
+
+- `trainer.algorithm.use_kl_in_reward=true`
+- `generator.apply_overlong_filtering=true`
+- `trainer.algorithm.policy_loss_type="gspo"`
+- `trainer.algorithm.loss_reduction in {"sequence_mean", "seq_mean_token_sum_norm"}`
+- sequence-scoped off-policy correction (`tis_ratio_type="sequence"` or any sequence mask metric)
+
 ## Configuration
 
 Enable step-wise training by setting:
@@ -88,6 +104,8 @@ When `step_wise_trajectories=True`, some related fields:
 
 ### Concrete Example
 
+The example below shows the **preferred conceptual representation** where each step row contains only model-generated tokens.
+
 Consider 2 trajectories: trajectory A has 3 turns, trajectory B has 2 turns.
 
 ```python
@@ -134,6 +152,8 @@ GeneratorOutput(
 )
 ```
 
+For `SkyRLGymGenerator` specifically, the current runtime is slightly lower level: each step row's `response_ids` may contain `assistant_tokens + observation_tokens`, with `loss_masks` set to `1` on assistant positions and `0` on observation positions. If `rollout_logprobs` are present, observation positions are filled with dummy values so the tensors still align.
+
 ### Key Invariants
 
 The following are validated by `_validate_step_wise_fields()` in [skyrl/train/utils/trainer_utils.py](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/utils/trainer_utils.py):
@@ -167,7 +187,13 @@ response = await litellm.acompletion(
 
 ### 2. Set Loss Masks
 
-Set `loss_mask = [1] * len(response_ids[i])` for each step. Since each step's response contains only the model's completion tokens (no interleaved observations), all tokens are trainable.
+If each step row contains only model-generated tokens, you can set:
+
+```python
+loss_mask = [1] * len(response_ids[i])
+```
+
+If your generator appends non-trainable observation tokens to `response_ids`, set those positions to `0` in `loss_mask` and, if applicable, pad `rollout_logprobs` with dummy values on the observation suffix.
 
 ### 3. Assign Rewards
 

--- a/skyrl/train/evaluate.py
+++ b/skyrl/train/evaluate.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -26,6 +25,7 @@ from skyrl.train.utils.logging_utils import log_example
 from skyrl.train.utils.trainer_utils import (
     calculate_per_dataset_metrics,
     dump_per_dataset_eval_results,
+    select_generator_output_for_metrics,
     validate_generator_output,
 )
 
@@ -181,7 +181,7 @@ async def evaluate_step_wise(
             concat_all_envs.append(traj_id_to_input[traj_id.instance_id]["env_class"])
             concat_env_extras.append(traj_id_to_input[traj_id.instance_id]["env_extras"])
             concat_uids.append(traj_id.instance_id)
-        validate_generator_output(generator_input, generator_output, step_wise=True)
+        validate_generator_output(len(generator_input["prompts"]), generator_output, step_wise=True)
         generator_outputs.append(generator_output)
     concat_generator_outputs: GeneratorOutput = concatenate_generator_outputs(generator_outputs)
 
@@ -190,21 +190,10 @@ async def evaluate_step_wise(
     vis = tokenizer.decode(generator_output["response_ids"][0])
     logger.info(f"Eval output example: {vis}")
 
-    # Only use the final step metrics
-    generator_output_last_step = defaultdict(list)
-    is_last_step_mask = concat_generator_outputs["is_last_step"]
-    for key in concat_generator_outputs:
-        if isinstance(concat_generator_outputs[key], list):
-            assert len(concat_generator_outputs[key]) == len(
-                is_last_step_mask
-            ), f"Length mismatch: {len(concat_generator_outputs[key])} != {len(is_last_step_mask)} for key {key}"
-            generator_output_last_step[key] = [
-                val for val, is_last_step in zip(concat_generator_outputs[key], is_last_step_mask) if is_last_step
-            ]
-    uids_last_step = [uid for uid, is_last_step in zip(concat_uids, is_last_step_mask) if is_last_step]
-    data_sources_last_step = [
-        data_source for data_source, is_last_step in zip(concat_data_sources, is_last_step_mask) if is_last_step
-    ]
+    generator_output_last_step, uids_last_step, last_step_indices = select_generator_output_for_metrics(
+        concat_generator_outputs, concat_uids
+    )
+    data_sources_last_step = [concat_data_sources[i] for i in last_step_indices]
 
     # 2. Group data by data source and calculate per-dataset metrics
     eval_metrics = calculate_per_dataset_metrics(

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -273,7 +273,11 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput]) -> G
     from skyrl.train.utils.trainer_utils import validate_generator_output
 
     num_prompts = len(result["prompt_token_ids"])
-    validate_generator_output(num_prompts, result)
+    validate_generator_output(
+        num_prompts,
+        result,
+        step_wise=result.get("is_last_step") is not None and result.get("trajectory_ids") is not None,
+    )
 
     return result
 

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -70,8 +70,10 @@ from skyrl.train.utils.trainer_utils import (
     ResumeMode,
     build_dataloader,
     cleanup_old_checkpoints,
+    expand_last_step_indices_to_rows,
     extract_step_from_path,
     run_on_each_node,
+    select_generator_output_for_metrics,
     validate_consistency_for_latest_checkpoint,
     validate_generator_output,
     zero_variance_filter,
@@ -718,20 +720,9 @@ class RayPPOTrainer:
 
         In the future algorithm specific reward or loss mask post processing should be done here.
         """
-        generator_output_for_metrics = generator_output
-        uids_for_metrics = uids
-        if self.cfg.generator.step_wise_trajectories:
-            generator_output_for_metrics = defaultdict(list)
-            for key in generator_output:
-                if isinstance(generator_output[key], list):
-                    generator_output_for_metrics[key] = [
-                        generator_output[key][i]
-                        for i in range(len(generator_output[key]))
-                        if generator_output["is_last_step"][i]
-                    ]
-            uids_for_metrics = [
-                uid for uid, is_last_step in zip(uids, generator_output["is_last_step"]) if is_last_step
-            ]
+        generator_output_for_metrics, uids_for_metrics, metric_indices = select_generator_output_for_metrics(
+            generator_output, uids
+        )
 
         # only use `generator_output_for_metrics` for metrics calculation
         # For step-wise training, we only calculate metrics for the last step of each trajectory
@@ -751,7 +742,12 @@ class RayPPOTrainer:
             per_token_rewards = rewards
         else:
             if self.cfg.trainer.algorithm.zero_variance_filter:
-                kept_indices_set = set(zero_variance_filter(rewards, uids))
+                kept_metric_indices = zero_variance_filter(generator_output_for_metrics["rewards"], uids_for_metrics)
+                if self.cfg.generator.step_wise_trajectories:
+                    kept_last_step_indices = [metric_indices[i] for i in kept_metric_indices]
+                    kept_indices_set = set(expand_last_step_indices_to_rows(generator_output, kept_last_step_indices))
+                else:
+                    kept_indices_set = set(kept_metric_indices)
                 generator_output["loss_masks"] = [
                     [0] * len(mask) if i not in kept_indices_set else mask
                     for i, mask in enumerate(generator_output["loss_masks"])

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -307,6 +307,64 @@ class DynamicSamplingState(TypedDict, total=False):
     num_prompts_in_batch: Optional[int]
 
 
+def is_step_wise_generator_output(generator_output: GeneratorOutput) -> bool:
+    return generator_output.get("is_last_step") is not None and generator_output.get("trajectory_ids") is not None
+
+
+def get_trajectory_row_groups(generator_output: GeneratorOutput) -> List[List[int]]:
+    """Return contiguous row indices for each trajectory.
+
+    In non-step-wise mode, each row is already a full trajectory.
+    """
+    num_rows = len(generator_output["response_ids"])
+    if not is_step_wise_generator_output(generator_output):
+        return [[i] for i in range(num_rows)]
+
+    groups: List[List[int]] = []
+    current_group: List[int] = []
+    is_last_step = generator_output["is_last_step"]
+    assert is_last_step is not None, "Expected non-null is_last_step for step-wise generator output"
+
+    for idx, is_last in enumerate(is_last_step):
+        current_group.append(idx)
+        if is_last:
+            groups.append(current_group)
+            current_group = []
+
+    assert not current_group, "Malformed step-wise output: final trajectory must end with is_last_step=True"
+    return groups
+
+
+def get_last_step_indices(generator_output: GeneratorOutput) -> List[int]:
+    return [group[-1] for group in get_trajectory_row_groups(generator_output)]
+
+
+def expand_last_step_indices_to_rows(generator_output: GeneratorOutput, last_step_indices: List[int]) -> List[int]:
+    selected_last_steps = set(last_step_indices)
+    return [
+        row_idx
+        for group in get_trajectory_row_groups(generator_output)
+        if group[-1] in selected_last_steps
+        for row_idx in group
+    ]
+
+
+def get_sequence_level_rewards(rewards: Union[List[float], List[List[float]]]) -> np.ndarray:
+    if rewards and isinstance(rewards[0], list):
+        return np.array([sum(reward) for reward in rewards], dtype=float)
+    return np.array(rewards, dtype=float)
+
+
+def select_generator_output_for_metrics(
+    generator_output: GeneratorOutput, uids: List[str]
+) -> Tuple[GeneratorOutput, List[str], List[int]]:
+    """Return the trajectory-final view used for step-wise metrics and grouping."""
+    kept_indices = get_last_step_indices(generator_output)
+    if not is_step_wise_generator_output(generator_output):
+        return generator_output, uids, kept_indices
+    return filter_generator_output(generator_output, kept_indices), [uids[i] for i in kept_indices], kept_indices
+
+
 def handle_dynamic_sampling(
     generator_output: GeneratorOutput,
     uids: List[str],
@@ -365,18 +423,15 @@ def handle_replace_sampling(
     n_samples_per_prompt = sampling_config["n_samples_per_prompt"]
     min_replace_ratio = sampling_config["min_replace_ratio"]
 
-    # Extract rewards and convert to sequence-level if needed
-    rewards_list = generator_output["rewards"]
-    if rewards_list and isinstance(rewards_list[0], list):
-        # Token-level rewards: sum to get sequence rewards
-        rewards = np.array([sum(r) for r in rewards_list])
-    else:
-        rewards = np.array(rewards_list)
+    is_step_wise = is_step_wise_generator_output(generator_output)
+    trajectory_row_groups = get_trajectory_row_groups(generator_output)
+    grouped_output, grouped_uids, _ = select_generator_output_for_metrics(generator_output, uids)
+    rewards = get_sequence_level_rewards(grouped_output["rewards"])
 
     # get mapping of uids to list of indices and metrics
     uid2indices = defaultdict(list)
     uid2metric_vals = defaultdict(list)
-    for idx, uid in enumerate(uids):
+    for idx, uid in enumerate(grouped_uids):
         uid2indices[uid].append(idx)
         uid2metric_vals[uid].append(rewards[idx])
 
@@ -386,8 +441,8 @@ def handle_replace_sampling(
         uid2metric_std[uid] = np.std(metric_vals)
 
     # Determine good UIDs: those with std > 0 (or group size == 1)
-    good_uids = set([uid for uid, std in uid2metric_std.items() if std > 0 or n_samples_per_prompt == 1])
-    bad_uids = set([uid for uid, std in uid2metric_std.items() if std == 0 and n_samples_per_prompt > 1])
+    good_uids = [uid for uid, std in uid2metric_std.items() if std > 0 or n_samples_per_prompt == 1]
+    bad_uids = [uid for uid, std in uid2metric_std.items() if std == 0 and n_samples_per_prompt > 1]
 
     logger.info(f"Replace sampling: {len(good_uids)} good UIDs out of {len(uid2metric_vals)} total prompts")
 
@@ -408,30 +463,47 @@ def handle_replace_sampling(
         for uid in bad_uids:
             bad_indices.extend(uid2indices[uid])
 
-        # Replace bad samples with good ones (modify in place because replacement_idx and bad_idx should not overlap)
-        for bad_idx, replacement_idx in zip(bad_indices, replacement_indices):
-            generator_output["prompt_token_ids"][bad_idx] = generator_output["prompt_token_ids"][replacement_idx].copy()
-            generator_output["response_ids"][bad_idx] = generator_output["response_ids"][replacement_idx].copy()
-            replacement_reward = generator_output["rewards"][replacement_idx]
-            generator_output["rewards"][bad_idx] = (
-                replacement_reward.copy() if isinstance(replacement_reward, list) else replacement_reward
-            )
-            generator_output["loss_masks"][bad_idx] = generator_output["loss_masks"][replacement_idx].copy()
-            if generator_output["stop_reasons"]:
-                generator_output["stop_reasons"][bad_idx] = generator_output["stop_reasons"][replacement_idx]
+        if is_step_wise:
+            selected_group_indices = list(range(len(trajectory_row_groups)))
+            for bad_idx, replacement_idx in zip(bad_indices, replacement_indices):
+                selected_group_indices[bad_idx] = replacement_idx
 
-            if generator_output["rollout_logprobs"]:
-                generator_output["rollout_logprobs"][bad_idx] = generator_output["rollout_logprobs"][replacement_idx]
+            selected_row_indices = [
+                row_idx for group_idx in selected_group_indices for row_idx in trajectory_row_groups[group_idx]
+            ]
+            replaced_output = filter_generator_output(generator_output, selected_row_indices)
+            replaced_uids = [
+                grouped_uids[group_idx] for group_idx in selected_group_indices for _ in trajectory_row_groups[group_idx]
+            ]
+        else:
+            # Replace bad samples with good ones (modify in place because replacement_idx and bad_idx should not overlap)
+            for bad_idx, replacement_idx in zip(bad_indices, replacement_indices):
+                generator_output["prompt_token_ids"][bad_idx] = generator_output["prompt_token_ids"][
+                    replacement_idx
+                ].copy()
+                generator_output["response_ids"][bad_idx] = generator_output["response_ids"][replacement_idx].copy()
+                replacement_reward = generator_output["rewards"][replacement_idx]
+                generator_output["rewards"][bad_idx] = (
+                    replacement_reward.copy() if isinstance(replacement_reward, list) else replacement_reward
+                )
+                generator_output["loss_masks"][bad_idx] = generator_output["loss_masks"][replacement_idx].copy()
+                if generator_output["stop_reasons"]:
+                    generator_output["stop_reasons"][bad_idx] = generator_output["stop_reasons"][replacement_idx]
 
-        # Update UIDs accordingly
-        replaced_uids = uids.copy()
-        for bad_idx, replacement_idx in zip(bad_indices, replacement_indices):
-            replaced_uids[bad_idx] = uids[replacement_idx]
+                if generator_output["rollout_logprobs"]:
+                    generator_output["rollout_logprobs"][bad_idx] = generator_output["rollout_logprobs"][
+                        replacement_idx
+                    ]
+
+            replaced_output = generator_output
+            replaced_uids = uids.copy()
+            for bad_idx, replacement_idx in zip(bad_indices, replacement_indices):
+                replaced_uids[bad_idx] = grouped_uids[replacement_idx]
 
         logger.info(f"After replacement - Replaced {len(bad_indices) // n_samples_per_prompt} bad prompts")
         logger.info("==================================================")
 
-        return generator_output, replaced_uids, False
+        return replaced_output, replaced_uids, False
     else:
         logger.warning("===================== Warning (Dynamic sampling replace) ====================")
         logger.warning("In this mini-batch, most training samples receive low variance rewards.")
@@ -462,17 +534,14 @@ def handle_filter_sampling(
     target_batch_size = sampling_config["train_batch_size"]
     n_samples_per_prompt = sampling_config["n_samples_per_prompt"]
 
-    # Extract rewards from collected output
-    rewards_list = generator_output["rewards"]
-    if rewards_list and isinstance(rewards_list[0], list):
-        # Token-level rewards: sum to get sequence rewards
-        rewards = np.array([sum(r) for r in rewards_list])
-    else:
-        rewards = np.array(rewards_list)
+    is_step_wise = is_step_wise_generator_output(generator_output)
+    trajectory_row_groups = get_trajectory_row_groups(generator_output)
+    grouped_output, grouped_uids, _ = select_generator_output_for_metrics(generator_output, uids)
+    rewards = get_sequence_level_rewards(grouped_output["rewards"])
 
     # Group by UID and calculate standard deviation
     uid2metric_vals = defaultdict(list)
-    for uid, reward in zip(uids, rewards):
+    for uid, reward in zip(grouped_uids, rewards):
         uid2metric_vals[uid].append(reward)
 
     uid2metric_std = {}
@@ -485,13 +554,18 @@ def handle_filter_sampling(
 
     # Filter trajectories based on kept UIDs
     kept_traj_idxs = []
-    for idx, traj_uid in enumerate(uids):
+    for idx, traj_uid in enumerate(grouped_uids):
         if traj_uid in kept_uids_set:
             kept_traj_idxs.append(idx)
 
+    if is_step_wise:
+        kept_row_indices = [row_idx for traj_idx in kept_traj_idxs for row_idx in trajectory_row_groups[traj_idx]]
+    else:
+        kept_row_indices = kept_traj_idxs
+
     # Apply filtering to generator output
-    filtered_output = filter_generator_output(generator_output, kept_traj_idxs)
-    filtered_uids = [uids[idx] for idx in kept_traj_idxs]
+    filtered_output = filter_generator_output(generator_output, kept_row_indices)
+    filtered_uids = [uids[idx] for idx in kept_row_indices]
 
     if "collected_generator_output" not in collected_state:
         collected_state.update(
@@ -527,7 +601,13 @@ def handle_filter_sampling(
         final_output = collected_state["collected_generator_output"]
         final_uids = collected_state["collected_uids"]
 
-        if len(final_uids) > max_trajectories:
+        if is_step_wise_generator_output(final_output):
+            trajectory_groups = get_trajectory_row_groups(final_output)
+            if len(trajectory_groups) > max_trajectories:
+                kept_row_indices = [row_idx for group in trajectory_groups[:max_trajectories] for row_idx in group]
+                final_output = filter_generator_output(final_output, kept_row_indices)
+                final_uids = [final_uids[idx] for idx in kept_row_indices]
+        elif len(final_uids) > max_trajectories:
             final_output = filter_generator_output(final_output, list(range(max_trajectories)))
             final_uids = final_uids[:max_trajectories]
 
@@ -550,38 +630,38 @@ def get_bad_sample_replacements(good_uids: List[str], bad_uids: List[str]) -> Li
 
 def filter_generator_output(output: GeneratorOutput, kept_indices: List[int]) -> GeneratorOutput:
     """Filter GeneratorOutput based on kept indices."""
-    filtered = {
-        "prompt_token_ids": [output["prompt_token_ids"][i] for i in kept_indices],
-        "response_ids": [output["response_ids"][i] for i in kept_indices],
-        "rewards": [output["rewards"][i] for i in kept_indices],
-        "loss_masks": [output["loss_masks"][i] for i in kept_indices],
-        "stop_reasons": None,
-        "rollout_metrics": output.get("rollout_metrics"),
-        "rollout_logprobs": (
-            [output["rollout_logprobs"][i] for i in kept_indices] if output["rollout_logprobs"] else None
-        ),
-    }
-
-    if output.get("stop_reasons"):
-        filtered["stop_reasons"] = [output["stop_reasons"][i] for i in kept_indices]
+    filtered = {"rollout_metrics": output.get("rollout_metrics")}
+    num_rows = len(output["response_ids"])
+    for key, value in output.items():
+        if key == "rollout_metrics":
+            continue
+        if isinstance(value, list):
+            if len(value) == num_rows:
+                filtered[key] = [value[i] for i in kept_indices]
+            else:
+                filtered[key] = value
+        else:
+            filtered[key] = value
 
     return filtered
 
 
-def zero_variance_filter(rewards: List[float], uids: List[str]) -> List[int]:
+def zero_variance_filter(rewards: Union[List[float], List[List[float]]], uids: List[str]) -> List[int]:
     """
-    Given a list of trajectory level rewards and uids, return the indices of the trajectories with non-zero variance rewards.
+    Given sequence-level rewards and uids, return indices for prompts with non-zero reward variance.
 
     Args:
-        rewards: List[float]
+        rewards: List[float] or token-level rewards per sequence
         uids: List[str]
 
     Returns:
         List[int]
     """
+    rewards_arr = get_sequence_level_rewards(rewards)
+
     # Group by UID and calculate standard deviation
     uid2metric_vals = defaultdict(list)
-    for uid, reward in zip(uids, rewards):
+    for uid, reward in zip(uids, rewards_arr):
         uid2metric_vals[uid].append(reward)
 
     # Identify UIDs to keep: non-zero variance or singletons

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -328,6 +328,8 @@ def validate_cfg(cfg: SkyRLTrainConfig):
                 "`trainer.algorithm.off_policy_correction` doesn't support clip_cov or kl_cov policy loss types"
             )
 
+    validate_step_wise_cfg(cfg)
+
     if cfg.trainer.policy.model.lora.rank > 0:
         # LoRA enabled
         # Right now: assert generator backend must be vllm, training backend must be fsdp/fsdp2
@@ -472,6 +474,41 @@ def validate_generator_cfg(cfg: SkyRLTrainConfig):
 
     # Validate new inference config options
     _validate_new_inference_cfg(cfg)
+
+
+def validate_step_wise_cfg(cfg: SkyRLTrainConfig):
+    """Validate step-wise specific feature compatibility."""
+    if not cfg.generator.step_wise_trajectories:
+        return
+
+    algorithm_cfg = cfg.trainer.algorithm
+    off_policy_correction = algorithm_cfg.off_policy_correction
+
+    if algorithm_cfg.use_kl_in_reward:
+        raise NotImplementedError(
+            "`generator.step_wise_trajectories=True` does not support `trainer.algorithm.use_kl_in_reward` yet."
+        )
+
+    if cfg.generator.apply_overlong_filtering:
+        raise NotImplementedError(
+            "`generator.step_wise_trajectories=True` does not support `generator.apply_overlong_filtering` yet."
+        )
+
+    if algorithm_cfg.policy_loss_type == "gspo":
+        raise NotImplementedError(
+            "`generator.step_wise_trajectories=True` does not support `trainer.algorithm.policy_loss_type='gspo'` yet."
+        )
+
+    if algorithm_cfg.loss_reduction in ("sequence_mean", "seq_mean_token_sum_norm"):
+        raise NotImplementedError(
+            "`generator.step_wise_trajectories=True` does not support sequence-scoped loss reductions "
+            f"like `{algorithm_cfg.loss_reduction}` yet."
+        )
+
+    if off_policy_correction.tis_ratio_type == "sequence" or off_policy_correction.sequence_mask_metric is not None:
+        raise NotImplementedError(
+            "`generator.step_wise_trajectories=True` only supports token-level off-policy correction today."
+        )
 
 
 def _validate_new_inference_cfg(cfg: SkyRLTrainConfig):

--- a/tests/train/generators/test_skyrl_gym_generator.py
+++ b/tests/train/generators/test_skyrl_gym_generator.py
@@ -1618,6 +1618,15 @@ async def test_step_wise_trajectories_basic_output_validation(mock_make, mock_to
         ), f"loss_masks[{i}] length should match response_ids[{i}] length"
         assert all(isinstance(val, int) for val in loss_mask), f"loss_masks[{i}] should contain integers"
 
+    # SkyRLGymGenerator currently appends observation tokens to step-wise response_ids and
+    # masks them out from the loss. The first step has one observation turn; the last step does not.
+    assert generator_output["response_ids"][0][:4] == [10, 11, 12, mock_tokenizer.eos_token_id]
+    assert len(generator_output["response_ids"][0]) > 4
+    assert generator_output["loss_masks"][0][:4] == [1, 1, 1, 1]
+    assert all(val == 0 for val in generator_output["loss_masks"][0][4:])
+    assert generator_output["response_ids"][1] == [10, 11, 12, mock_tokenizer.eos_token_id]
+    assert generator_output["loss_masks"][1] == [1, 1, 1, 1]
+
     # Validate stop_reasons
     for i, stop_reason in enumerate(generator_output["stop_reasons"]):
         assert isinstance(stop_reason, str), f"stop_reasons[{i}] should be a string"

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -16,6 +16,8 @@ from skyrl.train.config.config import (
     build_nested_dataclass,
 )
 from skyrl.train.config.utils import get_legacy_config
+from skyrl.train.utils.utils import validate_cfg
+from tests.train.util import example_dummy_config
 
 
 # Helper dataclasses for testing
@@ -212,3 +214,37 @@ class TestMaxSeqLenValidation:
         cfg = SkyRLTrainConfig.from_cli_overrides(["trainer.algorithm.max_seq_len=32768"])
 
         assert cfg.trainer.algorithm.max_seq_len == 32768
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        (("trainer.algorithm.use_kl_in_reward", True), "use_kl_in_reward"),
+        (("generator.apply_overlong_filtering", True), "apply_overlong_filtering"),
+        (("trainer.algorithm.policy_loss_type", "gspo"), "policy_loss_type='gspo'"),
+        (("trainer.algorithm.loss_reduction", "sequence_mean"), "sequence-scoped loss reductions"),
+        (("trainer.algorithm.loss_reduction", "seq_mean_token_sum_norm"), "sequence-scoped loss reductions"),
+        (("trainer.algorithm.off_policy_correction.tis_ratio_type", "sequence"), "token-level off-policy correction"),
+        (("trainer.algorithm.off_policy_correction.sequence_mask_metric", "product"), "token-level off-policy correction"),
+    ],
+)
+def test_validate_cfg_blocks_unsupported_stepwise_feature_combinations(overrides, match):
+    cfg = example_dummy_config()
+    cfg.generator.step_wise_trajectories = True
+    cfg.trainer.algorithm.use_kl_loss = False
+    cfg.trainer.train_batch_size = 4
+    cfg.trainer.policy_mini_batch_size = 1
+    cfg.trainer.micro_train_batch_size_per_gpu = 1
+    cfg.trainer.micro_forward_batch_size_per_gpu = 1
+    cfg.trainer.placement.policy_num_nodes = 1
+    cfg.trainer.placement.policy_num_gpus_per_node = 1
+
+    dotted_key, value = overrides
+    target = cfg
+    parts = dotted_key.split(".")
+    for part in parts[:-1]:
+        target = getattr(target, part)
+    setattr(target, parts[-1], value)
+
+    with pytest.raises(NotImplementedError, match=match):
+        validate_cfg(cfg)

--- a/tests/train/test_eval.py
+++ b/tests/train/test_eval.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from skyrl.train.config import EnvironmentConfig, SamplingParams
-from skyrl.train.evaluate import evaluate
-from skyrl.train.generators.base import GeneratorInterface, GeneratorOutput
+from skyrl.train.evaluate import evaluate, evaluate_step_wise
+from skyrl.train.generators.base import GeneratorInterface, GeneratorOutput, TrajectoryID
 from tests.train.util import example_dummy_config
 
 
@@ -111,3 +111,73 @@ async def test_evaluate_computes_expected_metrics(dummy_config, tmp_path):
     assert seen_batch["env_classes"] == ["gsm8k", "custom_env"]
     assert seen_batch["env_extras"] == [prompt["env_extras"] for prompt in prompts_batch]
     assert seen_batch["batch_metadata"].training_phase == "eval"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_step_wise_uses_last_step_rewards(dummy_config, tmp_path):
+    cfg = dummy_config
+    cfg.generator.inference_engine.backend = "vllm"
+    cfg.generator.eval_sampling_params = SamplingParams(
+        max_generate_length=20,
+        temperature=0.0,
+        top_p=1.0,
+        top_k=-1,
+        min_p=0.0,
+        logprobs=None,
+        stop=None,
+    )
+    cfg.generator.eval_n_samples_per_prompt = 1
+    cfg.generator.step_wise_trajectories = True
+    cfg.environment = EnvironmentConfig(env_class="gsm8k")
+    cfg.trainer.dump_eval_results = False
+    cfg.trainer.export_path = str(tmp_path)
+
+    prompts_batch = [
+        {
+            "prompt": [{"role": "user", "content": "question-1"}],
+            "env_class": None,
+            "env_extras": {"data_source": "dataset/a"},
+            "uid": "uid-1",
+        },
+        {
+            "prompt": [{"role": "user", "content": "question-2"}],
+            "env_class": None,
+            "env_extras": {"data_source": "dataset/b"},
+            "uid": "uid-2",
+        },
+    ]
+    eval_dataloader = DummyStatefulDataLoader([prompts_batch])
+
+    generator_output: GeneratorOutput = {
+        "prompt_token_ids": [[101], [101, 102], [201], [201, 202]],
+        "response_ids": [[11], [12], [21], [22]],
+        "rewards": [0.0, 1.0, 0.0, 0.0],
+        "loss_masks": [[1], [1], [1], [1]],
+        "stop_reasons": ["tool_call", "stop", "tool_call", "stop"],
+        "rollout_metrics": None,
+        "rollout_logprobs": None,
+        "trajectory_ids": [
+            TrajectoryID(instance_id="uid-1", repetition_id=0),
+            TrajectoryID(instance_id="uid-1", repetition_id=0),
+            TrajectoryID(instance_id="uid-2", repetition_id=0),
+            TrajectoryID(instance_id="uid-2", repetition_id=0),
+        ],
+        "is_last_step": [False, True, False, True],
+    }
+    generator = DummyGenerator(generator_output)
+
+    tokenizer = MagicMock()
+    tokenizer.decode.side_effect = lambda tokens: "decoded"
+
+    metrics = await evaluate_step_wise(
+        eval_dataloader=eval_dataloader,
+        generator=generator,
+        cfg=cfg,
+        global_step=5,
+        tokenizer=tokenizer,
+    )
+
+    assert metrics["eval/dataset_a/avg_score"] == pytest.approx(1.0)
+    assert metrics["eval/dataset_b/avg_score"] == pytest.approx(0.0)
+    assert metrics["eval/all/avg_score"] == pytest.approx(0.5)
+    assert metrics["eval/all/pass_at_1"] == pytest.approx(0.5)

--- a/tests/train/test_generator_postprocess.py
+++ b/tests/train/test_generator_postprocess.py
@@ -8,7 +8,7 @@ uv run --isolated --extra dev pytest tests/train/test_generator_postprocess.py
 from unittest.mock import MagicMock
 
 from skyrl.train.config import SkyRLTrainConfig
-from skyrl.train.generators.base import GeneratorOutput
+from skyrl.train.generators.base import GeneratorOutput, TrajectoryID
 from skyrl.train.trainer import RayPPOTrainer
 
 
@@ -146,3 +146,48 @@ def test_token_level_rewards():
 
     # Verify token-level rewards are unchanged
     assert result["rewards"] == per_token_rewards
+
+
+def test_stepwise_zero_variance_filter_masks_entire_trajectory():
+    config = create_config(2)
+    config.generator.step_wise_trajectories = True
+    config.trainer.algorithm.zero_variance_filter = True
+
+    trainer = RayPPOTrainer(
+        cfg=config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=None,
+        inference_engine_client=None,
+        generator=MagicMock(),
+    )
+
+    generator_output: GeneratorOutput = {
+        "prompt_token_ids": [[1], [1, 2], [3], [3, 4], [5], [5, 6], [7], [7, 8]],
+        "response_ids": [[10], [11], [12], [13], [14], [15], [16], [17]],
+        "rewards": [0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        "loss_masks": [[1], [1], [1], [1], [1], [1], [1], [1]],
+        "stop_reasons": ["tool_call", "stop", "tool_call", "stop", "tool_call", "stop", "tool_call", "stop"],
+        "rollout_metrics": None,
+        "rollout_logprobs": None,
+        "trajectory_ids": [
+            TrajectoryID(instance_id="uid-good", repetition_id=0),
+            TrajectoryID(instance_id="uid-good", repetition_id=0),
+            TrajectoryID(instance_id="uid-good", repetition_id=1),
+            TrajectoryID(instance_id="uid-good", repetition_id=1),
+            TrajectoryID(instance_id="uid-bad", repetition_id=0),
+            TrajectoryID(instance_id="uid-bad", repetition_id=0),
+            TrajectoryID(instance_id="uid-bad", repetition_id=1),
+            TrajectoryID(instance_id="uid-bad", repetition_id=1),
+        ],
+        "is_last_step": [False, True, False, True, False, True, False, True],
+    }
+
+    result = trainer.postprocess_generator_output(
+        generator_output,
+        ["uid-good", "uid-good", "uid-good", "uid-good", "uid-bad", "uid-bad", "uid-bad", "uid-bad"],
+    )
+
+    assert result["loss_masks"] == [[1], [1], [1], [1], [0], [0], [0], [0]]
+    assert result["rewards"] == [[0.0], [0.0], [0.0], [1.0], [0.0], [1.0], [0.0], [1.0]]

--- a/tests/train/test_trainer_utils.py
+++ b/tests/train/test_trainer_utils.py
@@ -19,12 +19,15 @@ from skyrl.train.utils.trainer_utils import (
     calculate_per_dataset_metrics,
     cleanup_old_checkpoints,
     dump_per_dataset_eval_results,
+    expand_last_step_indices_to_rows,
     filter_generator_output,
+    get_last_step_indices,
     handle_dynamic_sampling,
     handle_filter_sampling,
     handle_replace_sampling,
     run_on_each_node,
     sanitize_data_source,
+    select_generator_output_for_metrics,
     validate_consistency_for_latest_checkpoint,
     validate_generator_output,
     zero_variance_filter,
@@ -1063,3 +1066,140 @@ def test_validate_stepwise_multiple_is_last_step_true_per_trajectory():
     output["is_last_step"] = [True, True, True]
     with pytest.raises(AssertionError, match="is_last_step.*True.*trajectory continues"):
         validate_generator_output(num_prompts=1, generator_output=output, step_wise=True)
+
+
+def _make_stepwise_sampling_output(specs):
+    """Build a step-wise output and per-row uids from trajectory specs.
+
+    Each spec is `(uid, repetition_id, num_steps, final_reward)`.
+    """
+    prompt_token_ids = []
+    response_ids = []
+    rewards = []
+    loss_masks = []
+    trajectory_ids = []
+    is_last_step = []
+    uids = []
+
+    for traj_idx, (uid, repetition_id, num_steps, final_reward) in enumerate(specs):
+        tid = TrajectoryID(instance_id=uid, repetition_id=repetition_id)
+        for step in range(num_steps):
+            prompt_token_ids.append([10 + traj_idx, 20 + step])
+            response_ids.append([100 + traj_idx, 200 + step, 300 + step])
+            rewards.append([0.0, 0.0, final_reward if step == num_steps - 1 else 0.0])
+            loss_masks.append([1, 1, 1])
+            trajectory_ids.append(tid)
+            is_last_step.append(step == num_steps - 1)
+            uids.append(uid)
+
+    return (
+        {
+            "prompt_token_ids": prompt_token_ids,
+            "response_ids": response_ids,
+            "rewards": rewards,
+            "loss_masks": loss_masks,
+            "stop_reasons": ["stop"] * len(response_ids),
+            "rollout_metrics": {},
+            "rollout_logprobs": None,
+            "trajectory_ids": trajectory_ids,
+            "is_last_step": is_last_step,
+        },
+        uids,
+    )
+
+
+def test_select_generator_output_for_metrics_stepwise():
+    output, uids = _make_stepwise_sampling_output(
+        [
+            ("uid-a", 0, 2, 0.2),
+            ("uid-a", 1, 3, 0.8),
+            ("uid-b", 0, 1, 0.5),
+        ]
+    )
+
+    metric_output, metric_uids, metric_indices = select_generator_output_for_metrics(output, uids)
+
+    assert metric_indices == [1, 4, 5]
+    assert metric_uids == ["uid-a", "uid-a", "uid-b"]
+    assert metric_output["trajectory_ids"] == [
+        TrajectoryID(instance_id="uid-a", repetition_id=0),
+        TrajectoryID(instance_id="uid-a", repetition_id=1),
+        TrajectoryID(instance_id="uid-b", repetition_id=0),
+    ]
+
+
+def test_expand_last_step_indices_to_rows_stepwise():
+    output, _ = _make_stepwise_sampling_output(
+        [
+            ("uid-a", 0, 2, 0.2),
+            ("uid-a", 1, 3, 0.8),
+            ("uid-b", 0, 1, 0.5),
+        ]
+    )
+
+    assert expand_last_step_indices_to_rows(output, [4]) == [2, 3, 4]
+
+
+def test_filter_generator_output_preserves_stepwise_fields():
+    output, _ = _make_stepwise_sampling_output(
+        [
+            ("uid-a", 0, 2, 0.2),
+            ("uid-a", 1, 3, 0.8),
+        ]
+    )
+
+    filtered = filter_generator_output(output, [2, 3, 4])
+
+    assert filtered["trajectory_ids"] == [TrajectoryID(instance_id="uid-a", repetition_id=1)] * 3
+    assert filtered["is_last_step"] == [False, False, True]
+
+
+def test_handle_dynamic_sampling_filter_stepwise_keeps_full_trajectories():
+    generator_output, uids = _make_stepwise_sampling_output(
+        [
+            ("uid-good", 0, 2, 0.1),
+            ("uid-good", 1, 3, 0.9),
+            ("uid-bad", 0, 1, 0.5),
+            ("uid-bad", 1, 2, 0.5),
+        ]
+    )
+    sampling_config = {
+        "type": "filter",
+        "train_batch_size": 1,
+        "n_samples_per_prompt": 2,
+        "min_replace_ratio": 0.0,
+    }
+    state = {"sample_batch_count": 1}
+
+    result_output, result_uids, keep_sampling, updated_state = handle_dynamic_sampling(
+        generator_output, uids, sampling_config, state
+    )
+
+    assert keep_sampling is False
+    assert updated_state is None
+    assert set(result_uids) == {"uid-good"}
+    assert get_last_step_indices(result_output) == [1, 4]
+    assert [tid.instance_id for tid in result_output["trajectory_ids"]] == ["uid-good"] * len(result_uids)
+
+
+def test_handle_dynamic_sampling_replace_stepwise_replaces_full_trajectories():
+    generator_output, uids = _make_stepwise_sampling_output(
+        [
+            ("uid-good", 0, 2, 0.1),
+            ("uid-good", 1, 3, 0.9),
+            ("uid-bad", 0, 1, 0.5),
+            ("uid-bad", 1, 2, 0.5),
+        ]
+    )
+    sampling_config = {
+        "type": "replace",
+        "n_samples_per_prompt": 2,
+        "min_replace_ratio": 0.0,
+    }
+
+    result_output, result_uids, keep_sampling, _ = handle_dynamic_sampling(generator_output, uids, sampling_config)
+
+    assert keep_sampling is False
+    assert set(result_uids) == {"uid-good"}
+    assert len(get_last_step_indices(result_output)) == 4
+    assert [tid.instance_id for tid in result_output["trajectory_ids"]] == ["uid-good"] * len(result_uids)


### PR DESCRIPTION
## Summary

This draft PR implements the trainer-side parity and safety slice of #1278 for step-wise training.

The main goal is to make the existing step-wise path safer and more internally consistent without expanding into a larger runtime redesign. In particular, this PR:

- fails fast for step-wise feature combinations that are still unsupported
- makes trainer-side filtering, replacement sampling, zero-variance masking, and eval operate on full trajectories instead of accidentally mixing row-level and trajectory-level semantics
- aligns the step-wise docs and tests with the current `SkyRLGymGenerator` contract

## Issue Context

Addresses the trainer-side parity / correctness work called out in #1278.

This PR does **not** attempt to fully solve the grouped-loss / GSPO / sequence-reduction side of #1278. Instead, it blocks those combinations explicitly so step-wise mode behaves predictably today.

## What Changed

### 1. Add step-wise config guardrails

Step-wise mode now raises early for combinations that are not yet implemented correctly:

- `trainer.algorithm.use_kl_in_reward=true`
- `generator.apply_overlong_filtering=true`
- `trainer.algorithm.policy_loss_type="gspo"`
- `trainer.algorithm.loss_reduction in {"sequence_mean", "seq_mean_token_sum_norm"}`
- sequence-scoped off-policy correction (`tis_ratio_type="sequence"` or any `sequence_mask_metric`)

### 2. Normalize the trainer-side step-wise view

Added small shared helpers to:

- detect step-wise `GeneratorOutput`
- recover contiguous row groups per trajectory
- select the final-step view used for metrics/grouping
- expand final-step selections back to full row ranges when masking or filtering

This removes duplicated ad hoc last-step logic from trainer/eval paths and keeps the public `GeneratorOutput` contract unchanged.

### 3. Make dynamic sampling trajectory-aware in step-wise mode

`handle_filter_sampling()` and `handle_replace_sampling()` now:

- compute reward variance using final-step trajectory outcomes
- keep or replace **entire trajectories** rather than individual step rows
- preserve row-aligned `uids`, `trajectory_ids`, and `is_last_step`
- support variable numbers of rows per trajectory

### 4. Fix zero-variance filtering for step-wise training

`postprocess_generator_output()` now applies zero-variance filtering based on the trajectory-final view and expands the keep/drop decision back to all rows of the selected trajectories.

That means a low-variance prompt is masked consistently across all of its step rows, instead of only the final row.

### 5. Clean up step-wise evaluation / concatenation

- `evaluate_step_wise()` now uses the shared final-step selection helper
- step-wise concatenation validates with `step_wise=True` when the relevant fields are present
- fixed the step-wise eval validation call to pass the expected prompt count

### 6. Update docs and tests

The step-wise tutorial now documents the current support boundary and clarifies an important runtime detail:

- the conceptual format is assistant-only per step
- the current `SkyRLGymGenerator` may emit `response_ids = assistant_tokens + observation_tokens`
- `loss_masks` are expected to zero the observation suffix

The test coverage was expanded to cover:

- config guardrails
- full-trajectory filtering/replacement in step-wise mode
- step-wise zero-variance masking
- final-step-only eval metrics
- current `SkyRLGymGenerator` step-wise output structure

## Why This Design

The patch intentionally keeps the implementation small and local:

- no `GeneratorOutput` schema redesign
- no new runtime metadata plumbing beyond existing row-aligned fields
- no partial support for grouped/sequence losses that would still be semantically wrong in step-wise mode

Where step-wise parity is straightforward, this PR implements it. Where semantics are still incomplete, it fails fast.

## Validation

Ran the following focused regression suite outside the macOS sandbox because the Ray-backed tests require unrestricted `sysctl` access:

- `tests/train/test_config.py`
- `tests/train/test_trainer_utils.py`
- `tests/train/test_generator_postprocess.py`
- `tests/train/test_eval.py`
- `tests/train/generators/test_utils.py`
- `tests/train/generators/test_skyrl_gym_generator.py`
- `tests/train/algorithms/test_off_policy_correction.py`

Result:

- `185 passed, 4 warnings`

## Follow-ups

The remaining work from #1278 is the harder runtime/algorithm side, especially:

- GSPO / grouped-loss parity for step-wise trajectories
- sequence-style loss reductions in step-wise mode
- any future chunked-MDP / true per-step reward semantics beyond the current last-step-broadcast behavior

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
