### PR TITLE
[train][multimodal][1/3] Add vision support to generate() in new inference stack

### DIFF
--- a/skyrl/backends/skyrl_train/inference_engines/base.py
+++ b/skyrl/backends/skyrl_train/inference_engines/base.py
@@ -28,7 +28,7 @@ class InferenceEngineInput(TypedDict):
     prompt_token_ids: Optional[List[List[int]]]
     sampling_params: Optional[Dict[str, Any]]
     session_ids: Optional[List[Hashable]]
-    mm_features: Optional[MultiModalFeatures]
+    mm_features: Optional[List[MultiModalFeatures]]
 
 
 class InferenceEngineOutput(TypedDict):

--- a/skyrl/backends/skyrl_train/inference_engines/base.py
+++ b/skyrl/backends/skyrl_train/inference_engines/base.py
@@ -11,12 +11,24 @@ MessageType = Dict[str, str]
 ConversationType = List[MessageType]
 
 
+class MMPlaceholderRangeInfo(TypedDict):
+    offset: int
+    length: int
+
+
+class MultiModalFeatures(TypedDict):
+    mm_hashes: dict[str, list[str]]
+    mm_placeholders: dict[str, list[MMPlaceholderRangeInfo]]
+    kwargs_data: Optional[dict[str, list[str | None]]]
+
+
 class InferenceEngineInput(TypedDict):
     # Either prompts or prompt_token_ids must be provided, but not both.
     prompts: Optional[List[ConversationType]]
     prompt_token_ids: Optional[List[List[int]]]
     sampling_params: Optional[Dict[str, Any]]
     session_ids: Optional[List[Hashable]]
+    mm_features: Optional[MultiModalFeatures]
 
 
 class InferenceEngineOutput(TypedDict):

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -68,6 +68,7 @@ import aiohttp
 from skyrl.backends.skyrl_train.inference_engines.base import (
     InferenceEngineInput,
     InferenceEngineOutput,
+    MultiModalFeatures,
 )
 from skyrl.env_vars import (
     SKYRL_GENERATE_CONCURRENCY_PER_ENGINE,
@@ -325,6 +326,7 @@ class RemoteInferenceClient:
             raise ValueError("n > 1 is not supported. Use `config.generator.n_samples_per_prompt` instead.")
 
         session_ids = input_batch.get("session_ids")
+        mm_features = input_batch.get("mm_features")
         get_logprobs = sampling_params.get("logprobs") is not None
 
         # Two semaphores decouple the generate and detokenize stages:
@@ -347,12 +349,14 @@ class RemoteInferenceClient:
                     prompt_token_ids=prompt_token_ids[idx],
                     sampling_params=sampling_params,
                     session_id=session_ids[idx] if session_ids and idx < len(session_ids) else None,
+                    mm_features=mm_features,
                 )
             async with gen_sem:
                 return await self._generate_single(
                     prompt_token_ids=prompt_token_ids[idx],
                     sampling_params=sampling_params,
                     session_id=session_ids[idx] if session_ids and idx < len(session_ids) else None,
+                    mm_features=mm_features,
                 )
 
         async def _throttled_detokenize(token_ids: List[int]) -> str:
@@ -380,6 +384,7 @@ class RemoteInferenceClient:
         prompt_token_ids: List[int],
         sampling_params: Dict[str, Any],
         session_id: Optional[Any],
+        mm_features: Optional[MultiModalFeatures] = None,
     ) -> Dict[str, Any]:
         """
         Generate completion for a single prompt.
@@ -400,11 +405,13 @@ class RemoteInferenceClient:
         # Use LoRA adapter name if one is active, otherwise use base model name
         effective_model = self.active_lora_name if self.active_lora_name else self.model_name
 
-        payload = {
+        payload: dict[str, Any] = {
             "sampling_params": sampling_params,
             "model": effective_model,
             "token_ids": prompt_token_ids,
         }
+        if mm_features:
+            payload["features"] = mm_features
 
         headers = {"Content-Type": "application/json"}
         if session_id:

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -349,14 +349,14 @@ class RemoteInferenceClient:
                     prompt_token_ids=prompt_token_ids[idx],
                     sampling_params=sampling_params,
                     session_id=session_ids[idx] if session_ids and idx < len(session_ids) else None,
-                    mm_features=mm_features,
+                    mm_features=mm_features[idx] if mm_features and idx < len(mm_features) else None,
                 )
             async with gen_sem:
                 return await self._generate_single(
                     prompt_token_ids=prompt_token_ids[idx],
                     sampling_params=sampling_params,
                     session_id=session_ids[idx] if session_ids and idx < len(session_ids) else None,
-                    mm_features=mm_features,
+                    mm_features=mm_features[idx] if mm_features and idx < len(mm_features) else None,
                 )
 
         async def _throttled_detokenize(token_ids: List[int]) -> str:

--- a/skyrl/backends/skyrl_train/inference_servers/utils.py
+++ b/skyrl/backends/skyrl_train/inference_servers/utils.py
@@ -46,6 +46,7 @@ def build_vllm_cli_args(cfg: SkyRLTrainConfig) -> Namespace:
             if cfg.generator.inference_engine.served_model_name
             else None
         ),
+        mm_processor_cache_gb=0,
     )
     for key, value in overrides.items():
         setattr(args, key, value)

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_vlm_inference_generation.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_vlm_inference_generation.py
@@ -288,3 +288,66 @@ async def test_renderer_decodes_mm_kwargs(module_scoped_ray_init_fixture):
         assert isinstance(image_grid_thw, torch.Tensor)
         assert image_grid_thw.shape[1] == 3
         assert image_grid_thw.dtype == torch.long
+
+
+# ---------------------------------------------------------------------------
+# Render + Generate round-trip test
+# ---------------------------------------------------------------------------
+
+
+@requires_local_vllm
+@pytest.mark.vllm
+@pytest.mark.asyncio
+async def test_generate_with_multimodal_features_red_square(module_scoped_ray_init_fixture):
+    """Render a red square image, then generate with mm_features and verify the model sees red."""
+    cfg = get_test_actor_config(num_inference_engines=1, model=MODEL_QWEN3_VL)
+    cfg.generator.inference_engine.served_model_name = MODEL_QWEN3_VL
+    async with InferenceEngineState.create(
+        cfg=cfg,
+        use_local=True,
+        backend="vllm",
+        model=MODEL_QWEN3_VL,
+        sleep_level=1,
+        engine_init_kwargs={
+            "max_model_len": 4096,
+            "limit_mm_per_prompt": {"image": 1, "video": 0},
+        },
+        use_new_inference_servers=True,
+    ) as engines:
+        client = engines.client
+
+        # Step 1: Render the image prompt to get token_ids and multi-modal features
+        data_uri = _make_tiny_base64_image()
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": data_uri}},
+                    {"type": "text", "text": "What color is this square? Answer with just the color name."},
+                ],
+            }
+        ]
+
+        render_result = await client.render_chat_completion({"json": {"model": MODEL_QWEN3_VL, "messages": messages}})
+
+        token_ids = render_result["token_ids"]
+        features = render_result.get("features")
+        assert features is not None, "Render should return multi-modal features for image input"
+
+        # Step 2: Generate using the rendered token_ids + mm_features
+        input_batch = {
+            "prompt_token_ids": [token_ids],
+            "sampling_params": {"max_tokens": 64, "temperature": 0.0},
+            "mm_features": features,
+        }
+        gen_result = await client.generate(input_batch)
+
+        # Structural assertions
+        assert len(gen_result["responses"]) == 1
+        assert len(gen_result["response_ids"]) == 1
+        assert len(gen_result["response_ids"][0]) > 0
+        assert gen_result["stop_reasons"][0] in ("stop", "length")
+
+        # Semantic assertion: the model should identify the red square
+        response_text = gen_result["responses"][0].lower()
+        assert "red" in response_text, f"Expected model to identify the red square, got: {gen_result['responses'][0]}"

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_vlm_inference_generation.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_vlm_inference_generation.py
@@ -338,7 +338,7 @@ async def test_generate_with_multimodal_features_red_square(module_scoped_ray_in
         input_batch = {
             "prompt_token_ids": [token_ids],
             "sampling_params": {"max_tokens": 64, "temperature": 0.0},
-            "mm_features": features,
+            "mm_features": [features],
         }
         gen_result = await client.generate(input_batch)
 

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -658,7 +658,7 @@ class TestMultiModalGeneration:
         input_batch = {
             "prompt_token_ids": [[1, 2, 3]],
             "sampling_params": {"max_tokens": 50},
-            "mm_features": mm_features,
+            "mm_features": [mm_features],
         }
         result = await client.generate(input_batch)
 

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -22,10 +22,15 @@ from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import
 def create_mock_vllm_server(server_id: int) -> FastAPI:
     """Create a mock vLLM server with standard endpoints."""
     app = FastAPI()
+    app.state.last_generate_features = None
 
     @app.get("/health")
     async def health():
         return {"status": "ok"}
+
+    @app.get("/test/last_generate_features")
+    async def get_last_generate_features():
+        return {"features": app.state.last_generate_features}
 
     @app.get("/get_world_size")
     async def get_world_size():
@@ -68,6 +73,11 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
                 for i in range(num_choices)
             ]
         }
+
+        features = body.get("features")
+        app.state.last_generate_features = features
+        if features is not None:
+            response["features"] = features
 
         # Mock prompt_logprobs when requested via sampling_params
         pl = sp.get("prompt_logprobs")
@@ -633,6 +643,33 @@ class TestRenderChatCompletion:
             "mm_hashes": {"image": ["fd2700fd096d55f04c20dbfdc903f7e65421e282"]},
             "mm_placeholders": {"image": [{"offset": 4, "length": 100}]},
         }
+
+
+class TestMultiModalGeneration:
+    """Test that mm_features are correctly forwarded through generate()."""
+
+    @pytest.mark.asyncio
+    async def test_generate_with_mm_features(self, client, mock_servers):
+        """Passing mm_features in InferenceEngineInput sends features in the HTTP payload."""
+        mm_features = {
+            "mm_hashes": {"image": ["abc123hash"]},
+            "mm_placeholders": {"image": [{"offset": 0, "length": 10}]},
+        }
+        input_batch = {
+            "prompt_token_ids": [[1, 2, 3]],
+            "sampling_params": {"max_tokens": 50},
+            "mm_features": mm_features,
+        }
+        result = await client.generate(input_batch)
+
+        assert len(result["responses"]) == 1
+        assert len(result["response_ids"]) == 1
+        assert result["stop_reasons"][0] == "stop"
+
+        async with httpx.AsyncClient() as http:
+            resp = await http.get(f"{mock_servers['proxy_url']}/test/last_generate_features")
+            captured = resp.json()
+        assert captured["features"] == mm_features
 
 
 class TestContextManager:


### PR DESCRIPTION
## Summary

1/3 PRs for for #1493 - multi-turn VLM generator

Adds multimodal generation support to the inference client, enabling `RemoteInferenceClient.generate()` to forward multi-modal features (image hashes, placeholder ranges, kwargs) from vLLM's render endpoint through to the generation endpoint.

- Thread `mm_features` through `RemoteInferenceClient.generate()` and `_generate_single()`, conditionally attaching them as `"features"` in the HTTP payload to the vLLM server
- Add `mm_processor_cache_gb=0` to vLLM CLI args to disable the multimodal processor cache. Required otherwise vLLM won't return multi-modal features for repeated image rendering (`/render` is not idempotent).
- Add unit test verifying mm_features are forwarded in the HTTP payload via mock server
- Add GPU integration test (`test_generate_with_multimodal_features_red_square`) that exercises the full render -> generate round-trip with a VLM

## Test plan

- [x] Existing `test_remote_inference_client.py` tests pass: `uv run pytest tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py -v`
- [x] New `TestMultiModalGeneration` test passes: verifies mm_features reach the server payload
- [x] GPU integration test passes (requires local vLLM): `SKYRL_LOCAL_VLLM=1 uv run --isolated --extra dev --extra fsdp pytest tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_vlm_inference_generation.py -m vllm -v`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
