### PR TITLE
Refactor trainer evaluation hooks and reduce SkyRL-Agent forking

### DIFF
--- a/examples/train/async/async_trainer.py
+++ b/examples/train/async/async_trainer.py
@@ -8,8 +8,6 @@ from skyrl.train.utils import Timer
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.train.generators.base import GeneratorOutput
 from skyrl.train.utils.trainer_utils import ResumeMode
-from skyrl.train.generators.utils import prepare_generator_input
-from skyrl.backends.skyrl_train.inference_engines.utils import get_sampling_params_for_backend
 
 
 class AsyncRayPPOTrainer(RayPPOTrainer):
@@ -161,16 +159,7 @@ class AsyncRayPPOTrainer(RayPPOTrainer):
             for i, rand_prompts in enumerate(self.train_dataloader):
                 # truncate data to have even shards
                 rand_prompts = self._remove_tail_data(rand_prompts)
-                generator_input, uids = prepare_generator_input(
-                    rand_prompts,
-                    self.cfg.generator.n_samples_per_prompt,
-                    get_sampling_params_for_backend(
-                        self.cfg.generator.inference_engine.backend, self.cfg.generator.sampling_params
-                    ),
-                    self.cfg.environment.env_class,
-                    "train",
-                    self.global_step,
-                )
+                generator_input, uids = self.prepare_generator_input(rand_prompts, "train", self.global_step)
 
                 # generation phase
                 async with Timer("generate", self.all_timings):

--- a/skyrl-agent/skyrl_agent/integrations/skyrl_train/trainer.py
+++ b/skyrl-agent/skyrl_agent/integrations/skyrl_train/trainer.py
@@ -1,55 +1,27 @@
 """
-SkyRL Trainer overrides needed for SkyRLAgent integration.
+SkyRL Trainer overrides needed for SkyRL-Agent integration.
 
-NOTE(Charlie): we need to get rid of this ASAP, hacky. Either change SkyAgent code or SkyRL code.
-
-Two changes:
-- Do not check `input_batch["prompts"]` length in `validate_generator_output()`, since it is not
-  repeated n_samples_per_prompt times.
-- Do not repeat the prompts in `prepare_generator_input()` since SkyAgent would repeat it.
+SkyRL-Agent repeats trajectories inside `AgentRunner`, so it needs a custom
+generator-input shape and a slightly looser validation rule than the default
+trainer path.
 """
 
-from typing import List, Dict, Any, Tuple
+from typing import Any, Dict, List
 
-from loguru import logger
 import numpy as np
-from omegaconf import DictConfig
-from torch.utils.data import RandomSampler, SequentialSampler
-from torchdata.stateful_dataloader import StatefulDataLoader
 import torch
 
-from skyrl.train.trainer import RayPPOTrainer
+from skyrl.backends.skyrl_train.inference_engines.utils import get_sampling_params_for_backend
+from skyrl.backends.skyrl_train.utils.ppo_utils import register_advantage_estimator
 from skyrl.train.generators.base import (
+    BatchMetadata,
     GeneratorInput,
     GeneratorOutput,
-    TrajectoryID,
-    BatchMetadata,
     TrainingPhase,
+    TrajectoryID,
 )
-from skyrl.backends.skyrl_train.inference_engines.utils import get_sampling_params_for_backend
-from skyrl.train.dataset import PromptDataset
-
-from pathlib import Path
-import ray
-from tqdm import tqdm
-
-from skyrl.train.config import SkyRLTrainConfig
-from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
-from skyrl.train.generators.utils import prepare_generator_input, get_metrics_from_generator_output
-from skyrl.train.utils import Timer
-from skyrl.backends.skyrl_train.utils.ppo_utils import (
-    get_kl_controller,
-)
-from skyrl.train.utils.trainer_utils import (
-    validate_generator_output,
-    ResumeMode,
-    build_dataloader,
-    calculate_per_dataset_metrics,
-    dump_per_dataset_eval_results,
-    concatenate_generator_outputs,
-)
-
-from skyrl.backends.skyrl_train.utils.ppo_utils import register_advantage_estimator
+from skyrl.train.trainer import RayPPOTrainer
+from skyrl.train.utils.trainer_utils import validate_generator_output as validate_generator_output_impl
 
 
 @register_advantage_estimator("loop")
@@ -91,461 +63,108 @@ def compute_advantages_and_returns_loop(
         return scores, scores
 
 
-def validate_generator_output(input_batch: GeneratorInput, generator_output: GeneratorOutput):
-    """
-    Validate the generator output.
-
-    This is exactly the same as the one in SkyRL, except that we do not use the len(input_batch["prompts"])
-    since it is not repeated n_samples_per_prompt times.
-    """
-    if len(generator_output["response_ids"]) <= 0:
-        raise RuntimeError("No outputs generated")
-
-    # check that input prompts, response ids, and prompt token ids are all the same length
-    # num_prompts = len(input_batch["prompts"])
-    num_responses = len(generator_output["response_ids"])
-    num_prompt_tokens = len(generator_output["prompt_token_ids"])
-    # assert num_prompts == num_responses, f"Mismatch between prompts ({num_prompts}) and responses ({num_responses})"
-    assert (
-        num_responses == num_prompt_tokens
-    ), f"Mismatch between responses ({num_responses}) and prompt_token_ids ({num_prompt_tokens})"
-
-    # make sure all batch elements have the same length as response_ids (which should be non-zero)
-    for key in generator_output:
-        if isinstance(generator_output[key], list) and key in [
-            "response_ids",
-            "loss_masks",
-            "rewards",
-            "rollout_logprobs",
-        ]:
-            assert len(generator_output[key]) == len(
-                generator_output["response_ids"]
-            ), f"Generator output {key} length must be equal to response_ids length, got {len(generator_output[key])} and {len(generator_output['response_ids'])}"
-
-    # make sure that each element of response ids and loss masks are all the same length (and token level rewards if used)
-    for i, (response_ids, loss_masks, rewards) in enumerate(
-        zip(generator_output["response_ids"], generator_output["loss_masks"], generator_output["rewards"])
-    ):
-        assert len(response_ids) == len(
-            loss_masks
-        ), f"Response ids and loss masks must have the same length, for sample {i} got {len(response_ids)} and {len(loss_masks)}"
-        if isinstance(rewards, list):
-            assert len(rewards) == len(
-                response_ids
-            ), f"Token rewards and response ids must have the same length, for sample {i} got {len(rewards)} and {len(response_ids)}"
-
-        if generator_output["rollout_logprobs"]:
-            assert len(response_ids) == len(
-                generator_output["rollout_logprobs"][i]
-            ), f"Response ids and rollout logprobs must have the same length, for sample {i} got {len(response_ids)} and {len(generator_output['rollout_logprobs'][i])}"
-
-    # loss masks should be non-zero for at least one element for trainer
-    if np.concatenate(generator_output["loss_masks"]).sum() == 0:
-        logger.warning("All outputs are loss masked, which may lead to NaN loss, please check your generation logic!!")
-
-
-def build_dataloader(
-    cfg: SkyRLTrainConfig, dataset: PromptDataset, is_train=True, is_fully_async=False
-) -> StatefulDataLoader:
-    """
-    Build the dataloader for the training or evaluation dataset.
-
-    Args:
-        cfg: Config object
-        dataset: Dataset object
-        is_train: Whether to build the dataloader for training or evaluation
-        is_fully_async: If is_train, whether to build the dataloader for fully async training, which
-            mainly makes the batch size 1.
-    """
-    # prepare dataloader
-    batch_size = cfg.trainer.train_batch_size if is_train else cfg.trainer.eval_batch_size
-
-    # Seed the dataloader for reproducibility.
-    seeded_generator = torch.Generator()
-    seeded_generator.manual_seed(cfg.trainer.seed)
-
-    dataloader = StatefulDataLoader(
-        dataset,
-        batch_size=batch_size if not is_fully_async else 1,
-        shuffle=True if is_train else False,
-        collate_fn=dataset.collate_fn,
-        # TODO(Charlie): debug why inference http endpoint is slow when num_workers is 8
-        num_workers=0 if cfg.generator.inference_engine.enable_http_endpoint else 8,
-        drop_last=True if is_train else False,
-        generator=seeded_generator,
-        multiprocessing_context="spawn" if not cfg.generator.inference_engine.enable_http_endpoint else None,
-    )
-    if is_train:
-        if not is_fully_async:
-            logger.info(f"Total steps: {len(dataloader) * cfg.trainer.epochs}")
-        else:
-            logger.info(f"Total steps: {len(dataloader) // cfg.trainer.train_batch_size * cfg.trainer.epochs}")
-    else:
-        logger.info(f"Validation set size: {len(dataloader)}")
-
-    return dataloader
-
-
-def prepare_generator_input(
-    prompts: List[Any],
-    n_samples_per_prompt: int,
-    sampling_params: Dict[str, Any],
-    default_env_class: str,
-    training_phase: TrainingPhase,
-    global_step: int,
-) -> Tuple[GeneratorInput, List[str]]:
-    """Prepares the generator input for training and eval
-
-    Args:
-        prompts (List[Any]): list of prompts
-        n_samples_per_prompt (int): how many samples to create per prompt
-        sampling_params (Dict[str, Any]): sampling parameters
-        default_env_class (str): env class to use if env class missing from prompts
-        training_phase (TrainingPhase): training or eval
-        global_step (int): current global step
-
-    Returns:
-        Tuple[GeneratorInput, List[str]]: generator input and list of uuids
-    """
-    # skyagent's AgentRunner will repeat trajectories internally
-    all_prompts = [prompt["prompt"] for prompt in prompts]
-
-    # all the other columns are env_extras
-    env_extras = [prompt["env_extras"] for prompt in prompts]
-
-    # But for other items like uuids or env classes - repeat by `n_samples_per_prompt` because it is used by
-    # the trainer and for metrics
-    all_envs = [
-        prompt["env_class"] if prompt["env_class"] is not None else default_env_class
-        for prompt in prompts
-        for _ in range(n_samples_per_prompt)
-    ]
-    # Create TrajectoryID objects - one UID per row, repetition_id for multiple samples
-    trajectory_ids = []
-    uids = []
-    for _, prompt in enumerate(prompts):
-        uid: str = prompt["uid"]
-
-        # Create TrajectoryID for each repetition
-        for repetition_id in range(n_samples_per_prompt):
-            trajectory_ids.append(TrajectoryID(instance_id=uid, repetition_id=repetition_id))
-            uids.append(uid)
-
-    generator_input: GeneratorInput = {
-        "prompts": all_prompts,
-        "env_classes": all_envs,
-        "env_extras": env_extras,
-        "sampling_params": sampling_params,
-        "trajectory_ids": trajectory_ids,
-        "batch_metadata": BatchMetadata(global_step=global_step, training_phase=training_phase),
-    }
-
-    return generator_input, uids
-
-
 class SkyRLAgentPPOTrainer(RayPPOTrainer):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # reinitialize with new dataloader function for exact reproducibility across backends
-        self.train_dataloader = build_dataloader(self.cfg, self.train_dataset, is_train=True)
-        self.total_training_steps = len(self.train_dataloader) * self.cfg.trainer.epochs
-        self.eval_dataloader = (
-            build_dataloader(self.cfg, self.eval_dataset, is_train=False) if self.eval_dataset is not None else None
-        )
+    def prepare_generator_input(
+        self,
+        prompts: List[Any],
+        training_phase: TrainingPhase,
+        global_step: int | None,
+    ) -> tuple[GeneratorInput, List[str]]:
+        """Prepare generator input without repeating prompts for SkyRL-Agent."""
+        if training_phase == "eval":
+            n_samples_per_prompt = self.cfg.generator.eval_n_samples_per_prompt
+            sampling_params = self.cfg.generator.eval_sampling_params
+        else:
+            n_samples_per_prompt = self.cfg.generator.n_samples_per_prompt
+            sampling_params = self.cfg.generator.sampling_params
 
-    @torch.no_grad()
-    async def generate(
+        all_prompts = [prompt["prompt"] for prompt in prompts]
+        env_extras = [prompt["env_extras"] for prompt in prompts]
+        all_envs = [
+            prompt["env_class"] if prompt["env_class"] is not None else self.cfg.environment.env_class
+            for prompt in prompts
+            for _ in range(n_samples_per_prompt)
+        ]
+
+        trajectory_ids = []
+        uids = []
+        for prompt in prompts:
+            uid = prompt["uid"]
+            for repetition_id in range(n_samples_per_prompt):
+                trajectory_ids.append(TrajectoryID(instance_id=uid, repetition_id=repetition_id))
+                uids.append(uid)
+
+        generator_input: GeneratorInput = {
+            "prompts": all_prompts,
+            "env_classes": all_envs,
+            "env_extras": env_extras,
+            "sampling_params": get_sampling_params_for_backend(
+                self.cfg.generator.inference_engine.backend,
+                sampling_params,
+            ),
+            "trajectory_ids": trajectory_ids,
+            "batch_metadata": BatchMetadata(global_step=global_step, training_phase=training_phase),
+        }
+
+        return generator_input, uids
+
+    def get_eval_metadata(
+        self,
+        generator_input: GeneratorInput,
+        uids: List[str],
+        generator_output: GeneratorOutput,
+    ) -> tuple[List[str], List[Dict[str, Any]], List[str]]:
+        """Expand prompt-level metadata to match the evaluated trajectories."""
+        trajectory_ids = generator_input.get("trajectory_ids")
+        env_extras = generator_input.get("env_extras")
+        if trajectory_ids is None or env_extras is None:
+            return super().get_eval_metadata(generator_input, uids, generator_output)
+
+        env_classes_by_traj_id = {
+            (traj_id.instance_id, traj_id.repetition_id): env_class
+            for traj_id, env_class in zip(trajectory_ids, generator_input["env_classes"])
+        }
+
+        instance_id_order = []
+        seen_instance_ids = set()
+        for traj_id in trajectory_ids:
+            if traj_id.instance_id in seen_instance_ids:
+                continue
+            seen_instance_ids.add(traj_id.instance_id)
+            instance_id_order.append(traj_id.instance_id)
+
+        assert len(instance_id_order) == len(env_extras), (
+            f"Mismatch between unique trajectory instance IDs ({len(instance_id_order)}) "
+            f"and env_extras ({len(env_extras)})"
+        )
+        env_extras_by_instance_id = {
+            instance_id: env_extra for instance_id, env_extra in zip(instance_id_order, env_extras)
+        }
+
+        output_trajectory_ids = generator_output.get("trajectory_ids") or trajectory_ids
+        output_env_classes: List[str] = []
+        output_env_extras: List[Dict[str, Any]] = []
+        output_uids: List[str] = []
+        for traj_id in output_trajectory_ids:
+            key = (traj_id.instance_id, traj_id.repetition_id)
+            assert key in env_classes_by_traj_id, f"Trajectory ID {traj_id.to_string()} not found in input"
+            assert traj_id.instance_id in env_extras_by_instance_id, (
+                f"Trajectory instance {traj_id.instance_id} missing env_extras"
+            )
+            output_env_classes.append(env_classes_by_traj_id[key])
+            output_env_extras.append(env_extras_by_instance_id[traj_id.instance_id])
+            output_uids.append(traj_id.instance_id)
+
+        return output_env_classes, output_env_extras, output_uids
+
+    def validate_generator_output(
         self,
         input_batch: GeneratorInput,
-    ) -> GeneratorOutput:
-        """
-        Generate rollouts.
-
-        If colocate_all is enabled:
-        - before calling this method, the policy model should be on CPU and inference engine should
-            be awake (i.e. on GPU).
-        - after calling this method, the same model placement still holds.
-        """
-        # NOTE: we assume that .generate returns samples in the same order as passed in
-        # Here SkyAgent would return a repeated output (n_samples_per_prompt times)
-        generator_output: GeneratorOutput = await self.generator.generate(input_batch)
-
-        # add rollout metrics to self.all_metrics
-        if generator_output["rollout_metrics"] is not None:
-            self.all_metrics.update(generator_output["rollout_metrics"])
-
-        validate_generator_output(input_batch, generator_output)
-
-        return generator_output
-
-    async def train(self):
-        """
-        Main training loop for PPO
-        """
-        # Initialize weight sync state between policy model and inference engines.
-        with Timer("init_weight_sync_state"):
-            self.init_weight_sync_state()
-
-        # Load policy model to GPU before loading checkpoint.
-        if self.colocate_all:
-            self.policy_model.backload_to_gpu()
-
-        # Load checkpoint state if resumption is enabled.
-        if self.resume_mode != ResumeMode.NONE:
-            with Timer("load_checkpoints"):
-                self.global_step, _ = self.load_checkpoints()
-
-        if self.colocate_all:
-            self.policy_model.offload_to_cpu(offload_optimizer=True, offload_model=False)
-            await self.inference_engine_client.wake_up(tags=["weights"])
-        with Timer("sync_weights"):
-            ray.get(self.sync_policy_weights_to_inference_engines())
-        if self.colocate_all:
-            with Timer("offload_policy_model_to_cpu"):
-                self.policy_model.offload_to_cpu(offload_optimizer=False, offload_model=True)
-            await self.inference_engine_client.wake_up(tags=["kv_cache"])
-
-        # Eval before training
-        if self.cfg.trainer.eval_interval > 0 and self.cfg.trainer.eval_before_train:
-            with Timer("eval", self.all_timings):
-                eval_metrics = await self.eval()
-                self.tracker.log(eval_metrics, step=self.global_step, commit=True)
-
-        # initialize kl controller
-        if self.cfg.trainer.algorithm.use_kl_in_reward:
-            self.reward_kl_controller = get_kl_controller(self.cfg.trainer.algorithm)
-
-        # main training loop
-        pbar = tqdm(total=self.total_training_steps, initial=self.global_step, desc="Training Batches Processed")
-        self.global_step += 1  # start training at global_step 1
-        for epoch in range(self.cfg.trainer.epochs):
-            for iter, rand_prompts in enumerate(self.train_dataloader):
-                with Timer("step", self.all_timings):
-                    # for colocate_all=true, inference engine is always on GPU when starting the training step
-
-                    # 0. truncate data to have even shards
-                    rand_prompts = self._remove_tail_data(rand_prompts)
-                    generator_input, uids = prepare_generator_input(
-                        rand_prompts,
-                        self.cfg.generator.n_samples_per_prompt,
-                        get_sampling_params_for_backend(
-                            self.cfg.generator.inference_engine.backend, self.cfg.generator.sampling_params
-                        ),
-                        self.cfg.environment.env_class,
-                        "train",
-                        self.global_step,
-                    )
-
-                    # 1.1 generation phase
-                    with Timer("generate", self.all_timings):
-                        generator_output: GeneratorOutput = await self.generate(generator_input)
-
-                    # dynamic sampling
-                    if self.cfg.trainer.algorithm.dynamic_sampling.type is not None:
-                        generator_output, uids, keep_sampling = self.handle_dynamic_sampling(generator_output, uids)
-                        if keep_sampling:  # continue sampling
-                            # update progress bar for current batch (but not global step)
-                            pbar.update(1)
-                            continue
-
-                    if self.colocate_all:
-                        # if we are not continuing sampling, we sleep the inference engine
-                        await self.inference_engine_client.sleep()
-
-                    # 1.2 postprocess rewards
-                    with Timer("postprocess_generator_output", self.all_timings):
-                        generator_output = self.postprocess_generator_output(generator_output, uids)
-
-                    # 2. print example just for debugging
-                    vis = self.tokenizer.decode(generator_output["response_ids"][0])
-                    logger.info(f"Example:\n" f"  Input: {generator_input['prompts'][0]}\n" f"  Output:\n{vis}")
-
-                    with Timer("convert_to_training_input", self.all_timings):
-                        training_input: TrainingInputBatch = self.convert_to_training_input(generator_output, uids)
-                        logger.info(f"Number of sequences: {len(training_input['sequences'])}")
-
-                    # 1.4 inference and calculate values, log probs, rewards, kl divergence
-                    with Timer("fwd_logprobs_values_reward", self.all_timings):
-                        training_input = self.fwd_logprobs_values_reward(training_input)
-
-                    # 1.5 apply kl divergence penalty to rewards
-                    if self.cfg.trainer.algorithm.use_kl_in_reward:
-                        with Timer("apply_reward_kl_penalty", self.all_timings):
-                            training_input = self.apply_reward_kl_penalty(training_input)
-
-                    # 3. calculate advantages and returns
-                    with Timer("compute_advantages_and_returns", self.all_timings):
-                        training_input = self.compute_advantages_and_returns(training_input)
-                        # remove some unwanted keys
-                        for key in ["rewards"]:
-                            training_input.pop(key)
-                        training_input.metadata.pop("uids")
-
-                    if self.cfg.trainer.dump_data_batch:
-                        # dump data to file
-                        with Timer("dump_data_batch"):
-                            self.dump_data(training_input, file_name=f"global_step_{self.global_step}_training_input")
-
-                    # 4. train policy/critic model
-                    # Policy model is backloaded to GPU during training
-                    with Timer("train_critic_and_policy", self.all_timings):
-                        status = self.train_critic_and_policy(training_input)
-
-                    # 5. conditionally save checkpoints and hf model
-                    if self.cfg.trainer.ckpt_interval > 0 and self.global_step % self.cfg.trainer.ckpt_interval == 0:
-                        with Timer("save_checkpoints", self.all_timings):
-                            self.save_checkpoints()
-                    if (
-                        self.cfg.trainer.hf_save_interval > 0
-                        and self.global_step % self.cfg.trainer.hf_save_interval == 0
-                    ):
-                        with Timer("save_hf_model", self.all_timings):
-                            self.save_models()
-
-                    # 6. conditionally sync policy and ref at the end of the epoch
-                    if (
-                        self.cfg.trainer.update_ref_every_epoch
-                        and self.ref_model is not None
-                        and iter == len(self.train_dataloader) - 1
-                        and epoch != self.cfg.trainer.epochs - 1  # skip updating ref at the end of the last epoch
-                    ):
-                        with Timer("update_ref_with_policy", self.all_timings):
-                            self.update_ref_with_policy()
-
-                    # 7. sync weights to inference engines
-                    if self.colocate_all:
-                        self.policy_model.offload_to_cpu(offload_optimizer=True, offload_model=False)
-                        await self.inference_engine_client.wake_up(tags=["weights"])
-                    with Timer("sync_weights", self.all_timings):
-                        ray.get(self.sync_policy_weights_to_inference_engines())
-                    if self.colocate_all:
-                        with Timer("offload_policy_model_to_cpu"):
-                            self.policy_model.offload_to_cpu(offload_optimizer=False, offload_model=True)
-                        await self.inference_engine_client.wake_up(tags=["kv_cache"])
-
-                # 8. set logs
-                logger.info(status)
-                # log epoch info
-                self.all_metrics.update({"trainer/epoch": epoch, "trainer/global_step": self.global_step})
-                if self.cfg.trainer.eval_interval > 0 and (
-                    self.global_step % self.cfg.trainer.eval_interval == 0
-                    or self.global_step == self.total_training_steps
-                ):
-                    with Timer("eval", self.all_timings):
-                        eval_metrics = await self.eval()
-                        self.all_metrics.update(eval_metrics)
-
-                log_payload = {
-                    **self.all_metrics,
-                    **{f"timing/{k}": v for k, v in self.all_timings.items()},
-                }
-                self.tracker.log(log_payload, step=self.global_step, commit=True)
-                self.all_metrics = {}
-                self.all_timings = {}
-
-                # update progress bar after logging
-                pbar.update(1)
-
-                self.global_step += 1
-
-                del training_input, generator_output
-
-        pbar.close()
-        if self.colocate_all:
-            await self.inference_engine_client.sleep()
-            self.policy_model.backload_to_gpu()
-        if self.cfg.trainer.ckpt_interval > 0:
-            with Timer("save_checkpoints", self.all_timings):
-                self.save_checkpoints()
-                logger.info("Saved final checkpoint.")
-        if self.cfg.trainer.hf_save_interval > 0:
-            with Timer("save_hf_model", self.all_timings):
-                self.save_models()
-                logger.info("Saved final model.")
-        logger.info("Training done!")
-
-    @torch.no_grad()
-    async def eval(self):
-        """
-        Run generation and scoring on the evaluation dataset.
-
-        The eval metrics are recorded after having finished training `self.global_step` steps.
-        Metrics recorded in global_step 0 corresponds to evaluations before training.
-
-        Returns:
-            A dictionary of evaluation metrics.
-        """
-        # NOTE: We've only injected the custom `prepare_generator_input` function here
-
-        eval_dataloader = self.eval_dataloader
-        generator = self.generator
-        cfg = self.cfg
-        global_step = self.global_step
-        tokenizer = self.tokenizer
-
-        # 1. Get all generator outputs
-        generator_outputs: List[GeneratorOutput] = []
-        concat_all_envs: List[str] = []
-        concat_env_extras: List[Dict[str, Any]] = []
-        concat_uids: List[str] = []
-        sampling_params = cfg.generator.eval_sampling_params
-        pbar = tqdm(total=len(eval_dataloader), initial=0, desc="Evaluation Progress")
-        for _, prompts in enumerate(eval_dataloader):
-            pbar.update(1)
-            generator_input, uids = prepare_generator_input(
-                prompts,
-                cfg.generator.eval_n_samples_per_prompt,
-                get_sampling_params_for_backend(cfg.generator.inference_engine.backend, sampling_params),
-                cfg.environment.env_class,
-                "eval",
-                global_step,
-            )
-            generator_output: GeneratorOutput = await generator.generate(generator_input)
-            validate_generator_output(generator_input, generator_output)
-            generator_outputs.append(generator_output)
-            concat_all_envs.extend(generator_input["env_classes"])
-            concat_env_extras.extend(generator_input["env_extras"])
-            concat_uids.extend(uids)
-        concat_generator_outputs: GeneratorOutput = concatenate_generator_outputs(generator_outputs)
-
-        # Extract data_sources from env_extras
-        concat_data_sources = [env_extra.get("data_source") for env_extra in concat_env_extras]
-        vis = tokenizer.decode(generator_output["response_ids"][0])
-        logger.info(f"Eval output example: {vis}")
-
-        # 2. Group data by data source and calculate per-dataset metrics
-        eval_metrics = calculate_per_dataset_metrics(
-            concat_generator_outputs, concat_uids, concat_data_sources, cfg.generator.eval_n_samples_per_prompt
+        generator_output: GeneratorOutput,
+    ) -> None:
+        """Allow prompt lists that are not repeated by `n_samples_per_prompt`."""
+        step_wise = self.cfg.generator.step_wise_trajectories or generator_output.get("is_last_step") is not None
+        num_prompts = len(input_batch["trajectory_ids"]) if input_batch.get("trajectory_ids") is not None else len(
+            generator_output["response_ids"]
         )
-
-        # 3. Calculate overall metrics across all datasets
-        overall_metrics = get_metrics_from_generator_output(concat_generator_outputs, concat_uids)
-        eval_metrics.update(
-            {
-                "eval/all/avg_score": overall_metrics["avg_score"],
-                f"eval/all/pass_at_{cfg.generator.eval_n_samples_per_prompt}": overall_metrics["pass_at_n"],
-                "eval/all/mean_positive_reward": overall_metrics["mean_positive_reward"],
-            }
-        )
-
-        # 4. Prepare dumping data
-        # TODO[Ben] update this to be cloud-compatible
-        if cfg.trainer.dump_eval_results:
-            with Timer("dump_eval_results"):
-                data_save_dir = (
-                    Path(cfg.trainer.export_path)
-                    / "dumped_evals"
-                    / ("eval_only" if global_step is None else f"global_step_{global_step}_evals")
-                )
-                data_save_dir.mkdir(parents=True, exist_ok=True)
-                dump_per_dataset_eval_results(
-                    data_save_dir,
-                    tokenizer,
-                    concat_generator_outputs,
-                    concat_data_sources,
-                    concat_all_envs,
-                    concat_env_extras,
-                    eval_metrics,
-                )
-
-        return eval_metrics
+        validate_generator_output_impl(num_prompts, generator_output, step_wise=step_wise)

--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -26,6 +26,7 @@ from skyrl.backends.skyrl_train.inference_servers.utils import build_vllm_cli_ar
 from skyrl.env_vars import _SKYRL_USE_NEW_INFERENCE, SKYRL_RAY_PG_TIMEOUT_IN_S
 from skyrl.train.config import SkyRLTrainConfig, get_config_as_yaml_str
 from skyrl.train.dataset import PromptDataset
+from skyrl.train.evaluator import StandaloneEvaluator
 from skyrl.train.generators.base import GeneratorInterface
 from skyrl.train.trainer import RayPPOTrainer
 from skyrl.train.utils import validate_cfg
@@ -258,6 +259,10 @@ class BasePPOExp:
             generator=generator,
             colocate_pg=colocate_pg,
         )
+
+    def get_evaluator(self, cfg, tokenizer, generator):
+        """Initializes the standalone evaluator used by eval-only entrypoints."""
+        return StandaloneEvaluator(cfg=cfg, generator=generator, tokenizer=tokenizer)
 
     def get_tracker(self):
         """Initializes the tracker for experiment tracking.

--- a/skyrl/train/entrypoints/main_generate.py
+++ b/skyrl/train/entrypoints/main_generate.py
@@ -13,7 +13,6 @@ from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.entrypoints.main_base import (
     BasePPOExp,
 )
-from skyrl.train.evaluate import evaluate
 from skyrl.train.utils.trainer_utils import build_dataloader
 from skyrl.train.utils.utils import initialize_ray, validate_generator_cfg
 
@@ -29,14 +28,18 @@ class EvalOnlyEntrypoint(BasePPOExp):
         inference_engine_client = self.get_inference_client()
         await inference_engine_client.wake_up()
         generator = self.get_generator(self.cfg, self.tokenizer, inference_engine_client)
+        evaluator = self.get_evaluator(self.cfg, self.tokenizer, generator)
 
-        results: dict[str, Any] = await evaluate(
-            eval_dataloader=build_dataloader(self.cfg, self.eval_dataset, is_train=False),
-            generator=generator,
-            cfg=self.cfg,
-            global_step=None,
-            tokenizer=self.tokenizer,
-        )
+        if self.cfg.generator.step_wise_trajectories:
+            results = await evaluator.evaluate_step_wise(
+                eval_dataloader=build_dataloader(self.cfg, self.eval_dataset, is_train=False),
+                global_step=None,
+            )
+        else:
+            results = await evaluator.evaluate(
+                eval_dataloader=build_dataloader(self.cfg, self.eval_dataset, is_train=False),
+                global_step=None,
+            )
 
         tracker = self.get_tracker()
         tracker.log(results, step=0, commit=True)

--- a/skyrl/train/evaluate.py
+++ b/skyrl/train/evaluate.py
@@ -1,33 +1,12 @@
-from collections import defaultdict
-from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict
 
 import torch
-from loguru import logger
 from torchdata.stateful_dataloader import StatefulDataLoader
-from tqdm import tqdm
 from transformers import AutoTokenizer
 
-from skyrl.backends.skyrl_train.inference_engines.utils import (
-    get_sampling_params_for_backend,
-)
 from skyrl.train.config import SkyRLTrainConfig
-from skyrl.train.generators.base import (
-    GeneratorInterface,
-    GeneratorOutput,
-)
-from skyrl.train.generators.utils import (
-    concatenate_generator_outputs,
-    get_metrics_from_generator_output,
-    prepare_generator_input,
-)
-from skyrl.train.utils import Timer
-from skyrl.train.utils.logging_utils import log_example
-from skyrl.train.utils.trainer_utils import (
-    calculate_per_dataset_metrics,
-    dump_per_dataset_eval_results,
-    validate_generator_output,
-)
+from skyrl.train.evaluator import StandaloneEvaluator
+from skyrl.train.generators.base import GeneratorInterface
 
 
 @torch.no_grad()
@@ -38,94 +17,9 @@ async def evaluate(
     global_step: int | None,
     tokenizer: AutoTokenizer,
 ) -> Dict[str, float]:
-    """Runs generation and evaluation of trajectories.
-
-    Args:
-        eval_dataloader (StatefulDataLoader): dataloader of the eval dataset
-        generator (GeneratorInterface): generator to use
-        cfg (SkyRLTrainConfig): config
-        global_step (int | None): current global step, or
-            `None` to indicate a non-training context (e.g., eval-only)
-        tokenizer (AutoTokenizer): tokenizer to use
-
-    Returns:
-        Dict[str, float]: evaluation metrics
-    """
-
-    # 1. Get all generator outputs
-    generator_outputs: List[GeneratorOutput] = []
-    concat_all_envs: List[str] = []
-    concat_env_extras: List[Dict[str, Any]] = []
-    concat_uids: List[str] = []
-    sampling_params = cfg.generator.eval_sampling_params
-    pbar = tqdm(total=len(eval_dataloader), initial=0, desc="Evaluation Progress")
-    for _, prompts in enumerate(eval_dataloader):
-        pbar.update(1)
-        generator_input, uids = prepare_generator_input(
-            prompts,
-            cfg.generator.eval_n_samples_per_prompt,
-            get_sampling_params_for_backend(cfg.generator.inference_engine.backend, sampling_params),
-            cfg.environment.env_class,
-            "eval",
-            global_step,
-        )
-        generator_output: GeneratorOutput = await generator.generate(generator_input)
-        validate_generator_output(len(generator_input["prompts"]), generator_output)
-        generator_outputs.append(generator_output)
-        concat_all_envs.extend(generator_input["env_classes"])
-        concat_env_extras.extend(generator_input["env_extras"])
-        concat_uids.extend(uids)
-    concat_generator_outputs: GeneratorOutput = concatenate_generator_outputs(generator_outputs)
-
-    # Extract data_sources from env_extras
-    concat_data_sources = [env_extra.get("data_source") for env_extra in concat_env_extras]
-    vis = tokenizer.decode(generator_output["response_ids"][0])
-    log_example(
-        logger,
-        prompt=generator_input["prompts"][0],
-        response=vis,
-        reward=generator_output["rewards"][0],
-    )
-
-    # 2. Group data by data source and calculate per-dataset metrics
-    eval_metrics = calculate_per_dataset_metrics(
-        concat_generator_outputs, concat_uids, concat_data_sources, cfg.generator.eval_n_samples_per_prompt
-    )
-
-    # 3. Calculate overall metrics across all datasets
-    overall_metrics = get_metrics_from_generator_output(concat_generator_outputs, concat_uids)
-    eval_metrics.update(
-        {
-            "eval/all/avg_score": overall_metrics["avg_score"],
-            f"eval/all/pass_at_{cfg.generator.eval_n_samples_per_prompt}": overall_metrics["pass_at_n"],
-            "eval/all/mean_positive_reward": overall_metrics["mean_positive_reward"],
-        }
-    )
-
-    for key, value in concat_generator_outputs["rollout_metrics"].items():
-        eval_metrics[f"eval/all/{key}"] = value
-
-    # 4. Prepare dumping data
-    # TODO[Ben] update this to be cloud-compatible
-    if cfg.trainer.dump_eval_results:
-        with Timer("dump_eval_results"):
-            data_save_dir = (
-                Path(cfg.trainer.export_path)
-                / "dumped_evals"
-                / ("eval_only" if global_step is None else f"global_step_{global_step}_evals")
-            )
-            data_save_dir.mkdir(parents=True, exist_ok=True)
-            dump_per_dataset_eval_results(
-                data_save_dir,
-                tokenizer,
-                concat_generator_outputs,
-                concat_data_sources,
-                concat_all_envs,
-                concat_env_extras,
-                eval_metrics,
-            )
-
-    return eval_metrics
+    """Compatibility wrapper for standalone evaluation."""
+    evaluator = StandaloneEvaluator(cfg=cfg, generator=generator, tokenizer=tokenizer)
+    return await evaluator.evaluate(eval_dataloader=eval_dataloader, global_step=global_step)
 
 
 @torch.no_grad()
@@ -136,108 +30,6 @@ async def evaluate_step_wise(
     global_step: int | None,
     tokenizer: AutoTokenizer,
 ) -> Dict[str, float]:
-    """Runs generation and evaluation of trajectories for step-wise training.
-
-    Currently assumes that the rewards are assigned to the last step of each trajectory.
-
-    Args:
-        eval_dataloader (StatefulDataLoader): dataloader of the eval dataset
-        generator (GeneratorInterface): generator to use
-        cfg (SkyRLTrainConfig): config
-        global_step (int | None): current global step, or
-            `None` to indicate a non-training context (e.g., eval-only)
-        tokenizer (AutoTokenizer): tokenizer to use
-
-    Returns:
-        Dict[str, float]: evaluation metrics
-    """
-
-    # 1. Get all generator outputs
-    generator_outputs: List[GeneratorOutput] = []
-    concat_all_envs: List[str] = []
-    concat_env_extras: List[Dict[str, Any]] = []
-    concat_uids: List[str] = []
-    sampling_params = cfg.generator.eval_sampling_params
-    pbar = tqdm(total=len(eval_dataloader), initial=0, desc="Evaluation Progress")
-    for _, prompts in enumerate(eval_dataloader):
-        pbar.update(1)
-        generator_input, uids = prepare_generator_input(
-            prompts,
-            cfg.generator.eval_n_samples_per_prompt,
-            get_sampling_params_for_backend(cfg.generator.inference_engine.backend, sampling_params),
-            cfg.environment.env_class,
-            "eval",
-            global_step,
-        )
-        generator_output: GeneratorOutput = await generator.generate(generator_input)
-        traj_id_to_input = {
-            traj_id.instance_id: {"env_class": env_class, "env_extras": env_extra}
-            for traj_id, env_class, env_extra in zip(
-                generator_input["trajectory_ids"], generator_input["env_classes"], generator_input["env_extras"]
-            )
-        }
-        for traj_id in generator_output["trajectory_ids"]:
-            assert traj_id.instance_id in traj_id_to_input, f"Trajectory ID {traj_id.instance_id} not found in input"
-            concat_all_envs.append(traj_id_to_input[traj_id.instance_id]["env_class"])
-            concat_env_extras.append(traj_id_to_input[traj_id.instance_id]["env_extras"])
-            concat_uids.append(traj_id.instance_id)
-        validate_generator_output(generator_input, generator_output, step_wise=True)
-        generator_outputs.append(generator_output)
-    concat_generator_outputs: GeneratorOutput = concatenate_generator_outputs(generator_outputs)
-
-    # Extract data_sources from env_extras
-    concat_data_sources = [env_extra.get("data_source") for env_extra in concat_env_extras]
-    vis = tokenizer.decode(generator_output["response_ids"][0])
-    logger.info(f"Eval output example: {vis}")
-
-    # Only use the final step metrics
-    generator_output_last_step = defaultdict(list)
-    is_last_step_mask = concat_generator_outputs["is_last_step"]
-    for key in concat_generator_outputs:
-        if isinstance(concat_generator_outputs[key], list):
-            assert len(concat_generator_outputs[key]) == len(
-                is_last_step_mask
-            ), f"Length mismatch: {len(concat_generator_outputs[key])} != {len(is_last_step_mask)} for key {key}"
-            generator_output_last_step[key] = [
-                val for val, is_last_step in zip(concat_generator_outputs[key], is_last_step_mask) if is_last_step
-            ]
-    uids_last_step = [uid for uid, is_last_step in zip(concat_uids, is_last_step_mask) if is_last_step]
-    data_sources_last_step = [
-        data_source for data_source, is_last_step in zip(concat_data_sources, is_last_step_mask) if is_last_step
-    ]
-
-    # 2. Group data by data source and calculate per-dataset metrics
-    eval_metrics = calculate_per_dataset_metrics(
-        generator_output_last_step, uids_last_step, data_sources_last_step, cfg.generator.eval_n_samples_per_prompt
-    )
-    # 3. Calculate overall metrics across all datasets
-    overall_metrics = get_metrics_from_generator_output(generator_output_last_step, uids_last_step)
-    eval_metrics.update(
-        {
-            "eval/all/avg_score": overall_metrics["avg_score"],
-            f"eval/all/pass_at_{cfg.generator.eval_n_samples_per_prompt}": overall_metrics["pass_at_n"],
-            "eval/all/mean_positive_reward": overall_metrics["mean_positive_reward"],
-        }
-    )
-
-    # 4. Prepare dumping data
-    # TODO[Ben] update this to be cloud-compatible
-    if cfg.trainer.dump_eval_results:
-        with Timer("dump_eval_results"):
-            data_save_dir = (
-                Path(cfg.trainer.export_path)
-                / "dumped_evals"
-                / ("eval_only" if global_step is None else f"global_step_{global_step}_evals")
-            )
-            data_save_dir.mkdir(parents=True, exist_ok=True)
-            dump_per_dataset_eval_results(
-                data_save_dir,
-                tokenizer,
-                concat_generator_outputs,
-                concat_data_sources,
-                concat_all_envs,
-                concat_env_extras,
-                eval_metrics,
-            )
-
-    return eval_metrics
+    """Compatibility wrapper for standalone step-wise evaluation."""
+    evaluator = StandaloneEvaluator(cfg=cfg, generator=generator, tokenizer=tokenizer)
+    return await evaluator.evaluate_step_wise(eval_dataloader=eval_dataloader, global_step=global_step)

--- a/skyrl/train/evaluator.py
+++ b/skyrl/train/evaluator.py
@@ -1,0 +1,273 @@
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List
+
+import torch
+from loguru import logger
+from torchdata.stateful_dataloader import StatefulDataLoader
+from tqdm import tqdm
+from transformers import AutoTokenizer
+
+from skyrl.backends.skyrl_train.inference_engines.utils import (
+    get_sampling_params_for_backend,
+)
+from skyrl.train.config import SkyRLTrainConfig
+from skyrl.train.generators.base import (
+    GeneratorInput,
+    GeneratorInterface,
+    GeneratorOutput,
+    TrainingPhase,
+)
+from skyrl.train.generators.utils import (
+    concatenate_generator_outputs,
+    get_metrics_from_generator_output,
+    prepare_generator_input as prepare_generator_input_impl,
+)
+from skyrl.train.utils import Timer
+from skyrl.train.utils.logging_utils import log_example
+from skyrl.train.utils.trainer_utils import (
+    calculate_per_dataset_metrics,
+    dump_per_dataset_eval_results,
+    validate_generator_output as validate_generator_output_impl,
+)
+
+
+class EvaluationHooks:
+    cfg: SkyRLTrainConfig
+    generator: GeneratorInterface
+    tokenizer: AutoTokenizer
+
+    def prepare_generator_input(
+        self,
+        prompts: List[Any],
+        training_phase: TrainingPhase,
+        global_step: int | None,
+    ) -> tuple[GeneratorInput, List[str]]:
+        """Prepare generator input for the configured training phase."""
+        if training_phase == "eval":
+            n_samples_per_prompt = self.cfg.generator.eval_n_samples_per_prompt
+            sampling_params = self.cfg.generator.eval_sampling_params
+        else:
+            n_samples_per_prompt = self.cfg.generator.n_samples_per_prompt
+            sampling_params = self.cfg.generator.sampling_params
+
+        return prepare_generator_input_impl(
+            prompts,
+            n_samples_per_prompt,
+            get_sampling_params_for_backend(self.cfg.generator.inference_engine.backend, sampling_params),
+            self.cfg.environment.env_class,
+            training_phase,
+            global_step,
+        )
+
+    def validate_generator_output(
+        self,
+        input_batch: GeneratorInput,
+        generator_output: GeneratorOutput,
+    ) -> None:
+        """Validate generator output against the current config."""
+        step_wise = self.cfg.generator.step_wise_trajectories or generator_output.get("is_last_step") is not None
+        validate_generator_output_impl(
+            len(input_batch["prompts"]),
+            generator_output,
+            step_wise=step_wise,
+        )
+
+    def get_eval_metadata(
+        self,
+        generator_input: GeneratorInput,
+        uids: List[str],
+        generator_output: GeneratorOutput,
+    ) -> tuple[List[str], List[Dict[str, Any]], List[str]]:
+        """Return metadata aligned with the rows in ``generator_output``."""
+        if not self.cfg.generator.step_wise_trajectories:
+            env_extras = generator_input["env_extras"] or [{} for _ in generator_input["env_classes"]]
+            return list(generator_input["env_classes"]), list(env_extras), list(uids)
+
+        assert generator_input["trajectory_ids"] is not None, "Step-wise evaluation requires input trajectory_ids"
+        assert generator_output["trajectory_ids"] is not None, "Step-wise evaluation requires output trajectory_ids"
+
+        env_extras = generator_input["env_extras"] or [{} for _ in generator_input["trajectory_ids"]]
+        traj_id_to_input = {
+            (traj_id.instance_id, traj_id.repetition_id): {"env_class": env_class, "env_extras": env_extra}
+            for traj_id, env_class, env_extra in zip(
+                generator_input["trajectory_ids"], generator_input["env_classes"], env_extras
+            )
+        }
+
+        output_env_classes: List[str] = []
+        output_env_extras: List[Dict[str, Any]] = []
+        output_uids: List[str] = []
+        for traj_id in generator_output["trajectory_ids"]:
+            key = (traj_id.instance_id, traj_id.repetition_id)
+            assert key in traj_id_to_input, f"Trajectory ID {traj_id.to_string()} not found in input"
+            output_env_classes.append(traj_id_to_input[key]["env_class"])
+            output_env_extras.append(traj_id_to_input[key]["env_extras"])
+            output_uids.append(traj_id.instance_id)
+
+        return output_env_classes, output_env_extras, output_uids
+
+    @torch.no_grad()
+    async def evaluate(
+        self,
+        eval_dataloader: StatefulDataLoader,
+        global_step: int | None,
+    ) -> Dict[str, float]:
+        """Run evaluation for non-step-wise generation."""
+        generator_outputs: List[GeneratorOutput] = []
+        concat_all_envs: List[str] = []
+        concat_env_extras: List[Dict[str, Any]] = []
+        concat_uids: List[str] = []
+
+        pbar = tqdm(total=len(eval_dataloader), initial=0, desc="Evaluation Progress")
+        for _, prompts in enumerate(eval_dataloader):
+            pbar.update(1)
+            generator_input, uids = self.prepare_generator_input(prompts, "eval", global_step)
+            generator_output = await self.generator.generate(generator_input)
+            self.validate_generator_output(generator_input, generator_output)
+            generator_outputs.append(generator_output)
+            eval_envs, eval_env_extras, eval_uids = self.get_eval_metadata(generator_input, uids, generator_output)
+            concat_all_envs.extend(eval_envs)
+            concat_env_extras.extend(eval_env_extras)
+            concat_uids.extend(eval_uids)
+
+        concat_generator_outputs = concatenate_generator_outputs(generator_outputs)
+        concat_data_sources = [env_extra.get("data_source") for env_extra in concat_env_extras]
+        vis = self.tokenizer.decode(generator_output["response_ids"][0])
+        log_example(
+            logger,
+            prompt=generator_input["prompts"][0],
+            response=vis,
+            reward=generator_output["rewards"][0],
+        )
+
+        eval_metrics = calculate_per_dataset_metrics(
+            concat_generator_outputs,
+            concat_uids,
+            concat_data_sources,
+            self.cfg.generator.eval_n_samples_per_prompt,
+        )
+
+        overall_metrics = get_metrics_from_generator_output(concat_generator_outputs, concat_uids)
+        eval_metrics.update(
+            {
+                "eval/all/avg_score": overall_metrics["avg_score"],
+                f"eval/all/pass_at_{self.cfg.generator.eval_n_samples_per_prompt}": overall_metrics["pass_at_n"],
+                "eval/all/mean_positive_reward": overall_metrics["mean_positive_reward"],
+            }
+        )
+
+        for key, value in concat_generator_outputs["rollout_metrics"].items():
+            eval_metrics[f"eval/all/{key}"] = value
+
+        if self.cfg.trainer.dump_eval_results:
+            with Timer("dump_eval_results"):
+                data_save_dir = (
+                    Path(self.cfg.trainer.export_path)
+                    / "dumped_evals"
+                    / ("eval_only" if global_step is None else f"global_step_{global_step}_evals")
+                )
+                data_save_dir.mkdir(parents=True, exist_ok=True)
+                dump_per_dataset_eval_results(
+                    data_save_dir,
+                    self.tokenizer,
+                    concat_generator_outputs,
+                    concat_data_sources,
+                    concat_all_envs,
+                    concat_env_extras,
+                    eval_metrics,
+                )
+
+        return eval_metrics
+
+    @torch.no_grad()
+    async def evaluate_step_wise(
+        self,
+        eval_dataloader: StatefulDataLoader,
+        global_step: int | None,
+    ) -> Dict[str, float]:
+        """Run evaluation for step-wise generation."""
+        generator_outputs: List[GeneratorOutput] = []
+        concat_all_envs: List[str] = []
+        concat_env_extras: List[Dict[str, Any]] = []
+        concat_uids: List[str] = []
+
+        pbar = tqdm(total=len(eval_dataloader), initial=0, desc="Evaluation Progress")
+        for _, prompts in enumerate(eval_dataloader):
+            pbar.update(1)
+            generator_input, uids = self.prepare_generator_input(prompts, "eval", global_step)
+            generator_output = await self.generator.generate(generator_input)
+            self.validate_generator_output(generator_input, generator_output)
+            eval_envs, eval_env_extras, eval_uids = self.get_eval_metadata(generator_input, uids, generator_output)
+            concat_all_envs.extend(eval_envs)
+            concat_env_extras.extend(eval_env_extras)
+            concat_uids.extend(eval_uids)
+            generator_outputs.append(generator_output)
+
+        concat_generator_outputs = concatenate_generator_outputs(generator_outputs)
+
+        concat_data_sources = [env_extra.get("data_source") for env_extra in concat_env_extras]
+        vis = self.tokenizer.decode(generator_output["response_ids"][0])
+        logger.info(f"Eval output example: {vis}")
+
+        generator_output_last_step = defaultdict(list)
+        is_last_step_mask = concat_generator_outputs["is_last_step"]
+        for key in concat_generator_outputs:
+            if isinstance(concat_generator_outputs[key], list):
+                assert len(concat_generator_outputs[key]) == len(
+                    is_last_step_mask
+                ), f"Length mismatch: {len(concat_generator_outputs[key])} != {len(is_last_step_mask)} for key {key}"
+                generator_output_last_step[key] = [
+                    val for val, is_last_step in zip(concat_generator_outputs[key], is_last_step_mask) if is_last_step
+                ]
+        uids_last_step = [uid for uid, is_last_step in zip(concat_uids, is_last_step_mask) if is_last_step]
+        data_sources_last_step = [
+            data_source for data_source, is_last_step in zip(concat_data_sources, is_last_step_mask) if is_last_step
+        ]
+
+        eval_metrics = calculate_per_dataset_metrics(
+            generator_output_last_step,
+            uids_last_step,
+            data_sources_last_step,
+            self.cfg.generator.eval_n_samples_per_prompt,
+        )
+        overall_metrics = get_metrics_from_generator_output(generator_output_last_step, uids_last_step)
+        eval_metrics.update(
+            {
+                "eval/all/avg_score": overall_metrics["avg_score"],
+                f"eval/all/pass_at_{self.cfg.generator.eval_n_samples_per_prompt}": overall_metrics["pass_at_n"],
+                "eval/all/mean_positive_reward": overall_metrics["mean_positive_reward"],
+            }
+        )
+
+        if self.cfg.trainer.dump_eval_results:
+            with Timer("dump_eval_results"):
+                data_save_dir = (
+                    Path(self.cfg.trainer.export_path)
+                    / "dumped_evals"
+                    / ("eval_only" if global_step is None else f"global_step_{global_step}_evals")
+                )
+                data_save_dir.mkdir(parents=True, exist_ok=True)
+                dump_per_dataset_eval_results(
+                    data_save_dir,
+                    self.tokenizer,
+                    concat_generator_outputs,
+                    concat_data_sources,
+                    concat_all_envs,
+                    concat_env_extras,
+                    eval_metrics,
+                )
+
+        return eval_metrics
+
+
+class StandaloneEvaluator(EvaluationHooks):
+    def __init__(
+        self,
+        cfg: SkyRLTrainConfig,
+        generator: GeneratorInterface,
+        tokenizer: AutoTokenizer,
+    ):
+        self.cfg = cfg
+        self.generator = generator
+        self.tokenizer = tokenizer

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -24,15 +24,11 @@ from loguru import logger
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
-from skyrl.backends.skyrl_train.inference_engines.utils import (
-    get_sampling_params_for_backend,
-)
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.backends.skyrl_train.utils.io import io
 from skyrl.train.generators.base import GeneratorOutput
 from skyrl.train.generators.utils import (
     concatenate_generator_outputs,
-    prepare_generator_input,
 )
 from skyrl.train.trainer import RayPPOTrainer
 from skyrl.train.utils import Timer
@@ -543,16 +539,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
 
                 # 1. Prepare generator input
                 assert len(rand_prompts) == 1
-                generator_input, uids = prepare_generator_input(
-                    rand_prompts,
-                    self.cfg.generator.n_samples_per_prompt,
-                    get_sampling_params_for_backend(
-                        self.cfg.generator.inference_engine.backend, self.cfg.generator.sampling_params
-                    ),
-                    self.cfg.environment.env_class,
-                    "train",
-                    self.global_step,
-                )
+                generator_input, uids = self.prepare_generator_input(rand_prompts, "train", self.global_step)
                 assert all(uid == uids[0] for uid in uids), "Expect all uids to be the same"
 
                 # 2. Acquire capacity slot.

--- a/skyrl/train/generators/base.py
+++ b/skyrl/train/generators/base.py
@@ -18,7 +18,7 @@ class TrajectoryID:
 
 @dataclass
 class BatchMetadata:
-    global_step: int
+    global_step: int | None
     training_phase: TrainingPhase
 
 

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -367,7 +367,7 @@ def prepare_generator_input(
     sampling_params: Dict[str, Any],
     default_env_class: str,
     training_phase: TrainingPhase,
-    global_step: int,
+    global_step: int | None,
 ) -> Tuple[GeneratorInput, List[str]]:
     """Prepares the generator input for training and eval
 
@@ -377,7 +377,7 @@ def prepare_generator_input(
         sampling_params (Dict[str, Any]): sampling parameters
         default_env_class (str): env class to use if env class missing from prompts
         training_phase (TrainingPhase): training or eval
-        global_step (int): current global step
+        global_step (int | None): current global step, or `None` for eval-only contexts
 
     Returns:
         Tuple[GeneratorInput, List[str]]: generator input and list of uuids

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -24,9 +24,6 @@ from skyrl.backends.skyrl_train.distributed.dispatch import (
 from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import (
     InferenceEngineClient,
 )
-from skyrl.backends.skyrl_train.inference_engines.utils import (
-    get_sampling_params_for_backend,
-)
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.backends.skyrl_train.utils import ppo_utils
 from skyrl.backends.skyrl_train.utils.io import io
@@ -47,7 +44,7 @@ from skyrl.train.dataset import PromptDataset
 from skyrl.train.dataset.preprocess import (
     convert_prompts_responses_to_batch_tensors,
 )
-from skyrl.train.evaluate import evaluate, evaluate_step_wise
+from skyrl.train.evaluator import EvaluationHooks
 from skyrl.train.generators.base import (
     GeneratorInput,
     GeneratorInterface,
@@ -55,7 +52,6 @@ from skyrl.train.generators.base import (
 )
 from skyrl.train.generators.utils import (
     get_metrics_from_generator_output,
-    prepare_generator_input,
 )
 from skyrl.train.utils import (
     Timer,
@@ -73,13 +69,12 @@ from skyrl.train.utils.trainer_utils import (
     extract_step_from_path,
     run_on_each_node,
     validate_consistency_for_latest_checkpoint,
-    validate_generator_output,
     zero_variance_filter,
 )
 from skyrl.train.utils.utils import ResolvedPlacementGroup, configure_ray_worker_logging
 
 
-class RayPPOTrainer:
+class RayPPOTrainer(EvaluationHooks):
     def __init__(
         self,
         cfg: SkyRLTrainConfig,
@@ -157,20 +152,14 @@ class RayPPOTrainer:
             A dictionary of evaluation metrics.
         """
         if self.cfg.generator.step_wise_trajectories:
-            eval_metrics = await evaluate_step_wise(
+            eval_metrics = await self.evaluate_step_wise(
                 eval_dataloader=self.eval_dataloader,
-                generator=self.generator,
-                cfg=self.cfg,
                 global_step=self.global_step,
-                tokenizer=self.tokenizer,
             )
         else:
-            eval_metrics = await evaluate(
+            eval_metrics = await self.evaluate(
                 eval_dataloader=self.eval_dataloader,
-                generator=self.generator,
-                cfg=self.cfg,
                 global_step=self.global_step,
-                tokenizer=self.tokenizer,
             )
         return eval_metrics
 
@@ -212,16 +201,7 @@ class RayPPOTrainer:
 
                     # 0. truncate data to have even shards
                     rand_prompts = self._remove_tail_data(rand_prompts)
-                    generator_input, uids = prepare_generator_input(
-                        rand_prompts,
-                        self.cfg.generator.n_samples_per_prompt,
-                        get_sampling_params_for_backend(
-                            self.cfg.generator.inference_engine.backend, self.cfg.generator.sampling_params
-                        ),
-                        self.cfg.environment.env_class,
-                        "train",
-                        self.global_step,
-                    )
+                    generator_input, uids = self.prepare_generator_input(rand_prompts, "train", self.global_step)
 
                     # 1.1. generation phase
                     with Timer("generate", self.all_timings):
@@ -703,11 +683,7 @@ class RayPPOTrainer:
         if generator_output["rollout_metrics"] is not None:
             self.all_metrics.update(generator_output["rollout_metrics"])
 
-        validate_generator_output(
-            len(input_batch["prompts"]),
-            generator_output,
-            step_wise=self.cfg.generator.step_wise_trajectories,
-        )
+        self.validate_generator_output(input_batch, generator_output)
 
         return generator_output
 

--- a/tests/train/test_evaluator_hooks.py
+++ b/tests/train/test_evaluator_hooks.py
@@ -1,0 +1,387 @@
+"""
+uv run --isolated --extra dev pytest tests/train/test_evaluator_hooks.py
+"""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skyrl.train.entrypoints.main_generate import EvalOnlyEntrypoint
+from skyrl.train.evaluator import StandaloneEvaluator
+from skyrl.train.generators.base import BatchMetadata, GeneratorInterface, GeneratorOutput, TrajectoryID
+from skyrl.train.trainer import RayPPOTrainer
+from tests.train.util import example_dummy_config
+
+
+class DummyStatefulDataLoader:
+    def __init__(self, batches):
+        self._batches = batches
+
+    def __len__(self):
+        return len(self._batches)
+
+    def __iter__(self):
+        return iter(self._batches)
+
+
+class DummyGenerator(GeneratorInterface):
+    def __init__(self, output: GeneratorOutput):
+        self.output = output
+        self.seen_inputs = []
+
+    async def generate(self, input_batch):
+        self.seen_inputs.append(input_batch)
+        return self.output
+
+
+class DummyDataset:
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, idx):
+        return {
+            "prompt": [{"role": "user", "content": "question"}],
+            "env_class": None,
+            "env_extras": {"data_source": "test"},
+            "uid": "uid-1",
+        }
+
+    def collate_fn(self, batch):
+        return batch
+
+
+class SimpleLoader:
+    def __init__(self, batches):
+        self._batches = batches
+
+    def __len__(self):
+        return len(self._batches)
+
+    def __iter__(self):
+        return iter(self._batches)
+
+
+class PrepareCalled(RuntimeError):
+    pass
+
+
+def _load_skyrl_agent_trainer_cls():
+    module_path = (
+        Path(__file__).resolve().parents[2] / "skyrl-agent" / "skyrl_agent" / "integrations" / "skyrl_train" / "trainer.py"
+    )
+    spec = importlib.util.spec_from_file_location("skyrl_agent_skyrl_train_trainer", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.SkyRLAgentPPOTrainer
+
+
+@pytest.mark.asyncio
+async def test_standalone_evaluator_uses_prepare_hook():
+    cfg = example_dummy_config()
+    cfg.generator.inference_engine.backend = "vllm"
+    cfg.trainer.dump_eval_results = False
+
+    prompts_batch = [
+        {
+            "prompt": [{"role": "user", "content": "question"}],
+            "env_class": None,
+            "env_extras": {"data_source": "dataset/a"},
+            "uid": "uid-1",
+        }
+    ]
+    eval_dataloader = DummyStatefulDataLoader([prompts_batch])
+    generator = DummyGenerator(
+        {
+            "prompt_token_ids": [[101]],
+            "response_ids": [[201]],
+            "rewards": [1.0],
+            "loss_masks": [[1]],
+            "stop_reasons": ["stop"],
+            "rollout_logprobs": None,
+        }
+    )
+    tokenizer = MagicMock()
+    tokenizer.decode.return_value = "decoded"
+
+    class HookedEvaluator(StandaloneEvaluator):
+        def prepare_generator_input(self, prompts, training_phase, global_step):
+            return (
+                {
+                    "prompts": [[{"role": "user", "content": "hooked"}]],
+                    "env_classes": ["gsm8k"],
+                    "env_extras": [{"data_source": "dataset/a"}],
+                    "sampling_params": None,
+                    "trajectory_ids": None,
+                    "batch_metadata": BatchMetadata(global_step=global_step, training_phase=training_phase),
+                },
+                ["uid-1"],
+            )
+
+    metrics = await HookedEvaluator(cfg=cfg, generator=generator, tokenizer=tokenizer).evaluate(
+        eval_dataloader=eval_dataloader,
+        global_step=7,
+    )
+
+    assert generator.seen_inputs[0]["prompts"] == [[{"role": "user", "content": "hooked"}]]
+    assert metrics["eval/all/avg_score"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_standalone_evaluator_uses_eval_metadata_hook():
+    cfg = example_dummy_config()
+    cfg.generator.inference_engine.backend = "vllm"
+    cfg.generator.eval_n_samples_per_prompt = 2
+    cfg.trainer.dump_eval_results = False
+
+    prompts_batch = [
+        {
+            "prompt": [{"role": "user", "content": "question"}],
+            "env_class": None,
+            "env_extras": {"data_source": "dataset/a"},
+            "uid": "uid-1",
+        }
+    ]
+    eval_dataloader = DummyStatefulDataLoader([prompts_batch])
+    generator = DummyGenerator(
+        {
+            "prompt_token_ids": [[101], [102]],
+            "response_ids": [[201], [202]],
+            "rewards": [1.0, 0.0],
+            "loss_masks": [[1], [1]],
+            "stop_reasons": ["stop", "stop"],
+            "rollout_logprobs": None,
+        }
+    )
+    tokenizer = MagicMock()
+    tokenizer.decode.return_value = "decoded"
+
+    class HookedEvaluator(StandaloneEvaluator):
+        def prepare_generator_input(self, prompts, training_phase, global_step):
+            return (
+                {
+                    "prompts": [prompts[0]["prompt"], prompts[0]["prompt"]],
+                    "env_classes": ["gsm8k", "gsm8k"],
+                    "env_extras": [{"data_source": "dataset/a"}],
+                    "sampling_params": None,
+                    "trajectory_ids": [
+                        TrajectoryID(instance_id="uid-1", repetition_id=0),
+                        TrajectoryID(instance_id="uid-1", repetition_id=1),
+                    ],
+                    "batch_metadata": BatchMetadata(global_step=global_step, training_phase=training_phase),
+                },
+                ["uid-1", "uid-1"],
+            )
+
+        def get_eval_metadata(self, generator_input, uids, generator_output):
+            return (
+                ["gsm8k", "gsm8k"],
+                [{"data_source": "dataset/a"}, {"data_source": "dataset/a"}],
+                ["uid-1", "uid-1"],
+            )
+
+    metrics = await HookedEvaluator(cfg=cfg, generator=generator, tokenizer=tokenizer).evaluate(
+        eval_dataloader=eval_dataloader,
+        global_step=7,
+    )
+
+    assert metrics["eval/dataset_a/avg_score"] == pytest.approx(0.5)
+    assert metrics["eval/all/pass_at_2"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_trainer_train_uses_prepare_generator_input_hook():
+    cfg = example_dummy_config()
+    cfg.trainer.eval_interval = 0
+
+    class HookedTrainer(RayPPOTrainer):
+        def __init__(self, *args, **kwargs):
+            self.prepare_calls = []
+            super().__init__(*args, **kwargs)
+
+        def _build_train_dataloader_and_compute_training_steps(self):
+            self.train_dataloader = SimpleLoader(
+                [
+                    [
+                        {
+                            "prompt": [{"role": "user", "content": "question"}],
+                            "env_class": None,
+                            "env_extras": {},
+                            "uid": "uid-1",
+                        }
+                    ]
+                ]
+            )
+            self.total_training_steps = 1
+
+        def _remove_tail_data(self, prompts):
+            return prompts
+
+        def prepare_generator_input(self, prompts, training_phase, global_step):
+            self.prepare_calls.append((prompts, training_phase, global_step))
+            raise PrepareCalled
+
+    trainer = HookedTrainer(
+        cfg=cfg,
+        tracker=MagicMock(),
+        tokenizer=MagicMock(),
+        train_dataset=None,
+        eval_dataset=None,
+        inference_engine_client=MagicMock(),
+        generator=MagicMock(),
+    )
+    trainer.dispatch = MagicMock()
+    trainer.dispatch.init_weight_sync_state = MagicMock()
+    trainer.dispatch.save_weights_for_sampler = AsyncMock()
+
+    with pytest.raises(PrepareCalled):
+        await trainer.train()
+
+    assert trainer.prepare_calls
+    assert trainer.prepare_calls[0][1] == "train"
+
+
+@pytest.mark.asyncio
+async def test_trainer_generate_uses_validation_hook():
+    cfg = example_dummy_config()
+    input_batch = {
+        "prompts": [[{"role": "user", "content": "question"}]],
+        "env_classes": ["gsm8k"],
+        "env_extras": [{}],
+        "sampling_params": None,
+        "trajectory_ids": None,
+        "batch_metadata": BatchMetadata(global_step=1, training_phase="train"),
+    }
+    generator_output = {
+        "prompt_token_ids": [[101]],
+        "response_ids": [[201]],
+        "rewards": [1.0],
+        "loss_masks": [[1]],
+        "stop_reasons": ["stop"],
+        "rollout_logprobs": None,
+        "rollout_metrics": {"test_metric": 1.0},
+    }
+
+    class HookedTrainer(RayPPOTrainer):
+        def _build_train_dataloader_and_compute_training_steps(self):
+            self.train_dataloader = None
+            self.total_training_steps = None
+
+        def validate_generator_output(self, input_batch, generator_output):
+            self.validated = (input_batch, generator_output)
+
+    trainer = HookedTrainer(
+        cfg=cfg,
+        tracker=MagicMock(),
+        tokenizer=MagicMock(),
+        train_dataset=None,
+        eval_dataset=None,
+        inference_engine_client=MagicMock(),
+        generator=DummyGenerator(generator_output),
+    )
+
+    result = await trainer.generate(input_batch)
+
+    assert result == generator_output
+    assert trainer.validated[0] == input_batch
+    assert trainer.validated[1] == generator_output
+
+
+def test_skyrl_agent_eval_metadata_expands_prompt_level_extras():
+    SkyRLAgentPPOTrainer = _load_skyrl_agent_trainer_cls()
+
+    trainer = object.__new__(SkyRLAgentPPOTrainer)
+    trainer.cfg = example_dummy_config()
+
+    generator_input = {
+        "prompts": [
+            [{"role": "user", "content": "question-1"}],
+            [{"role": "user", "content": "question-2"}],
+        ],
+        "env_classes": ["env-a", "env-a", "env-b", "env-b"],
+        "env_extras": [{"data_source": "dataset/a"}, {"data_source": "dataset/b"}],
+        "sampling_params": None,
+        "trajectory_ids": [
+            TrajectoryID(instance_id="uid-1", repetition_id=0),
+            TrajectoryID(instance_id="uid-1", repetition_id=1),
+            TrajectoryID(instance_id="uid-2", repetition_id=0),
+            TrajectoryID(instance_id="uid-2", repetition_id=1),
+        ],
+        "batch_metadata": BatchMetadata(global_step=1, training_phase="eval"),
+    }
+    generator_output = {
+        "prompt_token_ids": [[101], [102], [103], [104]],
+        "response_ids": [[201], [202], [203], [204]],
+        "rewards": [1.0, 0.0, 0.5, 0.0],
+        "loss_masks": [[1], [1], [1], [1]],
+        "stop_reasons": ["stop", "stop", "stop", "stop"],
+        "rollout_logprobs": None,
+        "trajectory_ids": None,
+    }
+    uids = ["uid-1", "uid-1", "uid-2", "uid-2"]
+
+    env_classes, env_extras, expanded_uids = trainer.get_eval_metadata(generator_input, uids, generator_output)
+
+    assert env_classes == ["env-a", "env-a", "env-b", "env-b"]
+    assert env_extras == [
+        {"data_source": "dataset/a"},
+        {"data_source": "dataset/a"},
+        {"data_source": "dataset/b"},
+        {"data_source": "dataset/b"},
+    ]
+    assert expanded_uids == uids
+
+
+@pytest.mark.asyncio
+async def test_eval_only_entrypoint_uses_get_evaluator_hook():
+    cfg = example_dummy_config()
+    cfg.generator.inference_engine.enable_http_endpoint = True
+    cfg.trainer.placement.colocate_all = False
+
+    class DummyInferenceClient:
+        async def wake_up(self):
+            return None
+
+    class DummyTracker:
+        def __init__(self):
+            self.logged = None
+
+        def log(self, payload, step, commit):
+            self.logged = (payload, step, commit)
+
+    class DummyEvaluator:
+        def __init__(self):
+            self.called = False
+
+        async def evaluate(self, eval_dataloader, global_step):
+            self.called = True
+            return {"eval/all/avg_score": 1.0}
+
+    class HookedEvalOnlyEntrypoint(EvalOnlyEntrypoint):
+        def get_eval_dataset(self):
+            return DummyDataset()
+
+        def get_inference_client(self):
+            return DummyInferenceClient()
+
+        def get_generator(self, cfg, tokenizer, inference_engine_client):
+            return object()
+
+        def get_evaluator(self, cfg, tokenizer, generator):
+            self.evaluator = DummyEvaluator()
+            return self.evaluator
+
+        def get_tracker(self):
+            self.tracker_instance = DummyTracker()
+            return self.tracker_instance
+
+    with patch("skyrl.train.entrypoints.main_base.get_tokenizer", return_value=MagicMock()):
+        exp = HookedEvalOnlyEntrypoint(cfg)
+
+    result = await exp.run()
+
+    assert result == {"eval/all/avg_score": 1.0}
+    assert exp.evaluator.called is True
+    assert exp.tracker_instance.logged == (result, 0, True)


### PR DESCRIPTION
Closes #693.

## Summary
This PR restores a small, explicit evaluation hook seam for SkyRL trainers and eval-only entrypoints so integrations can customize evaluation behavior without forking the full training loop.

The main goal is to let `skyrl-agent` override the pieces it actually needs, while keeping the shared training, generation, and evaluation flow in core SkyRL.

## What Changed
- added `EvaluationHooks` and `StandaloneEvaluator` in `skyrl/train/evaluator.py`
- made `RayPPOTrainer` use overridable instance hooks for:
  - `prepare_generator_input(...)`
  - `validate_generator_output(...)`
  - `evaluate(...)`
  - `evaluate_step_wise(...)`
- kept `skyrl/train/evaluate.py` as a compatibility layer via thin wrappers over `StandaloneEvaluator`
- rewired trainer, fully-async trainer, and example async trainer call sites to use the shared hook path
- added a small `BasePPOExp.get_evaluator(...)` seam and updated eval-only generation to use it instead of instantiating trainer-bound logic
- reduced the `skyrl-agent` SkyRL integration from a forked trainer/eval/generate implementation down to focused overrides for generator-input shaping, validation, and eval metadata expansion
- added focused regression coverage for trainer hooks, eval-only hooks, and the SkyRL-Agent metadata-alignment path

## Design Notes
- the refactor keeps the shared logic in one place instead of duplicating train/eval loops in integrations
- eval-only remains standalone and does not need to instantiate a trainer just to customize evaluation behavior
- hook surface area stays intentionally small so the extension point is useful without becoming a second framework
- eval metadata alignment is handled explicitly so integrations like `skyrl-agent`, which keep some metadata at prompt granularity, still report correct per-dataset metrics during evaluation

## Testing
- `python3 -m py_compile skyrl/train/evaluator.py skyrl-agent/skyrl_agent/integrations/skyrl_train/trainer.py tests/train/test_evaluator_hooks.py`
- `/private/tmp/skyrl-1278-stepwise-parity/.venv/bin/python -m pytest --noconftest tests/train/test_evaluator_hooks.py tests/train/test_eval.py tests/train/test_trainer.py -q`

## Notes
This is intentionally scoped to the hook extraction and fork reduction requested in issue #693, without broadening into unrelated trainer or evaluator redesigns.
