### PR TITLE
[tinker] Validate skyrl-train backend config at startup and reject unsupported overrides

### DIFF
--- a/docs/content/docs/tinker/configuration.mdx
+++ b/docs/content/docs/tinker/configuration.mdx
@@ -16,7 +16,9 @@ uv run --extra tinker --extra fsdp -m skyrl.tinker.api \
     --backend-config '{"trainer.placement.policy_num_gpus_per_node": 4, "generator.inference_engine.num_engines": 4}'
 ```
 
-Any field in the [SkyRL-Train config](https://docs.skyrl.ai/docs/configuration/config) can be overridden this way (see the [default config YAML](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/config/ppo_base_config.yaml) for all available keys and defaults). The most commonly used options are listed below.
+The Tinker `fsdp` and `megatron` backends validate this dictionary at startup. Only the subset of SkyRL-Train config that is meaningful for Tinker's request-driven execution model is supported here. Keys that are request-owned, server-forced, or irrelevant to Tinker's lifecycle now fail fast instead of being accepted as silent no-ops.
+
+The most commonly used supported options are listed below.
 
 ### GPU and Parallelism
 
@@ -42,9 +44,27 @@ For large models that don't fit on a single GPU for inference, increase `generat
 --backend-config '{"trainer.placement.policy_num_gpus_per_node": 4, "generator.inference_engine.num_engines": 2, "generator.inference_engine.tensor_parallel_size": 2}'
 ```
 
+## Rejected Keys
+
+The following categories are rejected from `--backend-config` for Tinker's `fsdp` and `megatron` backends:
+
+- Request-owned values such as `trainer.policy.optimizer_config.lr` and `trainer.algorithm.policy_loss_type`
+- Server-forced values such as `trainer.policy.model.path`, `trainer.strategy`, `trainer.policy.optimizer_config.scheduler`, and `trainer.policy.optimizer_config.num_warmup_steps`
+- Tinker-irrelevant trainer-loop settings such as `data.*`, `trainer.ref.*`, `trainer.critic.*`, `trainer.eval_interval`, and `trainer.ckpt_interval`
+
+Examples:
+
+```bash
+# Rejected: learning rate is supplied per optim_step request
+--backend-config '{"trainer.policy.optimizer_config.lr": 1e-5}'
+
+# Rejected: loss type is supplied per forward_backward request
+--backend-config '{"trainer.algorithm.policy_loss_type": "ppo"}'
+```
+
 ## LoRA
 
-LoRA is configured from the **client side**, not the server. When creating a model via the Tinker SDK, pass a `lora_config` with the desired rank. For example, in tinker-cookbook recipes:
+LoRA rank and alpha are configured from the **client side**, not the server. When creating a model via the Tinker SDK, pass a `lora_config` with the desired rank. For example, in tinker-cookbook recipes:
 
 ```bash
 # LoRA training (default in most recipes)
@@ -54,8 +74,8 @@ python -m tinker_cookbook.recipes.sl_loop ... lora_rank=32
 python -m tinker_cookbook.recipes.sl_loop ... lora_rank=0
 ```
 
-No server-side configuration is needed to switch between LoRA and full-parameter fine-tuning.
+No server-side configuration is needed to switch between LoRA and full-parameter fine-tuning. Server-side LoRA options such as dropout or target modules may still be configured through `--backend-config`, but `trainer.policy.model.lora.rank` and `trainer.policy.model.lora.alpha` are rejected because those values come from `create_model(..., lora_config=...)`.
 
 ## Full Config Reference
 
-For the complete list of configuration options, see the [SkyRL-Train configuration docs](https://docs.skyrl.ai/docs/configuration/config) and the [default config YAML](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/config/ppo_base_config.yaml).
+For field semantics on the supported subset, see the [SkyRL-Train configuration docs](https://docs.skyrl.ai/docs/configuration/config) and the [default config YAML](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/config/ppo_base_config.yaml). Not every SkyRL-Train field is valid in Tinker's `--backend-config`.

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -28,6 +28,7 @@ from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
 from skyrl.backends.skyrl_train.workers.worker_dispatch import WorkerDispatch
 from skyrl.env_vars import SKYRL_RAY_PG_TIMEOUT_IN_S
 from skyrl.tinker import types
+from skyrl.tinker.skyrl_train_backend_config import build_tinker_skyrl_train_config
 from skyrl.train.config import SkyRLTrainConfig, get_config_as_yaml_str
 from skyrl.train.utils.utils import (
     ResolvedPlacementGroup,
@@ -68,31 +69,17 @@ def _build_skyrl_train_config(
         lora_config: LoRA configuration if using LoRA
     """
 
-    # Apply user overrides from backend_config
-    user_overrides = dict(overrides.model_extra)
-    # override base model path
-    # NOTE: It is better to add this as a part of the CLI overrides since we have post_init logic
-    # that will resolve other attributes such as the reference model path based on the policy model path.
-    user_overrides["trainer.policy.model.path"] = base_model
-    cfg = SkyRLTrainConfig.from_cli_overrides(user_overrides)
+    if isinstance(overrides, FSDPBackendOverrides) and overrides.strategy != "fsdp2":
+        raise ValueError("`strategy` is fixed by `--backend fsdp` and cannot be overridden.")
+    if isinstance(overrides, MegatronBackendOverrides) and overrides.strategy != "megatron":
+        raise ValueError("`strategy` is fixed by `--backend megatron` and cannot be overridden.")
 
-    # Disable scheduler - Tinker manages learning rate externally via set_lr()
-    cfg.trainer.policy.optimizer_config.scheduler = "constant_with_warmup"
-    cfg.trainer.policy.optimizer_config.num_warmup_steps = 0
-
-    # TODO(tyler): Support KL Loss
-    cfg.trainer.algorithm.use_kl_loss = False
-
-    assert overrides.strategy in (
-        "fsdp2",
-        "megatron",
-    ), "Only fsdp and megatron are supported for SkyRL-Train backend"
-    cfg.trainer.strategy = overrides.strategy
-
-    # Apply LoRA configuration
-    if lora_config is not None and lora_config.rank > 0:
-        cfg.trainer.policy.model.lora.rank = lora_config.rank
-        cfg.trainer.policy.model.lora.alpha = int(lora_config.alpha)
+    cfg = build_tinker_skyrl_train_config(
+        base_model=base_model,
+        backend=overrides.strategy,
+        overrides=dict(overrides.model_extra),
+        lora_config=lora_config,
+    )
 
     logger.info("SkyRL-Train config:\n%s", get_config_as_yaml_str(cfg))
     return cfg

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -13,6 +13,7 @@ from sqlmodel import Session, create_engine, func, select, update
 
 from skyrl.backends.utils import log_timing
 from skyrl.tinker import types
+from skyrl.tinker.skyrl_train_backend_config import validate_and_build_tinker_skyrl_train_config
 from skyrl.tinker.config import EngineConfig, add_model
 from skyrl.tinker.db_models import (
     CheckpointDB,
@@ -234,6 +235,10 @@ class TinkerEngine:
         self.config = config
         self.db_engine = create_engine(config.database_url, echo=False)
         enable_sqlite_wal(self.db_engine)
+
+        # Validate Tinker's skyrl-train backends before importing heavy backend dependencies.
+        if config.backend in {"fsdp", "megatron"}:
+            validate_and_build_tinker_skyrl_train_config(config.base_model, config.backend, config.backend_config)
 
         # Initialize the backend (handles model state, computation, and adapter management)
         backend_class, backend_config_class = get_backend_classes(config.backend)

--- a/skyrl/tinker/skyrl_train_backend_config.py
+++ b/skyrl/tinker/skyrl_train_backend_config.py
@@ -1,0 +1,158 @@
+"""Validation and config helpers for Tinker's SkyRL-Train backends."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from skyrl.tinker import types
+
+if TYPE_CHECKING:
+    from skyrl.train.config import SkyRLTrainConfig
+
+
+def resolve_tinker_skyrl_train_strategy(backend: str) -> str:
+    """Normalize Tinker backend names to the strategy used in SkyRL-Train config."""
+    if backend in ("fsdp", "fsdp2"):
+        return "fsdp2"
+    if backend == "megatron":
+        return "megatron"
+    raise ValueError(f"Unsupported Tinker skyrl-train backend: {backend}")
+
+
+_EXACT_KEY_REJECTIONS = {
+    "strategy": "fixed by `--backend`; remove `strategy` from `--backend-config`.",
+    "trainer.strategy": "fixed by `--backend` and cannot be overridden from `--backend-config`.",
+    "trainer.policy.model.path": "fixed by `--base-model` and cannot be overridden from `--backend-config`.",
+    "trainer.policy.optimizer_config.lr": (
+        "ignored by this backend; use `OptimStepInput.adam_params.learning_rate` for step-time learning rates."
+    ),
+    "trainer.policy.optimizer_config.scheduler": "forced by the Tinker skyrl-train backend and cannot be overridden.",
+    "trainer.policy.optimizer_config.num_warmup_steps": (
+        "forced by the Tinker skyrl-train backend and cannot be overridden."
+    ),
+    "trainer.algorithm.policy_loss_type": (
+        "chosen per `forward_backward` request; use `ForwardBackwardInput.loss_fn` instead."
+    ),
+    "trainer.algorithm.use_kl_loss": "currently forced to `False` by the Tinker skyrl-train backend.",
+    "trainer.policy.model.lora.rank": "set from `CreateModelInput.lora_config.rank`, not `--backend-config`.",
+    "trainer.policy.model.lora.alpha": "set from `CreateModelInput.lora_config.alpha`, not `--backend-config`.",
+    "trainer.epochs": "ignored because Tinker does not run the standard SkyRL-Train epoch loop.",
+    "trainer.train_batch_size": "ignored because Tinker batches requests dynamically through the API.",
+    "trainer.policy_mini_batch_size": "ignored because Tinker does not use the standard PPO trainer loop.",
+    "trainer.critic_mini_batch_size": "ignored because Tinker does not initialize a critic trainer loop.",
+    "trainer.eval_batch_size": "ignored because Tinker does not run the standard evaluation loop.",
+    "trainer.eval_before_train": "ignored because Tinker does not run the standard evaluation loop.",
+    "trainer.eval_interval": "ignored because Tinker does not run the standard evaluation loop.",
+    "trainer.ckpt_interval": "ignored because checkpointing in Tinker is driven by explicit API calls.",
+    "trainer.hf_save_interval": "ignored because checkpointing in Tinker is driven by explicit API calls.",
+    "trainer.resume_mode": "ignored because checkpoint loading in Tinker is driven by explicit API calls.",
+    "trainer.resume_path": "ignored because checkpoint loading in Tinker is driven by explicit API calls.",
+    "trainer.project_name": "ignored because Tinker does not use the standard trainer logging loop.",
+    "trainer.run_name": "ignored because Tinker does not use the standard trainer logging loop.",
+    "trainer.logger": "ignored because Tinker does not use the standard trainer logging loop.",
+    "trainer.dump_data_batch": "ignored because Tinker does not use the standard trainer logging loop.",
+    "trainer.dump_eval_results": "ignored because Tinker does not use the standard evaluation loop.",
+    "trainer.placement.critic_num_nodes": "ignored because Tinker only initializes a policy actor group.",
+    "trainer.placement.critic_num_gpus_per_node": "ignored because Tinker only initializes a policy actor group.",
+    "trainer.placement.ref_num_nodes": "ignored because Tinker only initializes a policy actor group.",
+    "trainer.placement.ref_num_gpus_per_node": "ignored because Tinker only initializes a policy actor group.",
+}
+
+_PREFIX_KEY_REJECTIONS = {
+    "data.": "ignored because Tinker does not use SkyRL-Train dataset loading; send data through the Tinker API.",
+    "trainer.ref.": "ignored because Tinker does not initialize a reference-model actor group.",
+    "trainer.critic.": "ignored because Tinker does not initialize a critic actor group.",
+    "trainer.fully_async.": "ignored because Tinker does not use the fully async trainer loop.",
+}
+
+_BACKEND_PREFIX_REJECTIONS = {
+    "fsdp2": {
+        "trainer.policy.megatron_config.": "only supported with `--backend megatron`.",
+    },
+    "megatron": {
+        "trainer.policy.fsdp_config.": "only supported with `--backend fsdp`.",
+    },
+}
+
+
+def _matches_prefix(key: str, prefix: str) -> bool:
+    root = prefix[:-1]
+    return key == root or key.startswith(prefix)
+
+
+def collect_tinker_skyrl_train_backend_override_errors(backend: str, overrides: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return sorted `(key, reason)` pairs for unsupported backend-config overrides."""
+    resolved_strategy = resolve_tinker_skyrl_train_strategy(backend)
+    errors: dict[str, str] = {}
+
+    for key in overrides:
+        if key in _EXACT_KEY_REJECTIONS:
+            errors[key] = _EXACT_KEY_REJECTIONS[key]
+            continue
+
+        backend_prefix_rejections = _BACKEND_PREFIX_REJECTIONS[resolved_strategy]
+        matched_backend_prefix = next(
+            (prefix for prefix in backend_prefix_rejections if _matches_prefix(key, prefix)),
+            None,
+        )
+        if matched_backend_prefix is not None:
+            errors[key] = backend_prefix_rejections[matched_backend_prefix]
+            continue
+
+        matched_prefix = next((prefix for prefix in _PREFIX_KEY_REJECTIONS if _matches_prefix(key, prefix)), None)
+        if matched_prefix is not None:
+            errors[key] = _PREFIX_KEY_REJECTIONS[matched_prefix]
+
+    return sorted(errors.items())
+
+
+def validate_tinker_skyrl_train_backend_overrides(backend: str, overrides: dict[str, Any]) -> None:
+    """Raise a clear error when `--backend-config` contains misleading Tinker overrides."""
+    errors = collect_tinker_skyrl_train_backend_override_errors(backend, overrides)
+    if not errors:
+        return
+
+    formatted_errors = "\n".join(f"- {key}: {reason}" for key, reason in errors)
+    raise ValueError(f"Invalid --backend-config for the Tinker skyrl-train backend:\n{formatted_errors}")
+
+
+def build_tinker_skyrl_train_config(
+    base_model: str,
+    backend: str,
+    overrides: dict[str, Any],
+    lora_config: types.LoraConfig | None = None,
+) -> "SkyRLTrainConfig":
+    """Build the effective SkyRL-Train config used by Tinker's FSDP/Megatron backends."""
+    resolved_strategy = resolve_tinker_skyrl_train_strategy(backend)
+    validate_tinker_skyrl_train_backend_overrides(resolved_strategy, overrides)
+
+    from skyrl.train.config import SkyRLTrainConfig
+
+    user_overrides = dict(overrides)
+    user_overrides.pop("strategy", None)
+    user_overrides["trainer.policy.model.path"] = base_model
+
+    cfg = SkyRLTrainConfig.from_cli_overrides(user_overrides)
+
+    # Tinker manages optimizer stepping and learning rate externally.
+    cfg.trainer.policy.optimizer_config.scheduler = "constant_with_warmup"
+    cfg.trainer.policy.optimizer_config.num_warmup_steps = 0
+
+    # TODO(tyler): Support KL loss in the Tinker skyrl-train backend.
+    cfg.trainer.algorithm.use_kl_loss = False
+    cfg.trainer.strategy = resolved_strategy
+
+    if lora_config is not None and lora_config.rank > 0:
+        cfg.trainer.policy.model.lora.rank = lora_config.rank
+        cfg.trainer.policy.model.lora.alpha = int(lora_config.alpha)
+
+    return cfg
+
+
+def validate_and_build_tinker_skyrl_train_config(
+    base_model: str,
+    backend: str,
+    overrides: dict[str, Any],
+) -> "SkyRLTrainConfig":
+    """Validate raw `--backend-config` keys and build the startup SkyRL-Train config."""
+    return build_tinker_skyrl_train_config(base_model=base_model, backend=backend, overrides=overrides)

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -12,6 +12,23 @@ from skyrl.tinker.engine import TinkerEngine, prepare_model_pass_batch
 BASE_MODEL = "trl-internal-testing/tiny-Qwen3ForCausalLM"
 
 
+def test_tinker_engine_rejects_invalid_skyrl_train_backend_config_before_backend_import(monkeypatch):
+    config = EngineConfig(
+        base_model=BASE_MODEL,
+        backend="fsdp",
+        backend_config={"trainer.policy.optimizer_config.lr": 1e-5},
+        database_url="sqlite:///:memory:",
+    )
+
+    def fail_if_called(_backend_name: str):
+        raise AssertionError("get_backend_classes should not be called for invalid backend config")
+
+    monkeypatch.setattr("skyrl.tinker.engine.get_backend_classes", fail_if_called)
+
+    with pytest.raises(ValueError, match="trainer.policy.optimizer_config.lr"):
+        TinkerEngine(config)
+
+
 def test_process_unload_model():
     """Test that process_unload_model removes model from backend."""
     config = EngineConfig(

--- a/tests/tinker/test_skyrl_train_backend_config.py
+++ b/tests/tinker/test_skyrl_train_backend_config.py
@@ -1,0 +1,101 @@
+import pytest
+
+from skyrl.tinker.skyrl_train_backend_config import (
+    build_tinker_skyrl_train_config,
+    collect_tinker_skyrl_train_backend_override_errors,
+    validate_tinker_skyrl_train_backend_overrides,
+)
+
+
+BASE_MODEL = "trl-internal-testing/tiny-Qwen3ForCausalLM"
+
+
+def _require_train_config_runtime() -> None:
+    pytest.importorskip("omegaconf")
+    pytest.importorskip("hydra")
+    pytest.importorskip("skyrl_gym")
+
+
+@pytest.mark.parametrize(
+    ("key", "reason_snippet"),
+    [
+        ("trainer.policy.optimizer_config.lr", "OptimStepInput.adam_params.learning_rate"),
+        ("trainer.algorithm.policy_loss_type", "ForwardBackwardInput.loss_fn"),
+        ("trainer.policy.model.path", "--base-model"),
+        ("trainer.policy.model.lora.rank", "CreateModelInput.lora_config.rank"),
+        ("strategy", "--backend"),
+        ("trainer.strategy", "--backend"),
+    ],
+)
+def test_validate_tinker_skyrl_train_backend_overrides_rejects_high_confidence_keys(
+    key: str, reason_snippet: str
+):
+    with pytest.raises(ValueError, match=key):
+        validate_tinker_skyrl_train_backend_overrides("fsdp", {key: "value"})
+
+    errors = dict(collect_tinker_skyrl_train_backend_override_errors("fsdp", {key: "value"}))
+    assert reason_snippet in errors[key]
+
+
+@pytest.mark.parametrize(
+    ("backend", "key"),
+    [
+        ("fsdp", "trainer.policy.megatron_config.tensor_model_parallel_size"),
+        ("megatron", "trainer.policy.fsdp_config.cpu_offload"),
+    ],
+)
+def test_validate_tinker_skyrl_train_backend_overrides_rejects_backend_specific_namespaces(
+    backend: str, key: str
+):
+    with pytest.raises(ValueError, match=key):
+        validate_tinker_skyrl_train_backend_overrides(backend, {key: 1})
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "data.train_data",
+        "trainer.ref.model.path",
+        "trainer.critic.optimizer_config.lr",
+        "trainer.fully_async.max_staleness_steps",
+    ],
+)
+def test_validate_tinker_skyrl_train_backend_overrides_rejects_irrelevant_prefixes(key: str):
+    with pytest.raises(ValueError, match=key):
+        validate_tinker_skyrl_train_backend_overrides("fsdp", {key: "value"})
+
+
+def test_build_tinker_skyrl_train_config_accepts_supported_startup_keys():
+    _require_train_config_runtime()
+
+    cfg = build_tinker_skyrl_train_config(
+        base_model=BASE_MODEL,
+        backend="fsdp",
+        overrides={
+            "trainer.algorithm.temperature": 0.7,
+            "trainer.policy.optimizer_config.weight_decay": 0.123,
+            "trainer.placement.policy_num_gpus_per_node": 2,
+            "generator.inference_engine.num_engines": 2,
+        },
+    )
+
+    assert cfg.trainer.algorithm.temperature == 0.7
+    assert cfg.trainer.policy.optimizer_config.weight_decay == 0.123
+    assert cfg.trainer.placement.policy_num_gpus_per_node == 2
+    assert cfg.generator.inference_engine.num_engines == 2
+    assert cfg.trainer.policy.model.path == BASE_MODEL
+    assert cfg.trainer.policy.optimizer_config.scheduler == "constant_with_warmup"
+    assert cfg.trainer.policy.optimizer_config.num_warmup_steps == 0
+    assert cfg.trainer.algorithm.use_kl_loss is False
+    assert cfg.trainer.strategy == "fsdp2"
+
+
+def test_build_tinker_skyrl_train_config_still_uses_typed_schema_validation():
+    _require_train_config_runtime()
+
+    with pytest.raises(ValueError, match="Invalid fields"):
+        build_tinker_skyrl_train_config(
+            base_model=BASE_MODEL,
+            backend="fsdp",
+            overrides={"trainer.policy.not_a_real_field": 1},
+        )


### PR DESCRIPTION
## Summary

Fixes #1279 by validating Tinker's `skyrl-train` backend config at startup instead of accepting unsupported overrides as silent no-ops.

This PR adds a small Tinker-specific validation layer for `--backend-config` when `--backend` is `fsdp` or `megatron`, and keeps the implementation intentionally narrow:

- reject request-owned keys such as `trainer.policy.optimizer_config.lr` and `trainer.algorithm.policy_loss_type`
- reject server-forced keys such as `trainer.policy.model.path`, `trainer.strategy`, and the scheduler / warmup overrides that Tinker already rewrites
- reject clearly irrelevant trainer-loop namespaces such as `data.*`, `trainer.ref.*`, `trainer.critic.*`, and `trainer.fully_async.*`
- reject backend-mismatched namespaces such as `trainer.policy.megatron_config.*` under FSDP and `trainer.policy.fsdp_config.*` under Megatron
- fail invalid config before importing the heavy `skyrl-train` backend

## What Changed

### Runtime behavior

- added `skyrl/tinker/skyrl_train_backend_config.py` to centralize:
  - Tinker-specific backend-config validation
  - strategy normalization for `fsdp` / `megatron`
  - shared config building for Tinker's `skyrl-train` backends
- updated `skyrl/tinker/engine.py` to run this validation during engine startup before backend import
- updated `skyrl/backends/skyrl_train_backend.py` to reuse the shared config builder so startup validation and runtime config construction stay aligned
- added a defensive check so direct backend construction cannot override the backend-selected strategy

### Tests

- added focused validator tests in `tests/tinker/test_skyrl_train_backend_config.py`
- added an engine regression test in `tests/tinker/test_engine.py` to verify invalid config fails before backend import

### Docs

- updated `docs/content/docs/tinker/configuration.mdx` to stop claiming that any SkyRL-Train config key is valid in Tinker
- documented the rejected key categories and clarified the LoRA ownership split

## Why This Design

I kept this intentionally local and denylist-based instead of introducing a large new config framework.

The base typed `SkyRLTrainConfig` still validates the general schema. This PR adds only the missing Tinker-specific semantic layer for keys that are currently misleading because they are request-owned, server-forced, or irrelevant to the Tinker lifecycle.

## Verification

Focused verification run in the isolated worktree environment:

```bash
PYTHONPATH=/private/tmp/skyrl-issue-1279/skyrl-gym .venv/bin/python -m pytest \
  tests/tinker/test_skyrl_train_backend_config.py \
  tests/tinker/test_engine.py::test_tinker_engine_rejects_invalid_skyrl_train_backend_config_before_backend_import \
  -q
```

Result:

```text
15 passed, 1 warning in 11.92s
```

The warning is an existing Hydra warning about unspecified `version_base`; it is not introduced by this PR.
