### PR TITLE
Fix Verifiers HTTP token metadata compatibility and refresh the integration test

### DIFF
--- a/examples/train_integrations/verifiers/README.md
+++ b/examples/train_integrations/verifiers/README.md
@@ -22,14 +22,14 @@ export ENV_ID="will/wordle"
 
 Then, install the environment, which adds it to the `uv` project:
 ```bash
-uv run integrations/verifiers/install_environment.py $ENV_ID
+uv run examples/train_integrations/verifiers/install_environment.py $ENV_ID
 ```
 
 ### 2) Prepare the dataset
 Next, load the environment's dataset and convert to SkyRL format:
 ```bash
 uv run --isolated --with verifiers \
-  python integrations/verifiers/prepare_dataset.py \
+  python examples/train_integrations/verifiers/prepare_dataset.py \
   --env_id $ENV_ID
 ```
 
@@ -58,12 +58,14 @@ LOGGER="wandb"
 Finally, launch your training run:
 
 ```bash
-bash integrations/verifiers/run_verifiers.sh
+bash examples/train_integrations/verifiers/run_verifiers.sh
 ```
 
 All training parameters can be modified in `run_verifiers.sh`, such as the model choice (`trainer.policy.model.path`), GRPO group size (`generator.n_samples_per_prompt`), or training batch size (`trainer.train_batch_size`).
 
 See all available training configuration parameters in `skyrl/train/config/config.py` (Python dataclass definitions).
+
+This integration relies on SkyRL's OpenAI-compatible HTTP endpoint and the endpoint returning raw token IDs from `/chat/completions`. If `generator.inference_engine.served_model_name` is set, that is the model name the Verifiers client must use instead of the underlying model path.
 
 
 ## Troubleshooting

--- a/examples/train_integrations/verifiers/entrypoints/main_verifiers.py
+++ b/examples/train_integrations/verifiers/entrypoints/main_verifiers.py
@@ -16,10 +16,11 @@ class VerifiersEntrypoint(BasePPOExp):
         tokenizer: PreTrainedTokenizer,
         inference_engine_client: InferenceEngineClient,
     ):
+        model_name = cfg.generator.inference_engine.served_model_name or cfg.trainer.policy.model.path
         return VerifiersGenerator(
             generator_cfg=cfg.generator,
             tokenizer=tokenizer,
-            model_name=cfg.trainer.policy.model.path,
+            model_name=model_name,
         )
 
 

--- a/examples/train_integrations/verifiers/install_environment.py
+++ b/examples/train_integrations/verifiers/install_environment.py
@@ -3,7 +3,7 @@
 # Helper that installs the Verifiers environment and adds it to the uv project.
 #
 # Example:
-#   uv run integrations/verifiers/install_environment.py will/wordle@0.1.4
+#   uv run examples/train_integrations/verifiers/install_environment.py will/wordle@0.1.4
 #
 
 import argparse

--- a/examples/train_integrations/verifiers/run_verifiers.sh
+++ b/examples/train_integrations/verifiers/run_verifiers.sh
@@ -1,7 +1,7 @@
 # Launches SkyRL training on the Verifiers environment.
 #
 # Example:
-#   bash integrations/verifiers/run_verifiers.sh
+#   bash examples/train_integrations/verifiers/run_verifiers.sh
 #
 set -x
 
@@ -38,5 +38,5 @@ uv run --isolated --with verifiers --extra fsdp -m examples.train_integrations.v
   trainer.project_name="verifiers" \
   trainer.run_name="verifiers_test" \
   trainer.ckpt_interval=-1 \
-  trainer.ckpt_path="$HOME/ckpts/verifiers_ckpt"
+  trainer.ckpt_path="$HOME/ckpts/verifiers_ckpt" \
   $@

--- a/examples/train_integrations/verifiers/verifiers_generator.py
+++ b/examples/train_integrations/verifiers/verifiers_generator.py
@@ -1,12 +1,24 @@
-from typing import Optional
-from skyrl.train.generators.base import GeneratorInterface, GeneratorInput, GeneratorOutput
-from openai import AsyncOpenAI
+from copy import deepcopy
+from typing import Any, Optional
+
 import httpx
+from openai import AsyncOpenAI
 from verifiers import load_environment
 from verifiers.types import GenerateOutputs, ProcessedOutputs, RolloutInput
+
+from skyrl.train.generators.base import GeneratorInterface, GeneratorInput, GeneratorOutput
+from skyrl.train.config import GeneratorConfig
 from skyrl.train.generators.utils import get_rollout_metrics
 
-from skyrl.train.config import GeneratorConfig
+
+_VERIFIERS_EXTRA_BODY_KEYS = (
+    "include_stop_str_in_output",
+    "min_p",
+    "min_tokens",
+    "repetition_penalty",
+    "skip_special_tokens",
+    "top_k",
+)
 
 
 class VerifiersGenerator(GeneratorInterface):
@@ -44,6 +56,30 @@ class VerifiersGenerator(GeneratorInterface):
             http_client=http_client,
         )
 
+    def _build_verifiers_sampling_args(self, input_batch: GeneratorInput) -> dict[str, Any]:
+        """Build sampling args for Verifiers' OpenAI client path.
+
+        Verifiers' current chat parsing expects prompt token IDs in the response, which vLLM
+        exposes when `return_token_ids` is requested. We pass this through `extra_body`
+        because the request is made via the OpenAI client.
+        """
+        sampling_params = deepcopy(input_batch.get("sampling_params", {}))
+        sampling_params["logprobs"] = True
+        sampling_params["top_logprobs"] = 1
+
+        extra_body = dict(sampling_params.pop("extra_body", {}) or {})
+        extra_body["return_token_ids"] = True
+        # Preserve existing behavior for token strings in logprob content until we confirm
+        # Verifiers no longer needs it.
+        extra_body.setdefault("return_tokens_as_token_ids", True)
+
+        for key in _VERIFIERS_EXTRA_BODY_KEYS:
+            if key in sampling_params:
+                extra_body[key] = sampling_params.pop(key)
+
+        sampling_params["extra_body"] = extra_body
+        return sampling_params
+
     async def generate(self, input_batch: GeneratorInput) -> GeneratorOutput:
         assert "env_extras" in input_batch, "Verifiers dataset fields are passed through env_extras"
 
@@ -66,35 +102,28 @@ class VerifiersGenerator(GeneratorInterface):
         environment_id = verifiers_dicts[0]["environment"]
         vf_env = load_environment(environment_id)
 
-        # Verifiers requires logprobs from vLLM for post-processing.
-        sampling_params = input_batch.get("sampling_params", {}).copy()
-        sampling_params["logprobs"] = True
-        sampling_params["top_logprobs"] = 1
-        sampling_params["extra_body"] = {
-            "return_tokens_as_token_ids": True,
-        }
-
-        # Clean the sampling params for Verifiers' generate.
-        extra_body_keys = [
-            "min_tokens",
-            "skip_special_tokens",
-            "include_stop_str_in_output",
-            "top_k",
-            "min_p",
-            "repetition_penalty",
-        ]
-        for key in extra_body_keys:
-            if key in sampling_params:
-                sampling_params["extra_body"][key] = sampling_params[key]
-                del sampling_params[key]
+        sampling_params = self._build_verifiers_sampling_args(input_batch)
 
         # Generate the trajectories.
-        generate_outputs: GenerateOutputs = await vf_env.generate(
-            inputs=rollout_inputs,
-            client=self.client,
-            model=self.model_name,
-            sampling_args=sampling_params,
-        )
+        try:
+            generate_outputs: GenerateOutputs = await vf_env.generate(
+                inputs=rollout_inputs,
+                client=self.client,
+                model=self.model_name,
+                sampling_args=sampling_params,
+            )
+        except Exception as exc:
+            if "prompt_token_ids" in str(exc) or (
+                isinstance(exc, TypeError) and "NoneType" in str(exc) and "len()" in str(exc)
+            ):
+                raise RuntimeError(
+                    "Verifiers generation failed while parsing token metadata from "
+                    "/chat/completions. This integration requires the HTTP endpoint to return "
+                    "prompt_token_ids, completion token_ids, and logprobs. Verify that "
+                    "`return_token_ids` is being requested through `extra_body` and that the "
+                    "served OpenAI-compatible vLLM endpoint supports it."
+                ) from exc
+            raise
 
         processed_outputs: ProcessedOutputs = vf_env.process_env_results_vllm(
             prompts=generate_outputs.prompt,

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_verifiers_generator.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_verifiers_generator.py
@@ -8,19 +8,18 @@ import pytest
 import ray
 from transformers import AutoTokenizer
 
+pytest.importorskip("verifiers")
+
 from skyrl.backends.skyrl_train.inference_engines.utils import (
     get_sampling_params_for_backend,
 )
-from skyrl.train.config import GeneratorConfig, SamplingParams
+from skyrl.train.config import GeneratorConfig, InferenceEngineConfig, SamplingParams
 from tests.backends.skyrl_train.gpu.utils import (
     InferenceEngineState,
     get_test_actor_config,
 )
 
-# Mark all tests in this file as "integrations"
-# NOTE (sumanthrh): Skipping these tests until we make the verifiers integration compatible with verifiers repo `main` again.
-# Error: cannot import name 'GenerateInputs' from 'verifiers.types'
-pytestmark = [pytest.mark.integrations, pytest.mark.skip]
+pytestmark = pytest.mark.integrations
 
 
 def _get_free_port() -> int:
@@ -31,21 +30,23 @@ def _get_free_port() -> int:
 
 @pytest.fixture(scope="module")
 def verifiers_runtime():
-    model = "Qwen/Qwen2.5-1.5B-Instruct"
+    backing_model = "Qwen/Qwen2.5-1.5B-Instruct"
+    served_model_name = "verifiers-test-model"
     http_port = _get_free_port()
 
     cfg = get_test_actor_config()
-    cfg.trainer.policy.model.path = model
+    cfg.trainer.policy.model.path = backing_model
     cfg.generator.max_input_length = 2048
     cfg.generator.inference_engine.enable_http_endpoint = True
     cfg.generator.inference_engine.http_endpoint_host = "127.0.0.1"
     cfg.generator.inference_engine.http_endpoint_port = http_port
+    cfg.generator.inference_engine.served_model_name = served_model_name
     cfg.generator.sampling_params.max_generate_length = 256
 
     # Reuse shared initializer for local engines and client
     engines = InferenceEngineState.create(
         cfg=cfg,
-        model=model,
+        model=backing_model,
         use_local=True,
         async_engine=True,
         tp_size=1,
@@ -55,10 +56,16 @@ def verifiers_runtime():
         sleep_level=1,  # since we do not explicitly sync weights
     )
 
-    tokenizer = AutoTokenizer.from_pretrained(model)
+    tokenizer = AutoTokenizer.from_pretrained(backing_model)
 
     try:
-        yield {"client": engines.client, "tokenizer": tokenizer, "http_port": http_port, "model": model}
+        yield {
+            "client": engines.client,
+            "tokenizer": tokenizer,
+            "http_port": http_port,
+            "model": served_model_name,
+            "backing_model": backing_model,
+        }
     finally:
         engines.close()
         ray.shutdown()
@@ -87,13 +94,16 @@ async def _run_verifiers_end_to_end(
     generator_cfg = GeneratorConfig(
         sampling_params=SamplingParams(max_generate_length=max_generate_length, logprobs=None),
         max_input_length=max_input_length,
-        backend="vllm",
-        enable_http_endpoint=True,
-        http_endpoint_host=http_host,
-        http_endpoint_port=http_port,
+        inference_engine=InferenceEngineConfig(
+            backend="vllm",
+            enable_http_endpoint=True,
+            http_endpoint_host=http_host,
+            http_endpoint_port=http_port,
+            served_model_name=model,
+        ),
     )
 
-    from integrations.verifiers.verifiers_generator import VerifiersGenerator
+    from examples.train_integrations.verifiers.verifiers_generator import VerifiersGenerator
 
     generator = VerifiersGenerator(
         generator_cfg=generator_cfg,
@@ -166,9 +176,14 @@ async def test_verifiers_e2e_wordle_http(verifiers_runtime):
 
     assert len(out["response_ids"]) == 2
     assert len(out["prompt_token_ids"]) == 2
-    for resp, mask, logp in zip(
-        out["response_ids"], out["loss_masks"], out["rollout_logprobs"] or [[]] * len(out["response_ids"])
+    for prompt_ids, resp, mask, logp in zip(
+        out["prompt_token_ids"],
+        out["response_ids"],
+        out["loss_masks"],
+        out["rollout_logprobs"] or [[]] * len(out["response_ids"]),
     ):
+        assert isinstance(prompt_ids, list) and prompt_ids
+        assert all(isinstance(t, int) for t in prompt_ids)
         assert isinstance(resp, list) and all(isinstance(t, int) for t in resp)
         assert len(resp) == len(mask)
         if out["rollout_logprobs"] is not None:


### PR DESCRIPTION
## Summary

This PR restores the Verifiers integration on SkyRL's OpenAI-compatible HTTP inference path and refreshes the stale integration coverage around it.

### What changed

- request `return_token_ids` for the Verifiers chat-completions path via `extra_body`, while preserving `return_tokens_as_token_ids` for compatibility
- prefer `generator.inference_engine.served_model_name` over the raw model path when wiring the Verifiers HTTP client model name
- modernize and re-enable the Verifiers GPU integration test to use the current nested config shape and current module paths
- update the Verifiers example docs and launcher/install comments so they point to the current `examples/train_integrations/verifiers/...` paths
- fix `run_verifiers.sh` so trailing CLI overrides are forwarded correctly

### Why

Current Verifiers expects `prompt_token_ids` on chat-completion responses. SkyRL's Verifiers generator was still requesting the older token-return contract, which caused the integration to fail while Verifiers was building prompt masks from the response metadata.

This addresses #854.

## Testing

- `python -m py_compile examples/train_integrations/verifiers/verifiers_generator.py examples/train_integrations/verifiers/entrypoints/main_verifiers.py tests/backends/skyrl_train/gpu/gpu_ci/test_verifiers_generator.py examples/train_integrations/verifiers/install_environment.py`
- `git diff --check`
- attempted:
  - `UV_CACHE_DIR=/tmp/uv-cache uv run --isolated --extra dev --extra fsdp --with verifiers pytest tests/backends/skyrl_train/gpu/gpu_ci/test_verifiers_generator.py -q`
  - `UV_CACHE_DIR=/tmp/uv-cache uv run --isolated --extra dev --extra fsdp pytest tests/backends/skyrl_train/gpu/gpu_ci/test_inference_engine_client_http_endpoint.py -q -k "served_model_name or custom_chat_template"`

The `uv`-backed test runs were blocked in this environment by network-restricted dependency resolution while fetching `flash-attn`.
