### PR TITLE
[train] Final ckpt for fully async

### DIFF
--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -494,6 +494,17 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
 
             # End of an epoch.
         pbar.close()
+
+        # safety net: always save final checkpoint at end of training.
+        if self.cfg.trainer.ckpt_interval > 0:
+            with Timer("save_checkpoints", self.all_timings):
+                await asyncio.to_thread(self.save_checkpoints)
+                logger.info("Saved final checkpoint.")
+        if self.cfg.trainer.hf_save_interval > 0:
+            with Timer("save_hf_model", self.all_timings):
+                await asyncio.to_thread(self.save_models)
+                logger.info("Saved final model.")
+
         self.tracker.finish()
         logger.info("Training done!")
 


### PR DESCRIPTION
Always save final ckpt for fully async. Despite might be redundant, but a safe thing to do
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
