### PR TITLE
Fix Mini-SWE step-wise training to use exact chat-completion token IDs and logprobs

### DIFF
--- a/docs/content/docs/examples/mini_swe_agent.mdx
+++ b/docs/content/docs/examples/mini_swe_agent.mdx
@@ -49,6 +49,8 @@ In `generate_trajectory` we start a Ray task to generate a trajectory and evalua
 
 By running this workflow as a Ray task, we are also able to scale up generation across all the nodes in the Ray cluster. 
 
+For training, the Mini-SWE integration uses SkyRL's step-wise trajectory format. Each assistant turn keeps the exact prompt token IDs, completion token IDs, and rollout logprobs returned by the HTTP `/chat/completions` endpoint, so SkyRL does not need to reconstruct training tokens from chat messages after rollout generation.
+
  At a high level, the code looks as follows:
 
 ```python
@@ -99,6 +101,8 @@ bash examples/train/mini_swe_agent/run_mini_swe_8B.sh
 # bash examples/train/mini_swe_agent/run_mini_swe_30B.sh
 
 ```
+
+These scripts enable `generator.step_wise_trajectories=true` and `generator.batched=false` so each Mini-SWE turn is trained with exact token-in/token-out data from the serving stack.
 
 ### Tips
 

--- a/examples/train/mini_swe_agent/README.md
+++ b/examples/train/mini_swe_agent/README.md
@@ -21,18 +21,20 @@ The Mini-SWE-Agent integration implements a custom `MiniSweAgentGenerator` that 
 
 We launch a Ray task per trajectory to scale this across all nodes in the cluster.
 
+For training correctness, this integration now uses SkyRL's step-wise trajectory format with exact prompt/completion token IDs and rollout logprobs captured from the HTTP `/chat/completions` responses. This avoids reconstructing assistant tokens from message text after the fact.
+
 ### 1) Prepare the dataset
 
 We use [SWE-Gym](https://huggingface.co/SWE-Gym), specifically the subset from [SumanthRH/SWE-Gym-Subset](https://huggingface.co/datasets/SumanthRH/SWE-Gym-Subset).
 
 Execute the following command:
 ```bash
-uv run --isolated examples/mini_swe_agent/preprocess_swegym.py --output_dir ~/data/swe_gym_subset # or modify to your desired path
+uv run --isolated examples/train/mini_swe_agent/preprocess_swegym.py --output_dir ~/data/swe_gym_subset # or modify to your desired path
 ```
 
 ### 2) Configure environment backend
 
-**Prerequisites**: Install the required environment backend. By default, we use [Podman](https://podman.io/docs). This can be modified in `examples/mini_swe_agent/swebench.yaml`.
+**Prerequisites**: Install the required environment backend. By default, we use [Podman](https://podman.io/docs). This can be modified in `examples/train/mini_swe_agent/swebench.yaml`.
 
 ### 3) Launch training
 
@@ -40,17 +42,18 @@ We provide example scripts for different model sizes:
 
 **Qwen3-8B** (requires 1x 8xH100 node):
 ```bash
-bash examples/mini_swe_agent/run_mini_swe_8B.sh
+bash examples/train/mini_swe_agent/run_mini_swe_8B.sh
 ```
 
 **Qwen3-Coder-30B** (requires 2x 8xH100 nodes):
 ```bash
-bash examples/mini_swe_agent/run_mini_swe_30B.sh
+bash examples/train/mini_swe_agent/run_mini_swe_30B.sh
 ```
 
 Make sure to update the `DATA_DIR` variable in the bash script if you saved the data to a custom path.
 
 All training parameters can be modified in the run scripts, such as model choice, GRPO group size, or training batch size.
+The provided scripts already enable `generator.step_wise_trajectories=true` and `generator.batched=false`, which are required for exact-token Mini-SWE training.
 
 ## Troubleshooting
 
@@ -73,7 +76,7 @@ For issues with SkyRL or the Mini-SWE-Agent integration, please [open an Issue](
 
 ## Configuration
 
-Beyond the configuration for SkyRL in the training script, the task-specific configuration file is `examples/mini_swe_agent/swebench.yaml`, which controls:
+Beyond the configuration for SkyRL in the training script, the task-specific configuration file is `examples/train/mini_swe_agent/swebench.yaml`, which controls:
 - Environment backend settings
 - Step limits for agent execution
 - Tool configurations for Mini-SWE-Agent

--- a/examples/train/mini_swe_agent/mini_swe_generator.py
+++ b/examples/train/mini_swe_agent/mini_swe_generator.py
@@ -1,35 +1,48 @@
 import asyncio
-from dataclasses import dataclass
-from typing import Dict, List, Optional, Any, Tuple
-import yaml
 import traceback
-import ray
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Dict, Optional
 
-from minisweagent.models import get_model
+import ray
+import yaml
 from minisweagent.agents.default import DefaultAgent
-from minisweagent.run.utils.save import save_traj
 from minisweagent.config import get_config_path
-from .mini_swe_utils import evaluate_trajectory, get_sb_environment
+from minisweagent.models import get_model
+from minisweagent.run.utils.save import save_traj
 
-from skyrl.train.config import GeneratorConfig, SkyRLGymConfig
-from skyrl.train.generators.skyrl_gym_generator import SkyRLGymGenerator, GeneratorOutput, GeneratorInput
-from skyrl.train.generators.base import TrajectoryID, TrainingPhase, BatchMetadata
+from .mini_swe_utils import evaluate_trajectory, get_sb_environment
+from .stepwise_utils import (
+    MiniSWEStepOutput,
+    build_stepwise_outputs_from_messages,
+    build_stepwise_sampling_params,
+)
 from skyrl.backends.skyrl_train.inference_engines.base import ConversationType
 from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
 from skyrl.backends.skyrl_train.inference_engines.utils import get_sampling_params_for_backend
-from skyrl.train.generators.utils import (
-    get_rollout_metrics,
-    get_response_ids_and_loss_mask_from_messages,
+from skyrl.train.config import GeneratorConfig, SkyRLGymConfig
+from skyrl.train.generators.base import (
+    BatchMetadata,
+    GeneratorInput,
+    GeneratorOutput,
+    TrajectoryID,
+    TrainingPhase,
 )
+from skyrl.train.generators.skyrl_gym_generator import SkyRLGymGenerator
+from skyrl.train.generators.utils import apply_overlong_filtering, get_rollout_metrics
 
 
 @dataclass
 class MiniSWEGeneratorConfig(GeneratorConfig):
     """Extended generator config with Mini-SWE-Agent-specific fields."""
 
+    batched: bool = False
+    step_wise_trajectories: bool = True
     miniswe_config_path: str = ""
     miniswe_traj_dir: str = ""
+
+    def __post_init__(self):
+        super().__post_init__()
 
 
 class DefaultAgentWithReminder(DefaultAgent):
@@ -106,7 +119,15 @@ def init_and_run(
                 eval_error = str(e)
                 error = str(e)
 
-            save_traj(agent, path, exit_status=exit_status, result=result, extra_info=extra_info, reward=reward, eval_error=eval_error)  # type: ignore[arg-type]
+            save_traj(
+                agent,
+                path,
+                exit_status=exit_status,
+                result=result,
+                extra_info=extra_info,
+                reward=reward,
+                eval_error=eval_error,
+            )  # type: ignore[arg-type]
 
     return (agent.messages if agent is not None else [], reward, error)
 
@@ -136,6 +157,14 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
         self.model_name = model_name
         self.litellm_model_name = "openai/" + self.model_name
 
+        if not self.generator_cfg.step_wise_trajectories:
+            raise ValueError("MiniSWEAgentGenerator requires `generator.step_wise_trajectories=true`.")
+        if self.generator_cfg.batched:
+            raise ValueError("MiniSWEAgentGenerator does not support `generator.batched=true`.")
+        if not self.generator_cfg.inference_engine.enable_http_endpoint:
+            raise ValueError(
+                "MiniSWEAgentGenerator requires `generator.inference_engine.enable_http_endpoint=true`."
+            )
         if self.generator_cfg.chat_template.name_or_path is not None:
             raise NotImplementedError("MiniSWEAgentGenerator doesn't support custom chat template")
 
@@ -148,9 +177,10 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
         sampling_params: Dict[str, Any],
         trajectory_id: TrajectoryID,
         batch_metadata: BatchMetadata,
-    ) -> Tuple[List[int], float, str, List[int], List[int], Optional[List[int]]]:
-
+    ) -> Optional[list[MiniSWEStepOutput]]:
+        sampling_params = build_stepwise_sampling_params(sampling_params, trajectory_id)
         sweagent_config = yaml.safe_load(get_config_path(self.generator_cfg.miniswe_config_path).read_text())
+
         # NOTE (sumanthrh): Input `prompt` is not used here because mini-swe-agent uses a similar entry from the `instance` obj
         messages, reward, error = await init_and_run.remote(
             env_extras["instance"],
@@ -164,54 +194,24 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
             batch_metadata.training_phase,
         )
         if not len(messages):
-            return None, None, None, None, None, None
+            if error:
+                return None
+            return None
 
-        # TODO (sumanthrh): This is currently hardcoded for SWEBench with 2 initial messages (system and user).
-        response_messages = messages[2:]
-
-        for message in messages[:2]:
-            assert message["role"] in (
-                "system",
-                "user",
-            ), "Expected the first two messages to be system and user messages"
-
-        initial_input_ids = self.tokenizer.apply_chat_template(
-            messages[:2], add_generation_prompt=False, return_dict=False, tokenize=True
+        step_outputs = build_stepwise_outputs_from_messages(
+            messages=messages,
+            reward=reward,
+            trajectory_id=trajectory_id,
+            max_seq_len=max_tokens + max_input_length,
         )
-        initial_prompt_length = len(initial_input_ids)
-
-        # We remove trailing `user` messages - this is added by Mini-SWE-Agent to capture the final git diff for the trajectory
-        last_idx = len(response_messages) - 1
-        while response_messages[last_idx]["role"] == "user":
-            last_idx -= 1
-        if last_idx < 0:
+        if not step_outputs:
             raise ValueError(
-                "Found no assistant messages. Please ensure that your environment is configured correctly and the `OPENAI_BASE_URL` points to the HTTP server from the inference engine client"
+                "Found no assistant responses with exact token metadata. Please ensure Mini-SWE-Agent is using "
+                "SkyRL's HTTP endpoint and exact token IDs/logprobs are enabled."
             )
-        response_messages = response_messages[: last_idx + 1]
-
-        response_ids, loss_mask, _ = get_response_ids_and_loss_mask_from_messages(
-            response_messages,
-            self.tokenizer,
-            assistant_logprobs=None,
-        )
-
-        # Extract prompt ids
-        prompt_ids = initial_input_ids
-
-        # Calculate maximum response tokens allowed
-        max_response_tokens = max_tokens + max_input_length - initial_prompt_length
-
-        # Determine stop reason
-        stop_reason = "complete"  # Default for trial completion
-        if len(response_ids) > max_response_tokens:
-            stop_reason = "length"
-
-        # Truncate to maximum allowed length
-        response_ids = response_ids[:max_response_tokens]
-        loss_mask = loss_mask[:max_response_tokens]
-
-        return (response_ids, reward, stop_reason, loss_mask, prompt_ids, None)
+        if any(step_output.rollout_logprobs is None for step_output in step_outputs):
+            raise ValueError("MiniSWEAgentGenerator requires per-token rollout logprobs for every assistant turn.")
+        return step_outputs
 
     async def generate(self, input_batch: GeneratorInput) -> GeneratorOutput:
         """
@@ -227,6 +227,10 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
         env_extras = input_batch["env_extras"]
         trajectory_ids = input_batch["trajectory_ids"]
         batch_metadata = input_batch["batch_metadata"]
+        if trajectory_ids is None:
+            raise ValueError("MiniSWEAgentGenerator requires `trajectory_ids` for step-wise training.")
+        if batch_metadata is None:
+            raise ValueError("MiniSWEAgentGenerator requires `batch_metadata` to save Mini-SWE trajectories.")
         max_tokens = self.generator_cfg.sampling_params.max_generate_length
         max_input_length = self.generator_cfg.max_input_length
         sampling_params = get_sampling_params_for_backend(
@@ -250,17 +254,36 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
 
         all_outputs = await asyncio.gather(*tasks)
 
-        # Filter out the `None` entries, which means that trajectory generation failed
-        responses = [output[0] for output in all_outputs if output[0] is not None]
-        rewards = [output[1] for output in all_outputs if output[0] is not None]
-        stop_reasons = [output[2] for output in all_outputs if output[0] is not None]
-        loss_masks = [output[3] for output in all_outputs if output[0] is not None]
-        prompt_token_ids = [output[4] for output in all_outputs if output[0] is not None]
-        if not len(responses):
+        step_outputs = [
+            step_output
+            for trajectory_steps in all_outputs
+            if trajectory_steps is not None
+            for step_output in trajectory_steps
+        ]
+        if not step_outputs:
             raise ValueError(
                 "Found no valid responses for this step. This means that generation failed for all trajectories, likely due to errors in environment setup."
             )
+
+        responses = [step_output.response_ids for step_output in step_outputs]
+        rewards = [step_output.rewards for step_output in step_outputs]
+        stop_reasons = [step_output.stop_reason for step_output in step_outputs]
+        loss_masks = [step_output.loss_mask for step_output in step_outputs]
+        prompt_token_ids = [step_output.prompt_token_ids for step_output in step_outputs]
+        rollout_logprobs = []
+        for step_output in step_outputs:
+            assert step_output.rollout_logprobs is not None
+            rollout_logprobs.append(step_output.rollout_logprobs)
+        out_trajectory_ids = [step_output.trajectory_id for step_output in step_outputs]
+        is_last_step = [step_output.is_last_step for step_output in step_outputs]
+
         rollout_metrics = get_rollout_metrics(responses, rewards)
+
+        if self.generator_cfg.zero_reward_on_non_stop:
+            rewards = self._zero_reward_if_not_stop(rewards, stop_reasons)
+
+        if self.generator_cfg.apply_overlong_filtering:
+            loss_masks = apply_overlong_filtering(loss_masks, stop_reasons)
 
         generator_output: GeneratorOutput = {
             "prompt_token_ids": prompt_token_ids,
@@ -269,7 +292,10 @@ class MiniSweAgentGenerator(SkyRLGymGenerator):
             "loss_masks": loss_masks,
             "stop_reasons": stop_reasons,
             "rollout_metrics": rollout_metrics,
-            "rollout_logprobs": None,
+            "rollout_logprobs": rollout_logprobs,
+            "trajectory_ids": out_trajectory_ids,
+            "rollout_expert_indices": None,
+            "is_last_step": is_last_step,
         }
 
         return generator_output

--- a/examples/train/mini_swe_agent/run_mini_swe_30B.sh
+++ b/examples/train/mini_swe_agent/run_mini_swe_30B.sh
@@ -60,7 +60,8 @@ uv run --isolated --extra fsdp --extra miniswe --env-file examples/train/mini_sw
   generator.inference_engine.http_endpoint_port=8001 \
   generator.inference_engine.weight_sync_backend=nccl \
   generator.inference_engine.async_engine=true \
-  generator.batched=true \
+  generator.batched=false \
+  generator.step_wise_trajectories=true \
   generator.n_samples_per_prompt=4 \
   generator.inference_engine.gpu_memory_utilization=0.8 \
   trainer.logger="$LOGGER" \
@@ -68,6 +69,6 @@ uv run --isolated --extra fsdp --extra miniswe --env-file examples/train/mini_sw
   trainer.run_name="mini_swe_32B_swe_gym" \
   trainer.resume_mode=null \
   trainer.ckpt_path="$CKPT_PATH" \
-  generator.miniswe_config_path="examples/mini_swe_agent/swebench.yaml" \
-  generator.miniswe_traj_dir=$MINISWE_TRAJ_DIR
+  generator.miniswe_config_path="examples/train/mini_swe_agent/swebench.yaml" \
+  generator.miniswe_traj_dir=$MINISWE_TRAJ_DIR \
   $@

--- a/examples/train/mini_swe_agent/run_mini_swe_8B.sh
+++ b/examples/train/mini_swe_agent/run_mini_swe_8B.sh
@@ -59,7 +59,8 @@ uv run --isolated --extra fsdp --extra miniswe --env-file examples/train/mini_sw
   generator.inference_engine.http_endpoint_port=8001 \
   generator.inference_engine.weight_sync_backend=nccl \
   generator.inference_engine.async_engine=true \
-  generator.batched=true \
+  generator.batched=false \
+  generator.step_wise_trajectories=true \
   generator.n_samples_per_prompt=4 \
   generator.inference_engine.gpu_memory_utilization=0.8 \
   trainer.logger="$LOGGER" \
@@ -67,6 +68,6 @@ uv run --isolated --extra fsdp --extra miniswe --env-file examples/train/mini_sw
   trainer.run_name="mini_swe_8B_swe_gym" \
   trainer.resume_mode=null \
   trainer.ckpt_path="$CKPT_PATH" \
-  generator.miniswe_config_path="examples/mini_swe_agent/swebench.yaml" \
-  generator.miniswe_traj_dir=$MINISWE_TRAJ_DIR
+  generator.miniswe_config_path="examples/train/mini_swe_agent/swebench.yaml" \
+  generator.miniswe_traj_dir=$MINISWE_TRAJ_DIR \
   $@

--- a/examples/train/mini_swe_agent/stepwise_utils.py
+++ b/examples/train/mini_swe_agent/stepwise_utils.py
@@ -1,0 +1,165 @@
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from skyrl.train.generators.base import TrajectoryID
+
+
+@dataclass
+class MiniSWEStepOutput:
+    prompt_token_ids: List[int]
+    response_ids: List[int]
+    loss_mask: List[int]
+    rewards: List[float]
+    rollout_logprobs: Optional[List[float]]
+    stop_reason: str
+    trajectory_id: TrajectoryID
+    is_last_step: bool
+
+
+def build_stepwise_sampling_params(base_sampling_params: Dict[str, Any], trajectory_id: TrajectoryID) -> Dict[str, Any]:
+    """Request exact chat-completion tokens and sticky-route the rollout."""
+    sampling_params = deepcopy(base_sampling_params)
+    sampling_params["logprobs"] = True
+    sampling_params["top_logprobs"] = 1
+    sampling_params["session_id"] = trajectory_id.to_string()
+
+    extra_body = dict(sampling_params.get("extra_body") or {})
+    extra_body["return_token_ids"] = True
+    extra_body["return_tokens_as_token_ids"] = True
+    sampling_params["extra_body"] = extra_body
+    return sampling_params
+
+
+def _get_first_choice(raw_response: Dict[str, Any]) -> Dict[str, Any]:
+    choices = raw_response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("Mini-SWE raw response is missing `choices[0]`.")
+    if not isinstance(choices[0], dict):
+        raise ValueError("Mini-SWE raw response `choices[0]` must be a dictionary.")
+    return choices[0]
+
+
+def _parse_token_id(token: Any) -> int:
+    if isinstance(token, int):
+        return token
+    if isinstance(token, str):
+        for part in reversed(token.split(":")):
+            if part.isdigit():
+                return int(part)
+    raise ValueError(f"Unable to parse token id from logprobs token entry: {token!r}")
+
+
+def _extract_response_ids(choice: Dict[str, Any]) -> List[int]:
+    token_ids = choice.get("token_ids")
+    if isinstance(token_ids, list) and all(isinstance(token_id, int) for token_id in token_ids):
+        return token_ids
+
+    logprobs = choice.get("logprobs", {})
+    content = logprobs.get("content") if isinstance(logprobs, dict) else None
+    if isinstance(content, list) and content:
+        return [_parse_token_id(entry.get("token")) for entry in content]
+
+    raise ValueError(
+        "Mini-SWE raw response is missing completion token ids. "
+        "Expected `choices[0].token_ids` or token-id annotated `choices[0].logprobs.content`."
+    )
+
+
+def _extract_rollout_logprobs(choice: Dict[str, Any], expected_length: int) -> Optional[List[float]]:
+    logprobs = choice.get("logprobs", {})
+    content = logprobs.get("content") if isinstance(logprobs, dict) else None
+    if content is None:
+        return None
+    if not isinstance(content, list):
+        raise ValueError("Mini-SWE raw response `choices[0].logprobs.content` must be a list when provided.")
+
+    rollout_logprobs = [float(entry["logprob"]) for entry in content]
+    if len(rollout_logprobs) != expected_length:
+        raise ValueError(
+            "Mini-SWE raw response logprobs length does not match completion token length: "
+            f"{len(rollout_logprobs)} != {expected_length}"
+        )
+    return rollout_logprobs
+
+
+def _extract_prompt_token_ids(raw_response: Dict[str, Any], choice: Dict[str, Any]) -> List[int]:
+    prompt_token_ids = raw_response.get("prompt_token_ids")
+    if prompt_token_ids is None:
+        prompt_token_ids = choice.get("prompt_token_ids")
+    if not isinstance(prompt_token_ids, list) or not all(isinstance(token_id, int) for token_id in prompt_token_ids):
+        raise ValueError(
+            "Mini-SWE raw response is missing prompt token ids. "
+            "Expected `prompt_token_ids` at the response or choice level."
+        )
+    return prompt_token_ids
+
+
+def _truncate_step_to_max_seq_len(
+    prompt_token_ids: List[int],
+    response_ids: List[int],
+    rollout_logprobs: Optional[List[float]],
+    stop_reason: str,
+    max_seq_len: int,
+) -> tuple[List[int], List[int], Optional[List[float]], str]:
+    max_response_tokens = max(0, max_seq_len - len(prompt_token_ids))
+    if len(response_ids) <= max_response_tokens:
+        return prompt_token_ids, response_ids, rollout_logprobs, stop_reason
+
+    truncated_response_ids = response_ids[:max_response_tokens]
+    truncated_logprobs = rollout_logprobs[:max_response_tokens] if rollout_logprobs is not None else None
+    return prompt_token_ids, truncated_response_ids, truncated_logprobs, "length"
+
+
+def build_stepwise_outputs_from_messages(
+    messages: List[Dict[str, Any]],
+    reward: float,
+    trajectory_id: TrajectoryID,
+    max_seq_len: int,
+) -> List[MiniSWEStepOutput]:
+    assistant_messages = [message for message in messages if message.get("role") == "assistant"]
+    if not assistant_messages:
+        raise ValueError("Found no assistant messages in Mini-SWE trajectory output.")
+
+    outputs: List[MiniSWEStepOutput] = []
+    for i, message in enumerate(assistant_messages):
+        raw_response = message.get("extra", {}).get("response")
+        if not isinstance(raw_response, dict):
+            raise ValueError(
+                "Mini-SWE assistant message is missing the raw LiteLLM response under `message['extra']['response']`."
+            )
+
+        choice = _get_first_choice(raw_response)
+        prompt_token_ids = _extract_prompt_token_ids(raw_response, choice)
+        response_ids = _extract_response_ids(choice)
+        rollout_logprobs = _extract_rollout_logprobs(choice, expected_length=len(response_ids))
+        stop_reason = choice.get("finish_reason") or "stop"
+
+        prompt_token_ids, response_ids, rollout_logprobs, stop_reason = _truncate_step_to_max_seq_len(
+            prompt_token_ids=prompt_token_ids,
+            response_ids=response_ids,
+            rollout_logprobs=rollout_logprobs,
+            stop_reason=stop_reason,
+            max_seq_len=max_seq_len,
+        )
+
+        loss_mask = [1] * len(response_ids)
+        per_token_rewards = [0.0] * len(response_ids)
+        is_last_step = i == len(assistant_messages) - 1
+        if is_last_step and per_token_rewards:
+            per_token_rewards[-1] = float(reward)
+
+        outputs.append(
+            MiniSWEStepOutput(
+                prompt_token_ids=prompt_token_ids,
+                response_ids=response_ids,
+                loss_mask=loss_mask,
+                rewards=per_token_rewards,
+                rollout_logprobs=rollout_logprobs,
+                stop_reason=stop_reason,
+                trajectory_id=trajectory_id,
+                is_last_step=is_last_step,
+            )
+        )
+
+    return outputs

--- a/tests/utils/test_mini_swe_stepwise_utils.py
+++ b/tests/utils/test_mini_swe_stepwise_utils.py
@@ -1,0 +1,205 @@
+"""Tests for the Mini-SWE step-wise exact-token helpers.
+
+uv run --isolated --extra dev --extra skyrl-train -- pytest tests/utils/test_mini_swe_stepwise_utils.py
+"""
+
+import pytest
+
+from examples.train.mini_swe_agent.stepwise_utils import (
+    build_stepwise_outputs_from_messages,
+    build_stepwise_sampling_params,
+)
+from skyrl.train.generators.base import TrajectoryID
+
+
+def test_build_stepwise_sampling_params_requests_exact_tokens_without_mutating_input():
+    base_sampling_params = {
+        "max_tokens": 128,
+        "temperature": 0.7,
+        "extra_body": {"skip_special_tokens": True},
+    }
+
+    sampling_params = build_stepwise_sampling_params(
+        base_sampling_params,
+        TrajectoryID(instance_id="instance-1", repetition_id=3),
+    )
+
+    assert sampling_params["logprobs"] is True
+    assert sampling_params["top_logprobs"] == 1
+    assert sampling_params["session_id"] == "instance-1_3"
+    assert sampling_params["extra_body"] == {
+        "skip_special_tokens": True,
+        "return_token_ids": True,
+        "return_tokens_as_token_ids": True,
+    }
+    assert base_sampling_params == {
+        "max_tokens": 128,
+        "temperature": 0.7,
+        "extra_body": {"skip_special_tokens": True},
+    }
+
+
+def test_build_stepwise_outputs_uses_exact_token_ids_and_marks_last_step():
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "task"},
+        {
+            "role": "assistant",
+            "content": "first",
+            "extra": {
+                "response": {
+                    "prompt_token_ids": [10, 11],
+                    "choices": [
+                        {
+                            "token_ids": [101, 102],
+                            "finish_reason": "stop",
+                            "logprobs": {
+                                "content": [
+                                    {"token": 101, "logprob": -0.1},
+                                    {"token": 102, "logprob": -0.2},
+                                ]
+                            },
+                        }
+                    ],
+                }
+            },
+        },
+        {
+            "role": "assistant",
+            "content": "second",
+            "extra": {
+                "response": {
+                    "prompt_token_ids": [10, 11, 12],
+                    "choices": [
+                        {
+                            "token_ids": [201, 202, 203],
+                            "finish_reason": "stop",
+                            "logprobs": {
+                                "content": [
+                                    {"token": 201, "logprob": -0.3},
+                                    {"token": 202, "logprob": -0.4},
+                                    {"token": 203, "logprob": -0.5},
+                                ]
+                            },
+                        }
+                    ],
+                }
+            },
+        },
+    ]
+
+    outputs = build_stepwise_outputs_from_messages(
+        messages=messages,
+        reward=2.5,
+        trajectory_id=TrajectoryID(instance_id="instance-2", repetition_id=1),
+        max_seq_len=32,
+    )
+
+    assert len(outputs) == 2
+
+    assert outputs[0].prompt_token_ids == [10, 11]
+    assert outputs[0].response_ids == [101, 102]
+    assert outputs[0].loss_mask == [1, 1]
+    assert outputs[0].rollout_logprobs == [-0.1, -0.2]
+    assert outputs[0].rewards == [0.0, 0.0]
+    assert outputs[0].stop_reason == "stop"
+    assert outputs[0].is_last_step is False
+
+    assert outputs[1].prompt_token_ids == [10, 11, 12]
+    assert outputs[1].response_ids == [201, 202, 203]
+    assert outputs[1].loss_mask == [1, 1, 1]
+    assert outputs[1].rollout_logprobs == [-0.3, -0.4, -0.5]
+    assert outputs[1].rewards == [0.0, 0.0, 2.5]
+    assert outputs[1].stop_reason == "stop"
+    assert outputs[1].is_last_step is True
+    assert outputs[1].trajectory_id.to_string() == "instance-2_1"
+
+
+def test_build_stepwise_outputs_falls_back_to_token_ids_from_logprobs():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "fallback",
+            "extra": {
+                "response": {
+                    "choices": [
+                        {
+                            "prompt_token_ids": [1, 2, 3],
+                            "finish_reason": "stop",
+                            "logprobs": {
+                                "content": [
+                                    {"token": "token_id:321", "logprob": -0.7},
+                                    {"token": "token_id:654", "logprob": -0.8},
+                                ]
+                            },
+                        }
+                    ]
+                }
+            },
+        }
+    ]
+
+    outputs = build_stepwise_outputs_from_messages(
+        messages=messages,
+        reward=1.0,
+        trajectory_id=TrajectoryID(instance_id="instance-3", repetition_id=0),
+        max_seq_len=16,
+    )
+
+    assert len(outputs) == 1
+    assert outputs[0].prompt_token_ids == [1, 2, 3]
+    assert outputs[0].response_ids == [321, 654]
+    assert outputs[0].rollout_logprobs == [-0.7, -0.8]
+    assert outputs[0].rewards == [0.0, 1.0]
+
+
+def test_build_stepwise_outputs_truncates_overlong_response_and_updates_stop_reason():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "too long",
+            "extra": {
+                "response": {
+                    "prompt_token_ids": [7, 8, 9],
+                    "choices": [
+                        {
+                            "token_ids": [40, 41, 42, 43],
+                            "finish_reason": "stop",
+                            "logprobs": {
+                                "content": [
+                                    {"token": 40, "logprob": -0.1},
+                                    {"token": 41, "logprob": -0.2},
+                                    {"token": 42, "logprob": -0.3},
+                                    {"token": 43, "logprob": -0.4},
+                                ]
+                            },
+                        }
+                    ],
+                }
+            },
+        }
+    ]
+
+    outputs = build_stepwise_outputs_from_messages(
+        messages=messages,
+        reward=3.0,
+        trajectory_id=TrajectoryID(instance_id="instance-4", repetition_id=0),
+        max_seq_len=5,
+    )
+
+    assert len(outputs) == 1
+    assert outputs[0].response_ids == [40, 41]
+    assert outputs[0].loss_mask == [1, 1]
+    assert outputs[0].rollout_logprobs == [-0.1, -0.2]
+    assert outputs[0].rewards == [0.0, 3.0]
+    assert outputs[0].stop_reason == "length"
+
+
+def test_build_stepwise_outputs_requires_raw_response_metadata():
+    with pytest.raises(ValueError, match="raw LiteLLM response"):
+        build_stepwise_outputs_from_messages(
+            messages=[{"role": "assistant", "content": "missing"}],
+            reward=0.0,
+            trajectory_id=TrajectoryID(instance_id="instance-5", repetition_id=0),
+            max_seq_len=8,
+        )


### PR DESCRIPTION
## Summary
Addresses #410.

This changes the Mini-SWE integration to train from exact per-turn inference data instead of reconstructing assistant tokens from post-hoc chat message text.

The main goal is to make Mini-SWE compatible with SkyRL's step-wise training contract using token-in/token-out data sourced from the HTTP `/chat/completions` path.

## What Changed
- switched `MiniSWEGeneratorConfig` to the step-wise path by default and enforced the constraints Mini-SWE actually relies on (`step_wise_trajectories=true`, `batched=false`, HTTP endpoint enabled)
- updated `MiniSweAgentGenerator` to request exact token metadata for each rollout via LiteLLM / SkyRL HTTP serving, including sticky `session_id`, `logprobs`, `top_logprobs`, `return_token_ids`, and `return_tokens_as_token_ids`
- replaced Mini-SWE's message re-tokenization path with exact parsing of prompt token IDs, completion token IDs, per-token rollout logprobs, stop reasons, per-token rewards, `trajectory_ids`, and `is_last_step`
- added a dedicated `stepwise_utils.py` helper module so request shaping and response parsing stay isolated and unit-testable
- updated the example run scripts to enable the step-wise path explicitly and fixed the Mini-SWE config path references to the actual `examples/train/mini_swe_agent/...` location
- updated the example docs / README to describe the exact-token step-wise behavior

## Verification
- `PYTHONPATH=/tmp/skyrl-issue-410-mini-swe-exact-tokens /Users/vuductai/Documents/Projects/SkyRL/.venv/bin/python -m pytest tests/utils/test_mini_swe_stepwise_utils.py -q`
- `/Users/vuductai/Documents/Projects/SkyRL/.venv/bin/python -m py_compile examples/train/mini_swe_agent/stepwise_utils.py examples/train/mini_swe_agent/mini_swe_generator.py tests/utils/test_mini_swe_stepwise_utils.py`
- `bash -n examples/train/mini_swe_agent/run_mini_swe_8B.sh examples/train/mini_swe_agent/run_mini_swe_30B.sh`
- validated locally that LiteLLM's OpenAI-compatible parameter shaping preserves the SkyRL-specific exact-token fields by forwarding `session_id` into `extra_body` alongside `return_token_ids` / `return_tokens_as_token_ids`

## Notes
- this intentionally fixes the active Mini-SWE path without turning issue #410 into a broader `/completions` rewrite or a multi-integration refactor
- the remaining unverified surface is full runtime execution against a live SkyRL HTTP endpoint + Mini-SWE + Podman/vLLM stack; that was not runnable in this sandboxed environment

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
