### PR TITLE
[megatron] Add DoRA support for PEFT training

### DIFF
--- a/examples/train/megatron/run_megatron_lora_qwen3-0.6b.sh
+++ b/examples/train/megatron/run_megatron_lora_qwen3-0.6b.sh
@@ -17,7 +17,8 @@ MEGATRON_TP=1
 MEGATRON_PP=1
 MEGATRON_CP=1
 
-# LoRA configuration
+# LoRA / DoRA configuration
+LORA_TYPE="lora" # set to "dora" to use DoRA instead of LoRA
 LORA_RANK=32
 LORA_ALPHA=64
 LORA_A_INIT_METHOD="kaiming"
@@ -43,6 +44,7 @@ uv run --isolated --extra megatron -m skyrl.train.entrypoints.main_base \
   trainer.policy.model.lora.rank=$LORA_RANK \
   trainer.policy.model.lora.alpha=$LORA_ALPHA \
   trainer.policy.model.lora.init_method=$LORA_A_INIT_METHOD \
+  trainer.policy.megatron_config.lora_config.lora_type=$LORA_TYPE \
   trainer.gradient_checkpointing=true \
   trainer.policy.model.lora.target_modules="all-linear" \
   trainer.use_sample_packing=true \
@@ -70,7 +72,7 @@ uv run --isolated --extra megatron -m skyrl.train.entrypoints.main_base \
   generator.inference_engine.gpu_memory_utilization=0.6 \
   trainer.logger="$LOGGER" \
   trainer.project_name="gsm8k_megatron" \
-  trainer.run_name="gsm8k_megatron_tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}_${MODEL_NAME}_lora_r${LORA_RANK}_a${LORA_ALPHA}" \
+  trainer.run_name="gsm8k_megatron_tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}_${MODEL_NAME}_${LORA_TYPE}_r${LORA_RANK}_a${LORA_ALPHA}" \
   trainer.resume_mode=null \
   trainer.ckpt_path="$HOME/ckpts/gsm8k_megatron_ckpt" \
   $@

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 from huggingface_hub import snapshot_download
 from megatron.bridge import AutoBridge
 from megatron.bridge.peft.canonical_lora import CanonicalLoRA
+from megatron.bridge.peft.dora import DoRA
 from megatron.bridge.peft.lora import LoRA
 from megatron.core.optimizer import ChainedOptimizer, DistributedOptimizer
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
@@ -323,43 +324,62 @@ class MegatronWorker:
         self.enable_router_replay = megatron_config.moe_enable_routing_replay
 
     def configure_lora(self, lora_config, lora_type: Optional[str] = "lora"):
+        target_modules = self._resolve_lora_target_modules(lora_config.target_modules, lora_type)
+        exclude_modules = [] if lora_config.exclude_modules is None else lora_config.exclude_modules
         if lora_type == "lora":
             self.lora_cls = LoRA(
-                target_modules=(
-                    ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"]
-                    if lora_config.target_modules == "all-linear"
-                    else lora_config.target_modules
-                ),
+                target_modules=target_modules,
                 dim=lora_config.rank,
                 alpha=lora_config.alpha,
                 dropout=lora_config.dropout,
                 lora_A_init_method=lora_config.init_method,
                 lora_B_init_method="zero",
-                exclude_modules=[] if lora_config.exclude_modules is None else lora_config.exclude_modules,
+                exclude_modules=exclude_modules,
                 lora_dtype=torch.bfloat16 if self.cfg.bf16 else torch.float32,
             )
         elif lora_type == "canonical_lora":
             self.lora_cls = CanonicalLoRA(
-                target_modules=(
-                    [
-                        "linear_q",
-                        "linear_k",
-                        "linear_v",
-                        "linear_proj",
-                        "linear_fc1_up",
-                        "linear_fc1_gate",
-                        "linear_fc2",
-                    ]
-                    if lora_config.target_modules == "all-linear"
-                    else lora_config.target_modules
-                ),
+                target_modules=target_modules,
                 dim=lora_config.rank,
                 alpha=lora_config.alpha,
                 dropout=lora_config.dropout,
                 lora_A_init_method=lora_config.init_method,
                 lora_B_init_method="zero",
-                exclude_modules=[] if lora_config.exclude_modules is None else lora_config.exclude_modules,
+                exclude_modules=exclude_modules,
             )
+        elif lora_type == "dora":
+            self.lora_cls = DoRA(
+                target_modules=target_modules,
+                dim=lora_config.rank,
+                alpha=lora_config.alpha,
+                dropout=lora_config.dropout,
+                lora_A_init_method=lora_config.init_method,
+                lora_B_init_method="zero",
+                exclude_modules=exclude_modules,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported megatron lora_type: {lora_type}. "
+                "Supported values are 'lora', 'canonical_lora', and 'dora'."
+            )
+
+    @staticmethod
+    def _resolve_lora_target_modules(target_modules, lora_type: Optional[str]):
+        if target_modules != "all-linear":
+            return target_modules
+
+        if lora_type == "canonical_lora":
+            return [
+                "linear_q",
+                "linear_k",
+                "linear_v",
+                "linear_proj",
+                "linear_fc1_up",
+                "linear_fc1_gate",
+                "linear_fc2",
+            ]
+
+        return ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"]
 
     def make_megatron_module(
         self,

--- a/skyrl/train/config/megatron_config/policy.yaml
+++ b/skyrl/train/config/megatron_config/policy.yaml
@@ -34,7 +34,7 @@ torch_profiler_config:
   save_path: null
 
 lora_config:
-  # see: https://docs.nvidia.com/nemo/megatron-bridge/0.2.0/apidocs/bridge/bridge.peft.lora.html for details - currently "lora" and "canonical_lora" are supported
+  # supported values: "lora", "canonical_lora", and "dora"
   lora_type: "lora"
 
 # pass-through kwargs to Megatron's `OptimizerConfig` object

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -221,6 +221,15 @@ def validate_megatron_cfg(cfg: SkyRLTrainConfig):
 
 # TODO (sumanthrh): Most of this should be moved to  __post_init__ for the dataclasses
 def validate_cfg(cfg: SkyRLTrainConfig):
+    if cfg.trainer.strategy == "megatron" and cfg.trainer.policy.model.lora.rank > 0:
+        lora_type = cfg.trainer.policy.megatron_config.lora_config.lora_type
+        supported_megatron_lora_types = ("lora", "canonical_lora", "dora")
+        if lora_type not in supported_megatron_lora_types:
+            raise ValueError(
+                f"Unsupported Megatron lora_type: {lora_type}. "
+                "Supported values are 'lora', 'canonical_lora', and 'dora'."
+            )
+
     # Validate generation config separately
     validate_generator_cfg(cfg)
     from skyrl.backends.skyrl_train.utils.ppo_utils import (

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
@@ -63,6 +63,11 @@ def get_test_actor_config(model_name=MODEL_NAME) -> SkyRLTrainConfig:
     return cfg
 
 
+def enable_megatron_adapter(cfg: SkyRLTrainConfig, adapter_type: str, rank: int = 16, alpha: int = 16) -> None:
+    cfg.trainer.policy.model.lora = SkyRLLoraConfig(rank=rank, alpha=alpha)
+    cfg.trainer.policy.megatron_config.lora_config.lora_type = adapter_type
+
+
 def get_test_training_batch(batch_size=4) -> TrainingInputBatch:
     """
     Returns a test training batch with padded seqs and attention masks
@@ -121,24 +126,25 @@ def get_test_training_batch(batch_size=4) -> TrainingInputBatch:
 
 
 @pytest.mark.parametrize(
-    ("colocate_all", "inference_tp", "megatron_tp", "megatron_pp", "megatron_ep", "megatron_etp", "lora"),
+    ("colocate_all", "inference_tp", "megatron_tp", "megatron_pp", "megatron_ep", "megatron_etp", "adapter_type"),
     [
-        pytest.param(True, 4, 2, 2, 1, None, False, marks=_skip_new_inference, id="colocate_all"),
-        pytest.param(False, 2, 2, 1, 1, None, False, id="non_colocated"),
-        pytest.param(True, 4, 2, 2, 1, None, True, marks=_skip_new_inference, id="colocate_all_lora"),
+        pytest.param(True, 4, 2, 2, 1, None, None, marks=_skip_new_inference, id="colocate_all"),
+        pytest.param(False, 2, 2, 1, 1, None, None, id="non_colocated"),
+        pytest.param(True, 4, 2, 2, 1, None, "lora", marks=_skip_new_inference, id="colocate_all_lora"),
+        pytest.param(True, 4, 2, 2, 1, None, "dora", marks=_skip_new_inference, id="colocate_all_dora"),
     ],
 )
 @pytest.mark.megatron
 def test_megatron_policy_weight_sync(
-    ray_init_fixture, colocate_all, inference_tp, megatron_tp, megatron_pp, megatron_ep, megatron_etp, lora
+    ray_init_fixture, colocate_all, inference_tp, megatron_tp, megatron_pp, megatron_ep, megatron_etp, adapter_type
 ):
     """
     Test that we can sync weights between policy and inference for megatron then run inference
     """
     try:
         cfg = get_test_actor_config(model_name=MODEL_NAME)
-        if lora:
-            cfg.trainer.policy.model.lora = SkyRLLoraConfig(rank=16, alpha=16)
+        if adapter_type is not None:
+            enable_megatron_adapter(cfg, adapter_type=adapter_type)
         cfg.trainer.placement.colocate_all = colocate_all
         cfg.generator.inference_engine.weight_sync_backend = "nccl"
         cfg.trainer.strategy = "megatron"
@@ -205,17 +211,18 @@ def test_megatron_policy_weight_sync(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("worker_type", "tp", "pp", "cp", "ep", "etp", "gpus_per_node", "use_sample_packing", "lora"),
+    ("worker_type", "tp", "pp", "cp", "ep", "etp", "gpus_per_node", "use_sample_packing", "adapter_type"),
     [
-        ("policy", 2, 1, 1, 1, None, 2, False, False),
+        ("policy", 2, 1, 1, 1, None, 2, False, None),
         # ref has same forward pass as policy - just duplicate one test to test setup
-        ("ref", 2, 1, 1, 1, None, 2, False, False),
-        ("policy", 2, 2, 1, 1, None, 4, False, False),
-        ("policy", 2, 2, 1, 1, None, 4, True, False),
-        ("policy", 2, 2, 1, 1, None, 4, True, True),
-        ("policy", 1, 1, 2, 1, None, 2, True, False),
-        ("policy", 2, 1, 2, 1, None, 4, True, False),
-        ("policy", 4, 1, 1, 4, 1, 4, True, False),
+        ("ref", 2, 1, 1, 1, None, 2, False, None),
+        ("policy", 2, 2, 1, 1, None, 4, False, None),
+        ("policy", 2, 2, 1, 1, None, 4, True, None),
+        ("policy", 2, 2, 1, 1, None, 4, True, "lora"),
+        ("policy", 2, 2, 1, 1, None, 4, True, "dora"),
+        ("policy", 1, 1, 2, 1, None, 2, True, None),
+        ("policy", 2, 1, 2, 1, None, 4, True, None),
+        ("policy", 4, 1, 1, 4, 1, 4, True, None),
     ],
     ids=[
         "tp2_pp1_policy",
@@ -223,6 +230,7 @@ def test_megatron_policy_weight_sync(
         "tp2_pp2_policy_unpacked",
         "tp2_pp2_policy_seq_packing",
         "tp2_pp2_lora",
+        "tp2_pp2_dora",
         "cp_2_policy_seq_packing",
         "tp_2_cp_2_policy_seq_packing",
         "tp4_pp1_cp1_ep4_etp1_policy_seq_packing",
@@ -230,7 +238,7 @@ def test_megatron_policy_weight_sync(
 )
 @pytest.mark.megatron
 async def test_megatron_forward(
-    ray_init_fixture, worker_type, tp, pp, cp, ep, etp, gpus_per_node, use_sample_packing, lora
+    ray_init_fixture, worker_type, tp, pp, cp, ep, etp, gpus_per_node, use_sample_packing, adapter_type
 ):
     """
     Test that the Megatron forward pass is numerically equivalent to just running a huggingface model forward.
@@ -252,8 +260,8 @@ async def test_megatron_forward(
             cfg.trainer.policy.megatron_config.transformer_config_kwargs = dict()
         cfg.trainer.policy.megatron_config.transformer_config_kwargs["num_layers"] = 2
 
-    if lora:
-        cfg.trainer.policy.model.lora = SkyRLLoraConfig(rank=16, alpha=16)
+    if adapter_type is not None:
+        enable_megatron_adapter(cfg, adapter_type=adapter_type)
 
     actor_group = init_worker_with_type(
         worker_type,
@@ -342,20 +350,24 @@ async def test_megatron_forward(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("tp", "pp", "cp", "ep", "etp", "gpus_per_node"),
+    ("adapter_type", "tp", "pp", "cp", "ep", "etp", "gpus_per_node"),
     [
-        (2, 2, 1, 1, None, 4),
-        (4, 1, 1, 4, 1, 4),
+        ("lora", 2, 2, 1, 1, None, 4),
+        ("dora", 2, 2, 1, 1, None, 4),
+        ("lora", 4, 1, 1, 4, 1, 4),
+        ("dora", 4, 1, 1, 4, 1, 4),
     ],
     ids=[
-        "tp2_pp2_policy",
-        "tp4_pp1_cp1_ep4_etp1_policy",
+        "lora_tp2_pp2_policy",
+        "dora_tp2_pp2_policy",
+        "lora_tp4_pp1_cp1_ep4_etp1_policy",
+        "dora_tp4_pp1_cp1_ep4_etp1_policy",
     ],
 )
 @pytest.mark.megatron
-async def test_megatron_lora_forward(ray_init_fixture, tp, pp, cp, ep, etp, gpus_per_node):
+async def test_megatron_adapter_forward(ray_init_fixture, adapter_type, tp, pp, cp, ep, etp, gpus_per_node):
     """
-    Test that the Megatron + lora forward pass is numerically equivalent to just running a megatron model forward.
+    Test that a freshly initialized Megatron adapter produces the same outputs as the base Megatron model.
     """
     cfg = get_test_actor_config(model_name=MOE_MODEL_NAME if ep > 1 else MODEL_NAME)
     #### Megatron forward pass ####
@@ -402,8 +414,7 @@ async def test_megatron_lora_forward(ray_init_fixture, tp, pp, cp, ep, etp, gpus
     cfg.trainer.use_sample_packing = True
     batch = get_test_training_batch(max(4, gpus_per_node))
 
-    # set lora this time
-    cfg.trainer.policy.model.lora = SkyRLLoraConfig(rank=16, alpha=16)
+    enable_megatron_adapter(cfg, adapter_type=adapter_type)
 
     if ep > 1:
         if cfg.trainer.policy.megatron_config.transformer_config_kwargs is None:
@@ -420,7 +431,7 @@ async def test_megatron_lora_forward(ray_init_fixture, tp, pp, cp, ep, etp, gpus
 
     action_log_probs_refs = actor_group.async_run_ray_method("mesh", "forward", data=batch)
     all_rank_action_log_probs = ray.get(action_log_probs_refs)
-    action_log_probs_lora = concatenate_outputs_after_mesh_dispatch(actor_group.actor_infos, all_rank_action_log_probs)[
+    action_log_probs_adapter = concatenate_outputs_after_mesh_dispatch(actor_group.actor_infos, all_rank_action_log_probs)[
         "output"
     ]
 
@@ -428,13 +439,13 @@ async def test_megatron_lora_forward(ray_init_fixture, tp, pp, cp, ep, etp, gpus
     # compare just non-padding tokens
     print(f"Comparing {action_log_probs_full.numel()} valid response tokens")
     print(f"Full sample: {action_log_probs_full[:5]}")
-    print(f"Lora sample: {action_log_probs_lora[:5]}")
+    print(f"{adapter_type} sample: {action_log_probs_adapter[:5]}")
 
     # max diff
-    max_diff = torch.max(torch.abs(action_log_probs_full - action_log_probs_lora))
+    max_diff = torch.max(torch.abs(action_log_probs_full - action_log_probs_adapter))
     print(f"Max diff: {max_diff}")
 
-    assert max_diff == 0, "Numerical difference between LoRA and full fine tuning at init should be 0"
+    assert max_diff == 0, f"Numerical difference between {adapter_type} and full fine tuning at init should be 0"
 
 
 @pytest.mark.asyncio

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py
@@ -10,6 +10,7 @@ uv run --isolated --extra dev --extra mcore -- pytest tests/backends/skyrl_train
 """
 
 import json
+import glob
 import os
 import shutil
 import uuid
@@ -19,7 +20,7 @@ import ray
 import torch
 from transformers import AutoTokenizer
 
-from skyrl.train.config import SkyRLTrainConfig
+from skyrl.train.config import SkyRLLoraConfig, SkyRLTrainConfig
 from skyrl.train.utils.utils import print_mem, validate_cfg
 from tests.backends.skyrl_train.gpu.utils import (
     get_model_logits_from_actor,
@@ -62,18 +63,24 @@ def get_test_actor_config(strategy: str) -> SkyRLTrainConfig:
     return cfg
 
 
+def enable_megatron_adapter(cfg: SkyRLTrainConfig, adapter_type: str, rank: int = 32, alpha: int = 32) -> None:
+    cfg.trainer.policy.model.lora = SkyRLLoraConfig(rank=rank, alpha=alpha)
+    cfg.trainer.policy.megatron_config.lora_config.lora_type = adapter_type
+
+
 @pytest.mark.parametrize(
-    ("strategy", "lora", "fully_reshardable", "optimizer_cpu_offload"),
+    ("strategy", "adapter_type", "fully_reshardable", "optimizer_cpu_offload"),
     [
-        ("fsdp", False, False, False),
-        ("fsdp2", False, False, False),
-        pytest.param("megatron", False, False, False, marks=pytest.mark.megatron),
-        pytest.param("megatron", False, False, True, marks=pytest.mark.megatron),
-        pytest.param("megatron", True, False, False, marks=[pytest.mark.megatron, pytest.mark.lora]),
-        pytest.param("megatron", False, True, False, marks=pytest.mark.megatron),
+        ("fsdp", None, False, False),
+        ("fsdp2", None, False, False),
+        pytest.param("megatron", None, False, False, marks=pytest.mark.megatron),
+        pytest.param("megatron", None, False, True, marks=pytest.mark.megatron),
+        pytest.param("megatron", "lora", False, False, marks=[pytest.mark.megatron, pytest.mark.lora]),
+        pytest.param("megatron", "dora", False, False, marks=pytest.mark.megatron),
+        pytest.param("megatron", None, True, False, marks=pytest.mark.megatron),
         pytest.param(
             "megatron",
-            False,
+            None,
             True,
             True,
             marks=[
@@ -92,11 +99,12 @@ def get_test_actor_config(strategy: str) -> SkyRLTrainConfig:
         "megatron",
         "megatron_optimizer_cpu_offload",
         "megatron_lora",
+        "megatron_dora",
         "megatron_fully_reshardable",
         "megatron_fully_reshardable_optimizer_cpu_offload",
     ],
 )
-def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardable, optimizer_cpu_offload):
+def test_save_load_checkpoint(ray_init_fixture, strategy, adapter_type, fully_reshardable, optimizer_cpu_offload):
     """
     Test checkpointing logic by:
     1. Creating model and doing one training step
@@ -106,10 +114,8 @@ def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardabl
     5. Repeating second training step and comparing logits
     """
     cfg = get_test_actor_config(strategy)
-    if lora:
-        from skyrl.train.config import SkyRLLoraConfig
-
-        cfg.trainer.policy.model.lora = SkyRLLoraConfig(rank=32, alpha=32)
+    if strategy == "megatron" and adapter_type is not None:
+        enable_megatron_adapter(cfg, adapter_type=adapter_type)
     if fully_reshardable:
         cfg.trainer.policy.megatron_config.dist_ckpt_optim_fully_reshardable = True
     if optimizer_cpu_offload:
@@ -186,6 +192,16 @@ def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardabl
             assert os.path.exists(
                 os.path.join(huggingface_dir, file)
             ), f"File {file} not found in huggingface directory"
+        if strategy == "megatron" and adapter_type == "dora":
+            adapter_paths = glob.glob(os.path.join(checkpoint_path, "adapter_tp*_pp*_cp*_dp*_ep*_etp*.pt"))
+            assert adapter_paths, f"No adapter checkpoints found in {checkpoint_path}"
+            found_weight_magnitude = False
+            for adapter_path in adapter_paths:
+                adapter_state = torch.load(adapter_path, map_location="cpu")
+                if any("weight_magnitude" in key for key in adapter_state["model_state_dict"]):
+                    found_weight_magnitude = True
+                    break
+            assert found_weight_magnitude, "DoRA adapter checkpoint is missing weight_magnitude parameters"
         if "fsdp" in strategy:
             fsdp_config_path = os.path.join(checkpoint_path, "fsdp_config.json")
             with open(fsdp_config_path, "r") as f:

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -16,6 +16,7 @@ from skyrl.train.config.config import (
     build_nested_dataclass,
 )
 from skyrl.train.config.utils import get_legacy_config
+from skyrl.train.utils.utils import validate_cfg
 
 
 # Helper dataclasses for testing
@@ -192,6 +193,37 @@ def test_cross_field_defaults():
     )  # same as `generator.sampling_params.max_generate_length`
     assert cfg.generator.rope_scaling == cfg.trainer.rope_scaling
     assert cfg.generator.rope_theta == cfg.trainer.rope_theta
+
+
+def test_validate_megatron_dora_lora_type():
+    cfg = SkyRLTrainConfig.from_cli_overrides(
+        [
+            "trainer.strategy=megatron",
+            "trainer.logger=console",
+            "trainer.flash_attn=false",
+            "trainer.policy.model.lora.rank=8",
+            "trainer.policy.megatron_config.lora_config.lora_type=dora",
+            "generator.inference_engine.backend=vllm",
+        ]
+    )
+
+    validate_cfg(cfg)
+
+
+def test_validate_megatron_invalid_lora_type():
+    cfg = SkyRLTrainConfig.from_cli_overrides(
+        [
+            "trainer.strategy=megatron",
+            "trainer.logger=console",
+            "trainer.flash_attn=false",
+            "trainer.policy.model.lora.rank=8",
+            "trainer.policy.megatron_config.lora_config.lora_type=invalid",
+            "generator.inference_engine.backend=vllm",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Unsupported Megatron lora_type"):
+        validate_cfg(cfg)
 
 
 class TestMaxSeqLenValidation:


### PR DESCRIPTION
## Summary

This draft PR adds Megatron DoRA support to SkyRL's PEFT training path.

It extends the existing Megatron LoRA integration so users can set:

- `trainer.policy.megatron_config.lora_config.lora_type=dora`

without introducing a new config shape or a separate checkpointing flow.

Closes #835.

## What Changed

### Runtime support

- Added upstream `DoRA` support in `megatron_worker.py`
- Kept the existing Megatron LoRA-enabled path and treated DoRA as another supported `lora_type`
- Reused the plain LoRA `all-linear` target-module mapping for DoRA:
  - `linear_qkv`
  - `linear_proj`
  - `linear_fc1`
  - `linear_fc2`
- Added an explicit error for unsupported Megatron adapter types

### Validation

- Added early Megatron `lora_type` validation in `validate_cfg(...)`
- Supported Megatron adapter types are now:
  - `lora`
  - `canonical_lora`
  - `dora`

### Config and example updates

- Updated Megatron policy config comments to document `dora`
- Updated the Megatron LoRA example script to accept:
  - `LORA_TYPE="lora"`
- The example can now be switched to DoRA by setting:
  - `LORA_TYPE="dora"`

### Tests

- Added config validation coverage for valid and invalid Megatron `lora_type` values
- Expanded Megatron worker tests to include DoRA adapter cases alongside LoRA where appropriate
- Expanded Megatron checkpoint coverage to include DoRA
- Added a DoRA-specific checkpoint assertion that verifies `weight_magnitude` is saved in the adapter checkpoint

## Design Notes

This change intentionally stays narrow:

- no new `dora_config` block
- no new checkpoint format
- no broader PEFT refactor
- no dependency bump up front

The implementation relies on the currently pinned `megatron-bridge` revision already containing upstream `DoRA` support.

## Validation

Ran locally:

- `UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.12 --extra dev --extra skyrl-train pytest tests/train/test_config.py -q`
  - `18 passed`
- `python3.12 -m py_compile` on the edited Python files
- `git diff --check`

Not run in this environment:

- Megatron GPU integration tests in `tests/backends/skyrl_train/gpu/gpu_ci/`

Those still need Linux/CUDA/Megatron runtime coverage for full end-to-end verification.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
