### PR TITLE
[skyrl][tinker] Multi-modal Tinker Sampling

### DIFF
--- a/skyrl/backends/skyrl_train/inference_engines/base.py
+++ b/skyrl/backends/skyrl_train/inference_engines/base.py
@@ -31,23 +31,6 @@ class InferenceEngineInput(TypedDict):
     mm_features: Optional[List[MultiModalFeatures]]
 
 
-class ImagePlaceholder(TypedDict):
-    offset: int
-    length: int
-
-
-class MultiModalPlaceholders(TypedDict):
-    image: List[ImagePlaceholder]
-
-
-class MultiModalFeatures(TypedDict, total=False):
-    """Mirrors the structure of vLLM's MultiModalFeatures with base64 encoded kwargs_data."""
-
-    mm_hashes: Dict[str, Any]
-    mm_placeholders: MultiModalPlaceholders
-    kwargs_data: Any
-
-
 class InferenceEngineOutput(TypedDict):
     # We always return both tokens and text outputs. The tokens are the outputs
     # of inference engine, and the text is the decoded text output. Therefore,

--- a/skyrl/backends/skyrl_train/inference_engines/base.py
+++ b/skyrl/backends/skyrl_train/inference_engines/base.py
@@ -31,6 +31,23 @@ class InferenceEngineInput(TypedDict):
     mm_features: Optional[List[MultiModalFeatures]]
 
 
+class ImagePlaceholder(TypedDict):
+    offset: int
+    length: int
+
+
+class MultiModalPlaceholders(TypedDict):
+    image: List[ImagePlaceholder]
+
+
+class MultiModalFeatures(TypedDict, total=False):
+    """Mirrors the structure of vLLM's MultiModalFeatures with base64 encoded kwargs_data."""
+
+    mm_hashes: Dict[str, Any]
+    mm_placeholders: MultiModalPlaceholders
+    kwargs_data: Any
+
+
 class InferenceEngineOutput(TypedDict):
     # We always return both tokens and text outputs. The tokens are the outputs
     # of inference engine, and the text is the decoded text output. Therefore,

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -67,9 +67,9 @@ from typing import (
 import aiohttp
 
 from skyrl.backends.skyrl_train.inference_engines.base import (
-    ImagePlaceholder,
     InferenceEngineInput,
     InferenceEngineOutput,
+    MMPlaceholderRangeInfo,
     MultiModalFeatures,
 )
 from skyrl.env_vars import (
@@ -520,7 +520,7 @@ class RemoteInferenceClient:
 
         # Splice: walk chunks in order, substituting image placeholder tokens.
         final_token_ids: List[int] = []
-        new_placeholders: List[ImagePlaceholder] = []
+        new_placeholders: List[MMPlaceholderRangeInfo] = []
         img_idx = 0
 
         for c in chunks:
@@ -533,13 +533,12 @@ class RemoteInferenceClient:
                 final_token_ids.extend(ph_tokens)
                 img_idx += 1
 
+        # No need to decode, vllm handles decoding
         adjusted_features: MultiModalFeatures = {
             "mm_hashes": features.get("mm_hashes", {}),
             "mm_placeholders": {"image": new_placeholders},
+            "kwargs_data": features.get("kwargs_data"),
         }
-        # No need to decode, vllm handles decoding
-        if features.get("kwargs_data") is not None:
-            adjusted_features["kwargs_data"] = features["kwargs_data"]
 
         return final_token_ids, adjusted_features
 

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -67,6 +67,7 @@ from typing import (
 import aiohttp
 
 from skyrl.backends.skyrl_train.inference_engines.base import (
+    ImagePlaceholder,
     InferenceEngineInput,
     InferenceEngineOutput,
     MultiModalFeatures,
@@ -455,6 +456,93 @@ class RemoteInferenceClient:
             "routed_experts": routed_experts,
         }
 
+    async def _render_for_sample(
+        self,
+        prompt: Dict[str, Any],
+        session_id: Optional[str],
+    ) -> Tuple[List[int], Optional[MultiModalFeatures]]:
+        """Build token_ids and optional multi-modal features from a Tinker prompt.
+
+        For text-only prompts this simply flattens chunk tokens (no HTTP call).
+        When image chunks are present, calls /v1/chat/completions/render to
+        process images, then splices the resulting placeholder tokens into the
+        pre-tokenized text stream and adjusts placeholder offsets.
+
+        Returns:
+            (token_ids, features) where features is None for text-only prompts.
+        """
+        chunks = prompt.get("chunks", [])
+
+        # No images → flatten text tokens directly.
+        image_chunks = [c for c in chunks if c.get("type") in ("image", "image_asset_pointer")]
+        if not image_chunks:
+            token_ids = [tok for c in chunks for tok in c.get("tokens", [])]
+            return token_ids, None
+
+        # Build OpenAI chat template with only image_urls
+        content_parts: List[Dict[str, Any]] = []
+        for c in image_chunks:
+            if c["type"] == "image":
+                # model_dump() on Base64Bytes produces bytes with the b64 string.
+                raw = c["data"]
+                b64_str = raw.decode("ascii") if isinstance(raw, bytes) else raw
+                url = f"data:image/{c.get('format', 'jpeg')};base64,{b64_str}"
+            else:  # image_asset_pointer
+                url = c["location"]
+            content_parts.append({"type": "image_url", "image_url": {"url": url}})
+
+        effective_model = self.active_lora_name if self.active_lora_name else self.model_name
+        render_payload: Dict[str, Any] = {
+            "json": {
+                "model": effective_model,
+                "messages": [{"role": "user", "content": content_parts}],
+            }
+        }
+        if session_id:
+            render_payload["json"]["session_id"] = session_id
+
+        render_resp = await self.render_chat_completion(render_payload)
+
+        # Extract per-image placeholder token slices from the render output.
+        features = render_resp.get("features") or {}
+        render_token_ids = render_resp.get("token_ids", [])
+        render_placeholders = features.get("mm_placeholders", {}).get("image", [])
+
+        placeholder_token_slices: List[List[int]] = []
+        for ph in render_placeholders:
+            offset, length = ph["offset"], ph["length"]
+            placeholder_token_slices.append(render_token_ids[offset : offset + length])
+
+        if len(placeholder_token_slices) != len(image_chunks):
+            raise ValueError(
+                f"Expected {len(image_chunks)} placeholder token slices, got {len(placeholder_token_slices)}"
+            )
+
+        # Splice: walk chunks in order, substituting image placeholder tokens.
+        final_token_ids: List[int] = []
+        new_placeholders: List[ImagePlaceholder] = []
+        img_idx = 0
+
+        for c in chunks:
+            ctype = c.get("type", "encoded_text")
+            if ctype == "encoded_text":
+                final_token_ids.extend(c.get("tokens", []))
+            elif ctype in ("image", "image_asset_pointer"):
+                ph_tokens = placeholder_token_slices[img_idx]
+                new_placeholders.append({"offset": len(final_token_ids), "length": len(ph_tokens)})
+                final_token_ids.extend(ph_tokens)
+                img_idx += 1
+
+        adjusted_features: MultiModalFeatures = {
+            "mm_hashes": features.get("mm_hashes", {}),
+            "mm_placeholders": {"image": new_placeholders},
+        }
+        # No need to decode, vllm handles decoding
+        if features.get("kwargs_data") is not None:
+            adjusted_features["kwargs_data"] = features["kwargs_data"]
+
+        return final_token_ids, adjusted_features
+
     async def sample(self, request_payload: SampleRequestPayload) -> SampleResponse:
         """
         Sample completions via /inference/v1/generate (Tinker API).
@@ -486,8 +574,9 @@ class RemoteInferenceClient:
         if include_prompt_logprobs:
             prompt_logprobs_sp = topk_prompt_logprobs_k if topk_prompt_logprobs_k > 0 else 0
 
-        # Flatten prompt chunks → token IDs
-        token_ids = [tok for chunk in prompt.get("chunks", []) for tok in chunk.get("tokens", [])]
+        # Render prompt: flatten text tokens and, if images are present,
+        # call the render endpoint to get placeholder tokens + features.
+        token_ids, mm_features = await self._render_for_sample(prompt, session_id)
 
         # Map Tinker SamplingParams → vLLM format
         sampling_params: Dict[str, Any] = {
@@ -504,11 +593,13 @@ class RemoteInferenceClient:
 
         effective_model = self.active_lora_name if self.active_lora_name else self.model_name
 
-        payload = {
+        payload: Dict[str, Any] = {
             "sampling_params": sampling_params,
             "model": effective_model,
             "token_ids": token_ids,
         }
+        if mm_features is not None:
+            payload["features"] = mm_features
 
         headers = {"Content-Type": "application/json"}
         if session_id:

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_vlm_inference_generation.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_vlm_inference_generation.py
@@ -1,9 +1,11 @@
 """
 VLM integration tests for the new inference path and tinker renderer.
 
-Tests /v1/chat/completions/render with a VLM to verify multimodal
-inputs are correctly tokenized and multimodal features are returned,
-and exercises VLLMRenderer end-to-end.
+
+Tests:
+    - vllm /v1/chat/completions/render with a VLM to verify multimodal inputs
+    - sample() with multimodal Tinker prompts end-to-end
+    - VLLMRenderer end-to-end
 
 Requires a local vLLM install with /v1/chat/completions/render support.
 
@@ -154,6 +156,73 @@ async def test_render_chat_completion_multimodal(module_scoped_ray_init_fixture)
         assert isinstance(placeholder["length"], int)
         assert placeholder["length"] > 0
         assert placeholder["offset"] + placeholder["length"] <= len(token_ids)
+
+
+@requires_local_vllm
+@pytest.mark.vllm
+@pytest.mark.asyncio
+async def test_sample_with_multimodal_image(module_scoped_ray_init_fixture):
+    """Test sample() with a Tinker prompt containing [text, image, text] chunks on a real VLM."""
+    cfg = get_test_actor_config(num_inference_engines=1, model=MODEL_QWEN3_VL)
+    cfg.generator.inference_engine.served_model_name = MODEL_QWEN3_VL
+    async with InferenceEngineState.create(
+        cfg=cfg,
+        use_local=True,
+        backend="vllm",
+        model=MODEL_QWEN3_VL,
+        sleep_level=1,
+        engine_init_kwargs={
+            "max_model_len": 4096,
+            "limit_mm_per_prompt": {"image": 1, "video": 0},
+        },
+        use_new_inference_servers=True,
+    ) as engines:
+        client = engines.client
+        tokenizer = AutoTokenizer.from_pretrained(MODEL_QWEN3_VL)
+
+        # Tokenize text portions using the model's tokenizer.
+        prefix_text = "<|im_start|>user\n"
+        suffix_text = "What color is this image? Answer in one word.<|im_end|>\n<|im_start|>assistant\n"
+        prefix_ids = tokenizer.encode(prefix_text, add_special_tokens=False)
+        suffix_ids = tokenizer.encode(suffix_text, add_special_tokens=False)
+
+        # Build a tiny JPEG as raw base64 (matching model_dump() output for Base64Bytes).
+        img = Image.new("RGB", (8, 8), color=(255, 0, 0))
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        image_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+
+        # Construct Tinker-style prompt: [text chunk, image chunk, text chunk]
+        prompt = {
+            "chunks": [
+                {"type": "encoded_text", "tokens": prefix_ids},
+                {"type": "image", "data": image_b64, "format": "jpeg"},
+                {"type": "encoded_text", "tokens": suffix_ids},
+            ]
+        }
+
+        request_payload = {
+            "json": {
+                "prompt": prompt,
+                "num_samples": 1,
+                "sampling_params": {"temperature": 0.0, "max_tokens": 20},
+            }
+        }
+
+        result = await client.sample(request_payload)
+
+        assert result["type"] == "sample"
+        sequences = result["sequences"]
+        assert len(sequences) == 1
+
+        seq = sequences[0]
+        assert isinstance(seq["tokens"], list)
+        assert len(seq["tokens"]) > 0
+        assert seq["stop_reason"] in ("stop", "length")
+
+        # Decode and check the model produced something reasonable.
+        output_text = tokenizer.decode(seq["tokens"], skip_special_tokens=True)
+        assert len(output_text.strip()) > 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -115,19 +115,44 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
     async def render_chat_completion(request: Request):
         body = await request.json()
         messages = body.get("messages", [])
-        has_multimodal = any(
-            isinstance(msg.get("content"), list) and any(c.get("type") == "image_url" for c in msg["content"])
+
+        # Count image_url parts across all messages.
+        num_images = sum(
+            1
             for msg in messages
+            if isinstance(msg.get("content"), list)
+            for c in msg["content"]
+            if c.get("type") == "image_url"
         )
+
         features = None
-        if has_multimodal:
+        if num_images > 0:
+            # Each image gets 100 placeholder tokens.  Token IDs are laid out as:
+            # [0..3] preamble, then 100 tokens per image, then [N..N+5] suffix.
+            placeholder_size = 100
+            preamble_len = 4
+            total_len = preamble_len + num_images * placeholder_size + 6
+
+            mm_hashes = []
+            mm_placeholders = []
+            kwargs_items = []
+            for i in range(num_images):
+                offset = preamble_len + i * placeholder_size
+                mm_hashes.append(f"hash-{i}")
+                mm_placeholders.append({"offset": offset, "length": placeholder_size})
+                kwargs_items.append(f"mock-encoded-tensor-{i}")
+
             features = {
-                "mm_hashes": {"image": ["fd2700fd096d55f04c20dbfdc903f7e65421e282"]},
-                "mm_placeholders": {"image": [{"offset": 4, "length": 100}]},
+                "mm_hashes": {"image": mm_hashes},
+                "mm_placeholders": {"image": mm_placeholders},
+                "kwargs_data": {"image": kwargs_items},
             }
+        else:
+            total_len = 10
+
         return {
             "request_id": f"chatcmpl-mock-{server_id}",
-            "token_ids": list(range(110)) if has_multimodal else list(range(10)),
+            "token_ids": list(range(total_len)),
             "features": features,
             "sampling_params": {"temperature": 0.7, "max_tokens": 100},
             "model": body.get("model", "test"),
@@ -583,6 +608,79 @@ class TestSample:
         assert result["prompt_logprobs"] is None
         assert result["topk_prompt_logprobs"] is None
 
+    @pytest.mark.asyncio
+    async def test_sample_with_image(self, client):
+        """Sample with [text, image, text] calls render and splices tokens correctly."""
+        import base64
+
+        image_bytes = base64.b64encode(b"fake-jpeg-data").decode("ascii")
+        request_payload = {
+            "json": {
+                "prompt": {
+                    "chunks": [
+                        {"type": "encoded_text", "tokens": [100, 101, 102]},
+                        {
+                            "type": "image",
+                            "data": image_bytes,
+                            "format": "jpeg",
+                        },
+                        {"type": "encoded_text", "tokens": [200, 201]},
+                    ]
+                },
+                "num_samples": 1,
+                "sampling_params": {"temperature": 0.7, "max_tokens": 64},
+            }
+        }
+        result = await client.sample(request_payload)
+
+        assert result["type"] == "sample"
+        assert len(result["sequences"]) == 1
+
+        seq = result["sequences"][0]
+        assert "tokens" in seq
+        assert "logprobs" in seq
+        assert seq["stop_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_sample_with_image_asset_pointer(self, client):
+        """Sample with image_asset_pointer sends location URL to render."""
+        request_payload = {
+            "json": {
+                "prompt": {
+                    "chunks": [
+                        {"type": "encoded_text", "tokens": [10, 11]},
+                        {
+                            "type": "image_asset_pointer",
+                            "format": "png",
+                            "location": "https://example.com/image.png",
+                        },
+                        {"type": "encoded_text", "tokens": [20, 21]},
+                    ]
+                },
+                "num_samples": 1,
+                "sampling_params": {"temperature": 0.7, "max_tokens": 64},
+            }
+        }
+        result = await client.sample(request_payload)
+
+        assert result["type"] == "sample"
+        assert len(result["sequences"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_sample_text_only_no_features(self, client):
+        """Text-only sample does not include features in the generate payload."""
+        request_payload = {
+            "json": {
+                "prompt": {"chunks": [{"type": "encoded_text", "tokens": [1, 2, 3]}]},
+                "num_samples": 1,
+                "sampling_params": {"temperature": 0.7, "max_tokens": 64},
+            }
+        }
+        result = await client.sample(request_payload)
+
+        assert result["type"] == "sample"
+        assert len(result["sequences"]) == 1
+
 
 class TestRenderChatCompletion:
     """Test render_chat_completion method (multimodal and text-only)."""
@@ -642,8 +740,9 @@ class TestRenderChatCompletion:
         assert result["kv_transfer_params"] is None
 
         assert result["features"] == {
-            "mm_hashes": {"image": ["fd2700fd096d55f04c20dbfdc903f7e65421e282"]},
+            "mm_hashes": {"image": ["hash-0"]},
             "mm_placeholders": {"image": [{"offset": 4, "length": 100}]},
+            "kwargs_data": {"image": ["mock-encoded-tensor-0"]},
         }
 
 


### PR DESCRIPTION
## Summary

Adds VLM sampling support to `RemoteInferenceClient` sample endpoint. Finalizes inference side changes for #1200. 

- Extract `_render_for_sample` to handle both text-only and image-containing prompts. For text-only prompts, it flattens chunk tokens directly. When images are present, it calls `/v1/chat/completions/render` to process images, then splices placeholder tokens into the pre-tokenized text stream with adjusted offsets.
- Update `sample()` to pass multi-modal features through to the generate payload when present.

## Test plan

- [x] Verify text-only sampling still works (no render call made, features is `None`)
- [x] Verify image sampling works end-to-end (render call is made, placeholder tokens are spliced correctly, features are included in the generate payload)
- [x] New multi-modal sampling tests in `test_vlm_inference_generation.py`





<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
