### PR TITLE
[qoc] Remove thread for sleep() in _get_new_inference_client

### DIFF
--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -6,7 +6,6 @@ import asyncio
 import multiprocessing as mp
 import os
 import sys
-import threading
 from pathlib import Path
 from typing import Optional
 
@@ -394,25 +393,8 @@ class BasePPOExp:
         )
 
         if is_colocated:
-            # This method is called from both sync (BasePPOExp.run) and async
-            # (EvalOnlyEntrypoint.run) contexts. Using a thread with its own
-            # event loop avoids the "cannot call asyncio.run() from a running
-            # event loop" error that occurs in the async case.
-            exc_holder = [None]
-
-            def _sleep_engines():
-                try:
-                    asyncio.run(client.sleep())
-                except Exception as e:
-                    exc_holder[0] = e
-
-            thread = threading.Thread(target=_sleep_engines)
-            thread.start()
-            thread.join()
-
-            if exc_holder[0] is not None:
-                raise RuntimeError("Failed to sleep colocated inference engines") from exc_holder[0]
-
+            # Callers must invoke get_inference_client() from a sync context (no running event loop).
+            asyncio.run(client.sleep())
             logger.info("HTTP Inference: Colocated mode - slept inference engines after startup")
 
         return client

--- a/skyrl/train/entrypoints/main_generate.py
+++ b/skyrl/train/entrypoints/main_generate.py
@@ -9,12 +9,12 @@ from typing import Any
 import ray
 from loguru import logger
 
+from skyrl.backends.skyrl_train.inference_engines.base import InferenceEngineInterface
 from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.entrypoints.main_base import (
     BasePPOExp,
 )
 from skyrl.train.evaluate import evaluate
-from skyrl.backends.skyrl_train.inference_engines.base import InferenceEngineInterface
 from skyrl.train.utils.trainer_utils import build_dataloader
 from skyrl.train.utils.utils import initialize_ray, validate_generator_cfg
 

--- a/skyrl/train/entrypoints/main_generate.py
+++ b/skyrl/train/entrypoints/main_generate.py
@@ -14,6 +14,7 @@ from skyrl.train.entrypoints.main_base import (
     BasePPOExp,
 )
 from skyrl.train.evaluate import evaluate
+from skyrl.backends.skyrl_train.inference_engines.base import InferenceEngineInterface
 from skyrl.train.utils.trainer_utils import build_dataloader
 from skyrl.train.utils.utils import initialize_ray, validate_generator_cfg
 
@@ -23,10 +24,9 @@ class EvalOnlyEntrypoint(BasePPOExp):
         """Override to avoid requiring a train dataset for eval-only runs."""
         return None
 
-    async def run(self) -> dict[str, Any]:
+    async def run(self, inference_engine_client: InferenceEngineInterface) -> dict[str, Any]:
         assert self.eval_dataset is not None, "The evaluation only entrypoint requires an eval dataset is provided"
 
-        inference_engine_client = self.get_inference_client()
         await inference_engine_client.wake_up()
         generator = self.get_generator(self.cfg, self.tokenizer, inference_engine_client)
 
@@ -47,7 +47,10 @@ class EvalOnlyEntrypoint(BasePPOExp):
 @ray.remote(num_cpus=1)
 def eval_entrypoint(cfg: SkyRLTrainConfig) -> dict:
     exp = EvalOnlyEntrypoint(cfg)
-    return asyncio.run(exp.run())
+    # Build the inference client from a sync context so _get_new_inference_client
+    # can run its own asyncio.run() for the colocated-mode sleep step.
+    inference_engine_client = exp.get_inference_client()
+    return asyncio.run(exp.run(inference_engine_client))
 
 
 def main() -> None:

--- a/tests/backends/skyrl_train/gpu/test_main_generate.py
+++ b/tests/backends/skyrl_train/gpu/test_main_generate.py
@@ -8,7 +8,6 @@ import pytest
 import ray
 
 from skyrl.train.entrypoints.main_generate import EvalOnlyEntrypoint
-from skyrl.train.utils.utils import initialize_ray
 from tests.backends.skyrl_train.gpu.utils import (
     get_test_actor_config,
     get_test_generator_input,
@@ -30,7 +29,7 @@ def create_dataset(tmp_path, model_name: str):
 
 
 @pytest.mark.asyncio
-async def test_main_generate(tmp_path):
+async def test_main_generate(ray_init_fixture, tmp_path):
     cfg = get_test_actor_config()
 
     # Minimize resources and side effects
@@ -49,7 +48,6 @@ async def test_main_generate(tmp_path):
 
     cfg.environment.skyrl_gym.max_env_workers = 1
 
-    initialize_ray(cfg)
     try:
         data_path = create_dataset(tmp_path, cfg.trainer.policy.model.path)
         cfg.data.val_data = [data_path]
@@ -58,7 +56,8 @@ async def test_main_generate(tmp_path):
         cfg.trainer.eval_interval = 1
 
         exp = EvalOnlyEntrypoint(cfg)
-        metrics = await exp.run()
+        inference_engine_client = exp.get_inference_client()
+        metrics = await exp.run(inference_engine_client)
         assert isinstance(metrics, dict) and len(metrics) > 0, f"Eval results not correctly computed: {metrics}"
     finally:
         ray.shutdown()


### PR DESCRIPTION
We had a ~12 LOCs hacky threading for sleeping engine in `_get_new_inference_client()`.

It was primarily due to how `.get_inference_client()` is called inside `asyncio.run(exp.run())` in the eval entrypoint. The actual RL entrypoint is okay because we call `get_inference_client()` outside of `asyncio.run(exp.run())`.

To remove this hack, for eval entrypoint, we call `.get_inference_client()` before `exp.run()` and pass it in.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
