### PR TITLE
[train] Save checkpoints at epoch boundaries

### DIFF
--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -382,7 +382,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 for _ in range(self.num_parallel_generation_workers)
             ]
 
-            for _ in range(self.global_step, (1 + epoch) * self.num_steps_per_epoch + 1):
+            for iter in range(self.global_step, (1 + epoch) * self.num_steps_per_epoch + 1):
                 with Timer("step", self.all_timings):
                     # 1. Wait until we have enough groups buffered.
                     cur_generation_group_mini_batch: List[GeneratedOutputGroup] = []
@@ -431,8 +431,8 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 self.all_metrics = {}
                 pbar.update(1)
 
-                # 6. Eval and checkpointing if needed.
-                # NOTE(Charlie): eval does not overlap with training, but can overlap with generation. Is it fine?
+                # 6. Eval. At interval and at the last step.
+                # NOTE(Charlie): eval does not overlap with training, but overlaps with generation.
                 if self.cfg.trainer.eval_interval > 0 and (
                     self.global_step % self.cfg.trainer.eval_interval == 0
                     or self.global_step == self.total_training_steps
@@ -440,17 +440,23 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                     with Timer("eval", self.all_timings):
                         eval_metrics = await self.eval()
                         self.all_metrics.update(eval_metrics)
-                if self.cfg.trainer.ckpt_interval > 0 and self.global_step % self.cfg.trainer.ckpt_interval == 0:
-                    with Timer("save_checkpoints", self.all_timings):
-                        await asyncio.to_thread(self.save_checkpoints)
-                if self.cfg.trainer.hf_save_interval > 0 and self.global_step % self.cfg.trainer.hf_save_interval == 0:
-                    with Timer("save_hf_model", self.all_timings):
-                        await asyncio.to_thread(self.save_models)
+
+                # 7. Checkpointing. At interval and at the last step of each epoch.
+                is_epoch_end = iter == (1 + epoch) * self.num_steps_per_epoch
+                if self.cfg.trainer.ckpt_interval > 0:
+                    if is_epoch_end or self.global_step % self.cfg.trainer.ckpt_interval == 0:
+                        with Timer("save_checkpoints", self.all_timings):
+                            await asyncio.to_thread(self.save_checkpoints)
+                if self.cfg.trainer.hf_save_interval > 0:
+                    if is_epoch_end or self.global_step % self.cfg.trainer.hf_save_interval == 0:
+                        with Timer("save_hf_model", self.all_timings):
+                            await asyncio.to_thread(self.save_models)
+
                 self.tracker.log({"timing/" + k: v for k, v in self.all_timings.items()}, step=self.global_step)
                 self.all_timings = {}
                 self.global_step += 1
 
-                # 7. Notify generation workers that the capacity has increased, unblocking them.
+                # 8. Notify generation workers that the capacity has increased, unblocking them.
                 await self._staleness_manager.notify_capacity_change(self.global_step)
                 steps_completed_in_epoch = (self.global_step - 1) % self.num_steps_per_epoch
                 if steps_completed_in_epoch == 0:
@@ -463,7 +469,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                     f"{actual_consumed_in_epoch} != {expected_consumed_in_epoch}"
                 )
 
-            # 8. Per-epoch epilogue.
+            # 9. Per-epoch epilogue.
             if self.cfg.trainer.update_ref_every_epoch and self.ref_model is not None:
                 with Timer("update_ref_with_policy", self.all_timings):
                     await asyncio.to_thread(self.update_ref_with_policy)
@@ -488,14 +494,6 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
 
             # End of an epoch.
         pbar.close()
-        if self.cfg.trainer.ckpt_interval > 0:
-            with Timer("save_checkpoints", self.all_timings):
-                await asyncio.to_thread(self.save_checkpoints)
-                logger.info("Saved final checkpoint.")
-        if self.cfg.trainer.hf_save_interval > 0:
-            with Timer("save_hf_model", self.all_timings):
-                await asyncio.to_thread(self.save_models)
-                logger.info("Saved final model.")
         self.tracker.finish()
         logger.info("Training done!")
 

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -382,7 +382,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 for _ in range(self.num_parallel_generation_workers)
             ]
 
-            for iter in range(self.global_step, (1 + epoch) * self.num_steps_per_epoch + 1):
+            for step_idx in range(self.global_step, (1 + epoch) * self.num_steps_per_epoch + 1):
                 with Timer("step", self.all_timings):
                     # 1. Wait until we have enough groups buffered.
                     cur_generation_group_mini_batch: List[GeneratedOutputGroup] = []
@@ -442,7 +442,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                         self.all_metrics.update(eval_metrics)
 
                 # 7. Checkpointing. At interval and at the last step of each epoch.
-                is_epoch_end = iter == (1 + epoch) * self.num_steps_per_epoch
+                is_epoch_end = step_idx == (1 + epoch) * self.num_steps_per_epoch
                 if self.cfg.trainer.ckpt_interval > 0:
                     if is_epoch_end or self.global_step % self.cfg.trainer.ckpt_interval == 0:
                         with Timer("save_checkpoints", self.all_timings):

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -289,7 +289,7 @@ class RayPPOTrainer:
                         status = self.train_critic_and_policy(training_input)
 
                     # 8. conditionally save checkpoints and hf model
-                    is_epoch_end = step_idx == len(self.train_dataloader) - 1
+                    is_epoch_end = self.global_step % len(self.train_dataloader) == 0
                     if self.cfg.trainer.ckpt_interval > 0:
                         if is_epoch_end or self.global_step % self.cfg.trainer.ckpt_interval == 0:
                             with Timer("save_checkpoints", self.all_timings):
@@ -343,6 +343,16 @@ class RayPPOTrainer:
         pbar.close()
         if self.colocate_all:
             await self.inference_engine_client.sleep()
+
+        # Safety net: always save final checkpoint at end of training.
+        if self.cfg.trainer.ckpt_interval > 0:
+            with Timer("save_checkpoints", self.all_timings):
+                self.save_checkpoints()
+                logger.info("Saved final checkpoint.")
+        if self.cfg.trainer.hf_save_interval > 0:
+            with Timer("save_hf_model", self.all_timings):
+                self.save_models()
+                logger.info("Saved final model.")
         self.tracker.finish()
         logger.info("Training done!")
 

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -206,7 +206,7 @@ class RayPPOTrainer:
         start_epoch = self.global_step // len(self.train_dataloader)
         self.global_step += 1  # start training at global_step 1
         for epoch in range(start_epoch, self.cfg.trainer.epochs):
-            for step_idx, rand_prompts in enumerate(self.train_dataloader):
+            for _, rand_prompts in enumerate(self.train_dataloader):
                 with Timer("step", self.all_timings):
                     # for colocate_all=true, inference engine is always on GPU when starting the training step
 

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -206,7 +206,7 @@ class RayPPOTrainer:
         start_epoch = self.global_step // len(self.train_dataloader)
         self.global_step += 1  # start training at global_step 1
         for epoch in range(start_epoch, self.cfg.trainer.epochs):
-            for iter, rand_prompts in enumerate(self.train_dataloader):
+            for step_idx, rand_prompts in enumerate(self.train_dataloader):
                 with Timer("step", self.all_timings):
                     # for colocate_all=true, inference engine is always on GPU when starting the training step
 
@@ -289,7 +289,7 @@ class RayPPOTrainer:
                         status = self.train_critic_and_policy(training_input)
 
                     # 8. conditionally save checkpoints and hf model
-                    is_epoch_end = iter == len(self.train_dataloader) - 1
+                    is_epoch_end = step_idx == len(self.train_dataloader) - 1
                     if self.cfg.trainer.ckpt_interval > 0:
                         if is_epoch_end or self.global_step % self.cfg.trainer.ckpt_interval == 0:
                             with Timer("save_checkpoints", self.all_timings):
@@ -303,7 +303,7 @@ class RayPPOTrainer:
                     if (
                         self.cfg.trainer.update_ref_every_epoch
                         and self.ref_model is not None
-                        and iter == len(self.train_dataloader) - 1
+                        and is_epoch_end
                         and epoch != self.cfg.trainer.epochs - 1  # skip updating ref at the end of the last epoch
                     ):
                         with Timer("update_ref_with_policy", self.all_timings):

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -289,15 +289,15 @@ class RayPPOTrainer:
                         status = self.train_critic_and_policy(training_input)
 
                     # 8. conditionally save checkpoints and hf model
-                    if self.cfg.trainer.ckpt_interval > 0 and self.global_step % self.cfg.trainer.ckpt_interval == 0:
-                        with Timer("save_checkpoints", self.all_timings):
-                            self.save_checkpoints()
-                    if (
-                        self.cfg.trainer.hf_save_interval > 0
-                        and self.global_step % self.cfg.trainer.hf_save_interval == 0
-                    ):
-                        with Timer("save_hf_model", self.all_timings):
-                            self.save_models()
+                    is_epoch_end = iter == len(self.train_dataloader) - 1
+                    if self.cfg.trainer.ckpt_interval > 0:
+                        if is_epoch_end or self.global_step % self.cfg.trainer.ckpt_interval == 0:
+                            with Timer("save_checkpoints", self.all_timings):
+                                self.save_checkpoints()
+                    if self.cfg.trainer.hf_save_interval > 0:
+                        if is_epoch_end or self.global_step % self.cfg.trainer.hf_save_interval == 0:
+                            with Timer("save_hf_model", self.all_timings):
+                                self.save_models()
 
                     # 9. conditionally sync policy and ref at the end of the epoch
                     if (
@@ -343,14 +343,6 @@ class RayPPOTrainer:
         pbar.close()
         if self.colocate_all:
             await self.inference_engine_client.sleep()
-        if self.cfg.trainer.ckpt_interval > 0:
-            with Timer("save_checkpoints", self.all_timings):
-                self.save_checkpoints()
-                logger.info("Saved final checkpoint.")
-        if self.cfg.trainer.hf_save_interval > 0:
-            with Timer("save_hf_model", self.all_timings):
-                self.save_models()
-                logger.info("Saved final model.")
         self.tracker.finish()
         logger.info("Training done!")
 


### PR DESCRIPTION
Before this PR, we save checkpoints only every `ckpt_interval`. This is slightly awkward. If I have a dataset of 37 steps, and I set `ckpt_interval` to 10, I cannot evaluate my model offline for the epoch 1 or 2 checkpoints. I can only evaluate at either step 30 or step 40.

This PR updates the logic such that we checkpoint when the following condition holds: 

```python
        is_epoch_end = iter == len(self.train_dataloader) - 1
        if self.cfg.trainer.ckpt_interval > 0:
            if is_epoch_end or self.global_step % self.cfg.trainer.ckpt_interval == 0:
                with Timer("save_checkpoints", self.all_timings):
                    self.save_checkpoints()
```

Same thing for HF export.

We apply this change for both the sync and fully async trainer script.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
