### PR TITLE
[SkyRLGymGenerator] Respect remaining context budget in agent_loop

### DIFF
--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -8,7 +8,7 @@ For details, see https://docs.skyrl.ai/docs/tutorials/skyrl_gym_generator
 import asyncio
 import copy
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
@@ -22,6 +22,9 @@ from skyrl.backends.skyrl_train.inference_engines.base import (
 )
 from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import (
     InferenceEngineClient,
+)
+from skyrl.backends.skyrl_train.inference_engines.utils import (
+    get_sampling_params_for_backend,
 )
 from skyrl.train.config import GeneratorConfig, SkyRLGymConfig
 from skyrl.train.generators.base import (
@@ -218,6 +221,36 @@ class SkyRLGymGenerator(GeneratorInterface):
         else:
             return func(*args, **kwargs)
 
+    def _get_turn_sampling_params(
+        self,
+        sampling_params: Optional[Dict[str, Any]],
+        current_input_length: int,
+        max_input_length: int,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Build the effective sampling params for the current turn.
+
+        For training/eval, ``sampling_params`` is typically already a backend-normalized dict
+        (e.g. vLLM-style with ``max_tokens``). For direct callers/tests that omit it, fall back
+        to the generator config and normalize it for the configured backend.
+        """
+        if sampling_params is None:
+            turn_sampling_params = get_sampling_params_for_backend(
+                self.generator_cfg.inference_engine.backend, self.generator_cfg.sampling_params
+            )
+        else:
+            turn_sampling_params = copy.deepcopy(sampling_params)
+
+        remaining_budget = max_input_length - current_input_length
+        if "max_tokens" in turn_sampling_params:
+            turn_sampling_params["max_tokens"] = min(turn_sampling_params["max_tokens"], remaining_budget)
+        elif "max_generate_length" in turn_sampling_params:
+            turn_sampling_params["max_generate_length"] = min(
+                turn_sampling_params["max_generate_length"], remaining_budget
+            )
+
+        return turn_sampling_params
+
     async def agent_loop(
         self,
         prompt: ConversationType,
@@ -289,14 +322,9 @@ class SkyRLGymGenerator(GeneratorInterface):
         loss_mask = []  # this excludes the prompt
         rollout_logprobs = None
 
-        # `sampling_params` if provided is a dict in the format expected by the inference engine backend
-        # we cast default config to a dict for consistency
-        current_sampling_params: dict = (
-            sampling_params if sampling_params is not None else asdict(self.generator_cfg.sampling_params)
-        )
-
         # Accumulate per-step rewards. Format: (reward, response_end_token_idx)
         per_step_rewards: List[Tuple[float, Optional[int]]] = []
+        new_obs: ConversationType = []
 
         is_step_wise = self.generator_cfg.step_wise_trajectories
 
@@ -314,10 +342,6 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         while not agent_loop_state.done:
 
-            if len(agent_loop_state.input_ids) > max_input_length:
-                stop_reason = "length"
-                break
-
             # 1. Generate output
             if is_step_wise or retokenize_chat_history:
                 # re-apply whole chat template so length check is correct
@@ -332,8 +356,20 @@ class SkyRLGymGenerator(GeneratorInterface):
                 agent_loop_state.loss_mask = []
                 agent_loop_state.rollout_logprobs = None
 
+            current_input_length = len(agent_loop_state.input_ids)
+            if current_input_length >= max_input_length:
+                stop_reason = "length"
+                break
+
+            current_sampling_params = self._get_turn_sampling_params(
+                sampling_params=sampling_params,
+                current_input_length=current_input_length,
+                max_input_length=max_input_length,
+            )
             engine_input = InferenceEngineInput(
-                prompt_token_ids=[agent_loop_state.input_ids], session_ids=[session_id], sampling_params=sampling_params
+                prompt_token_ids=[agent_loop_state.input_ids],
+                session_ids=[session_id],
+                sampling_params=current_sampling_params,
             )
             engine_output = await self.inference_engine_client.generate(engine_input)
             output = engine_output["responses"][0]
@@ -453,38 +489,50 @@ class SkyRLGymGenerator(GeneratorInterface):
         # Note that during the agent loop, we still add the final observation messages/ tokens because we terminate the agent loop if the input length
         # exceeds the maximum
         if retokenize_chat_history:
-            response_encodings = self.tokenizer.apply_chat_template(
-                agent_loop_state.chat_history[
-                    initial_chat_history_length : len(agent_loop_state.chat_history) - len(new_obs)
-                ],
-                chat_template=self.custom_chat_template,
-                add_generation_prompt=False,
-                return_dict=True,
-                return_assistant_tokens_mask=True,
-                tokenize=True,
-                **self.generator_cfg.chat_template_kwargs,
-            )
-            loss_mask = response_encodings["assistant_masks"]
-            response_ids = response_encodings["input_ids"]
+            if agent_loop_state.response_end_idx is None:
+                loss_mask = []
+                response_ids = []
+            else:
+                response_encodings = self.tokenizer.apply_chat_template(
+                    agent_loop_state.chat_history[
+                        initial_chat_history_length : len(agent_loop_state.chat_history) - len(new_obs)
+                    ],
+                    chat_template=self.custom_chat_template,
+                    add_generation_prompt=False,
+                    return_dict=True,
+                    return_assistant_tokens_mask=True,
+                    tokenize=True,
+                    **self.generator_cfg.chat_template_kwargs,
+                )
+                loss_mask = response_encodings["assistant_masks"]
+                response_ids = response_encodings["input_ids"]
         elif not self.generator_cfg.step_wise_trajectories:
-            assert not any(
-                agent_loop_state.loss_mask[agent_loop_state.response_end_idx - initial_prompt_length + 1 :]
-            ), "loss_mask at index after response end should be all 0"
-            loss_mask = agent_loop_state.loss_mask[: agent_loop_state.response_end_idx - initial_prompt_length + 1]
-            response_ids = agent_loop_state.input_ids[initial_prompt_length : agent_loop_state.response_end_idx + 1]
-            if agent_loop_state.rollout_logprobs is not None:
-                rollout_logprobs = agent_loop_state.rollout_logprobs[
-                    : agent_loop_state.response_end_idx - initial_prompt_length + 1
-                ]
-            if agent_loop_state.rollout_expert_indices is not None:
-                rollout_expert_indices_out = agent_loop_state.rollout_expert_indices[
-                    : agent_loop_state.response_end_idx + 1
-                ]
-            # fix index for per_step_rewards
-            per_step_rewards = [(reward, idx - initial_prompt_length) for reward, idx in per_step_rewards]
-            assert len(loss_mask) == len(
-                response_ids
-            ), f"loss_mask and response_ids should have the same length, got {len(loss_mask)} and {len(response_ids)}"
+            if agent_loop_state.response_end_idx is None:
+                loss_mask = []
+                response_ids = []
+                if agent_loop_state.rollout_logprobs is not None:
+                    rollout_logprobs = []
+                if agent_loop_state.rollout_expert_indices is not None:
+                    rollout_expert_indices_out = []
+            else:
+                assert not any(
+                    agent_loop_state.loss_mask[agent_loop_state.response_end_idx - initial_prompt_length + 1 :]
+                ), "loss_mask at index after response end should be all 0"
+                loss_mask = agent_loop_state.loss_mask[: agent_loop_state.response_end_idx - initial_prompt_length + 1]
+                response_ids = agent_loop_state.input_ids[initial_prompt_length : agent_loop_state.response_end_idx + 1]
+                if agent_loop_state.rollout_logprobs is not None:
+                    rollout_logprobs = agent_loop_state.rollout_logprobs[
+                        : agent_loop_state.response_end_idx - initial_prompt_length + 1
+                    ]
+                if agent_loop_state.rollout_expert_indices is not None:
+                    rollout_expert_indices_out = agent_loop_state.rollout_expert_indices[
+                        : agent_loop_state.response_end_idx + 1
+                    ]
+                # fix index for per_step_rewards
+                per_step_rewards = [(reward, idx - initial_prompt_length) for reward, idx in per_step_rewards]
+                assert len(loss_mask) == len(
+                    response_ids
+                ), f"loss_mask and response_ids should have the same length, got {len(loss_mask)} and {len(response_ids)}"
 
         appended_eos_token = False
         if not self.use_conversation_multi_turn:
@@ -539,6 +587,9 @@ class SkyRLGymGenerator(GeneratorInterface):
             Union[float, List[float]]: If custom_chat_template is used, returns the last step's reward (float).
                 Otherwise, returns a list of token-level rewards (List[float]).
         """
+        if not per_step_rewards:
+            return []
+
         if self.custom_chat_template:
             # TODO(Charlie): Currently, the possible response truncation will not affect the reward
             # in the if branch, but some final rewards may be lost in the else branch. Fix this

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -203,9 +203,8 @@ def get_metrics_from_generator_output(generator_output: GeneratorOutput, uids: L
 
         # Assume the last token's reward signifies the trajectory's reward for `pass_at_n` computation
         for i, cur_trajectory_rewards in enumerate(rewards):
-            if len(cur_trajectory_rewards) == 0:
-                raise ValueError("Token-level rewards must be a non-empty list.")
-            uid_to_trajectory_rewards[uids[i]].append(cur_trajectory_rewards[-1])
+            trajectory_reward = cur_trajectory_rewards[-1] if len(cur_trajectory_rewards) > 0 else 0.0
+            uid_to_trajectory_rewards[uids[i]].append(trajectory_reward)
     else:
         mean_raw_reward = float(np.mean(rewards))
         mean_positive_reward = float(np.mean(np.maximum(rewards, 0.0)))

--- a/tests/train/generators/test_skyrl_gym_generator.py
+++ b/tests/train/generators/test_skyrl_gym_generator.py
@@ -161,6 +161,17 @@ def validate_generator_input(input_batch: GeneratorInput) -> bool:
     return True
 
 
+def get_sampling_max_len(input_batch, fallback_max_len):
+    sampling_params = input_batch.get("sampling_params")
+    if sampling_params is None:
+        return fallback_max_len
+    if "max_tokens" in sampling_params:
+        return sampling_params["max_tokens"]
+    if "max_generate_length" in sampling_params:
+        return sampling_params["max_generate_length"]
+    return fallback_max_len
+
+
 def validate_generator_output(output: GeneratorOutput) -> bool:
     """Validate that output conforms to GeneratorOutput TypedDict interface."""
     # Check that output has all required keys
@@ -465,6 +476,18 @@ def test_get_metrics_from_generator_output():
     assert metrics["pass_at_n"] == 0.5
     assert metrics["mean_positive_reward"] == 0.75
 
+    # Empty token-level rewards can occur when generation is skipped due to length budget.
+    generator_output["rewards"] = [[]]
+    generator_output["response_ids"] = [[]]
+    generator_output["prompt_token_ids"] = [[]]
+    generator_output["loss_masks"] = [[]]
+    generator_output["stop_reasons"] = ["length"]
+    uids = ["a"]
+    metrics = get_metrics_from_generator_output(generator_output, uids)
+    assert metrics["avg_score"] == 0.0
+    assert metrics["pass_at_n"] == 0.0
+    assert metrics["mean_positive_reward"] == 0.0
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("batched", [True, False])
@@ -629,6 +652,169 @@ async def test_length_limit_exceeded_during_conversation(
     assert isinstance(output.response_ids, list)
     assert isinstance(output.loss_mask, list)
     assert isinstance(output.reward, float) or isinstance(output.reward, list)
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_agent_loop_caps_sampling_params_by_remaining_budget(
+    mock_make, mock_tokenizer, mock_llm, mock_env_cfg, generator_cfg
+):
+    """Verify that agent_loop caps the turn-level generation budget before each engine call."""
+    generator_cfg.batched = False
+    generator_cfg.max_turns = 3
+    generator_cfg.use_conversation_multi_turn = False
+    generator_cfg.chat_template = ChatTemplateConfig(source="name", name_or_path=None)
+
+    class TwoTurnEnv(BaseTextEnv):
+        def __init__(self):
+            super().__init__()
+            self.turns = 0
+
+        def init(self, prompt):
+            return prompt, {}
+
+        def step(self, action):
+            self.turns += 1
+            if self.turns == 1:
+                return BaseTextEnvStepOutput(observations=[], reward=0.0, done=False, metadata={})
+            return BaseTextEnvStepOutput(observations=[], reward=1.0, done=True, metadata={})
+
+    mock_make.return_value = TwoTurnEnv()
+
+    # Initial prompt length is 4 tokens.
+    mock_tokenizer.apply_chat_template.side_effect = lambda *args, **kwargs: [1, 2, 3, 4]
+    mock_tokenizer.encode.side_effect = lambda *args, **kwargs: [9, 9, 9]
+
+    seen_max_tokens = []
+
+    async def llm_generate_side_effect(input_batch):
+        max_len = input_batch["sampling_params"]["max_tokens"]
+        seen_max_tokens.append(max_len)
+        response_ids = [7] * max_len
+        return {
+            "responses": ["x" * max_len],
+            "stop_reasons": ["stop"],
+            "response_logprobs": None,
+            "response_ids": [response_ids],
+        }
+
+    mock_llm.generate = AsyncMock(side_effect=llm_generate_side_effect)
+
+    generator = SkyRLGymGenerator(
+        generator_cfg=generator_cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+    )
+    generator.base_conversation_token_ids = []
+
+    prompt = [{"role": "user", "content": "Initial prompt"}]
+    output = await generator.agent_loop(
+        prompt,
+        "test_env",
+        {},
+        max_tokens=5,
+        max_input_length=10,
+        sampling_params={"max_tokens": 5},
+    )
+
+    assert seen_max_tokens == [5, 1], f"Expected capped per-turn max_tokens [5, 1], got {seen_max_tokens}"
+    assert output.stop_reason == "stop"
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_agent_loop_stops_without_engine_call_when_prompt_is_at_limit(
+    mock_make, mock_tokenizer, mock_llm, mock_env_cfg, generator_cfg
+):
+    """Verify that agent_loop exits before generation when no context budget remains."""
+    generator_cfg.batched = False
+    generator_cfg.max_turns = 1
+    generator_cfg.use_conversation_multi_turn = True
+    generator_cfg.chat_template = ChatTemplateConfig(source="name", name_or_path=None)
+
+    class NeverStepEnv(BaseTextEnv):
+        def init(self, prompt):
+            return prompt, {}
+
+        def step(self, action):
+            raise AssertionError("env.step should not be called when prompt is already at the input limit")
+
+    mock_make.return_value = NeverStepEnv()
+    mock_tokenizer.apply_chat_template.side_effect = lambda *args, **kwargs: [1, 2, 3, 4, 5]
+    mock_tokenizer.encode.side_effect = lambda *args, **kwargs: [9]
+
+    generator = SkyRLGymGenerator(
+        generator_cfg=generator_cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+    )
+    generator.base_conversation_token_ids = []
+
+    prompt = [{"role": "user", "content": "Initial prompt"}]
+    output = await generator.agent_loop(
+        prompt,
+        "test_env",
+        {},
+        max_tokens=5,
+        max_input_length=5,
+        sampling_params={"max_tokens": 5},
+    )
+
+    assert output.stop_reason == "length"
+    assert output.response_ids == []
+    assert output.loss_mask == []
+    assert output.reward == []
+    assert mock_llm.generate.await_count == 0
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_agent_loop_with_custom_chat_template_stops_cleanly_at_input_limit(
+    mock_make, mock_tokenizer, mock_llm, mock_env_cfg, generator_cfg
+):
+    """Verify prompt-at-limit exits also work when the retokenize path is active."""
+    generator_cfg.batched = False
+    generator_cfg.max_turns = 1
+    generator_cfg.use_conversation_multi_turn = True
+    generator_cfg.chat_template = ChatTemplateConfig(source="name", name_or_path=None)
+
+    class NeverStepEnv(BaseTextEnv):
+        def init(self, prompt):
+            return prompt, {}
+
+        def step(self, action):
+            raise AssertionError("env.step should not be called when prompt is already at the input limit")
+
+    mock_make.return_value = NeverStepEnv()
+    mock_tokenizer.apply_chat_template.side_effect = lambda *args, **kwargs: [1, 2, 3, 4, 5]
+    mock_tokenizer.encode.side_effect = lambda *args, **kwargs: [9]
+
+    generator = SkyRLGymGenerator(
+        generator_cfg=generator_cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+    )
+    generator.base_conversation_token_ids = []
+    generator.custom_chat_template = "<custom>"
+
+    prompt = [{"role": "user", "content": "Initial prompt"}]
+    output = await generator.agent_loop(
+        prompt,
+        "test_env",
+        {},
+        max_tokens=5,
+        max_input_length=5,
+        sampling_params={"max_tokens": 5},
+    )
+
+    assert output.stop_reason == "length"
+    assert output.response_ids == []
+    assert output.loss_mask == []
+    assert output.reward == []
+    assert mock_llm.generate.await_count == 0
 
 
 @pytest.mark.asyncio
@@ -846,11 +1032,7 @@ async def test_apply_overlong_filtering_non_batched(
 
     # First test: response that doesn't end with eos token (should be filtered)
     async def llm_generate_side_effect(input_batch):
-
-        if input_batch.get("sampling_params") is not None:
-            max_len = input_batch["sampling_params"]["max_generate_length"]
-        else:
-            max_len = generator_cfg.sampling_params.max_generate_length
+        max_len = get_sampling_max_len(input_batch, generator_cfg.sampling_params.max_generate_length)
 
         base_response = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]  # 10 token base
         num = len(input_batch["prompts"]) if "prompts" in input_batch else len(input_batch["prompt_token_ids"])
@@ -1272,11 +1454,7 @@ async def test_agent_loop_truncation_drops_out_of_range_rewards(mock_make, mock_
     # LLM returns 4 assistant tokens per turn (no eos here; final EOS appended by generator for non-conv-mt)
     async def llm_generate_side_effect(input_batch):
         num = len(input_batch["prompt_token_ids"]) if "prompt_token_ids" in input_batch else len(input_batch["prompts"])
-
-        if input_batch.get("sampling_params") is not None:
-            max_len = input_batch["sampling_params"]["max_generate_length"]
-        else:
-            max_len = cfg.sampling_params.max_generate_length
+        max_len = get_sampling_max_len(input_batch, cfg.sampling_params.max_generate_length)
 
         base_response = [10, 11, 12, 13]
         response_tokens = [base_response[:max_len] for _ in range(num)]


### PR DESCRIPTION
## Summary
This PR improves non-batched `SkyRLGymGenerator.agent_loop()` length handling so generation respects the remaining context budget instead of sending stale or overly large per-turn generation limits to the inference engine.

Addresses issue [#279](https://github.com/NovaSky-AI/SkyRL/issues/279): `[SkyRLGymGenerator] Cleaner generation length handling`.

## Problem
- `agent_loop()` built a turn-local sampling params object but still passed the original `sampling_params` into the inference engine request.
- Length handling only stopped after the prompt had already grown past the allowed budget, instead of capping the next turn's generation by the remaining context space.
- Prompt-at-limit trajectories could exit before generation but still fall through finalization paths that assumed at least one generated turn.
- Immediate length-stop trajectories could surface as empty token-level rewards, which needed to be handled cleanly by metrics/postprocessing.

## What Changed
- Added `_get_turn_sampling_params()` to derive the effective turn-level sampling params and cap `max_tokens` / `max_generate_length` by the remaining context budget.
- Moved the length check to the correct point in `agent_loop()`: after any retokenization needed for the current turn and before the inference engine call.
- Passed the capped turn-level sampling params into `InferenceEngineInput` instead of the stale original request payload.
- Made prompt-at-limit exits return valid empty outputs in both the normal multi-turn path and the custom-chat-template retokenization path.
- Updated generator metrics handling so empty token-level rewards are treated as zero-reward trajectories instead of raising.
- Expanded the generator tests to cover:
  - capped per-turn generation by remaining budget
  - prompt-at-limit exits without any engine call
  - prompt-at-limit exits in the custom chat-template retokenize path
  - downstream handling of empty token-level rewards

## Scope
- This PR fixes the non-batched `SkyRLGymGenerator.agent_loop()` path discussed in #279.
- Batched generation behavior is intentionally left unchanged in this PR.

## Testing
- `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 RAY_ADDRESS=local /Users/vuductai/Documents/Projects/SkyRL/.venv/bin/python -m pytest tests/train/generators/test_skyrl_gym_generator.py -q`
- `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0 RAY_ADDRESS=local /Users/vuductai/Documents/Projects/SkyRL/.venv/bin/python -m pytest tests/train/test_generator_postprocess.py -q`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
