### PR TITLE
Add a GPT-OSS multi-turn GSM8K example and align chat-template kwargs handling

### DIFF
--- a/examples/train/README.md
+++ b/examples/train/README.md
@@ -35,7 +35,7 @@ Welcome to the SkyRL-Train examples! In this folder you can find the following e
 ## Large Scale Model Training
 - `megatron/`: Examples for running SkyRL with the Megatron Backend for 5D parallelism.
 - `moe/`: Work-in-progress MoE training example used for development and testing large-scale multi-node Mixture-of-Experts support.
-- `gptoss/`: Training example for the GPT-OSS-20B model using patched attention to support attention sinks.
+- `gptoss/`: Single-turn and multi-turn GPT-OSS-20B training examples using patched attention to support attention sinks.
 
 ## Features and More
 - `lora/`: LoRA RL fine-tuning recipes.

--- a/examples/train/gptoss/README.md
+++ b/examples/train/gptoss/README.md
@@ -1,0 +1,60 @@
+# GPT-OSS Examples
+
+This folder contains SkyRL examples for training `unsloth/gpt-oss-20b-BF16`.
+
+## Requirements and caveats
+
+- GPT-OSS support in SkyRL currently depends on a Transformers version that exposes `GptOssConfig`.
+  In practice, use `transformers>=4.56.2`.
+- Flash attention must be disabled for GPT-OSS because attention sinks are not supported there yet.
+- Sample packing is also disabled in these recipes.
+- These examples use BF16.
+- GPT-OSS chat templating benefits from passing `generator.chat_template_kwargs={reasoning_effort:'low'}`.
+
+## Single-turn GSM8K
+
+Generate the dataset:
+
+```bash
+uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir "$HOME/data/gsm8k"
+```
+
+Run training:
+
+```bash
+bash examples/train/gptoss/run_gsm8k_gptoss.sh
+```
+
+## Multi-turn GSM8K
+
+This is the minimal GPT-OSS multi-turn example in the repo. It uses the built-in
+`gsm8k_multi_turn` environment with turn-level rewards, so it exercises real multi-turn RL
+without requiring extra infrastructure.
+
+Generate the dataset:
+
+```bash
+uv run examples/train/turn_level_rewards/gsm8k_multi_turn_dataset.py \
+  --output_dir "$HOME/data/gsm8k_multi_turn" \
+  --max_turns 5
+```
+
+Run training:
+
+```bash
+bash examples/train/gptoss/run_gsm8k_multi_turn_gptoss.sh
+```
+
+If you generate the dataset with a different `--max_turns`, update `MAX_TURNS` in
+`run_gsm8k_multi_turn_gptoss.sh` to match.
+
+## When to use other multi-turn examples
+
+If you want more operationally involved agentic tasks, see:
+
+- `examples/train/search/` for SearchR1
+- `examples/train/text_to_sql/` for SkyRL-SQL
+- `examples/train/step_wise/` for step-wise multi-turn training
+
+Those examples are useful follow-ups, but the GPT-OSS multi-turn GSM8K script here is the
+smallest end-to-end recipe to start from.

--- a/examples/train/gptoss/run_gsm8k_gptoss.sh
+++ b/examples/train/gptoss/run_gsm8k_gptoss.sh
@@ -1,9 +1,12 @@
 set -exo pipefail
 
 # Colocated GRPO training+generation for GPT-OSS-20B on GSM8K.
+# This is the single-turn GPT-OSS example. For a minimal multi-turn recipe, see
+# `examples/train/gptoss/run_gsm8k_multi_turn_gptoss.sh`.
 # NOTE (sumanthrh): Currently, gpt-oss requires flash attention to be disabled since attention sinks are not supported: https://github.com/Dao-AILab/flash-attention/issues/1797
 # We thus disable flash attention as well as sample packing
-# We only support GPT-OSS training in BF16 precision and single-turn tasks at the moment, and are actively working on multi-turn support.
+# GPT-OSS support in SkyRL currently requires BF16 precision and a Transformers version
+# new enough to expose `GptOssConfig` in the runtime patch path (>= 4.56.2).
 
 # uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 # export WANDB_API_KEY=<your_key_here>

--- a/examples/train/gptoss/run_gsm8k_multi_turn_gptoss.sh
+++ b/examples/train/gptoss/run_gsm8k_multi_turn_gptoss.sh
@@ -1,0 +1,81 @@
+set -exo pipefail
+
+# Colocated GRPO training+generation for GPT-OSS-20B on multi-turn GSM8K.
+# This is the minimal GPT-OSS multi-turn recipe in the repo: it reuses the built-in
+# `gsm8k_multi_turn` environment instead of adding extra infra like search or SQL servers.
+#
+# GPT-OSS-specific notes:
+# - GPT-OSS currently requires flash attention to be disabled because attention sinks are not
+#   supported there yet: https://github.com/Dao-AILab/flash-attention/issues/1797
+# - We also disable sample packing for the same reason.
+# - GPT-OSS support in SkyRL requires a Transformers version new enough to expose `GptOssConfig`
+#   (the runtime patch path currently gates on >= 4.56.2).
+#
+# Dataset setup:
+#   uv run examples/train/turn_level_rewards/gsm8k_multi_turn_dataset.py \
+#     --output_dir $HOME/data/gsm8k_multi_turn \
+#     --max_turns 5
+#
+# Usage:
+#   export WANDB_API_KEY=<your_key_here>
+#   bash examples/train/gptoss/run_gsm8k_multi_turn_gptoss.sh
+#
+# NOTE: If you generated the dataset with a different `--max_turns`, keep MAX_TURNS below in sync.
+
+DATA_DIR="$HOME/data/gsm8k_multi_turn"
+CKPT_PATH="$HOME/ckpts/gsm8k_multi_turn_gptoss_ckpt"
+NUM_GPUS=8
+MAX_TURNS=5
+MAX_INPUT_LENGTH=4096
+MAX_GENERATE_LENGTH=1024
+TRAIN_BATCH_SIZE=16
+LOGGER="wandb"  # change to "console" to print to stdout
+INFERENCE_BACKEND="vllm"
+
+uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
+  data.train_data="['$DATA_DIR/train.parquet']" \
+  data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.algorithm.advantage_estimator="grpo" \
+  trainer.policy.model.path="unsloth/gpt-oss-20b-BF16" \
+  trainer.placement.colocate_all=true \
+  trainer.strategy=fsdp2 \
+  trainer.placement.policy_num_gpus_per_node=$NUM_GPUS \
+  trainer.placement.ref_num_gpus_per_node=$NUM_GPUS \
+  generator.inference_engine.num_engines=2 \
+  trainer.flash_attn=false \
+  trainer.use_sample_packing=false \
+  generator.inference_engine.tensor_parallel_size=4 \
+  generator.inference_engine.enforce_eager=true \
+  trainer.epochs=20 \
+  trainer.eval_batch_size=16 \
+  trainer.eval_before_train=false \
+  trainer.eval_interval=5 \
+  trainer.update_epochs_per_batch=1 \
+  trainer.train_batch_size=$TRAIN_BATCH_SIZE \
+  trainer.policy_mini_batch_size=$TRAIN_BATCH_SIZE \
+  trainer.micro_forward_batch_size_per_gpu=1 \
+  trainer.micro_train_batch_size_per_gpu=1 \
+  trainer.ckpt_interval=5 \
+  trainer.max_prompt_length=512 \
+  generator.max_input_length=$MAX_INPUT_LENGTH \
+  generator.max_turns=$MAX_TURNS \
+  generator.sampling_params.max_generate_length=$MAX_GENERATE_LENGTH \
+  generator.use_conversation_multi_turn=true \
+  trainer.policy.optimizer_config.lr=1.0e-6 \
+  trainer.algorithm.use_kl_loss=true \
+  generator.inference_engine.backend=$INFERENCE_BACKEND \
+  generator.inference_engine.run_engines_locally=true \
+  generator.inference_engine.weight_sync_backend=nccl \
+  generator.inference_engine.async_engine=true \
+  generator.batched=false \
+  environment.env_class=gsm8k_multi_turn \
+  generator.n_samples_per_prompt=2 \
+  generator.inference_engine.gpu_memory_utilization=0.7 \
+  trainer.logger="$LOGGER" \
+  trainer.project_name="gsm8k_multi_turn_gptoss" \
+  trainer.run_name="gsm8k_multi_turn_gptoss_low" \
+  trainer.resume_mode=latest \
+  trainer.ckpt_path="$CKPT_PATH" \
+  generator.chat_template_kwargs={reasoning_effort:'low'} \
+  trainer.dump_data_batch=true \
+  $@

--- a/skyrl/train/dataset/dataset.py
+++ b/skyrl/train/dataset/dataset.py
@@ -1,14 +1,18 @@
 import os
-from typing import List
+from typing import Any, Dict, List, Optional
 
 import datasets
 from loguru import logger
 from transformers import PreTrainedTokenizerBase
 
 
-def _prompt_not_too_long(doc, tokenizer, prompt_key, max_length):
+def _prompt_not_too_long(doc, tokenizer, prompt_key, max_length, chat_template_kwargs: Optional[Dict[str, Any]] = None):
     tokens = tokenizer.apply_chat_template(
-        doc[prompt_key], add_generation_prompt=True, return_dict=False, tokenize=True
+        doc[prompt_key],
+        add_generation_prompt=True,
+        return_dict=False,
+        tokenize=True,
+        **(chat_template_kwargs or {}),
     )
     return len(tokens) <= max_length
 
@@ -22,12 +26,14 @@ class PromptDataset:
         num_workers: int = 8,
         prompt_key: str = "prompt",
         env_class_key: str = "env_class",
+        chat_template_kwargs: Optional[Dict[str, Any]] = None,
     ):
         self.tokenizer = tokenizer
         self.max_prompt_length = max_prompt_length
         self.prompt_key = prompt_key
         self.env_class_key = env_class_key
         self.num_workers = num_workers
+        self.chat_template_kwargs = dict(chat_template_kwargs or {})
 
         self.datasets = datasets
         if isinstance(self.datasets, str):
@@ -76,6 +82,7 @@ class PromptDataset:
                 "tokenizer": self.tokenizer,
                 "prompt_key": self.prompt_key,
                 "max_length": self.max_prompt_length,
+                "chat_template_kwargs": self.chat_template_kwargs,
             },
             num_proc=self.num_workers,
             desc=f"Filtering prompts longer than {self.max_prompt_length} tokens",

--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -168,6 +168,7 @@ class BasePPOExp:
             tokenizer=self.tokenizer,
             max_prompt_length=self.cfg.trainer.max_prompt_length,
             num_workers=8,
+            chat_template_kwargs=self.cfg.generator.chat_template_kwargs,
         )
         # make sure the dataset is large enough to train on
         assert (
@@ -187,6 +188,7 @@ class BasePPOExp:
                 tokenizer=self.tokenizer,
                 max_prompt_length=self.cfg.trainer.max_prompt_length,
                 num_workers=8,
+                chat_template_kwargs=self.cfg.generator.chat_template_kwargs,
             )
             return prompts_dataset
         return None

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -156,7 +156,15 @@ class SkyRLGymGenerator(GeneratorInterface):
         # optionally use custom chat template to get loss masks (i.e. for Qwen3)
         self.custom_chat_template = get_custom_chat_template(generator_cfg.chat_template)
         # get generation prompt ids for the tokenizer if needed
-        self.generation_prompt_ids = get_generation_prompt_ids(tokenizer) if self.use_conversation_multi_turn else None
+        self.generation_prompt_ids = (
+            get_generation_prompt_ids(
+                tokenizer,
+                chat_template=self.custom_chat_template,
+                chat_template_kwargs=self.generator_cfg.chat_template_kwargs,
+            )
+            if self.use_conversation_multi_turn
+            else None
+        )
         if self.skyrl_gym_cfg.max_env_workers > 0:
             self.env_executor = ThreadPoolExecutor(
                 max_workers=self.skyrl_gym_cfg.max_env_workers, thread_name_prefix="skyrl-gym-env-"

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -147,19 +147,28 @@ def get_custom_chat_template(chat_template_config: Optional[Union[dict, ChatTemp
         raise ValueError(f"Invalid source '{source}'. Must be 'name' or 'file'")
 
 
-def get_generation_prompt_ids(tokenizer, chat_template: Optional[str] = None) -> List[int]:
+def get_generation_prompt_ids(
+    tokenizer,
+    chat_template: Optional[str] = None,
+    chat_template_kwargs: Optional[Dict[str, Any]] = None,
+) -> List[int]:
     """
     Helper function to get the generation prompt ids for a given tokenizer.
 
     Args:
         tokenizer: HuggingFace tokenizer with chat_template support.
         chat_template: Optional custom chat template string. If None, uses the tokenizer's default.
+        chat_template_kwargs: Optional kwargs passed to ``tokenizer.apply_chat_template``.
 
     Returns:
         List[int]: Token IDs for the generation prompt (e.g., "<|im_start|>assistant\n" for Qwen).
     """
     empty_user = tokenizer.apply_chat_template(
-        [{"role": "user", "content": ""}], tokenize=True, return_dict=False, chat_template=chat_template
+        [{"role": "user", "content": ""}],
+        tokenize=True,
+        return_dict=False,
+        chat_template=chat_template,
+        **(chat_template_kwargs or {}),
     )
     empty_user_with_generation_prompt = tokenizer.apply_chat_template(
         [{"role": "user", "content": ""}],
@@ -167,6 +176,7 @@ def get_generation_prompt_ids(tokenizer, chat_template: Optional[str] = None) ->
         tokenize=True,
         return_dict=False,
         chat_template=chat_template,
+        **(chat_template_kwargs or {}),
     )
 
     generation_prompt_ids = empty_user_with_generation_prompt[len(empty_user) :]

--- a/tests/train/dataset/test_dataset.py
+++ b/tests/train/dataset/test_dataset.py
@@ -9,7 +9,11 @@ from skyrl.train.dataset import PromptDataset
 class SimpleTokenizer:
     name_or_path = "simple-tokenizer"
 
+    def __init__(self):
+        self.calls = []
+
     def apply_chat_template(self, x, add_generation_prompt=False, **kwargs):
+        self.calls.append({"input": x, "add_generation_prompt": add_generation_prompt, "kwargs": kwargs})
         return x
 
 
@@ -144,6 +148,25 @@ def test_prompt_dataset_hf_real_dataset(mock_tokenizer):
         env_class_key="env_class",
     )
     assert len(ds) > 0
+
+
+@patch("datasets.load_dataset")
+def test_prompt_dataset_filtering_passes_chat_template_kwargs(mock_load_dataset, sample_dataset):
+    tokenizer = SimpleTokenizer()
+    mock_load_dataset.return_value = {"train": sample_dataset}
+
+    PromptDataset(
+        datasets=["dummy1.parquet"],
+        tokenizer=tokenizer,
+        max_prompt_length=150,
+        num_workers=1,
+        prompt_key="prompt",
+        env_class_key="env_class",
+        chat_template_kwargs={"reasoning_effort": "low"},
+    )
+
+    assert tokenizer.calls, "Prompt filtering should invoke apply_chat_template"
+    assert all(call["kwargs"].get("reasoning_effort") == "low" for call in tokenizer.calls)
 
 
 @patch("datasets.load_dataset")

--- a/tests/train/generators/test_utils.py
+++ b/tests/train/generators/test_utils.py
@@ -143,6 +143,39 @@ dummy_chat_template = (
 )
 
 
+class RecordingTokenizer:
+    def __init__(self):
+        self.calls = []
+
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=True,
+        return_dict=False,
+        add_generation_prompt=False,
+        chat_template=None,
+        **kwargs,
+    ):
+        self.calls.append(
+            {
+                "messages": messages,
+                "tokenize": tokenize,
+                "return_dict": return_dict,
+                "add_generation_prompt": add_generation_prompt,
+                "chat_template": chat_template,
+                "kwargs": kwargs,
+            }
+        )
+        base = [10]
+        if chat_template is not None:
+            base.append(20)
+        if kwargs.get("reasoning_effort") == "low":
+            base.append(30)
+        if add_generation_prompt:
+            return base + [99]
+        return base
+
+
 @pytest.fixture
 def tokenizer_w_dummy_template():
     tokenizer = AutoTokenizer.from_pretrained("unsloth/llama-2-7b")
@@ -178,6 +211,21 @@ def test_encode_messages(messages, tokenizer_w_dummy_template):
     expected_str = tokenizer_w_dummy_template.decode(expected_token_ids)
     actual_str = tokenizer_w_dummy_template.decode(actual_token_ids)
     assert expected_str == actual_str
+
+
+def test_get_generation_prompt_ids_passes_chat_template_kwargs():
+    tokenizer = RecordingTokenizer()
+
+    generation_prompt_ids = get_generation_prompt_ids(
+        tokenizer,
+        chat_template="custom-template",
+        chat_template_kwargs={"reasoning_effort": "low"},
+    )
+
+    assert generation_prompt_ids == [99]
+    assert len(tokenizer.calls) == 2
+    assert all(call["chat_template"] == "custom-template" for call in tokenizer.calls)
+    assert all(call["kwargs"].get("reasoning_effort") == "low" for call in tokenizer.calls)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Closes #638.

This PR adds a minimal but real GPT-OSS multi-turn training example to SkyRL and updates the surrounding GPT-OSS documentation so the repo no longer implies GPT-OSS is single-turn-only.

The new recipe is intentionally narrow: it uses the built-in `gsm8k_multi_turn` environment rather than introducing a more operationally heavy task such as SearchR1 or Text-to-SQL. That keeps the first GPT-OSS multi-turn example easy to run while still exercising genuine multi-turn RL behavior.

## What Changed

### New example and docs

- Added `examples/train/gptoss/run_gsm8k_multi_turn_gptoss.sh`
  - minimal GPT-OSS multi-turn recipe
  - uses `gsm8k_multi_turn`
  - preserves existing GPT-OSS constraints such as `flash_attn=false`, `use_sample_packing=false`, and `reasoning_effort='low'`
- Added `examples/train/gptoss/README.md`
  - documents single-turn vs multi-turn GPT-OSS usage
  - calls out the current GPT-OSS caveats and dataset setup steps
- Updated `examples/train/README.md`
  - makes the new GPT-OSS multi-turn capability discoverable
- Updated `examples/train/gptoss/run_gsm8k_gptoss.sh`
  - keeps it as the single-turn reference and points readers to the new multi-turn script

### Small runtime consistency fix for GPT-OSS chat-template kwargs

GPT-OSS examples depend on `generator.chat_template_kwargs={reasoning_effort:'low'}`. Before this change, that information was not flowing through all of the helper paths that matter to rollout setup.

This PR now threads `chat_template_kwargs` through:

- prompt filtering in `PromptDataset`
- dataset construction in `main_base.py`
- generation-prompt derivation in `get_generation_prompt_ids(...)`
- multi-turn generator setup in `SkyRLGymGenerator`

That keeps prompt filtering and generation-prompt bookkeeping aligned with the same chat-template kwargs used during GPT-OSS rollouts.

### Regression coverage

- Added a dataset-side regression test to verify prompt filtering passes `chat_template_kwargs`
- Added a generator-utils regression test to verify `get_generation_prompt_ids(...)` passes `chat_template_kwargs`

## Why This Design

- Solves the exact request in #638 without broadening scope into a larger GPT-OSS runtime refactor
- Reuses the existing built-in multi-turn environment instead of introducing extra infra
- Keeps the first GPT-OSS multi-turn example easy to understand and operate
- Adds only the smallest helper fix needed to keep GPT-OSS chat-template kwargs behavior consistent

## Validation

Completed locally:

- `python3 -m py_compile skyrl/train/dataset/dataset.py skyrl/train/entrypoints/main_base.py skyrl/train/generators/utils.py skyrl/train/generators/skyrl_gym_generator.py tests/train/dataset/test_dataset.py tests/train/generators/test_utils.py`
- `bash -n examples/train/gptoss/run_gsm8k_gptoss.sh examples/train/gptoss/run_gsm8k_multi_turn_gptoss.sh`
- `git diff --check`
- additional targeted stub-based sanity checks for the two helper changes (`PromptDataset` prompt filtering and `get_generation_prompt_ids(...)`)

Not completed in this sandbox:

- full `pytest` with training extras
- real GPU smoke test of the GPT-OSS multi-turn script

The `pytest` path was blocked here because the shared `tests/train` conftest imports `ray`, and the `skyrl-train` extra path needed network access for the `flash-attn` wheel.
