### PR TITLE
fix(ray): Disable metrics to suppress connection error logs

### DIFF
--- a/ci/anyscale_gpu_ci.yaml
+++ b/ci/anyscale_gpu_ci.yaml
@@ -6,3 +6,5 @@ ray_version: "2.51.1"
 compute_config: l4_ci
 working_dir: .
 max_retries: 0
+env_vars:
+  RAY_METRICS_ENABLED: "0"

--- a/ci/anyscale_gpu_e2e_test.yaml
+++ b/ci/anyscale_gpu_e2e_test.yaml
@@ -8,4 +8,5 @@ working_dir: . # (Optional) Use current working directory "." as the working_dir
 env_vars:
   RAY_OVERRIDE_JOB_RUNTIME_ENV: "1"
   WANDB_API_KEY: $WANDB_API_KEY
+  RAY_METRICS_ENABLED: "0"
 max_retries: 1 # (Optional) Maximum number of times the job will be retried before being marked failed. Defaults to `1`.

--- a/examples/train_scripts/launch_multiple_remote_servers.py
+++ b/examples/train_scripts/launch_multiple_remote_servers.py
@@ -180,6 +180,9 @@ def main():
     parser.add_argument("--timeout", type=int, default=180, help="Timeout in seconds for server readiness")
     args = parser.parse_args()
 
+    # Disable Ray metrics to avoid connection errors in logs
+    os.environ["RAY_METRICS_ENABLED"] = "0"
+
     cfg = SkyRLTrainConfig()
     cfg.generator.inference_engine.backend = "vllm"
     cfg.generator.inference_engine.weight_sync_backend = "nccl"


### PR DESCRIPTION
## Summary

This commit disables Ray's metrics reporting to fix the recurring log message 'Failed to establish connection to the metrics exporter agent...'. The metrics agent is not being used, so disabling it via the `RAY_METRICS_ENABLED=0` environment variable is a clean way to suppress these errors. The change is applied to the Anyscale CI configurations and an example script to ensure a consistent experience.

## Changes

- **ci/anyscale_gpu_ci.yaml**: Added `RAY_METRICS_ENABLED: "0"` to the environment variables to disable Ray metrics and prevent connection error logs in the CI job.
- **ci/anyscale_gpu_e2e_test.yaml**: Added `RAY_METRICS_ENABLED: "0"` to the environment variables to disable Ray metrics and prevent connection error logs in the end-to-end test CI job.
- **examples/train_scripts/launch_multiple_remote_servers.py**: Set the `RAY_METRICS_ENABLED` environment variable to `0` at the beginning of the main function. This prevents Ray from trying to connect to the metrics agent, thus suppressing the connection error logs when running this example script.

## Related Issue

Closes #1103


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
