### PR TITLE
[skyrl-train] Add GeneratorOutput builders for custom generators

### DIFF
--- a/docs/content/docs/tutorials/agent-integration.mdx
+++ b/docs/content/docs/tutorials/agent-integration.mdx
@@ -49,7 +49,9 @@ There are roughly three ways to integrate an agent, each with different trade-of
 
 ### 1. Re-Tokenization
 
-For each trajectory, record a `chat_history: List[Dict[str, str]]`, re-tokenize it with the chat template, and construct `loss_mask` based on roles. You can use the helper method [`get_response_ids_and_loss_mask_from_messages()`](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/generators/utils.py) to construct `prompt_token_ids`, `response_ids`, and `loss_masks`.
+For each trajectory, record the prompt-side messages and the response-side chat history, then re-tokenize them with the chat template. The easiest way to do this in SkyRL is [`build_generator_output_from_messages()`](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/generators/output_builders.py), which prepares a full `GeneratorOutput` for a batch of message-based trajectories.
+
+If you need lower-level control, you can still use [`get_response_ids_and_loss_mask_from_messages()`](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/generators/utils.py) directly for response-side tokenization and masking.
 
 **Pros:**
 - Simplest approach — works almost out of the box for most agent harnesses. Despite re-tokenization drift, some successful open-source recipes were trained this way.
@@ -71,6 +73,8 @@ This likely involves rewriting your agent to use `/completions` (not `/chat/comp
 
 **Cons:**
 - More implementation work. But likely worth it since doing RL is a significant investment of time and effort.
+
+If your custom generator already has exact prompt and response token IDs, use [`build_generator_output_from_tokenized()`](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/generators/output_builders.py) to assemble the final `GeneratorOutput`.
 
 ### 3. Step-Wise Training
 

--- a/examples/train_integrations/harbor/harbor_generator.py
+++ b/examples/train_integrations/harbor/harbor_generator.py
@@ -2,15 +2,23 @@ import asyncio
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import List, Optional
-from loguru import logger
 from uuid import uuid4
-from skyrl.train.generators.base import GeneratorInterface, GeneratorInput, GeneratorOutput, TrajectoryID
-from skyrl.train.generators.utils import get_rollout_metrics, get_response_ids_and_loss_mask_from_messages
-from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
-from skyrl.backends.skyrl_train.inference_engines.base import ConversationType
-from skyrl.train.utils.rate_limiter import create_rate_limiter
+
+from loguru import logger
+from omegaconf import DictConfig
 from tqdm import tqdm
-from omegaconf import DictConfig, OmegaConf
+
+from skyrl.backends.skyrl_train.inference_engines.base import ConversationType
+from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
+from skyrl.train.generators.base import GeneratorInput, GeneratorInterface, GeneratorOutput, TrajectoryID
+from skyrl.train.generators.output_builders import (
+    RetokenizedTrajectory,
+    TokenizedTrajectory,
+    build_generator_output_from_messages,
+    build_generator_output_from_tokenized,
+)
+from skyrl.train.generators.utils import get_rollout_metrics
+from skyrl.train.utils.rate_limiter import create_rate_limiter
 from harbor.trial.trial import Trial
 from harbor.models.trial.config import TrialConfig
 
@@ -128,17 +136,19 @@ class HarborGenerator(GeneratorInterface):
             progress.close()
         all_outputs, rollout_metrics = self._mask_failed_instances_and_compute_metrics(all_outputs)
 
-        generator_output: GeneratorOutput = {
-            "prompt_token_ids": [output.prompt_ids for output in all_outputs],
-            "response_ids": [output.response_ids for output in all_outputs],
-            "rewards": [output.reward for output in all_outputs],
-            "loss_masks": [output.loss_mask for output in all_outputs],
-            "stop_reasons": [output.stop_reason for output in all_outputs],
-            "rollout_metrics": rollout_metrics,
-            "rollout_logprobs": None,
-        }
-
-        return generator_output
+        return build_generator_output_from_tokenized(
+            [
+                TokenizedTrajectory(
+                    prompt_token_ids=output.prompt_ids,
+                    response_ids=output.response_ids,
+                    loss_mask=output.loss_mask,
+                    reward=output.reward,
+                    stop_reason=output.stop_reason,
+                )
+                for output in all_outputs
+            ],
+            rollout_metrics=rollout_metrics,
+        )
 
     @staticmethod
     def _mask_failed_instances_and_compute_metrics(
@@ -302,21 +312,28 @@ class HarborGenerator(GeneratorInterface):
         # Use the first message as the prompt. We assume to be no systems messages.
         assert chat_history[0]["role"] == "user", "The first message should be a user message"
         prompt = [chat_history[0]]
-        prompt_ids = self.tokenizer.apply_chat_template(
-            prompt,
-            add_generation_prompt=False,  # the message below will add it themselves
-            return_dict=False,
-            tokenize=True,
-            chat_template=self.custom_chat_template_content,
-        )
-        initial_prompt_length = len(prompt_ids)
 
         # Process response messages (everything after the first message)
         response_messages = chat_history[1:]
         assistant_logprobs = getattr(results.agent_result, "output_logprobs", None)
-        response_ids, loss_mask, rollout_logprobs = get_response_ids_and_loss_mask_from_messages(
-            response_messages, self.tokenizer, assistant_logprobs, chat_template=self.custom_chat_template_content
+        generated_output = build_generator_output_from_messages(
+            [
+                RetokenizedTrajectory(
+                    prompt_messages=prompt,
+                    response_messages=response_messages,
+                    reward=reward,
+                    assistant_message_logprobs=assistant_logprobs,
+                )
+            ],
+            self.tokenizer,
+            chat_template=self.custom_chat_template_content,
+            rollout_metrics={},
+            validate=False,
         )
+        prompt_ids = generated_output["prompt_token_ids"][0]
+        response_ids = generated_output["response_ids"][0]
+        loss_mask = generated_output["loss_masks"][0]
+        initial_prompt_length = len(prompt_ids)
 
         # Determine stop reason
         max_response_tokens = max(0, self.max_seq_len - initial_prompt_length)

--- a/skyrl/train/generators/__init__.py
+++ b/skyrl/train/generators/__init__.py
@@ -1,4 +1,52 @@
-from .base import GeneratorInput, GeneratorInterface, GeneratorOutput
-from .skyrl_gym_generator import SkyRLGymGenerator
+from typing import TYPE_CHECKING
 
-__all__ = ["GeneratorInterface", "GeneratorInput", "GeneratorOutput", "SkyRLGymGenerator"]
+from .base import GeneratorInput, GeneratorInterface, GeneratorOutput
+
+if TYPE_CHECKING:
+    from .output_builders import (
+        RetokenizedTrajectory,
+        TokenizedTrajectory,
+        build_generator_output_from_messages,
+        build_generator_output_from_tokenized,
+    )
+    from .skyrl_gym_generator import SkyRLGymGenerator
+
+__all__ = [
+    "GeneratorInterface",
+    "GeneratorInput",
+    "GeneratorOutput",
+    "RetokenizedTrajectory",
+    "TokenizedTrajectory",
+    "build_generator_output_from_messages",
+    "build_generator_output_from_tokenized",
+    "SkyRLGymGenerator",
+]
+
+
+def __getattr__(name: str):
+    if name == "SkyRLGymGenerator":
+        from .skyrl_gym_generator import SkyRLGymGenerator
+
+        return SkyRLGymGenerator
+
+    if name in {
+        "RetokenizedTrajectory",
+        "TokenizedTrajectory",
+        "build_generator_output_from_messages",
+        "build_generator_output_from_tokenized",
+    }:
+        from .output_builders import (
+            RetokenizedTrajectory,
+            TokenizedTrajectory,
+            build_generator_output_from_messages,
+            build_generator_output_from_tokenized,
+        )
+
+        return {
+            "RetokenizedTrajectory": RetokenizedTrajectory,
+            "TokenizedTrajectory": TokenizedTrajectory,
+            "build_generator_output_from_messages": build_generator_output_from_messages,
+            "build_generator_output_from_tokenized": build_generator_output_from_tokenized,
+        }[name]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/skyrl/train/generators/output_builders.py
+++ b/skyrl/train/generators/output_builders.py
@@ -1,0 +1,275 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, TypeVar, Union
+
+from skyrl.backends.skyrl_train.inference_engines.base import ConversationType
+from skyrl.train.generators.base import GeneratorOutput
+from skyrl.train.generators.utils import (
+    get_response_ids_and_loss_mask_from_messages,
+    get_rollout_metrics,
+)
+
+RewardType = Union[float, List[float]]
+
+
+@dataclass
+class RetokenizedTrajectory:
+    prompt_messages: ConversationType
+    response_messages: ConversationType
+    reward: RewardType
+    stop_reason: Optional[str] = None
+    assistant_message_logprobs: Optional[List[List[float]]] = None
+    env_class: Optional[str] = None
+    env_metrics: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class TokenizedTrajectory:
+    prompt_token_ids: List[int]
+    response_ids: List[int]
+    loss_mask: List[int]
+    reward: RewardType
+    stop_reason: Optional[str] = None
+    rollout_logprobs: Optional[List[float]] = None
+    env_class: Optional[str] = None
+    env_metrics: Optional[Dict[str, Any]] = None
+    rollout_expert_indices: Optional[List[List[List[int]]]] = None
+
+
+T = TypeVar("T")
+
+
+def _normalize_optional_values(name: str, values: Sequence[Optional[T]]) -> Optional[List[T]]:
+    has_values = [value is not None for value in values]
+    if any(has_values) and not all(has_values):
+        raise ValueError(f"`{name}` must be provided for all trajectories or omitted for all trajectories")
+    if not any(has_values):
+        return None
+    return [value for value in values if value is not None]
+
+
+def _validate_rollout_expert_indices(
+    prompt_token_ids: Sequence[List[int]],
+    response_ids: Sequence[List[int]],
+    rollout_expert_indices: Optional[List[List[List[List[int]]]]],
+) -> None:
+    if rollout_expert_indices is None:
+        return
+    for i, (prompt_ids, cur_response_ids, cur_expert_indices) in enumerate(
+        zip(prompt_token_ids, response_ids, rollout_expert_indices)
+    ):
+        expected_seq_len = len(prompt_ids) + len(cur_response_ids)
+        if len(cur_expert_indices) != expected_seq_len:
+            raise ValueError(
+                "Expected `rollout_expert_indices` to cover the full prompt + response sequence for every "
+                f"trajectory, but sample {i} had sequence length {len(cur_expert_indices)} and expected "
+                f"{expected_seq_len}"
+            )
+
+
+def _validate_generator_output(
+    *,
+    prompt_token_ids: Sequence[List[int]],
+    response_ids: Sequence[List[int]],
+    rewards: Sequence[RewardType],
+    loss_masks: Sequence[List[int]],
+    rollout_logprobs: Optional[Sequence[List[float]]],
+) -> None:
+    if len(response_ids) <= 0:
+        raise ValueError("No outputs generated")
+
+    if len(prompt_token_ids) != len(response_ids):
+        raise ValueError(
+            "Mismatch between the number of prompts and responses in GeneratorOutput: "
+            f"{len(prompt_token_ids)} prompt sequences vs {len(response_ids)} response sequences"
+        )
+
+    if len(loss_masks) != len(response_ids):
+        raise ValueError(
+            "Mismatch between the number of response IDs and loss masks in GeneratorOutput: "
+            f"{len(response_ids)} responses vs {len(loss_masks)} loss masks"
+        )
+
+    if len(rewards) != len(response_ids):
+        raise ValueError(
+            "Mismatch between the number of response IDs and rewards in GeneratorOutput: "
+            f"{len(response_ids)} responses vs {len(rewards)} rewards"
+        )
+
+    if rollout_logprobs is not None and len(rollout_logprobs) != len(response_ids):
+        raise ValueError(
+            "Mismatch between the number of response IDs and rollout logprob lists in GeneratorOutput: "
+            f"{len(response_ids)} responses vs {len(rollout_logprobs)} rollout logprob lists"
+        )
+
+    rewards_are_token_level = [isinstance(reward, list) for reward in rewards]
+    if any(rewards_are_token_level) and not all(rewards_are_token_level):
+        raise ValueError("`rewards` must be either all response-level scalars or all token-level reward lists")
+
+    for i, cur_response_ids in enumerate(response_ids):
+        if len(cur_response_ids) != len(loss_masks[i]):
+            raise ValueError(
+                f"Response ids and loss masks must have the same length for sample {i}, "
+                f"got {len(cur_response_ids)} and {len(loss_masks[i])}"
+            )
+
+        if rewards_are_token_level[i] and len(cur_response_ids) != len(rewards[i]):
+            raise ValueError(
+                f"Token-level rewards must match response length for sample {i}, "
+                f"got {len(rewards[i])} rewards and {len(cur_response_ids)} response ids"
+            )
+
+        if rollout_logprobs is not None and len(cur_response_ids) != len(rollout_logprobs[i]):
+            raise ValueError(
+                f"Rollout logprobs must match response length for sample {i}, "
+                f"got {len(rollout_logprobs[i])} rollout logprobs and {len(cur_response_ids)} response ids"
+            )
+
+
+def _finalize_generator_output(
+    *,
+    prompt_token_ids: List[List[int]],
+    response_ids: List[List[int]],
+    rewards: List[RewardType],
+    loss_masks: List[List[int]],
+    stop_reasons: Sequence[Optional[str]],
+    rollout_logprobs: Sequence[Optional[List[float]]],
+    env_classes: Sequence[Optional[str]],
+    env_metrics: Sequence[Optional[Dict[str, Any]]],
+    rollout_metrics: Optional[Dict[str, Any]] = None,
+    rollout_expert_indices: Optional[Sequence[Optional[List[List[List[int]]]]]] = None,
+    validate: bool = True,
+) -> GeneratorOutput:
+    if not prompt_token_ids:
+        raise ValueError("Expected at least one trajectory when building GeneratorOutput")
+
+    normalized_stop_reasons = _normalize_optional_values("stop_reasons", stop_reasons)
+    normalized_rollout_logprobs = _normalize_optional_values("rollout_logprobs", rollout_logprobs)
+    normalized_env_classes = _normalize_optional_values("env_class", env_classes)
+    normalized_env_metrics = _normalize_optional_values("env_metrics", env_metrics)
+    normalized_rollout_expert_indices = (
+        _normalize_optional_values("rollout_expert_indices", rollout_expert_indices)
+        if rollout_expert_indices is not None
+        else None
+    )
+
+    if normalized_env_metrics is not None and normalized_env_classes is None:
+        raise ValueError("`env_class` must be provided for all trajectories when `env_metrics` are provided")
+
+    _validate_rollout_expert_indices(prompt_token_ids, response_ids, normalized_rollout_expert_indices)
+
+    if rollout_metrics is None:
+        rollout_metrics = get_rollout_metrics(
+            response_ids,
+            rewards,
+            env_metrics=normalized_env_metrics,
+            env_classes=normalized_env_classes,
+        )
+
+    generator_output: GeneratorOutput = {
+        "prompt_token_ids": prompt_token_ids,
+        "response_ids": response_ids,
+        "rewards": rewards,
+        "loss_masks": loss_masks,
+        "stop_reasons": normalized_stop_reasons,
+        "rollout_metrics": rollout_metrics,
+        "rollout_logprobs": normalized_rollout_logprobs,
+        "rollout_expert_indices": normalized_rollout_expert_indices,
+        "trajectory_ids": None,
+        "is_last_step": None,
+    }
+
+    if validate:
+        _validate_generator_output(
+            prompt_token_ids=prompt_token_ids,
+            response_ids=response_ids,
+            rewards=rewards,
+            loss_masks=loss_masks,
+            rollout_logprobs=normalized_rollout_logprobs,
+        )
+
+    return generator_output
+
+
+def build_generator_output_from_messages(
+    trajectories: Sequence[RetokenizedTrajectory],
+    tokenizer,
+    *,
+    chat_template: Optional[str] = None,
+    rollout_metrics: Optional[Dict[str, Any]] = None,
+    validate: bool = True,
+) -> GeneratorOutput:
+    prompt_token_ids: List[List[int]] = []
+    response_ids: List[List[int]] = []
+    rewards: List[RewardType] = []
+    loss_masks: List[List[int]] = []
+    stop_reasons: List[Optional[str]] = []
+    rollout_logprobs: List[Optional[List[float]]] = []
+    env_classes: List[Optional[str]] = []
+    env_metrics: List[Optional[Dict[str, Any]]] = []
+
+    for trajectory in trajectories:
+        cur_prompt_token_ids = tokenizer.apply_chat_template(
+            trajectory.prompt_messages,
+            add_generation_prompt=False,
+            tokenize=True,
+            return_dict=False,
+            chat_template=chat_template,
+        )
+        cur_response_ids, cur_loss_mask, cur_rollout_logprobs = get_response_ids_and_loss_mask_from_messages(
+            trajectory.response_messages,
+            tokenizer,
+            assistant_logprobs=trajectory.assistant_message_logprobs,
+            chat_template=chat_template,
+        )
+        prompt_token_ids.append(cur_prompt_token_ids)
+        response_ids.append(cur_response_ids)
+        rewards.append(trajectory.reward)
+        loss_masks.append(cur_loss_mask)
+        stop_reasons.append(trajectory.stop_reason)
+        rollout_logprobs.append(cur_rollout_logprobs)
+        env_classes.append(trajectory.env_class)
+        env_metrics.append(trajectory.env_metrics)
+
+    return _finalize_generator_output(
+        prompt_token_ids=prompt_token_ids,
+        response_ids=response_ids,
+        rewards=rewards,
+        loss_masks=loss_masks,
+        stop_reasons=stop_reasons,
+        rollout_logprobs=rollout_logprobs,
+        env_classes=env_classes,
+        env_metrics=env_metrics,
+        rollout_metrics=rollout_metrics,
+        validate=validate,
+    )
+
+
+def build_generator_output_from_tokenized(
+    trajectories: Sequence[TokenizedTrajectory],
+    *,
+    rollout_metrics: Optional[Dict[str, Any]] = None,
+    validate: bool = True,
+) -> GeneratorOutput:
+    prompt_token_ids = [trajectory.prompt_token_ids for trajectory in trajectories]
+    response_ids = [trajectory.response_ids for trajectory in trajectories]
+    rewards = [trajectory.reward for trajectory in trajectories]
+    loss_masks = [trajectory.loss_mask for trajectory in trajectories]
+    stop_reasons = [trajectory.stop_reason for trajectory in trajectories]
+    rollout_logprobs = [trajectory.rollout_logprobs for trajectory in trajectories]
+    env_classes = [trajectory.env_class for trajectory in trajectories]
+    env_metrics = [trajectory.env_metrics for trajectory in trajectories]
+    rollout_expert_indices = [trajectory.rollout_expert_indices for trajectory in trajectories]
+
+    return _finalize_generator_output(
+        prompt_token_ids=prompt_token_ids,
+        response_ids=response_ids,
+        rewards=rewards,
+        loss_masks=loss_masks,
+        stop_reasons=stop_reasons,
+        rollout_logprobs=rollout_logprobs,
+        env_classes=env_classes,
+        env_metrics=env_metrics,
+        rollout_metrics=rollout_metrics,
+        rollout_expert_indices=rollout_expert_indices,
+        validate=validate,
+    )

--- a/tests/train/generators/test_output_builders.py
+++ b/tests/train/generators/test_output_builders.py
@@ -1,0 +1,265 @@
+"""
+uv run --extra dev --extra skyrl-train --isolated pytest tests/train/generators/test_output_builders.py
+"""
+
+import pytest
+
+from skyrl.train.generators.output_builders import (
+    RetokenizedTrajectory,
+    TokenizedTrajectory,
+    build_generator_output_from_messages,
+    build_generator_output_from_tokenized,
+)
+from skyrl.train.generators.utils import (
+    encode_messages_subset,
+    get_generation_prompt_ids,
+    get_response_ids_and_loss_mask_from_messages,
+)
+
+dummy_chat_template = (
+    "{%- for message in messages %}"
+    "{%- if message['role'] == 'user' %}"
+    "<USER>{{ message['content'] }}</s>\n"
+    "{%- elif message['role'] == 'assistant' %}"
+    "<ASSISTANT>{{ message['content'] }}</s>\n"
+    "{%- elif message['role'] == 'system' %}"
+    "<SYSTEM>{{ message['content'] }}</s>\n"
+    "{%- endif %}"
+    "{%- endfor %}"
+    "{%- if add_generation_prompt %}"
+    "<ASSISTANT>"
+    "{%- endif %}"
+)
+
+
+class FakeTokenizer:
+    eos_token_id = 0
+
+    def apply_chat_template(
+        self,
+        messages,
+        add_generation_prompt=False,
+        tokenize=True,
+        return_dict=False,
+        chat_template=None,
+    ):
+        role_prefixes = {
+            "system": [101],
+            "user": [102],
+            "assistant": [103],
+        }
+        token_ids = []
+        for message in messages:
+            token_ids.extend(role_prefixes[message["role"]])
+            token_ids.extend(ord(char) + 200 for char in message["content"])
+            token_ids.append(self.eos_token_id)
+        if add_generation_prompt:
+            token_ids.extend(role_prefixes["assistant"])
+        return token_ids
+
+
+@pytest.fixture
+def tokenizer_w_dummy_template():
+    return FakeTokenizer()
+
+
+def _assistant_generated_token_count(message, tokenizer, chat_template):
+    generation_prompt_ids = get_generation_prompt_ids(tokenizer, chat_template=chat_template)
+    cur_token_ids = encode_messages_subset([message], tokenizer, chat_template=chat_template)
+    if tokenizer.eos_token_id in cur_token_ids:
+        last_eos_idx = len(cur_token_ids) - 1 - cur_token_ids[::-1].index(tokenizer.eos_token_id)
+        return last_eos_idx + 1 - len(generation_prompt_ids)
+    return len(cur_token_ids) - len(generation_prompt_ids)
+
+
+def test_build_generator_output_from_messages_matches_low_level_helper(tokenizer_w_dummy_template):
+    prompt_messages = [{"role": "user", "content": "What is 2 + 2?"}]
+    response_messages = [
+        {"role": "assistant", "content": "The answer is 4."},
+        {"role": "user", "content": "Explain why."},
+        {"role": "assistant", "content": "Because 2 + 2 sums to 4."},
+    ]
+
+    output = build_generator_output_from_messages(
+        [
+            RetokenizedTrajectory(
+                prompt_messages=prompt_messages,
+                response_messages=response_messages,
+                reward=1.0,
+            )
+        ],
+        tokenizer_w_dummy_template,
+        chat_template=dummy_chat_template,
+    )
+
+    expected_prompt_token_ids = tokenizer_w_dummy_template.apply_chat_template(
+        prompt_messages,
+        add_generation_prompt=False,
+        tokenize=True,
+        return_dict=False,
+        chat_template=dummy_chat_template,
+    )
+    expected_response_ids, expected_loss_mask, expected_rollout_logprobs = get_response_ids_and_loss_mask_from_messages(
+        response_messages,
+        tokenizer_w_dummy_template,
+        chat_template=dummy_chat_template,
+    )
+
+    assert output["prompt_token_ids"] == [expected_prompt_token_ids]
+    assert output["response_ids"] == [expected_response_ids]
+    assert output["loss_masks"] == [expected_loss_mask]
+    assert output["rewards"] == [1.0]
+    assert output["stop_reasons"] is None
+    assert output["rollout_logprobs"] == expected_rollout_logprobs
+    assert output["rollout_metrics"] is not None
+
+
+def test_build_generator_output_from_messages_supports_assistant_message_logprobs(tokenizer_w_dummy_template):
+    prompt_messages = [{"role": "user", "content": "Say hi."}]
+    response_messages = [
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "user", "content": "Say bye."},
+        {"role": "assistant", "content": "Bye now!"},
+    ]
+    assistant_messages = [message for message in response_messages if message["role"] == "assistant"]
+    assistant_logprobs = [
+        [-(i + 1) / 10.0 for i in range(_assistant_generated_token_count(message, tokenizer_w_dummy_template, dummy_chat_template))]
+        for message in assistant_messages
+    ]
+
+    output = build_generator_output_from_messages(
+        [
+            RetokenizedTrajectory(
+                prompt_messages=prompt_messages,
+                response_messages=response_messages,
+                reward=1.0,
+                assistant_message_logprobs=assistant_logprobs,
+            )
+        ],
+        tokenizer_w_dummy_template,
+        chat_template=dummy_chat_template,
+    )
+
+    _, _, expected_rollout_logprobs = get_response_ids_and_loss_mask_from_messages(
+        response_messages,
+        tokenizer_w_dummy_template,
+        assistant_logprobs=assistant_logprobs,
+        chat_template=dummy_chat_template,
+    )
+
+    assert output["rollout_logprobs"] == [expected_rollout_logprobs]
+
+
+def test_build_generator_output_from_tokenized_computes_metrics_and_preserves_optional_fields():
+    trajectories = [
+        TokenizedTrajectory(
+            prompt_token_ids=[1, 2],
+            response_ids=[3, 4],
+            loss_mask=[1, 1],
+            reward=1.0,
+            stop_reason="complete",
+            rollout_logprobs=[-0.1, -0.2],
+            rollout_expert_indices=[[[0]], [[1]], [[2]], [[3]]],
+        ),
+        TokenizedTrajectory(
+            prompt_token_ids=[5],
+            response_ids=[6, 7, 8],
+            loss_mask=[1, 0, 1],
+            reward=0.5,
+            stop_reason="length",
+            rollout_logprobs=[-0.3, -0.4, -0.5],
+            rollout_expert_indices=[[[4]], [[5]], [[6]], [[7]]],
+        ),
+    ]
+
+    output = build_generator_output_from_tokenized(trajectories)
+
+    assert output["prompt_token_ids"] == [[1, 2], [5]]
+    assert output["response_ids"] == [[3, 4], [6, 7, 8]]
+    assert output["loss_masks"] == [[1, 1], [1, 0, 1]]
+    assert output["stop_reasons"] == ["complete", "length"]
+    assert output["rollout_logprobs"] == [[-0.1, -0.2], [-0.3, -0.4, -0.5]]
+    assert output["rollout_expert_indices"] == [
+        [[[0]], [[1]], [[2]], [[3]]],
+        [[[4]], [[5]], [[6]], [[7]]],
+    ]
+    assert output["rollout_metrics"] is not None
+    assert "generate/avg_num_tokens" in output["rollout_metrics"]
+
+
+def test_build_generator_output_from_tokenized_preserves_token_level_rewards():
+    output = build_generator_output_from_tokenized(
+        [
+            TokenizedTrajectory(
+                prompt_token_ids=[1],
+                response_ids=[2, 3],
+                loss_mask=[1, 1],
+                reward=[0.0, 1.0],
+            )
+        ]
+    )
+
+    assert output["rewards"] == [[0.0, 1.0]]
+
+
+def test_build_generator_output_from_tokenized_respects_rollout_metrics_override():
+    output = build_generator_output_from_tokenized(
+        [
+            TokenizedTrajectory(
+                prompt_token_ids=[1],
+                response_ids=[2],
+                loss_mask=[1],
+                reward=1.0,
+            )
+        ],
+        rollout_metrics={"custom/metric": 123.0},
+    )
+
+    assert output["rollout_metrics"] == {"custom/metric": 123.0}
+
+
+def test_build_generator_output_from_tokenized_requires_all_or_none_stop_reasons():
+    with pytest.raises(ValueError, match="stop_reasons"):
+        build_generator_output_from_tokenized(
+            [
+                TokenizedTrajectory(prompt_token_ids=[1], response_ids=[2], loss_mask=[1], reward=1.0),
+                TokenizedTrajectory(
+                    prompt_token_ids=[3],
+                    response_ids=[4],
+                    loss_mask=[1],
+                    reward=0.0,
+                    stop_reason="complete",
+                ),
+            ]
+        )
+
+
+def test_build_generator_output_from_tokenized_requires_all_or_none_rollout_logprobs():
+    with pytest.raises(ValueError, match="rollout_logprobs"):
+        build_generator_output_from_tokenized(
+            [
+                TokenizedTrajectory(
+                    prompt_token_ids=[1],
+                    response_ids=[2],
+                    loss_mask=[1],
+                    reward=1.0,
+                    rollout_logprobs=[-0.1],
+                ),
+                TokenizedTrajectory(prompt_token_ids=[3], response_ids=[4], loss_mask=[1], reward=0.0),
+            ]
+        )
+
+
+def test_build_generator_output_from_tokenized_validates_rollout_expert_index_length():
+    with pytest.raises(ValueError, match="rollout_expert_indices"):
+        build_generator_output_from_tokenized(
+            [
+                TokenizedTrajectory(
+                    prompt_token_ids=[1, 2],
+                    response_ids=[3, 4],
+                    loss_mask=[1, 1],
+                    reward=1.0,
+                    rollout_expert_indices=[[[0]], [[1]], [[2]]],
+                )
+            ]
+        )


### PR DESCRIPTION
## Summary

Refs #253.

This draft PR adds a small `GeneratorOutput` builder layer for custom generators so integrations no longer need to hand-roll the final output dict shape themselves.

The implementation stays intentionally focused:

- adds one new builder module for custom generator outputs
- supports both message-based re-tokenization and exact-token inputs
- migrates Harbor as the first in-repo consumer
- updates the custom generator docs to point authors at the new builders
- adds focused unit coverage for the new builder behavior

## What Changed

### New builder module

Added [`skyrl/train/generators/output_builders.py`](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/generators/output_builders.py) with:

- `RetokenizedTrajectory`
- `TokenizedTrajectory`
- `build_generator_output_from_messages(...)`
- `build_generator_output_from_tokenized(...)`

The builders handle:

- assembling `prompt_token_ids`, `response_ids`, `rewards`, and `loss_masks`
- optional `stop_reasons`, `rollout_logprobs`, and `rollout_expert_indices`
- `rollout_metrics` computation when not overridden
- local validation of the constructed `GeneratorOutput`

### Package exports

Updated `skyrl.train.generators.__init__` to expose the new builder API.

I used lazy exports so importing the builder symbols does not eagerly pull in unrelated generator dependencies.

### Harbor adoption

Updated `examples/train_integrations/harbor/harbor_generator.py` to use the new builders:

- message-based builder when Harbor converts chat history into tokenized prompt/response fields
- tokenized builder when Harbor assembles the final batch output

This keeps Harbor's existing timeout/error masking and rollout-metric behavior intact while removing the ad hoc `GeneratorOutput` assembly.

### Docs

Updated `docs/content/docs/tutorials/agent-integration.mdx` to point custom generator authors at:

- `build_generator_output_from_messages(...)` for message-based integrations
- `build_generator_output_from_tokenized(...)` for exact-token integrations

## Verification

Focused verification completed in the isolated worktree:

- `.venv/bin/python -m py_compile skyrl/train/generators/output_builders.py skyrl/train/generators/__init__.py examples/train_integrations/harbor/harbor_generator.py tests/train/generators/test_output_builders.py`
- `.venv/bin/python -c "from skyrl.train.generators import build_generator_output_from_messages, build_generator_output_from_tokenized; print('lazy builder exports ok')"`
- `.venv/bin/python -m pytest tests/train/generators/test_output_builders.py -q --confcutdir=tests/train/generators`

Test result:

- `8 passed`

## Scope / Non-goals

This PR does **not** try to solve the broader custom generator contract cleanup in #1156.

It also intentionally does **not**:

- rewrite `SkyRLGymGenerator` around the new builders
- add public step-wise builder APIs yet
- fix the upstream Verifiers compatibility drift tracked in #854
- change stop-reason semantics or move generator-specific policies into trainer-wide postprocessing

## Notes for Reviewers

One implementation detail worth calling out:

- I kept builder validation local to the new module instead of importing the trainer-side validator directly. This avoids pulling heavier training/runtime dependencies into a lightweight generator utility.

This is a draft because I wanted to land the narrow issue #253 builder layer first and keep broader follow-up scope separate.
