### PR TITLE
[tinker] Forbid extra keys in EngineConfig

### DIFF
--- a/skyrl/tinker/config.py
+++ b/skyrl/tinker/config.py
@@ -6,11 +6,13 @@ import os
 from pathlib import Path
 
 from cloudpathlib import AnyPath
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class EngineConfig(BaseModel):
     """Configuration for the Tinker engine."""
+
+    model_config = ConfigDict(extra="forbid")
 
     base_model: str = Field(..., description="Base model name (e.g., Qwen/Qwen3-0.6B)")
     backend: str = Field(default="jax", description="Backend to use for training and inference")


### PR DESCRIPTION
## Summary
The CLI path (argparse) was already safe since unknown `--args` are rejected by argparse. This change adds the same protection for direct dict instantiation.

Any unrecognized key passed to `EngineConfig` (e.g. via `model_validate` or direct construction) now raises a Pydantic `ValidationError` immediately instead of being silently ignored

Matches the strict key validation already present in `skyrl/train` via `validate_dict_keys_against_dataclass()`

## Testing
Verified that unknown keys now throw a `ValidationError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
