### PR TITLE
[CI] Fix moe model initialization timeout

### DIFF
--- a/tests/backends/skyrl_train/gpu/utils.py
+++ b/tests/backends/skyrl_train/gpu/utils.py
@@ -226,14 +226,15 @@ def get_available_gpus():
 def wait_for_server(url: str, health_path: str, timeout: int = 60, interval: float = 1.0):
     start_time = time.time()
     while True:
+        if time.time() - start_time > timeout:
+            raise TimeoutError(f"Server at {url} did not come online within {timeout} seconds")
         try:
             response = requests.get(f"http://{url}/{health_path}")
             if response.ok:
                 return
         except requests.exceptions.ConnectionError:
-            if time.time() - start_time > timeout:
-                raise TimeoutError(f"Server at {url} did not come online within {timeout} seconds")
-            time.sleep(interval)
+            pass
+        time.sleep(interval)
 
 
 def levenshtein(s1, s2):
@@ -702,7 +703,7 @@ def init_remote_inference_servers(
     # Start the vLLM server process
     server_process = subprocess.Popen(remote_server_command, env=env)
     try:
-        wait_for_server(url=f"localhost:{engine_port}", health_path="health", timeout=200)
+        wait_for_server(url=f"localhost:{engine_port}", health_path="health", timeout=400)
     except TimeoutError as e:
         print(f"Received timeout error while waiting for server: {e}")
         server_process.terminate()


### PR DESCRIPTION
# What does this PR do?

Increase vLLM server startup timeout from 200s to 400s for the MoE model
(Qwen/Qwen1.5-MoE-A2.7B) in test_engine_generation. The vLLM 0.19.0
upgrade increased initialization time.

Also fix a bug in wait_for_server where the timeout was only checked
inside the ConnectionError handler — if the server responded with a
non-OK status (e.g. 503), the loop would run forever.


Fixes CI failure: https://github.com/NovaSky-AI/SkyRL/actions/runs/24231625026/job/70744328255

```
=========================== short test summary info ============================
FAILED tests/backends/skyrl_train/gpu/gpu_ci/test_engine_generation.py::test_inference_engines_generation[tp2_pp1_dp2_moe] - TimeoutError: Server at localhost:49687 did not come online within 200 seconds
```
