### PR TITLE
[Bug][CI] Increase server timeout for MoE model initialization

### DIFF
--- a/tests/backends/skyrl_train/gpu/utils.py
+++ b/tests/backends/skyrl_train/gpu/utils.py
@@ -670,6 +670,7 @@ def init_remote_inference_servers(
         print(f"Received timeout error while waiting for server: {e}")
         server_process.terminate()
         server_process.wait()
+        raise
 
     print(f"Server at localhost:{engine_port} is online")
 


### PR DESCRIPTION
# What does this PR do?

Fixes timeout issue on GPU CI: https://github.com/NovaSky-AI/SkyRL/actions/runs/23917919773/job/69756500504

The tests were hanging at `test_transfer_strategies_e2e.py`

I reproduced the hang and the issue was that the test required 4 GPUs but only 2 were available. There was a stray vLLM instance occupying 2 GPUs. 

Looking through the `RayWorkerWrapper` actor logs on the Ray Dashboard (i.e worker process logs for the vLLM instance), I saw that the model was `Qwen/Qwen1.5-MoE-A2.7B`. This is only used `test_engine_generation.py` in our GPU CI suite at the moment. 

I was able to reproduce the issue by running `test_engine_generation.py` and  `test_transfer_strategies_e2e.py` in the same pytest session, one after another. Since initialization seemed to proceed fine for the MoE model, I simply increased server timeout and the tests passed. 


### The fix

Increased server timeout to 200 seconds. Also, I improved cleanup in `init_remote_inference_servers` : If a timeout error happens, we should terminate the remote server process right there - the finally block in the caller : https://github.com/NovaSky-AI/SkyRL/blob/3619c18dfc84b9c34674e86d25e36d933a3e117a/tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py#L145-L147

will be a no-op because server initialized fails. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
