### PR TITLE
[skyrl] vLLM Renderer for rendering Multi-Modal ModelInputChunks for training backend

### DIFF
--- a/skyrl/backends/renderer.py
+++ b/skyrl/backends/renderer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from typing import TYPE_CHECKING, NamedTuple, Tuple, Union
+from typing import TYPE_CHECKING, NamedTuple, Union
 
 import torch
 
@@ -11,6 +11,7 @@ from skyrl.tinker.types import (
     ImageAssetPointerChunk,
     ImageChunk,
     ModelInput,
+    MultiModalKwargs,
     MultiModalPlaceholder,
     RenderedModelInput,
 )
@@ -31,15 +32,18 @@ def render_model_input(model_inputs: list[ModelInput]) -> list[RenderedModelInpu
     ]
 
 
-def decode_mm_kwargs(rendered: RenderedModelInput) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Decode a RenderedModelInput's multi_modal_kwargs into vision tensors.
+def decode_mm_kwargs(mm_kwargs: dict[str, list[str]] | None) -> MultiModalKwargs:
+    """Decode raw base64-encoded multimodal kwargs from vLLM into vision arrays.
+
+    Args:
+        mm_kwargs: Raw kwargs dict from vLLM's render endpoint, e.g. {"image": [b64_str, ...]}.
 
     Returns:
-        (pixel_values, image_grid_thw) — concatenated across all images in this
-        sample.  Returns empty tensors when the sample has no vision data.
+        MultiModalKwargs with decoded and concatenated pixel_values and image_grid_thw.
+        Values are None when no vision data is present.
     """
-    if not rendered.multi_modal_kwargs or "image" not in rendered.multi_modal_kwargs:
-        return torch.empty(0), torch.empty(0, 3, dtype=torch.long)
+    if not mm_kwargs or "image" not in mm_kwargs:
+        return MultiModalKwargs(pixel_values=None, image_grid_thw=None)
 
     from vllm.entrypoints.serve.disagg.mm_serde import (
         decode_mm_kwargs_item as _vllm_decode,
@@ -47,7 +51,7 @@ def decode_mm_kwargs(rendered: RenderedModelInput) -> Tuple[torch.Tensor, torch.
 
     pv_parts: list[torch.Tensor] = []
     thw_parts: list[torch.Tensor] = []
-    for b64_str in rendered.multi_modal_kwargs["image"]:
+    for b64_str in mm_kwargs["image"]:
         item = _vllm_decode(b64_str)
         data = item.get_data()
         if "pixel_values" in data and isinstance(data["pixel_values"], torch.Tensor):
@@ -55,10 +59,10 @@ def decode_mm_kwargs(rendered: RenderedModelInput) -> Tuple[torch.Tensor, torch.
         if "image_grid_thw" in data and isinstance(data["image_grid_thw"], torch.Tensor):
             thw_parts.append(data["image_grid_thw"])
 
-    pixel_values = torch.cat(pv_parts, dim=0) if pv_parts else torch.empty(0)
+    pixel_values = torch.cat(pv_parts, dim=0) if pv_parts else None
     thw_parts = [t.reshape(1, -1) if t.dim() == 1 else t for t in thw_parts]
-    image_grid_thw = torch.cat(thw_parts, dim=0) if thw_parts else torch.empty(0, 3, dtype=torch.long)
-    return pixel_values, image_grid_thw
+    image_grid_thw = torch.cat(thw_parts, dim=0) if thw_parts else None
+    return MultiModalKwargs(pixel_values=pixel_values, image_grid_thw=image_grid_thw)
 
 
 class RenderedImage(NamedTuple):
@@ -108,12 +112,12 @@ class VLLMRenderer:
                 image_idx += 1
 
         kwargs_data_items = [ri.kwargs_data for ri in rendered_images if ri.kwargs_data is not None]
-        mm_kwargs = {"image": kwargs_data_items} if kwargs_data_items else None
+        mm_kwargs_raw = {"image": kwargs_data_items} if kwargs_data_items else None
 
         return RenderedModelInput(
             prompt_ids=token_ids,
             multi_modal_placeholders=placeholders if placeholders else None,
-            multi_modal_kwargs=mm_kwargs,
+            multi_modal_kwargs=decode_mm_kwargs(mm_kwargs_raw),
         )
 
     async def _render_images(

--- a/skyrl/tinker/types.py
+++ b/skyrl/tinker/types.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal, TypedDict
 from urllib.parse import urlparse
 
 from pydantic import Base64Bytes, BaseModel, Discriminator
@@ -128,9 +128,14 @@ class MultiModalPlaceholder(BaseModel):
     length: int  # Length of the placeholder tokens
 
 
+class MultiModalKwargs(TypedDict):
+    pixel_values: Any | None
+    image_grid_thw: Any | None
+
+
 class RenderedModelInput(BaseModel):
     prompt_ids: list[int]
-    multi_modal_kwargs: dict[str, list[str]] | None = None
+    multi_modal_kwargs: MultiModalKwargs | None = None
     multi_modal_placeholders: list[MultiModalPlaceholder] | None = None
 
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_vlm_inference_generation.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_vlm_inference_generation.py
@@ -3,7 +3,7 @@ VLM integration tests for the new inference path and tinker renderer.
 
 Tests /v1/chat/completions/render with a VLM to verify multimodal
 inputs are correctly tokenized and multimodal features are returned,
-and exercises VLLMRenderer + decode_mm_kwargs end-to-end.
+and exercises VLLMRenderer end-to-end.
 
 Requires a local vLLM install with /v1/chat/completions/render support.
 
@@ -20,7 +20,7 @@ import torch
 from PIL import Image
 from transformers import AutoTokenizer
 
-from skyrl.backends.renderer import VLLMRenderer, decode_mm_kwargs
+from skyrl.backends.renderer import VLLMRenderer
 from skyrl.tinker.types import EncodedTextChunk, ImageChunk, ModelInput
 from skyrl.train.config import SkyRLTrainConfig
 from tests.backends.skyrl_train.gpu.utils import InferenceEngineState
@@ -244,15 +244,15 @@ async def test_renderer_mixed_text_and_image(module_scoped_ray_init_fixture):
 
 
 # ---------------------------------------------------------------------------
-# decode_mm_kwargs tests
+# multi_modal_kwargs tests
 # ---------------------------------------------------------------------------
 
 
 @requires_local_vllm
 @pytest.mark.vllm
 @pytest.mark.asyncio
-async def test_decode_mm_kwargs_with_image(module_scoped_ray_init_fixture):
-    """decode_mm_kwargs should produce valid pixel_values and image_grid_thw tensors."""
+async def test_renderer_decodes_mm_kwargs(module_scoped_ray_init_fixture):
+    """VLLMRenderer should produce decoded pixel_values and image_grid_thw in multi_modal_kwargs."""
     cfg = get_test_actor_config(num_inference_engines=1, model=MODEL_QWEN3_VL)
     cfg.generator.inference_engine.served_model_name = MODEL_QWEN3_VL
     async with InferenceEngineState.create(
@@ -275,9 +275,11 @@ async def test_decode_mm_kwargs_with_image(module_scoped_ray_init_fixture):
 
         assert len(results) == 1
         rendered = results[0]
-        assert rendered.multi_modal_kwargs is not None
+        mm = rendered.multi_modal_kwargs
+        assert mm is not None
 
-        pixel_values, image_grid_thw = decode_mm_kwargs(rendered)
+        pixel_values = mm["pixel_values"]
+        image_grid_thw = mm["image_grid_thw"]
 
         assert isinstance(pixel_values, torch.Tensor)
         assert pixel_values.numel() > 0

--- a/tests/backends/skyrl_train/test_renderer.py
+++ b/tests/backends/skyrl_train/test_renderer.py
@@ -1,9 +1,12 @@
 """Unit tests for VLLMRenderer with a mocked RemoteInferenceClient."""
 
 import base64
-from unittest.mock import AsyncMock, MagicMock
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import torch
 
 from skyrl.backends.renderer import VLLMRenderer, render_model_input
 from skyrl.tinker.types import (
@@ -25,6 +28,29 @@ def _make_text_input(token_lists: list[list[int]]) -> ModelInput:
 
 def _make_image_chunk(fmt: str = "jpeg") -> ImageChunk:
     return ImageChunk(data=base64.b64encode(b"\xff\xd8\xff\xe0"), format=fmt)
+
+
+def _encode_kwargs_data(pixel_values: torch.Tensor, image_grid_thw: torch.Tensor) -> str:
+    """Encode tensors into a base64 JSON string matching the shape vLLM returns."""
+    payload = {
+        "pixel_values": pixel_values.tolist(),
+        "image_grid_thw": image_grid_thw.tolist(),
+    }
+    return base64.b64encode(json.dumps(payload).encode()).decode("ascii")
+
+
+class _FakeMMKwargsItem:
+    """Fake return value for vLLM's decode_mm_kwargs_item."""
+
+    def __init__(self, b64_str: str) -> None:
+        data = json.loads(base64.b64decode(b64_str))
+        self._data = {
+            "pixel_values": torch.tensor(data["pixel_values"]),
+            "image_grid_thw": torch.tensor(data["image_grid_thw"], dtype=torch.long),
+        }
+
+    def get_data(self) -> dict:
+        return self._data
 
 
 def _make_render_response(
@@ -80,58 +106,95 @@ class TestVLLMRendererTextOnly:
         assert vllm_result.prompt_ids == free_fn_result.prompt_ids
 
 
+_VLLM_SERDE_MODULE = "vllm.entrypoints.serve.disagg.mm_serde"
+
+
+def _patch_vllm_decode():
+    """Context manager that stubs out the vLLM serde module so decode_mm_kwargs_item
+    can be imported even when vLLM is not installed."""
+    fake_serde = MagicMock()
+    fake_serde.decode_mm_kwargs_item = MagicMock(side_effect=lambda b64_str: _FakeMMKwargsItem(b64_str))
+    # Ensure parent packages exist in sys.modules
+    modules = {
+        "vllm": MagicMock(),
+        "vllm.entrypoints": MagicMock(),
+        "vllm.entrypoints.serve": MagicMock(),
+        "vllm.entrypoints.serve.disagg": MagicMock(),
+        _VLLM_SERDE_MODULE: fake_serde,
+    }
+    return patch.dict(sys.modules, modules)
+
+
 class TestVLLMRendererMixed:
     @pytest.mark.asyncio
     async def test_text_image_text(self):
         """Interleaved [text, image, text] should produce tokens in correct order."""
         client = _make_mock_client()
+        pv = torch.tensor([[1.0, 2.0, 3.0]])
+        thw = torch.tensor([[1, 1, 3]], dtype=torch.long)
+        kwargs_b64 = _encode_kwargs_data(pv, thw)
+
         placeholder_tokens = [50, 51, 52]
         client.render_chat_completion.return_value = _make_render_response(
             token_ids=placeholder_tokens,
             placeholders=[{"offset": 0, "length": 3}],
-            kwargs_data=["img-data"],
+            kwargs_data=[kwargs_b64],
         )
 
-        renderer = VLLMRenderer(client, model_name="test-model")
-        mi = ModelInput(
-            chunks=[
-                EncodedTextChunk(tokens=[1, 2]),
-                _make_image_chunk(),
-                EncodedTextChunk(tokens=[3, 4]),
-            ]
-        )
-        results = await renderer([mi])
+        with _patch_vllm_decode():
+            renderer = VLLMRenderer(client, model_name="test-model")
+            mi = ModelInput(
+                chunks=[
+                    EncodedTextChunk(tokens=[1, 2]),
+                    _make_image_chunk(),
+                    EncodedTextChunk(tokens=[3, 4]),
+                ]
+            )
+            results = await renderer([mi])
 
         assert results[0].prompt_ids == [1, 2, 50, 51, 52, 3, 4]
         assert results[0].multi_modal_placeholders is not None
         ph = results[0].multi_modal_placeholders[0]
         assert ph.offset == 2
         assert ph.length == 3
-        assert results[0].multi_modal_kwargs == {"image": ["img-data"]}
+
+        mm = results[0].multi_modal_kwargs
+        assert mm is not None
+        assert torch.equal(mm["pixel_values"], pv)
+        assert torch.equal(mm["image_grid_thw"], thw)
 
     @pytest.mark.asyncio
     async def test_two_images(self):
-        """Two images should produce two placeholder regions."""
+        """Two images should produce two placeholder regions with concatenated kwargs."""
         client = _make_mock_client()
+        pv_a = torch.tensor([[1.0, 2.0, 3.0]])
+        thw_a = torch.tensor([[1, 1, 3]], dtype=torch.long)
+        pv_b = torch.tensor([[4.0, 5.0, 6.0]])
+        thw_b = torch.tensor([[1, 1, 3]], dtype=torch.long)
+
         client.render_chat_completion.return_value = _make_render_response(
             token_ids=[10, 11, 20, 21, 22],
             placeholders=[
                 {"offset": 0, "length": 2},
                 {"offset": 2, "length": 3},
             ],
-            kwargs_data=["data-a", "data-b"],
+            kwargs_data=[
+                _encode_kwargs_data(pv_a, thw_a),
+                _encode_kwargs_data(pv_b, thw_b),
+            ],
         )
 
-        renderer = VLLMRenderer(client, model_name="test-model")
-        mi = ModelInput(
-            chunks=[
-                EncodedTextChunk(tokens=[1]),
-                _make_image_chunk(),
-                _make_image_chunk(),
-                EncodedTextChunk(tokens=[2]),
-            ]
-        )
-        results = await renderer([mi])
+        with _patch_vllm_decode():
+            renderer = VLLMRenderer(client, model_name="test-model")
+            mi = ModelInput(
+                chunks=[
+                    EncodedTextChunk(tokens=[1]),
+                    _make_image_chunk(),
+                    _make_image_chunk(),
+                    EncodedTextChunk(tokens=[2]),
+                ]
+            )
+            results = await renderer([mi])
 
         assert results[0].prompt_ids == [1, 10, 11, 20, 21, 22, 2]
         phs = results[0].multi_modal_placeholders
@@ -140,4 +203,8 @@ class TestVLLMRendererMixed:
         assert phs[0].length == 2
         assert phs[1].offset == 3
         assert phs[1].length == 3
-        assert results[0].multi_modal_kwargs == {"image": ["data-a", "data-b"]}
+
+        mm = results[0].multi_modal_kwargs
+        assert mm is not None
+        assert torch.equal(mm["pixel_values"], torch.cat([pv_a, pv_b], dim=0))
+        assert torch.equal(mm["image_grid_thw"], torch.cat([thw_a, thw_b], dim=0))


### PR DESCRIPTION
### Summary

This PR introduces a vLLM renderer which used by the SkyRL backend to convert `ModelInputChunk`s into tokenized text, `pixel_values`, and `image_grid_thw`. The scope of this PR is limited to the actual renderer implementation, not adding to the backend yet.

- Add `VLLMRenderer`.
- Add `RenderedImage` NamedTuple return type from `_render_images`.
- Reuse `render_model_input` for the text-only fast path in `_render_single` instead of duplicating the token concatenation logic.
- Fix `RenderedModelInput.multi_modal_kwargs` type annotation from `dict[str, bytes]` to `dict[str, list[str]]` to match actual usage (list of base64-encoded strings per modality key).
- Add unit tests for `VLLMRenderer` with a mocked `RemoteInferenceClient` (text-only, image-only, mixed, error cases).
- Add GPU CI integration test (`test_vlm_renderer.py`) that exercises the full renderer against a real VLM via `InferenceEngineState`.
- Gate all VLM render tests behind `SKYRL_LOCAL_VLLM=1` since they depend on a local vLLM fork with `/v1/chat/completions/render` support that is not yet upstreamed.

### Test plan

- [x] Unit tests pass: `python -m pytest tests/backends/skyrl_train/test_renderer.py -v` (8 tests, no GPU required)
- [x] GPU CI integration tests: `SKYRL_LOCAL_VLLM=1 uv run --extra fsdp --extra dev --extra tinker pytest tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_vlm_inference_generation.py -m vllm -v`


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
