### PR TITLE
fix: use gloo for CPU collectives in Megatron workers to fix multi-node checkpointing

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -494,7 +494,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         if not torch.distributed.is_initialized():
             # Default torch dist pg init timeout is 10 minutes (600 seconds)
             torch.distributed.init_process_group(
-                backend="nccl", timeout=timedelta(seconds=SKYRL_WORKER_NCCL_TIMEOUT_IN_S)
+                backend="cpu:gloo,cuda:nccl", timeout=timedelta(seconds=SKYRL_WORKER_NCCL_TIMEOUT_IN_S)
             )
 
         # Explicitly wrap torch.distributed.broadcast in torch.no_grad() to avoid a warning in Megatron training where the
@@ -824,7 +824,7 @@ class MegatronRefWorkerBase(MegatronWorker, RefWorkerBase):
         if not torch.distributed.is_initialized():
             # Default torch dist pg init timeout is 10 minutes (600 seconds)
             torch.distributed.init_process_group(
-                backend="nccl", timeout=timedelta(seconds=SKYRL_WORKER_NCCL_TIMEOUT_IN_S)
+                backend="cpu:gloo,cuda:nccl", timeout=timedelta(seconds=SKYRL_WORKER_NCCL_TIMEOUT_IN_S)
             )
 
         self.strategy = MegatronStrategy(


### PR DESCRIPTION
## Summary

- **Fix `_pickle.UnpicklingError: invalid load key, '\x00'`** during multi-node Megatron distributed checkpointing by changing `backend="nccl"` to `backend="cpu:gloo,cuda:nccl"` in both `MegatronPolicyWorkerBase.init_worker_process_group()` and `MegatronRefWorker.init_worker_process_group()`.
- This routes CPU-based object collectives (`gather_object`, `all_gather_object`, `broadcast_object_list`) through gloo while keeping GPU tensor operations on NCCL.
- Aligns the Megatron worker overrides with the base class `DistributedTorchRayActor` in `worker.py`, which already correctly uses `"cpu:gloo,cuda:nccl"`.

## Root cause

`MegatronPolicyWorkerBase.init_worker_process_group()` calls `torch.distributed.init_process_group(backend="nccl")`, creating an NCCL-only default process group. Megatron's `dist_checkpointing.save()` uses `torch.distributed.gather_object`, which serializes Python objects via pickle into CPU byte tensors. With an NCCL-only backend, `_get_object_coll_device()` returns `"cuda"`, routing the gather through NCCL. NCCL corrupts variable-length pickle payloads across nodes, causing the unpickling error.

Single-node works because NCCL intra-node shared memory handles this correctly. Multi-node fails because NCCL's cross-node transport corrupts the variable-length pickle buffers.

## Debug evidence

Reproduced on a 2x8xB200 cluster. Inspecting the default process group showed:

```
backend: nccl
device types: cuda
```

With only `cuda` device type registered, CPU tensor collectives are forced through NCCL, which cannot reliably handle the variable-length pickle byte buffers used by `gather_object`.

## Test plan

- [x] Verified the fix matches what the base class `DistributedTorchRayActor` already does in `worker.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
