### PR TITLE
[skyrl] New inference client in the skyrl-train tinker backend

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/common.py
+++ b/skyrl/backends/skyrl_train/inference_servers/common.py
@@ -89,6 +89,7 @@ def find_and_reserve_port(start_port: int) -> Tuple[int, socket.socket]:
     while True:
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.bind(("", port))
             sock.listen(1)
             return port, sock


### PR DESCRIPTION
## Summary
Addresses issue #1451 by adding the support for the new inference server in the skyrl-train tinker backend.

- Integrates `RemoteInferenceClient` (HTTP-based inference) into the Tinker SkyRL-Train backend, gated behind the `_SKYRL_USE_NEW_INFERENCE=1` env var
- Supports all 4 config modes from `main_base.py`: fully external, proxy-only, servers-only, and build internally (ServerGroup + VLLMRouter)
- Adds `_sample_with_remote_client()` that forwards `ModelInput` chunks directly to `RemoteInferenceClient.sample()`

## Test plan

- [x] End-to-end Tinker RL loop with `_SKYRL_USE_NEW_INFERENCE=1`:

```bash
 _SKYRL_USE_NEW_INFERENCE=1 uv run --extra tinker --extra fsdp -m skyrl.tinker.api   \
 --base-model "Qwen/Qwen3-0.6B" --backend fsdp  

 TINKER_API_KEY=tml-dummy uv run --with tinker --with datasets --with torch \
 python -m tinker_cookbook.recipes.rl_loop base_url=http://localhost:8000 model_name="Qwen/Qwen3-0.6B"
  ```

Reward curves with LoRA rank = 32. Tested against vLLM 0.19.0 

Reward curve:
<img width="1200" height="675" alt="reward-comparison" src="https://github.com/user-attachments/assets/f570363c-2deb-48f9-aba5-8a47f1d0f854" />




<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
