### PR TITLE
Improve sample-packing dispatch balancing to reduce packed micro-batch skew

### DIFF
--- a/skyrl/backends/skyrl_train/training_batch.py
+++ b/skyrl/backends/skyrl_train/training_batch.py
@@ -148,6 +148,63 @@ class TensorBatch(dict, Generic[DictType]):
         new_batch.metadata = selected_metadata
         return new_batch
 
+    def _take_metadata_value(self, value: Any, indices: List[int]) -> Any:
+        if isinstance(value, list):
+            if len(value) != self.batch_size:
+                raise ValueError(f"Metadata list length mismatch. Expected {self.batch_size}, got {len(value)}.")
+            return [value[i] for i in indices]
+        if isinstance(value, tuple):
+            if len(value) != self.batch_size:
+                raise ValueError(f"Metadata tuple length mismatch. Expected {self.batch_size}, got {len(value)}.")
+            return tuple(value[i] for i in indices)
+        if isinstance(value, np.ndarray):
+            if len(value) != self.batch_size:
+                raise ValueError(
+                    f"Metadata array length mismatch. Expected {self.batch_size}, got {len(value)}."
+                )
+            return value[indices].copy()
+        if isinstance(value, torch.Tensor):
+            if len(value) != self.batch_size:
+                raise ValueError(
+                    f"Metadata tensor length mismatch. Expected {self.batch_size}, got {len(value)}."
+                )
+            take_indices = torch.as_tensor(indices, dtype=torch.long, device=value.device)
+            return value.index_select(0, take_indices)
+        raise TypeError(f"Unsupported metadata type for reordering: {type(value)}")
+
+    def take(self, indices: List[int], metadata_keys: Optional[List[str]] = None) -> "TensorBatch[DictType]":
+        """Take rows in an arbitrary order.
+
+        Args:
+            indices: Batch indices to select in-order.
+            metadata_keys: Metadata keys to reorder alongside the tensors. All
+                other metadata entries are copied through unchanged.
+
+        Returns:
+            A new batch with rows reordered by ``indices``.
+        """
+        take_indices = list(indices)
+        take_data = {}
+        for key, value in self.items():
+            if value is None:
+                take_data[key] = value
+            elif isinstance(value, TensorList):
+                take_data[key] = TensorList([value[i] for i in take_indices])
+            else:
+                assert isinstance(value, torch.Tensor), f"Field {key} must be a tensor, got {type(value)}"
+                tensor_indices = torch.as_tensor(take_indices, dtype=torch.long, device=value.device)
+                take_data[key] = value.index_select(0, tensor_indices)
+
+        metadata = None if self.metadata is None else dict(self.metadata)
+        if metadata is not None:
+            for key in metadata_keys or []:
+                if key in metadata:
+                    metadata[key] = self._take_metadata_value(metadata[key], take_indices)
+
+        new_batch = self.__class__(take_data)
+        new_batch.metadata = metadata
+        return new_batch
+
     def _check_consistency(self):
         """Check consistency of all present fields"""
         keys = list(self.keys())

--- a/skyrl/backends/skyrl_train/utils/packing_balance.py
+++ b/skyrl/backends/skyrl_train/utils/packing_balance.py
@@ -1,0 +1,140 @@
+"""Helpers for balancing packed-sequence workloads before dispatch."""
+
+import math
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import torch
+
+from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
+from skyrl.train.config import MegatronConfig, SkyRLTrainConfig
+
+
+@dataclass
+class _Slot:
+    rank: int
+    slot: int
+    remaining_capacity: int
+    total_cost: int = 0
+    sample_indices: List[int] = field(default_factory=list)
+
+
+def _get_megatron_config(cfg: SkyRLTrainConfig, model: str) -> MegatronConfig:
+    if model == "ref":
+        return cfg.trainer.ref.megatron_config
+    return cfg.trainer.policy.megatron_config
+
+
+def get_megatron_alignment_size(cfg: SkyRLTrainConfig, model: str) -> int:
+    megatron_config = _get_megatron_config(cfg, model)
+    tp_size = megatron_config.tensor_model_parallel_size
+    cp_size = megatron_config.context_parallel_size
+    return tp_size * cp_size * 2 if cp_size > 1 else tp_size
+
+
+def get_real_sequence_lengths(data: TrainingInputBatch) -> List[int]:
+    attention_mask = data.get("attention_mask")
+    if attention_mask is None:
+        raise ValueError("Packed-sequence balancing requires attention_mask to be present.")
+    assert isinstance(attention_mask, torch.Tensor), "attention_mask must be a tensor"
+    return attention_mask.sum(dim=-1, dtype=torch.int64).tolist()
+
+
+def compute_effective_sequence_costs(data: TrainingInputBatch, model: str, cfg: SkyRLTrainConfig) -> List[int]:
+    lengths = get_real_sequence_lengths(data)
+    if cfg.trainer.strategy != "megatron":
+        return lengths
+
+    align_size = get_megatron_alignment_size(cfg, model)
+    return [math.ceil(length / align_size) * align_size for length in lengths]
+
+
+def plan_balanced_slot_permutation(costs: List[int], dp_size: int, local_micro_bsz: int) -> List[int]:
+    if len(costs) == 0:
+        return []
+    if dp_size <= 0:
+        raise ValueError(f"dp_size must be positive, got {dp_size}")
+    if local_micro_bsz <= 0:
+        raise ValueError(f"local_micro_bsz must be positive, got {local_micro_bsz}")
+    if len(costs) % dp_size != 0:
+        raise ValueError(f"Batch size {len(costs)} must be divisible by dp_size {dp_size}.")
+
+    chunk_size = len(costs) // dp_size
+    if chunk_size == 0:
+        return []
+
+    slot_capacities: List[int] = [local_micro_bsz] * (chunk_size // local_micro_bsz)
+    if chunk_size % local_micro_bsz != 0:
+        slot_capacities.append(chunk_size % local_micro_bsz)
+
+    slots = [
+        _Slot(rank=rank, slot=slot, remaining_capacity=capacity)
+        for rank in range(dp_size)
+        for slot, capacity in enumerate(slot_capacities)
+    ]
+
+    sorted_indices = sorted(range(len(costs)), key=lambda idx: (-costs[idx], idx))
+    for sample_idx in sorted_indices:
+        candidate_slots = [slot for slot in slots if slot.remaining_capacity > 0]
+        chosen_slot = min(candidate_slots, key=lambda slot: (slot.total_cost, slot.rank, slot.slot))
+        chosen_slot.sample_indices.append(sample_idx)
+        chosen_slot.remaining_capacity -= 1
+        chosen_slot.total_cost += costs[sample_idx]
+
+    permutation: List[int] = []
+    for rank in range(dp_size):
+        rank_slots = [slot for slot in slots if slot.rank == rank]
+        for slot in rank_slots:
+            permutation.extend(slot.sample_indices)
+    return permutation
+
+
+def invert_permutation(permutation: List[int]) -> List[int]:
+    inverse = [0] * len(permutation)
+    for new_idx, old_idx in enumerate(permutation):
+        inverse[old_idx] = new_idx
+    return inverse
+
+
+def compute_slot_costs(
+    costs: List[int],
+    dp_size: int,
+    local_micro_bsz: int,
+    permutation: Optional[List[int]] = None,
+) -> List[int]:
+    if len(costs) == 0:
+        return []
+    if len(costs) % dp_size != 0:
+        raise ValueError(f"Batch size {len(costs)} must be divisible by dp_size {dp_size}.")
+
+    ordered_costs = costs if permutation is None else [costs[idx] for idx in permutation]
+    chunk_size = len(ordered_costs) // dp_size
+    if chunk_size == 0:
+        return []
+
+    slot_costs: List[int] = []
+    for rank in range(dp_size):
+        start = rank * chunk_size
+        end = start + chunk_size
+        rank_costs = ordered_costs[start:end]
+        for slot_start in range(0, chunk_size, local_micro_bsz):
+            slot_costs.append(sum(rank_costs[slot_start : slot_start + local_micro_bsz]))
+    return slot_costs
+
+
+def compute_slot_cost_stats(
+    costs: List[int],
+    dp_size: int,
+    local_micro_bsz: int,
+    permutation: Optional[List[int]] = None,
+) -> dict[str, float]:
+    slot_costs = compute_slot_costs(costs, dp_size, local_micro_bsz, permutation=permutation)
+    if not slot_costs:
+        return {
+            "max_slot_cost": 0.0,
+            "mean_slot_cost": 0.0,
+        }
+    return {
+        "max_slot_cost": float(max(slot_costs)),
+        "mean_slot_cost": float(sum(slot_costs) / len(slot_costs)),
+    }

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -25,6 +25,11 @@ from skyrl.backends.skyrl_train.training_batch import (
     TrainingInputBatch,
     TrainingOutputBatch,
 )
+from skyrl.backends.skyrl_train.utils.packing_balance import (
+    compute_effective_sequence_costs,
+    invert_permutation,
+    plan_balanced_slot_permutation,
+)
 from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
 from skyrl.train.config import SkyRLTrainConfig
 
@@ -152,14 +157,63 @@ class WorkerDispatch:
         for model in self._actor_groups:
             self._gpu_state[model] = GPUState()
 
+    @staticmethod
+    def _reorderable_metadata_keys(batch: TrainingInputBatch | TrainingOutputBatch) -> List[str]:
+        if batch.metadata is None:
+            return []
+        return [key for key in ("uids", "trajectory_ids") if key in batch.metadata]
+
+    def _get_dp_size(self, model: str) -> int:
+        return self._actor_groups[model].actor_infos[0].rank.dp_size
+
+    def _balance_batch_for_dispatch(
+        self,
+        model: str,
+        data: TrainingInputBatch,
+        local_micro_bsz: int,
+    ) -> tuple[TrainingInputBatch, Optional[List[int]]]:
+        if not self.cfg.trainer.use_sample_packing:
+            return data, None
+
+        costs = compute_effective_sequence_costs(data, model, self.cfg)
+        permutation = plan_balanced_slot_permutation(costs, self._get_dp_size(model), local_micro_bsz)
+        if permutation == list(range(len(costs))):
+            return data, None
+
+        balanced = data.take(permutation, metadata_keys=self._reorderable_metadata_keys(data))
+        return balanced, invert_permutation(permutation)
+
+    @staticmethod
+    def _stage_dp_chunks(data: TrainingInputBatch, dp_size: int) -> List[ObjectRef]:
+        assert len(data) % dp_size == 0, f"data batch size must be divisible by dp_size, got {len(data)} and {dp_size}"
+        chunk_size = len(data) // dp_size
+        return [ray.put(chunk) for chunk in data.chunk(chunk_size)]
+
     def forward(self, model: str, data: TrainingInputBatch) -> TrainingOutputBatch:
         """Run inference forward pass. Only loads model (not optimizer)."""
         self._ensure_on_gpu(model, need_optimizer=False, need_model=True)
 
-        refs = self._actor_groups[model].async_run_ray_method("mesh", "forward", data=data)
-        results = ray.get(refs)
+        if not self.cfg.trainer.use_sample_packing:
+            refs = self._actor_groups[model].async_run_ray_method("mesh", "forward", data=data)
+            results = ray.get(refs)
+            output = concatenate_outputs_after_mesh_dispatch(self._actor_groups[model].actor_infos, results)
+            return output
 
+        balanced_data, inverse_permutation = self._balance_batch_for_dispatch(
+            model,
+            data,
+            self.cfg.trainer.micro_forward_batch_size_per_gpu,
+        )
+        chunk_refs = self._stage_dp_chunks(balanced_data, self._get_dp_size(model))
+        refs = MeshDispatch.dispatch_from_staged(
+            self._actor_groups[model].actor_infos,
+            "forward",
+            chunk_refs=chunk_refs,
+        )
+        results = ray.get(refs)
         output = concatenate_outputs_after_mesh_dispatch(self._actor_groups[model].actor_infos, results)
+        if inverse_permutation is not None:
+            output = output.take(inverse_permutation, metadata_keys=self._reorderable_metadata_keys(output))
         return output
 
     def stage_data(self, model: str, data: TrainingInputBatch, mini_batch_size: int) -> List[List[ObjectRef]]:
@@ -178,8 +232,27 @@ class WorkerDispatch:
             ``result[i][dp_rank]`` is the ObjectRef for mini-batch *i*,
             DP rank *dp_rank*.
         """
-        dp_size = self._actor_groups[model].actor_infos[0].rank.dp_size
-        return MeshDispatch.stage_chunks(dp_size, data, mini_batch_size)
+        dp_size = self._get_dp_size(model)
+        if not self.cfg.trainer.use_sample_packing:
+            return MeshDispatch.stage_chunks(dp_size, data, mini_batch_size)
+
+        assert (
+            len(data) % mini_batch_size == 0
+        ), f"data batch size must be divisible by mini_batch_size, got {len(data)} and {mini_batch_size}"
+        assert (
+            mini_batch_size % dp_size == 0
+        ), f"mini_batch_size must be divisible by dp_size, got {mini_batch_size} and {dp_size}"
+
+        all_chunk_refs: List[List[ObjectRef]] = []
+        for start in range(0, len(data), mini_batch_size):
+            mini_batch = data[start : start + mini_batch_size]
+            balanced_mini_batch, _ = self._balance_batch_for_dispatch(
+                model,
+                mini_batch,
+                self.cfg.trainer.micro_train_batch_size_per_gpu,
+            )
+            all_chunk_refs.append(self._stage_dp_chunks(balanced_mini_batch, dp_size))
+        return all_chunk_refs
 
     def forward_backward(
         self,

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -27,7 +27,7 @@ from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import
 from skyrl.backends.skyrl_train.inference_engines.utils import (
     get_sampling_params_for_backend,
 )
-from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
+from skyrl.backends.skyrl_train.training_batch import TensorList, TrainingInputBatch
 from skyrl.backends.skyrl_train.utils import ppo_utils
 from skyrl.backends.skyrl_train.utils.io import io
 from skyrl.backends.skyrl_train.utils.ppo_utils import (
@@ -887,34 +887,46 @@ class RayPPOTrainer:
 
     def pad_batch(self, training_input: TrainingInputBatch) -> TrainingInputBatch:
         """Pad the batch to be divisible by dp size"""
-        import math
-
         dp_size = self.dispatch.get_lcm_dp_size()
         pad_size = math.ceil(training_input.batch_size / dp_size) * dp_size - training_input.batch_size
         new_tensors = {}
+        if training_input.metadata is None:
+            training_input.metadata = {}
         training_input.metadata["pad_size"] = pad_size
         if pad_size == 0:
             return training_input
+
+        pad_source_positions = list(range(training_input.batch_size))
+        if self.cfg.trainer.use_sample_packing and training_input.get("attention_mask") is not None:
+            assert training_input["attention_mask"] is not None
+            real_token_counts = training_input["attention_mask"].sum(dim=-1, dtype=torch.int64).tolist()
+            pad_source_positions = sorted(range(training_input.batch_size), key=lambda idx: (real_token_counts[idx], idx))
+        pad_source_positions = [pad_source_positions[i % len(pad_source_positions)] for i in range(pad_size)]
+
         for key, tensor in training_input.items():
             if tensor is not None:
-                additional_dims = tuple(tensor.shape[1:]) if len(tensor.shape) > 1 else ()
-
-                if key == "is_last_step":
-                    padding_tensor = torch.ones(pad_size, *additional_dims, dtype=tensor.dtype, device=tensor.device)
-                elif key == "loss_mask":
-                    # ensures that padding tensors don't count towards the loss
-                    padding_tensor = torch.zeros(pad_size, *additional_dims, dtype=tensor.dtype, device=tensor.device)
+                if isinstance(tensor, TensorList):
+                    padding_tensor = TensorList([tensor[idx].clone() for idx in pad_source_positions])
+                    new_tensors[key] = TensorList.cat([tensor, padding_tensor])
                 else:
-                    # ensures all padding tensors are in a valid format by cloning `pad_size` from the original input
-                    # `pad_size` is guaranteed to be smaller than batch_size
-                    padding_tensor = tensor[:pad_size].clone()
-                new_tensors[key] = torch.cat([tensor, padding_tensor], dim=0)
+                    additional_dims = tuple(tensor.shape[1:]) if len(tensor.shape) > 1 else ()
+                    if key == "is_last_step":
+                        padding_tensor = torch.ones(pad_size, *additional_dims, dtype=tensor.dtype, device=tensor.device)
+                    elif key == "loss_mask":
+                        # ensures that padding tensors don't count towards the loss
+                        padding_tensor = torch.zeros(
+                            pad_size, *additional_dims, dtype=tensor.dtype, device=tensor.device
+                        )
+                    else:
+                        pad_indices = torch.as_tensor(pad_source_positions, dtype=torch.long, device=tensor.device)
+                        padding_tensor = tensor.index_select(0, pad_indices).clone()
+                    new_tensors[key] = torch.cat([tensor, padding_tensor], dim=0)
 
         new_training_input = TrainingInputBatch(new_tensors)
         new_training_input.metadata = {}
-        new_training_input.metadata["uids"] = training_input.metadata["uids"] + [f"pad{i}" for i in range(pad_size)]
+        new_training_input.metadata["uids"] = list(training_input.metadata["uids"]) + [f"pad{i}" for i in range(pad_size)]
         if "trajectory_ids" in training_input.metadata:
-            new_training_input.metadata["trajectory_ids"] = training_input.metadata["trajectory_ids"] + [
+            new_training_input.metadata["trajectory_ids"] = list(training_input.metadata["trajectory_ids"]) + [
                 f"pad{i}" for i in range(pad_size)
             ]
         for key, value in training_input.metadata.items():

--- a/tests/backends/skyrl_train/test_train_batch.py
+++ b/tests/backends/skyrl_train/test_train_batch.py
@@ -334,6 +334,25 @@ def test_train_batch_get_item():
     assert torch.equal(new_data["b"], torch.tensor([4, 5]))
 
 
+def test_train_batch_take_reorders_tensor_list_and_explicit_metadata():
+    batch = _make_mixed_batch(batch_size=3)
+    batch.metadata = {
+        "uids": np.array(["u0", "u1", "u2"]),
+        "trajectory_ids": ["t0", "t1", "t2"],
+        "response_length": 7,
+    }
+
+    taken = batch.take([2, 0], metadata_keys=["uids", "trajectory_ids"])
+
+    assert taken.batch_size == 2
+    assert torch.equal(taken["sequences"], batch["sequences"][torch.tensor([2, 0])])
+    assert torch.equal(taken["pixel_values"][0], batch["pixel_values"][2])
+    assert torch.equal(taken["pixel_values"][1], batch["pixel_values"][0])
+    assert taken.metadata["uids"].tolist() == ["u2", "u0"]
+    assert taken.metadata["trajectory_ids"] == ["t2", "t0"]
+    assert taken.metadata["response_length"] == 7
+
+
 # ── TensorList unit tests ────────────────────────────────────────────────────
 
 

--- a/tests/backends/skyrl_train/utils/test_packing_balance.py
+++ b/tests/backends/skyrl_train/utils/test_packing_balance.py
@@ -1,0 +1,57 @@
+import torch
+
+from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
+from skyrl.backends.skyrl_train.utils.packing_balance import (
+    compute_effective_sequence_costs,
+    compute_slot_costs,
+    invert_permutation,
+    plan_balanced_slot_permutation,
+)
+from tests.train.util import example_dummy_config
+
+
+def _make_batch_from_lengths(lengths: list[int]) -> TrainingInputBatch:
+    max_len = max(lengths)
+    attention_mask = torch.zeros(len(lengths), max_len, dtype=torch.int64)
+    for row, length in enumerate(lengths):
+        attention_mask[row, :length] = 1
+    return TrainingInputBatch(
+        {
+            "sequences": torch.arange(len(lengths) * max_len, dtype=torch.int64).reshape(len(lengths), max_len),
+            "attention_mask": attention_mask,
+        }
+    )
+
+
+def test_plan_balanced_slot_permutation_is_deterministic_and_invertible():
+    costs = [9, 8, 7, 6, 5, 4, 3, 2]
+    permutation = plan_balanced_slot_permutation(costs, dp_size=2, local_micro_bsz=2)
+
+    assert permutation == plan_balanced_slot_permutation(costs, dp_size=2, local_micro_bsz=2)
+    assert sorted(permutation) == list(range(len(costs)))
+
+    inverse = invert_permutation(permutation)
+    restored = [permutation[inverse_idx] for inverse_idx in inverse]
+    assert restored == list(range(len(costs)))
+
+
+def test_plan_balanced_slot_permutation_reduces_max_slot_cost_on_skewed_case():
+    costs = [100, 99, 98, 97, 4, 3, 2, 1]
+
+    baseline_slot_costs = compute_slot_costs(costs, dp_size=2, local_micro_bsz=2)
+    permutation = plan_balanced_slot_permutation(costs, dp_size=2, local_micro_bsz=2)
+    balanced_slot_costs = compute_slot_costs(costs, dp_size=2, local_micro_bsz=2, permutation=permutation)
+
+    assert max(balanced_slot_costs) < max(baseline_slot_costs)
+
+
+def test_compute_effective_sequence_costs_megatron_uses_alignment():
+    cfg = example_dummy_config()
+    cfg.trainer.strategy = "megatron"
+    cfg.trainer.policy.megatron_config.tensor_model_parallel_size = 4
+    cfg.trainer.policy.megatron_config.context_parallel_size = 2
+
+    batch = _make_batch_from_lengths([1, 16, 17, 31])
+    costs = compute_effective_sequence_costs(batch, model="policy", cfg=cfg)
+
+    assert costs == [16, 16, 32, 32]

--- a/tests/backends/skyrl_train/workers/test_worker_dispatch_packing.py
+++ b/tests/backends/skyrl_train/workers/test_worker_dispatch_packing.py
@@ -1,0 +1,107 @@
+from types import SimpleNamespace
+
+import ray
+import torch
+
+from skyrl.backends.skyrl_train.distributed.dispatch import ActorInfo, MeshDispatch, MeshRank
+from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch, TrainingOutputBatch
+from skyrl.backends.skyrl_train.utils.packing_balance import compute_slot_costs
+from skyrl.backends.skyrl_train.workers.worker_dispatch import WorkerDispatch
+from tests.train.util import example_dummy_config
+
+
+@ray.remote
+class ForwardEchoActor:
+    def forward(self, data: TrainingInputBatch) -> TrainingOutputBatch:
+        output = TrainingOutputBatch({"output": data["sample_ids"].clone()})
+        output.metadata = data.metadata
+        return output
+
+
+def _make_actor_infos(dp_size: int) -> list[ActorInfo]:
+    actors = [ForwardEchoActor.remote() for _ in range(dp_size)]
+    return [
+        ActorInfo(
+            actor,
+            MeshRank(dp=dp_rank, sp=0, tp=0, pp=0, world_size=dp_size, dp_size=dp_size, pp_size=1),
+        )
+        for dp_rank, actor in enumerate(actors)
+    ]
+
+
+def _make_dispatch(cfg, dp_size: int) -> WorkerDispatch:
+    actor_group = SimpleNamespace(
+        actor_infos=_make_actor_infos(dp_size),
+        backload_to_gpu=lambda **kwargs: None,
+        offload_to_cpu=lambda **kwargs: None,
+    )
+    return WorkerDispatch(cfg, policy_actor_group=actor_group)
+
+
+def _make_training_batch(lengths: list[int]) -> TrainingInputBatch:
+    max_len = max(lengths)
+    attention_mask = torch.zeros(len(lengths), max_len, dtype=torch.int64)
+    for row, length in enumerate(lengths):
+        attention_mask[row, :length] = 1
+
+    batch = TrainingInputBatch(
+        {
+            "sample_ids": torch.arange(len(lengths), dtype=torch.int64).unsqueeze(-1),
+            "attention_mask": attention_mask,
+            "sequences": torch.arange(len(lengths) * max_len, dtype=torch.int64).reshape(len(lengths), max_len),
+        }
+    )
+    batch.metadata = {
+        "uids": [f"u{i}" for i in range(len(lengths))],
+        "response_length": 1,
+    }
+    return batch
+
+
+def test_worker_dispatch_stage_data_matches_mesh_dispatch_when_packing_disabled():
+    cfg = example_dummy_config()
+    cfg.trainer.use_sample_packing = False
+    dispatch = _make_dispatch(cfg, dp_size=2)
+
+    data = _make_training_batch([4, 4, 4, 4, 4, 4, 4, 4])
+    expected = MeshDispatch.stage_chunks(2, data, mini_batch_size=4)
+    actual = dispatch.stage_data("policy", data, mini_batch_size=4)
+
+    expected_batches = [[ray.get(ref) for ref in mini_batch] for mini_batch in expected]
+    actual_batches = [[ray.get(ref) for ref in mini_batch] for mini_batch in actual]
+    assert actual_batches == expected_batches
+
+
+def test_worker_dispatch_stage_data_balances_sample_packing():
+    cfg = example_dummy_config()
+    cfg.trainer.use_sample_packing = True
+    cfg.trainer.micro_train_batch_size_per_gpu = 2
+    dispatch = _make_dispatch(cfg, dp_size=2)
+
+    lengths = [100, 99, 98, 97, 4, 3, 2, 1]
+    data = _make_training_batch(lengths)
+    chunk_refs = dispatch.stage_data("policy", data, mini_batch_size=8)
+
+    chunks = [ray.get(ref) for ref in chunk_refs[0]]
+    permutation = torch.cat([chunk["sample_ids"].squeeze(-1) for chunk in chunks]).tolist()
+
+    baseline_slot_costs = compute_slot_costs(lengths, dp_size=2, local_micro_bsz=2)
+    balanced_slot_costs = compute_slot_costs(lengths, dp_size=2, local_micro_bsz=2, permutation=permutation)
+
+    assert sorted(permutation) == list(range(len(lengths)))
+    assert max(balanced_slot_costs) < max(baseline_slot_costs)
+    assert chunks[0].metadata["uids"] == [data.metadata["uids"][idx] for idx in permutation]
+
+
+def test_worker_dispatch_forward_restores_original_order_with_sample_packing():
+    cfg = example_dummy_config()
+    cfg.trainer.use_sample_packing = True
+    cfg.trainer.micro_forward_batch_size_per_gpu = 2
+    dispatch = _make_dispatch(cfg, dp_size=2)
+
+    data = _make_training_batch([100, 99, 98, 97, 4, 3, 2, 1])
+    output = dispatch.forward("policy", data)
+
+    expected_ids = torch.arange(data.batch_size, dtype=torch.int64).unsqueeze(-1)
+    assert torch.equal(output["output"], expected_ids)
+    assert output.metadata["uids"] == data.metadata["uids"]

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -202,6 +202,55 @@ def test_micro_batches_accumulated_initialized():
     assert critic_worker._micro_batches_accumulated == 0
 
 
+def test_pad_batch_prefers_shortest_rows_when_sample_packing_enabled(dummy_config, dummy_generator):
+    dummy_config.trainer.use_sample_packing = True
+
+    trainer = RayPPOTrainer(
+        cfg=dummy_config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=DummyDataset(),
+        inference_engine_client=None,
+        generator=dummy_generator,
+    )
+    trainer.dispatch = MagicMock()
+    trainer.dispatch.get_lcm_dp_size.return_value = 4
+
+    sequences = torch.tensor(
+        [
+            [10, 11, 12, 13, 14],
+            [20, 21, 22, 23, 24],
+            [30, 31, 32, 33, 34],
+        ]
+    )
+    attention_mask = torch.tensor(
+        [
+            [1, 1, 1, 1, 1],
+            [1, 0, 0, 0, 0],
+            [1, 1, 1, 0, 0],
+        ]
+    )
+    loss_mask = torch.ones_like(attention_mask)
+
+    batch = TrainingInputBatch(
+        {
+            "sequences": sequences,
+            "attention_mask": attention_mask,
+            "loss_mask": loss_mask,
+        }
+    )
+    batch.metadata = {"uids": ["u0", "u1", "u2"], "response_length": 2}
+
+    padded = trainer.pad_batch(batch)
+
+    assert padded.batch_size == 4
+    assert torch.equal(padded["sequences"][-1], sequences[1])
+    assert torch.equal(padded["attention_mask"][-1], attention_mask[1])
+    assert torch.equal(padded["loss_mask"][-1], torch.zeros_like(loss_mask[1]))
+    assert padded.metadata["uids"][-1] == "pad0"
+
+
 def test_validate_batch_sizes():
     """Test the validate_batch_sizes function with various configurations to trigger all error cases."""
 


### PR DESCRIPTION
## Summary
- add a deterministic batch reordering primitive to `TensorBatch` for explicit batch-aligned metadata
- add backend-aware packed-sequence balancing utilities with Megatron alignment-aware cost estimation
- balance sample-packed training staging and forward dispatch in `WorkerDispatch`, including output-order restoration
- reduce avoidable padding overhead by choosing the cheapest rows when `pad_batch(...)` needs to clone entries
- add focused tests for reordering, planner behavior, dispatch integration, and padding behavior

## Problem
Closes #204.

Issue #204 points out that sample packing currently happens only after batches have already been split by sample count. That means long sequences can cluster into unlucky DP shards or local micro-batches, which hurts packing efficiency and can create OOM hotspots.

## Approach
- keep the fix local to the current batching path instead of expanding generic dispatch infrastructure
- compute a per-row effective cost before dispatch
- use a stable greedy slot planner to rebalance rows across fixed local micro-batch slots
- preserve user-visible semantics by reordering only after the fully prepared `TrainingInputBatch` exists
- restore original output order for forward-only dispatches

## Testing
- `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 /Users/vuductai/Documents/Projects/SkyRL/.venv/bin/python -m pytest tests/backends/skyrl_train/test_train_batch.py tests/backends/skyrl_train/utils/test_packing_balance.py tests/backends/skyrl_train/distributed/test_dispatch.py tests/backends/skyrl_train/workers/test_worker_dispatch_packing.py tests/train/test_trainer.py -q`
- result: `47 passed, 1 warning in 23.88s`
