### PR TITLE
[tinker] Fix single request batching in TinkerEngine

### DIFF
--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -409,10 +409,11 @@ class TinkerEngine:
                     | (FutureDB.request_type == types.RequestType.FORWARD)
                 )
                 .where(FutureDB.status == RequestStatus.PENDING)
+                .where(FutureDB.model_id.in_(destructive_barriers.keys()))
                 .order_by(FutureDB.request_id)
             ).all()
             for model_id, req_id in pending_passes:
-                if model_id in destructive_barriers and req_id >= destructive_barriers[model_id]:
+                if req_id >= destructive_barriers[model_id]:
                     blocked_pass_barriers.setdefault(model_id, req_id)
 
         statement = (

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -296,6 +296,23 @@ class TinkerEngine:
                     )
                 session.commit()
 
+    def _find_destructive_barriers(self, session: Session) -> dict[str, int]:
+        """Find the earliest pending destructive operation (optim_step/load_weights) per model.
+
+        These act as scheduling barriers: model passes before them can be batched
+        safely, and single requests after a blocked pass must wait.
+        """
+        query = (
+            select(FutureDB.model_id, func.min(FutureDB.request_id).label("barrier_id"))
+            .where(
+                (FutureDB.request_type == types.RequestType.OPTIM_STEP)
+                | (FutureDB.request_type == types.RequestType.LOAD_WEIGHTS)
+            )
+            .where(FutureDB.status == RequestStatus.PENDING)
+            .group_by(FutureDB.model_id)
+        )
+        return dict(session.exec(query).all())
+
     def find_batchable_model_passes(
         self, session: Session, request_type: types.RequestType
     ) -> dict[str, tuple[str, types.ForwardBackwardInput]]:
@@ -311,17 +328,7 @@ class TinkerEngine:
         Returns:
             Dict mapping request_id to (model_id, request_data) tuples
         """
-        # Find the earliest pending optim_step or load_weights per model (these act as barriers)
-        barriers_query = (
-            select(FutureDB.model_id, func.min(FutureDB.request_id).label("barrier_id"))
-            .where(
-                (FutureDB.request_type == types.RequestType.OPTIM_STEP)
-                | (FutureDB.request_type == types.RequestType.LOAD_WEIGHTS)
-            )
-            .where(FutureDB.status == RequestStatus.PENDING)
-            .group_by(FutureDB.model_id)
-        )
-        barriers = dict(session.exec(barriers_query).all())
+        barriers = self._find_destructive_barriers(session)
 
         # Get all pending operations of the requested type ordered by request_id
         query = (
@@ -389,6 +396,25 @@ class TinkerEngine:
         Returns:
             Dict mapping request_id to (model_id, request_type, request_data) tuples
         """
+        # Find the first blocked forward pass per model: a pending FORWARD/FORWARD_BACKWARD
+        # that sits behind a destructive barrier and won't be batched this iteration.
+        # Single requests must not jump ahead of these.
+        destructive_barriers = self._find_destructive_barriers(session)
+        blocked_pass_barriers: dict[str, int] = {}
+        if destructive_barriers:
+            pending_passes = session.exec(
+                select(FutureDB.model_id, FutureDB.request_id)
+                .where(
+                    (FutureDB.request_type == types.RequestType.FORWARD_BACKWARD)
+                    | (FutureDB.request_type == types.RequestType.FORWARD)
+                )
+                .where(FutureDB.status == RequestStatus.PENDING)
+                .order_by(FutureDB.request_id)
+            ).all()
+            for model_id, req_id in pending_passes:
+                if model_id in destructive_barriers and req_id >= destructive_barriers[model_id]:
+                    blocked_pass_barriers.setdefault(model_id, req_id)
+
         statement = (
             select(FutureDB)
             .where(FutureDB.status == RequestStatus.PENDING)
@@ -399,6 +425,13 @@ class TinkerEngine:
             .order_by(FutureDB.request_id)
         )
         other_futures = session.exec(statement).all()
+
+        # Filter: only include ops that come before the first blocked pass for their model
+        other_futures = [
+            op
+            for op in other_futures
+            if op.model_id not in blocked_pass_barriers or op.request_id < blocked_pass_barriers[op.model_id]
+        ]
 
         return {str(f.request_id): (f.model_id, f.request_type, f.request_data) for f in other_futures}
 

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -6,7 +6,7 @@ from sqlmodel import Session, SQLModel
 
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
-from skyrl.tinker.db_models import ModelDB, SessionDB
+from skyrl.tinker.db_models import FutureDB, ModelDB, RequestStatus, SessionDB
 from skyrl.tinker.engine import TinkerEngine, prepare_model_pass_batch
 
 BASE_MODEL = "trl-internal-testing/tiny-Qwen3ForCausalLM"
@@ -134,3 +134,112 @@ def test_prepare_model_pass_batch_loss_fn_and_config(
     assert batch.all_loss_fns == [loss_fn]
     assert batch.all_loss_fn_configs == [loss_fn_config]
     assert batch.all_model_inputs == [datum.model_input]
+
+
+@pytest.fixture()
+def scheduling_engine():
+    """Create a TinkerEngine with only the DB initialized (no backend) for scheduling tests."""
+    from sqlalchemy import create_engine
+
+    from skyrl.tinker.db_models import enable_sqlite_wal
+
+    engine = object.__new__(TinkerEngine)
+    engine.db_engine = create_engine("sqlite:///:memory:", echo=False)
+    enable_sqlite_wal(engine.db_engine)
+    SQLModel.metadata.create_all(engine.db_engine)
+    return engine
+
+
+def test_find_single_requests_respects_forward_backward_barriers(scheduling_engine):
+    """Regression: optim_step must not run before a preceding forward_backward for the same model.
+
+    Given pending requests [fwdbwd1, optim1, fwdbwd2, optim2] for the same model,
+    find_single_requests should only return optim1 (not optim2), because fwdbwd2
+    acts as a barrier — optim2 depends on fwdbwd2's gradients.
+    """
+    engine = scheduling_engine
+    model_id = "test_model"
+
+    with Session(engine.db_engine) as session:
+        # Insert requests in order: fwdbwd1, optim1, fwdbwd2, optim2
+        for req_type in [
+            types.RequestType.FORWARD_BACKWARD,
+            types.RequestType.OPTIM_STEP,
+            types.RequestType.FORWARD_BACKWARD,
+            types.RequestType.OPTIM_STEP,
+        ]:
+            session.add(
+                FutureDB(
+                    request_type=req_type,
+                    model_id=model_id,
+                    request_data={},
+                    status=RequestStatus.PENDING,
+                )
+            )
+        session.commit()
+
+    with Session(engine.db_engine) as session:
+        # find_single_requests should return only optim1 (request_id=2), NOT optim2 (request_id=4)
+        singles = engine.find_single_requests(session)
+        assert list(singles.keys()) == ["2"]
+
+
+def test_find_single_requests_no_barrier_when_no_pending_passes(scheduling_engine):
+    """When there are no pending forward/forward_backward requests, all single requests are returned."""
+    engine = scheduling_engine
+
+    with Session(engine.db_engine) as session:
+        for model_id in ["model_a", "model_b"]:
+            session.add(
+                FutureDB(
+                    request_type=types.RequestType.OPTIM_STEP,
+                    model_id=model_id,
+                    request_data={},
+                    status=RequestStatus.PENDING,
+                )
+            )
+        session.commit()
+
+    with Session(engine.db_engine) as session:
+        singles = engine.find_single_requests(session)
+        assert len(singles) == 2
+
+
+def test_find_single_requests_barrier_is_per_model(scheduling_engine):
+    """A blocked forward_backward on model_a should not block an optim_step on model_b."""
+    engine = scheduling_engine
+
+    with Session(engine.db_engine) as session:
+        # model_a: fwdbwd(1), optim(2), fwdbwd(3), optim(4)
+        # model_b: optim(5)
+        for req_type in [
+            types.RequestType.FORWARD_BACKWARD,
+            types.RequestType.OPTIM_STEP,
+            types.RequestType.FORWARD_BACKWARD,
+            types.RequestType.OPTIM_STEP,
+        ]:
+            session.add(
+                FutureDB(
+                    request_type=req_type,
+                    model_id="model_a",
+                    request_data={},
+                    status=RequestStatus.PENDING,
+                )
+            )
+        session.add(
+            FutureDB(
+                request_type=types.RequestType.OPTIM_STEP,
+                model_id="model_b",
+                request_data={},
+                status=RequestStatus.PENDING,
+            )
+        )
+        session.commit()
+
+    with Session(engine.db_engine) as session:
+        singles = engine.find_single_requests(session)
+        # model_a: optim(2) returned, optim(4) blocked by fwdbwd(3)
+        # model_b: optim(5) returned (not affected by model_a's barrier)
+        assert list(singles.keys()) == ["2", "5"]
+        assert singles["2"][0] == "model_a"
+        assert singles["5"][0] == "model_b"


### PR DESCRIPTION
For each model, we currently make sure to not batch forward/backward requests that come after a destructive update like optim_step or load_weights. In addition, we also need to make sure to not batch destructive updates that come after forward/backward requests.

E.g. for a sequence like optim1 → fwdbwd2 → optim2, we do not want to process optim2 before fwdbwd2 has run.

End-to-end repro:

```python
"""Reproducer for https://github.com/NovaSky-AI/SkyRL/pull/1489.

Bug: with pending queue [fwdbwd_1, optim_1, fwdbwd_2, optim_2], the engine
deferred fwdbwd_2 behind the optim_1 barrier but still ran optim_2 in the
same iteration — so optim_2 fired before fwdbwd_2.

This script fires the sequence without awaiting so all four requests sit
pending when the scheduler wakes up. Compare the final model against a
sequential run (awaits between ops). They should match; with the bug they
diverge.

Run the server first (see docs/content/docs/tinker/quickstart.mdx), then:
    TINKER_API_KEY=tml-dummy python repro_pr1489.py
"""

import tinker
from tinker import types

BASE_URL = "http://localhost:8000/"
BASE_MODEL = "Qwen/Qwen3-0.6B"


def make_datum(tok):
    prompt = tok.encode("Q: 2+2=?\nA:", add_special_tokens=True)
    completion = tok.encode(" 4\n\n", add_special_tokens=False)
    all_tokens = prompt + completion
    weights = [0.0] * len(prompt) + [1.0] * len(completion)
    return types.Datum(
        model_input=types.ModelInput.from_ints(all_tokens),
        loss_fn_inputs={
            "target_tokens": all_tokens[1:] + [tok.eos_token_id],
            "weights": weights[1:] + [1.0],
        },
    )


def probe(client, data):
    out = client.forward(data, "cross_entropy").result()
    return sum(sum(r["elementwise_loss"].data) for r in out.loss_fn_outputs)


def run(service, parallel):
    client = service.create_lora_training_client(base_model=BASE_MODEL, seed=0)
    data = [make_datum(client.get_tokenizer())]
    adam = types.AdamParams(learning_rate=1e-3)

    if parallel:
        fs = [
            client.forward_backward(data, "cross_entropy"),
            client.optim_step(adam),
            client.forward_backward(data, "cross_entropy"),
            client.optim_step(adam),
        ]
        for f in fs:
            f.result()
    else:
        client.forward_backward(data, "cross_entropy").result()
        client.optim_step(adam).result()
        client.forward_backward(data, "cross_entropy").result()
        client.optim_step(adam).result()

    return probe(client, data)


def main():
    service = tinker.ServiceClient(base_url=BASE_URL)
    seq = run(service, parallel=False)
    par = run(service, parallel=True)
    print(f"sequential probe loss = {seq:.6f}")
    print(f"parallel   probe loss = {par:.6f}")
    print(f"|delta| = {abs(seq - par):.3e}")
    if abs(seq - par) < 1e-6:
        print("No divergence — bug not triggered (server patched, or scheduler drained between submits).")
    else:
        print("Divergence — optim_2 ran before fwdbwd_2 (PR #1489 fixes this).")


if __name__ == "__main__":
    main()
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
