### PR TITLE
[train] Tighten FlashRL runtime contract for vLLM migration groundwork

### DIFF
--- a/ci/gpu_ci_run_skyrl_train.sh
+++ b/ci/gpu_ci_run_skyrl_train.sh
@@ -20,15 +20,11 @@ uv run --directory . --isolated --extra dev --extra fsdp pytest -s tests/backend
 #     echo "$add_integrations"
 # fi
 
-# TODO (sumanthrh): Migrate flashrl to vllm 0.16.0 and re-enable integration test
-# Run tests for vllm 0.9.2
-# TODO (sumanthrh): We should have a better way to override without pinning a flash-attn wheel
-# uv run --isolated --extra fsdp --extra dev \
-#     --with vllm==0.9.2 \
-#     --with transformers==4.53.0 \
-#     --with torch==2.7.0 \
-#     --with "flash-attn@https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.7cxx11abiTRUE-cp312-cp312-linux_x86_64.whl" \
-#     -- pytest -s -vvv tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py::test_token_based_generation
+# Run repo-side FlashRL compatibility checks that do not require the custom wheel.
+uv run --directory . --isolated --extra dev pytest -s tests/utils/test_flashrl_runtime.py
+
+# TODO (sumanthrh): Re-enable end-to-end FlashRL GPU coverage once the
+# vLLM-0.18-compatible FlashRL wheel is published.
 
 # Run tests for new inference layer
 # TODO (sumanthrh): Migrate the remaining tests: test_verifiers_generator.py , test_pause_and_continue_generation.py

--- a/docs/content/docs/examples/flash_rl.mdx
+++ b/docs/content/docs/examples/flash_rl.mdx
@@ -3,7 +3,7 @@ title: "FlashRL + SkyRL: Training with Quantized Rollouts"
 ---
 
 <Callout type="info">
-FlashRL is supported with the `fsdp` backend.
+FlashRL examples are supported with `fsdp` and `fsdp2`.
 </Callout>
 
 In this example, we walk through how to train a model with quantized rollouts using [FlashRL](https://fengyao.notion.site/flash-rl) and SkyRL.
@@ -17,10 +17,10 @@ In this example, we walk through how to train a model with quantized rollouts us
 
 ## FlashRL + SkyRL
 
-SkyRL now has a native integration with FlashRL. Currently, we support training with Int8 quantization as well as [online FP8 quantization](https://docs.vllm.ai/en/v0.9.2/features/quantization/fp8.html#online-dynamic-quantization) in vLLM. 
+SkyRL now has a native integration with FlashRL. Currently, the example path supports training with Int8 quantization and online FP8 quantization in vLLM.
 
 <Callout type="warn">
-FlashRL integration only supports single-turn training at the moment.
+FlashRL integration currently supports the local Ray-wrapped inference path with synchronous engines only. The examples are single-turn only.
 </Callout>
 
 ### How does it work?
@@ -29,11 +29,13 @@ At a high level, we sample generations from the inference engine with quantized 
 
 ## Examples
 
-We provide examples for training with FP8 and Int8 rollouts for DAPO. The FlashRL related files are in the `examples/train/flash_rl/` folder. 
+We provide examples for training with FP8 and Int8 rollouts for DAPO. The FlashRL-related files are in `examples/train/flash_rl/`.
+
+The `skyrl[flashrl]` extra does not install the custom vLLM wheel by itself. Use the installation flow documented in `examples/train/flash_rl/README.md`. The example scripts also accept `FLASHRL_VLLM_WHEEL_URL` and `FLASHRL_TRANSFORMERS_VERSION` so you can swap in a newer FlashRL wheel without editing the scripts.
 
 For FP8, you simply need to specify `FLASHRL_CONFIG=fp8_vllm` in your environment variables. 
 
-For Int8, we need to provide calibration data. We leverage the provided calibration data from FlashRL for `Qwen/Qwen2.5-0.5B-Instruct` and `Qwen/Qwen-32B` models. You can simply specify the appropriate `FLASHRL_CONFIG` in your environment variables. See [flashrl-config](#flashrl-config) for more details on how this works.
+For Int8, we need to provide calibration data. We leverage the provided calibration data from FlashRL for `Qwen/Qwen2.5-0.5B-Instruct` and `Qwen/Qwen2.5-32B` models. You can simply specify the appropriate `FLASHRL_CONFIG` in your environment variables. See [flashrl-config](#flashrl-config) for more details on how this works.
 
 - 0.5B: `FLASHRL_CONFIG=LiyuanLucasLiu/Qwen2.5-0.5B-Instruct-quantized.w8a8-RedHatAI/flashrl_config.yaml`
 - 32B: `FLASHRL_CONFIG=LiyuanLucasLiu/Qwen2.5-32B-quantized.w8a8/flashrl_config.yaml`
@@ -49,26 +51,30 @@ DATA_DIR="$HOME/data/dapo" bash examples/train/algorithms/dapo/prepare_dapo_data
 
 ```
 
-We highlight some important training parameters configured for FlashRL from our example configuration at `examples/train/flash_rl/run_dapo_repro_flashrl_32b_int8.sh`:
+We highlight some important training parameters configured for FlashRL from `examples/train/flash_rl/run_dapo_repro_flashrl_32b_int8.sh`:
 
 ```bash title="examples/train/flash_rl/run_dapo_repro_flashrl_32b_int8.sh"
 # path for dataset (.parquet files) containing the prompts and metadata for each question
 DATA_DIR="$HOME/data/dapo"
 
 # TIS parameters
-USE_TIS=true
+TIS_TYPE=token
 TIS_IMP_RATIO_CAP=8.0
 
-uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.int8 -m examples.train.flash_rl.main_dapo_flashrl \
+uv run --isolated --extra flashrl \
+    --env-file examples/train/flash_rl/.env.int8 \
+    --with "vllm@${FLASHRL_VLLM_WHEEL_URL}" \
+    --with "transformers==${FLASHRL_TRANSFORMERS_VERSION}" \
+    -m examples.train.flash_rl.main_dapo_flashrl \
     ...
-    trainer.algorithm.use_tis=$USE_TIS \
-    trainer.algorithm.tis_imp_ratio_cap=$TIS_IMP_RATIO_CAP \
-    generator.sampling_params.logprobs=1 \
+    trainer.algorithm.off_policy_correction.tis_ratio_type=$TIS_TYPE \
+    trainer.algorithm.off_policy_correction.token_tis_ratio_clip_high=$TIS_IMP_RATIO_CAP \
+    generator.sampling_params.logprobs=0 \
     ...
 
 ```
 
-Here, we've configured training to use TIS with the importance sampling ratio cap of 8.0. `generator.sampling_params.logprobs=1` ensures that logprobs for the chosen tokens are returned by the inference engine, which is required for TIS. Note that for making sure the FlashRL patches are applied for vLLM, we use the `FLASHRL_CONFIG` environment variable in `examples/train/flash_rl/.env.int8`: 
+Here, we've configured training to use token-level off-policy correction with an importance-sampling ratio cap of 8.0. The examples set `generator.sampling_params.logprobs=0`, which is sufficient for chosen-token logprobs. If you leave `logprobs` unset, SkyRL will auto-enable chosen-token logprobs when off-policy correction is enabled. To make sure the FlashRL patches are applied for vLLM, we also set `FLASHRL_CONFIG` in `examples/train/flash_rl/.env.int8`:
 
 ```bash title="examples/train/flash_rl/.env.int8"
 FLASHRL_CONFIG=LiyuanLucasLiu/Qwen2.5-32B-quantized.w8a8/flashrl_config.yaml
@@ -80,11 +86,11 @@ For a more lightweight example, we also provide scripts for training on Qwen2.5-
 
 ### Training with FP8
 
-The configuration is similar to the Int8 example. The only difference is the value for `FLASHRL_CONFIG` in `examples/train/flash_rl/.env.0.5b_fp8`. We provide a script for training Qwen2.5-0.5B-Instruct with FP8 rollouts  at `examples/train/flash_rl/run_dapo_gsm8k_flashrl_0.5b_fp8.sh`.
+The configuration is similar to the Int8 example. The main difference is the value for `FLASHRL_CONFIG` in `examples/train/flash_rl/.env.fp8`. We provide a script for training Qwen2.5-0.5B-Instruct with FP8 rollouts at `examples/train/flash_rl/run_dapo_gsm8k_flashrl_0.5b_fp8.sh`.
 
 ## What does the `FLASHRL_CONFIG` do?
 
-We use a custom vLLM wheel (in the `--flashrl` extra) to apply some patches from FlashRL. 
+We use a custom vLLM wheel together with the `skyrl[flashrl]` extra to apply some patches from FlashRL.
 The `FLASHRL_CONFIG` is used to customize vLLM initialization as well as weight syncing behavior. 
 
 For FP8, this is simply a string (`fp8_vllm`) while for Int8, this is a path to a YAML file (either locally, accessible to all nodes in your Ray cluster, or a file path on the HuggingFace Hub). 

--- a/examples/train/flash_rl/README.md
+++ b/examples/train/flash_rl/README.md
@@ -1,0 +1,61 @@
+# FlashRL Example Setup
+
+This directory contains the example-local FlashRL integration used by SkyRL's
+quantized rollout examples.
+
+## Support Boundary
+
+The current example path supports:
+
+- local Ray-wrapped inference engines
+- synchronous vLLM engines only
+- `fsdp` and `fsdp2`
+- single-turn generation
+
+It does not currently support the new HTTP/server-group inference path or
+`async_engine`.
+
+## Installation
+
+The `skyrl[flashrl]` extra installs the shared SkyRL training dependencies, but
+it does not install the custom FlashRL-compatible vLLM wheel. You must provide
+that wheel separately.
+
+The example scripts in this directory all accept these optional environment
+overrides:
+
+- `FLASHRL_VLLM_WHEEL_URL`
+- `FLASHRL_TRANSFORMERS_VERSION`
+
+If those are unset, the scripts default to the legacy `skyrl_train-v0.1.0`
+wheel asset and `transformers==4.53.3`. During the vLLM migration, override
+`FLASHRL_VLLM_WHEEL_URL` to test a newer wheel without editing each script.
+
+## Required Environment Variables
+
+`FLASHRL_CONFIG` is required.
+
+- For FP8 examples, set `FLASHRL_CONFIG=fp8_vllm`.
+- For Int8 examples, set `FLASHRL_CONFIG` to the FlashRL YAML config path.
+
+The bundled env files are:
+
+- `examples/train/flash_rl/.env.fp8`
+- `examples/train/flash_rl/.env.int8`
+- `examples/train/flash_rl/.env.0.5b_int8`
+
+## Patch Hook Contract
+
+The example wrapper expects the custom vLLM wheel to expose a patch hook before
+engine construction.
+
+Default import target:
+
+- `vllm.model_executor.layers.patch:apply_patch`
+
+If your migrated FlashRL wheel exposes the hook at a different import path, set:
+
+- `SKYRL_FLASHRL_PATCH_FN=<module>:<callable>`
+
+This lets the example wrapper adopt the new hook location without another repo
+edit.

--- a/examples/train/flash_rl/flash_rl_engine.py
+++ b/examples/train/flash_rl/flash_rl_engine.py
@@ -1,22 +1,21 @@
 from typing import List
+
 import ray
 import vllm
-from skyrl.backends.skyrl_train.inference_engines.vllm.vllm_engine import VLLMInferenceEngine
-from skyrl.backends.skyrl_train.inference_engines.ray_wrapped_inference_engine import RayWrappedInferenceEngine
 from ray.util.placement_group import PlacementGroupSchedulingStrategy, placement_group
+
+from skyrl.backends.skyrl_train.inference_engines.base import InferenceEngineInterface
+from skyrl.backends.skyrl_train.inference_engines.ray_wrapped_inference_engine import RayWrappedInferenceEngine
+from skyrl.backends.skyrl_train.inference_engines.vllm.vllm_engine import VLLMInferenceEngine
 from skyrl.train.utils.utils import ResolvedPlacementGroup
 
-from skyrl.backends.skyrl_train.inference_engines.base import (
-    InferenceEngineInterface,
-)
+from .runtime import load_flashrl_patch_fn
 
 
 class FlashRLVLLMInferenceEngine(VLLMInferenceEngine):
-
     def _create_engine(self, *args, **kwargs):
         # apply flashrl's patch just before init
-        from vllm.model_executor.layers.patch import apply_patch as apply_flashrl_patch
-
+        apply_flashrl_patch = load_flashrl_patch_fn()
         apply_flashrl_patch()
 
         llm = vllm.LLM(*args, **kwargs)

--- a/examples/train/flash_rl/main_dapo_flashrl.py
+++ b/examples/train/flash_rl/main_dapo_flashrl.py
@@ -20,6 +20,8 @@ from skyrl.backends.skyrl_train.inference_engines.base import InferenceEngineInt
 from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
 from skyrl.train.generators.base import GeneratorOutput
 
+from .runtime import validate_flashrl_environment
+
 
 @dataclass
 class DAPOAlgorithmConfig(AlgorithmConfig):
@@ -148,10 +150,23 @@ def main() -> None:
     validate_cfg(cfg)
 
     if not cfg.generator.inference_engine.run_engines_locally:
-        raise ValueError("FlashRL only supports colocated training.")
+        raise ValueError("FlashRL only supports local colocated inference engines.")
+
+    if cfg.generator.inference_engine.backend != "vllm":
+        raise ValueError(f"FlashRL only supports the vLLM backend, got: {cfg.generator.inference_engine.backend}")
+
+    if cfg.generator.inference_engine.async_engine:
+        raise ValueError("FlashRL does not support `async_engine`.")
 
     if cfg.trainer.strategy not in ("fsdp", "fsdp2"):
         raise ValueError(f"FlashRL only supports fsdp/fsdp2 strategy, got: {cfg.trainer.strategy}")
+
+    if cfg.generator.max_turns != 1:
+        raise ValueError(
+            f"FlashRL examples only support single-turn generation (`generator.max_turns=1`), got: {cfg.generator.max_turns}"
+        )
+
+    validate_flashrl_environment()
 
     initialize_ray(cfg)
     ray.get(skyrl_entrypoint.remote(cfg))

--- a/examples/train/flash_rl/run_dapo_gsm8k_flashrl_0.5b_fp8.sh
+++ b/examples/train/flash_rl/run_dapo_gsm8k_flashrl_0.5b_fp8.sh
@@ -10,6 +10,9 @@ set -x
 DATA_DIR="$HOME/data/gsm8k"
 NUM_GPUS=4
 LOGGER="wandb"  # change to "console" to print to stdout
+# Override these env vars to test a newer FlashRL wheel without editing the script.
+FLASHRL_VLLM_WHEEL_URL="${FLASHRL_VLLM_WHEEL_URL:-https://github.com/NovaSky-AI/SkyRL/releases/download/skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl}"
+FLASHRL_TRANSFORMERS_VERSION="${FLASHRL_TRANSFORMERS_VERSION:-4.53.3}"
 
 # main DAPO parameters
 EPS_CLIP_LOW=0.2
@@ -36,7 +39,7 @@ CKPT_PATH="$HOME/ckpts/gsm8k_0.5B_ckpt"
 TIS_TYPE=token
 TIS_IMP_RATIO_CAP=2.0
 
-uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.fp8 --with vllm@https://github.com/NovaSky-AI/SkyRL/releases/download/skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl --with transformers==4.53.3 -- python -m examples.train.flash_rl.main_dapo_flashrl \
+uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.fp8 --with "vllm@${FLASHRL_VLLM_WHEEL_URL}" --with "transformers==${FLASHRL_TRANSFORMERS_VERSION}" -- python -m examples.train.flash_rl.main_dapo_flashrl \
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \

--- a/examples/train/flash_rl/run_dapo_gsm8k_flashrl_0.5b_int8.sh
+++ b/examples/train/flash_rl/run_dapo_gsm8k_flashrl_0.5b_int8.sh
@@ -10,6 +10,9 @@ set -x
 DATA_DIR="$HOME/data/gsm8k"
 NUM_GPUS=4
 LOGGER="wandb"  # change to "console" to print to stdout
+# Override these env vars to test a newer FlashRL wheel without editing the script.
+FLASHRL_VLLM_WHEEL_URL="${FLASHRL_VLLM_WHEEL_URL:-https://github.com/NovaSky-AI/SkyRL/releases/download/skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl}"
+FLASHRL_TRANSFORMERS_VERSION="${FLASHRL_TRANSFORMERS_VERSION:-4.53.3}"
 
 # main DAPO parameters
 EPS_CLIP_LOW=0.2
@@ -36,7 +39,7 @@ CKPT_PATH="$HOME/ckpts/gsm8k_0.5B_ckpt"
 TIS_TYPE=token
 TIS_IMP_RATIO_CAP=2.0
 
-uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.int8 --with vllm@https://github.com/NovaSky-AI/SkyRL/releases/download/skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl --with transformers==4.53.3 -- python -m examples.train.flash_rl.main_dapo_flashrl \
+uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.0.5b_int8 --with "vllm@${FLASHRL_VLLM_WHEEL_URL}" --with "transformers==${FLASHRL_TRANSFORMERS_VERSION}" -- python -m examples.train.flash_rl.main_dapo_flashrl \
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \

--- a/examples/train/flash_rl/run_dapo_gsm8k_flashrl_32b_int8.sh
+++ b/examples/train/flash_rl/run_dapo_gsm8k_flashrl_32b_int8.sh
@@ -1,6 +1,6 @@
 set -x
 
-# Colocated DAPO training+generation for Qwen3-32B on GSM8K with FP8 rollouts.
+# Colocated DAPO training+generation for Qwen2.5-32B on GSM8K with Int8 rollouts.
 # The configuration is tested on 2 8xH100 GPUs.
 
 # uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
@@ -10,6 +10,9 @@ set -x
 DATA_DIR="$HOME/data/gsm8k"
 NUM_GPUS=16
 LOGGER="wandb"  # change to "console" to print to stdout
+# Override these env vars to test a newer FlashRL wheel without editing the script.
+FLASHRL_VLLM_WHEEL_URL="${FLASHRL_VLLM_WHEEL_URL:-https://github.com/NovaSky-AI/SkyRL/releases/download/skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl}"
+FLASHRL_TRANSFORMERS_VERSION="${FLASHRL_TRANSFORMERS_VERSION:-4.53.3}"
 
 # main DAPO parameters
 EPS_CLIP_LOW=0.2
@@ -36,7 +39,7 @@ CKPT_PATH="$HOME/ckpts/gsm8k_32B_ckpt"
 TIS_TYPE=token
 TIS_IMP_RATIO_CAP=2.0
 
-uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.int8 --with vllm@https://github.com/NovaSky-AI/SkyRL/releases/download/skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl --with transformers==4.53.3 -m examples.train.flash_rl.main_dapo_flashrl \
+uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.int8 --with "vllm@${FLASHRL_VLLM_WHEEL_URL}" --with "transformers==${FLASHRL_TRANSFORMERS_VERSION}" -m examples.train.flash_rl.main_dapo_flashrl \
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \

--- a/examples/train/flash_rl/run_dapo_repro_flashrl_0.5b_int8.sh
+++ b/examples/train/flash_rl/run_dapo_repro_flashrl_0.5b_int8.sh
@@ -1,7 +1,7 @@
 set -x
 
-# Colocated DAPO training+generation for Qwen2.5-1.5B-Instruct on the original DAPO dataset with Int8 rollouts.
-# The configuration is tested on 2 H100 GPUs.
+# Colocated DAPO training+generation for Qwen2.5-0.5B-Instruct on the original DAPO dataset with Int8 rollouts.
+# The configuration is tested on 4 H100 GPUs.
 
 # DATA_DIR=$HOME/data/dapo bash examples/train/algorithms/dapo/prepare_dapo_data.sh
 # export WANDB_API_KEY=<your_key_here>
@@ -10,6 +10,9 @@ set -x
 DATA_DIR="$HOME/data/dapo"
 NUM_GPUS=4
 LOGGER="wandb"  # change to "console" to print to stdout
+# Override these env vars to test a newer FlashRL wheel without editing the script.
+FLASHRL_VLLM_WHEEL_URL="${FLASHRL_VLLM_WHEEL_URL:-https://github.com/NovaSky-AI/SkyRL/releases/download/skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl}"
+FLASHRL_TRANSFORMERS_VERSION="${FLASHRL_TRANSFORMERS_VERSION:-4.53.3}"
 
 # main DAPO parameters
 EPS_CLIP_LOW=0.2
@@ -19,7 +22,7 @@ DYNAMIC_SAMPLING_MAX_SAMPLE_BATCHES=30
 LOSS_REDUCTION="token_mean"
 # applies overlong filtering (but not soft overlong punishment)
 APPLY_OVERLONG_FILTERING=true
-# apply soft overlong punishment with custom trainer impl in main_dapo.py
+# apply soft overlong punishment with custom trainer impl in main_dapo_flashrl.py
 OVERLONG_BUFFER_LEN=512
 OVERLONG_BUFFER_PENALTY_FACTOR=1.0
 
@@ -33,7 +36,9 @@ MAX_RESPONSE_LENGTH=4096
 
 TIS_TYPE=token
 TIS_IMP_RATIO_CAP=2.0
-uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.0.5b_int8 --with vllm@https://github.com/NovaSky-AI/SkyRL/releases/download/skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl --with transformers==4.53.3 -- python -m examples.train.flash_rl.main_dapo_flashrl \
+CKPT_PATH="$HOME/ckpts/dapo_0.5B_ckpt"
+
+uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.0.5b_int8 --with "vllm@${FLASHRL_VLLM_WHEEL_URL}" --with "transformers==${FLASHRL_TRANSFORMERS_VERSION}" -- python -m examples.train.flash_rl.main_dapo_flashrl \
   data.train_data="['$DATA_DIR/dapo-math-17k-cleaned.parquet']" \
   data.val_data="['$DATA_DIR/aime-2024-cleaned.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \

--- a/examples/train/flash_rl/run_dapo_repro_flashrl_32b_int8.sh
+++ b/examples/train/flash_rl/run_dapo_repro_flashrl_32b_int8.sh
@@ -10,6 +10,9 @@ set -x
 DATA_DIR="$HOME/data/dapo"
 NUM_GPUS=16
 LOGGER="wandb"  # change to "console" to print to stdout
+# Override these env vars to test a newer FlashRL wheel without editing the script.
+FLASHRL_VLLM_WHEEL_URL="${FLASHRL_VLLM_WHEEL_URL:-https://github.com/NovaSky-AI/SkyRL/releases/download/skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl}"
+FLASHRL_TRANSFORMERS_VERSION="${FLASHRL_TRANSFORMERS_VERSION:-4.53.3}"
 
 # main DAPO parameters
 EPS_CLIP_LOW=0.2
@@ -38,7 +41,7 @@ LOGPROBS=0
 
 CKPT_PATH="$HOME/ckpts/dapo_32b_ckpt"
 
-uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.int8 --with vllm@https://github.com/NovaSky-AI/SkyRL/releases/download/skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl --with transformers==4.53.3 -m examples.train.flash_rl.main_dapo_flashrl \
+uv run --isolated --extra flashrl --env-file examples/train/flash_rl/.env.int8 --with "vllm@${FLASHRL_VLLM_WHEEL_URL}" --with "transformers==${FLASHRL_TRANSFORMERS_VERSION}" -m examples.train.flash_rl.main_dapo_flashrl \
   data.train_data="['$DATA_DIR/dapo-math-17k-cleaned.parquet']" \
   data.val_data="['$DATA_DIR/aime-2024-cleaned.parquet']" \
   trainer.algorithm.advantage_estimator="grpo" \

--- a/examples/train/flash_rl/runtime.py
+++ b/examples/train/flash_rl/runtime.py
@@ -1,0 +1,86 @@
+"""Helpers for the example-local FlashRL runtime contract."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from functools import lru_cache
+from typing import Callable
+
+FLASHRL_CONFIG_ENV_VAR = "FLASHRL_CONFIG"
+FLASHRL_PATCH_FN_ENV_VAR = "SKYRL_FLASHRL_PATCH_FN"
+
+DEFAULT_FLASHRL_PATCH_TARGET = "vllm.model_executor.layers.patch:apply_patch"
+DEFAULT_FLASHRL_TRANSFORMERS_VERSION = "4.53.3"
+DEFAULT_FLASHRL_VLLM_WHEEL_URL = (
+    "https://github.com/NovaSky-AI/SkyRL/releases/download/"
+    "skyrl_train-v0.1.0/vllm-0.1.dev7509+gcc487699a.d20250821-cp312-cp312-linux_x86_64.whl"
+)
+
+FLASHRL_README_PATH = "examples/train/flash_rl/README.md"
+
+
+def get_flashrl_config() -> str:
+    """Return the required FlashRL config path/name from the environment."""
+    flashrl_config = os.environ.get(FLASHRL_CONFIG_ENV_VAR, "").strip()
+    if not flashrl_config:
+        raise RuntimeError(
+            f"FlashRL requires `{FLASHRL_CONFIG_ENV_VAR}` to be set. "
+            f"See {FLASHRL_README_PATH} for the expected setup."
+        )
+    return flashrl_config
+
+
+def get_flashrl_patch_target() -> str:
+    """Return the import target for the FlashRL patch hook."""
+    return os.environ.get(FLASHRL_PATCH_FN_ENV_VAR, DEFAULT_FLASHRL_PATCH_TARGET).strip()
+
+
+def _parse_patch_target(import_target: str) -> tuple[str, str]:
+    module_name, separator, attr_name = import_target.partition(":")
+    if not separator or not module_name or not attr_name:
+        raise RuntimeError(
+            f"`{FLASHRL_PATCH_FN_ENV_VAR}` must have the format `<module>:<callable>`, "
+            f"got {import_target!r}."
+        )
+    return module_name, attr_name
+
+
+@lru_cache(maxsize=1)
+def load_flashrl_patch_fn() -> Callable[[], None]:
+    """Import and return the FlashRL patch hook from the custom vLLM build."""
+    import_target = get_flashrl_patch_target()
+    module_name, attr_name = _parse_patch_target(import_target)
+
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        raise RuntimeError(
+            "FlashRL requires a custom vLLM wheel that exposes a patch hook at "
+            f"`{import_target}`. Install a FlashRL-compatible wheel and, if the hook moved, "
+            f"set `{FLASHRL_PATCH_FN_ENV_VAR}` accordingly. See {FLASHRL_README_PATH}."
+        ) from exc
+
+    try:
+        patch_fn = getattr(module, attr_name)
+    except AttributeError as exc:
+        raise RuntimeError(
+            f"Imported `{module_name}` but could not find `{attr_name}`. "
+            f"Set `{FLASHRL_PATCH_FN_ENV_VAR}` to the correct `<module>:<callable>` for "
+            "your FlashRL-compatible vLLM wheel."
+        ) from exc
+
+    if not callable(patch_fn):
+        raise RuntimeError(
+            f"`{import_target}` resolved successfully, but `{attr_name}` is not callable."
+        )
+
+    return patch_fn
+
+
+def validate_flashrl_environment(validate_patch_fn: bool = True) -> str:
+    """Validate the minimal environment required for the FlashRL example path."""
+    flashrl_config = get_flashrl_config()
+    if validate_patch_fn:
+        load_flashrl_patch_fn()
+    return flashrl_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,8 @@ megatron = [
 
 flashrl = [
     "skyrl[skyrl-train]",
-    # NOTE: Custom vLLM wheel must be installed separately.
-    # See examples/train/flash_rl/README.md for installation instructions.
+    # NOTE: The FlashRL examples require a custom vLLM wheel in addition to this extra.
+    # See examples/train/flash_rl/README.md for the supported install flow.
     "flash-attn==2.8.3; sys_platform == 'linux'",
     "torch==2.7.0; sys_platform == 'linux'",
     "flashinfer-python; sys_platform == 'linux'",

--- a/tests/utils/test_flashrl_runtime.py
+++ b/tests/utils/test_flashrl_runtime.py
@@ -1,0 +1,72 @@
+import sys
+import types
+
+import pytest
+
+from examples.train.flash_rl import runtime
+
+
+@pytest.fixture(autouse=True)
+def _clear_flashrl_runtime_cache(monkeypatch):
+    runtime.load_flashrl_patch_fn.cache_clear()
+    monkeypatch.delenv(runtime.FLASHRL_CONFIG_ENV_VAR, raising=False)
+    monkeypatch.delenv(runtime.FLASHRL_PATCH_FN_ENV_VAR, raising=False)
+    yield
+    runtime.load_flashrl_patch_fn.cache_clear()
+
+
+def _register_module_chain(monkeypatch, module_name: str):
+    parts = module_name.split(".")
+    for index in range(1, len(parts) + 1):
+        current_name = ".".join(parts[:index])
+        module = sys.modules.get(current_name, types.ModuleType(current_name))
+        monkeypatch.setitem(sys.modules, current_name, module)
+        if index > 1:
+            parent_name = ".".join(parts[: index - 1])
+            setattr(sys.modules[parent_name], parts[index - 1], module)
+    return sys.modules[module_name]
+
+
+def test_validate_flashrl_environment_requires_flashrl_config():
+    with pytest.raises(RuntimeError, match="FLASHRL_CONFIG"):
+        runtime.validate_flashrl_environment(validate_patch_fn=False)
+
+
+def test_load_flashrl_patch_fn_requires_module_callable_format(monkeypatch):
+    monkeypatch.setenv(runtime.FLASHRL_CONFIG_ENV_VAR, "fp8_vllm")
+    monkeypatch.setenv(runtime.FLASHRL_PATCH_FN_ENV_VAR, "invalid-target")
+
+    with pytest.raises(RuntimeError, match="<module>:<callable>"):
+        runtime.load_flashrl_patch_fn()
+
+
+def test_load_flashrl_patch_fn_uses_default_patch_target(monkeypatch):
+    monkeypatch.setenv(runtime.FLASHRL_CONFIG_ENV_VAR, "fp8_vllm")
+    patch_module = _register_module_chain(monkeypatch, "vllm.model_executor.layers.patch")
+
+    calls = {"count": 0}
+
+    def apply_patch():
+        calls["count"] += 1
+
+    patch_module.apply_patch = apply_patch
+
+    patch_fn = runtime.load_flashrl_patch_fn()
+    assert patch_fn is apply_patch
+    assert runtime.validate_flashrl_environment() == "fp8_vllm"
+
+    patch_fn()
+    assert calls["count"] == 1
+
+
+def test_load_flashrl_patch_fn_supports_env_override(monkeypatch):
+    monkeypatch.setenv(runtime.FLASHRL_CONFIG_ENV_VAR, "fp8_vllm")
+    monkeypatch.setenv(runtime.FLASHRL_PATCH_FN_ENV_VAR, "flashrl_custom.patch:install")
+    patch_module = _register_module_chain(monkeypatch, "flashrl_custom.patch")
+
+    def install():
+        return None
+
+    patch_module.install = install
+
+    assert runtime.load_flashrl_patch_fn() is install


### PR DESCRIPTION
## Summary
- add an example-local FlashRL runtime helper that validates `FLASHRL_CONFIG` and supports an overridable patch hook via `SKYRL_FLASHRL_PATCH_FN`
- fail early in the FlashRL example entrypoint when unsupported configs are used, including non-local engines, non-`vllm` backends, `async_engine`, and multi-turn generation
- clean up the FlashRL example scripts and docs so the custom wheel contract is explicit and the wheel / transformers versions can be overridden without editing each script
- add a lightweight repo-side FlashRL compatibility test and hook it into CI without depending on the custom FlashRL vLLM wheel

## Why
Issue #1338 tracks migrating the FlashRL fork to the latest vLLM.

This PR handles the SkyRL-side groundwork so the eventual FlashRL-compatible `vLLM 0.18.0` wheel can be swapped in with less repo churn:
- the example path now validates its runtime contract up front
- the patch-hook import path is configurable for the migrated wheel
- the docs and scripts now describe the current support boundary more accurately
- we have a small automated test for the repo-side FlashRL contract

This PR does **not** complete the external custom vLLM fork / wheel migration yet, which is why it is still a draft.

## Testing
- `python3 -m py_compile examples/train/flash_rl/runtime.py examples/train/flash_rl/flash_rl_engine.py examples/train/flash_rl/main_dapo_flashrl.py tests/utils/test_flashrl_runtime.py`
- `bash -n examples/train/flash_rl/run_dapo_repro_flashrl_0.5b_int8.sh examples/train/flash_rl/run_dapo_repro_flashrl_32b_int8.sh examples/train/flash_rl/run_dapo_gsm8k_flashrl_0.5b_int8.sh examples/train/flash_rl/run_dapo_gsm8k_flashrl_0.5b_fp8.sh examples/train/flash_rl/run_dapo_gsm8k_flashrl_32b_int8.sh`
- `git diff --check`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --directory . --isolated --extra dev pytest -q tests/utils/test_flashrl_runtime.py`

## Issue
- Related to #1338
