### PR TITLE
[ci] Add ability to trigger skyrl-train gpu CI (and megatron CI) by adding run_train_gpu_ci and run_train_megatron_gpu_ci labels

### DIFF
--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -13,7 +13,7 @@ on:
       - '!docs/**'
       - '!examples/**'
       - '.github/workflows/**'
-  pull_request:
+  pull_request_target:
     types: [labeled]
   workflow_dispatch:
 
@@ -21,7 +21,6 @@ on:
 permissions:
   checks: write   # for status checks to appear
   contents: read
-  pull-requests: read
 
 jobs:
   
@@ -30,7 +29,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
         contains(github.event.pull_request.labels.*.name, 'run_train_gpu_ci') &&
         (
@@ -47,6 +46,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -15,7 +15,7 @@ on:
       - '!docs/**'
       - '!examples/**'
       - '.github/workflows/**'
-  pull_request:
+  pull_request_target:
     types: [labeled]
   workflow_dispatch:
 
@@ -23,7 +23,6 @@ on:
 permissions:
   checks: write   # for status checks to appear
   contents: read
-  pull-requests: read
 
 jobs:
   
@@ -32,7 +31,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
         contains(github.event.pull_request.labels.*.name, 'run_train_megatron_gpu_ci') &&
         (
@@ -49,6 +48,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
^
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
