### PR TITLE
[train][multimodal][3/3] Trainer changes to extract multi-modal outputs from GeneratorOutput

### DIFF
--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -615,6 +615,9 @@ class RayPPOTrainer:
         pixel_values = generator_output.get("pixel_values", None)
         image_grid_thw = generator_output.get("image_grid_thw", None)
         if pixel_values is not None:
+            assert (
+                pixel_values is not None and image_grid_thw is not None
+            ), "Both pixel_values and image_grid_thw must exist for multi-modal inputs"
             assert len(pixel_values) == len(
                 image_grid_thw
             ), "Number of pixel values should match number of image grid thw"
@@ -926,8 +929,9 @@ class RayPPOTrainer:
                     new_tensors[key] = torch.cat([tensor, padding_tensor], dim=0)
                 else:
                     # ensures all padding tensors are in a valid format by cloning `pad_size` from the original input
-                    # `pad_size` is guaranteed to be smaller than batch_size
-                    padding_tensor = tensor[:pad_size].clone()
+                    n = tensor.shape[0]
+                    pad_indices = torch.arange(pad_size, device=tensor.device) % n
+                    padding_tensor = tensor[pad_indices].clone()
                     new_tensors[key] = torch.cat([tensor, padding_tensor], dim=0)
 
         new_training_input = TrainingInputBatch(new_tensors)

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -965,6 +965,10 @@ class RayPPOTrainer:
         fwd_keys = ["sequences", "attention_mask"]
         if training_input.get("rollout_expert_indices") is not None:
             fwd_keys.append("rollout_expert_indices")
+        if training_input.get("pixel_values") is not None:
+            fwd_keys.append("pixel_values")
+        if training_input.get("image_grid_thw") is not None:
+            fwd_keys.append("image_grid_thw")
         data_fwd_pass = training_input.select(keys=fwd_keys, metadata_keys=["response_length"])
 
         values = None

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -27,7 +27,7 @@ from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import
 from skyrl.backends.skyrl_train.inference_engines.utils import (
     get_sampling_params_for_backend,
 )
-from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
+from skyrl.backends.skyrl_train.training_batch import TensorList, TrainingInputBatch
 from skyrl.backends.skyrl_train.utils import ppo_utils
 from skyrl.backends.skyrl_train.utils.io import io
 from skyrl.backends.skyrl_train.utils.ppo_utils import (
@@ -612,6 +612,15 @@ class RayPPOTrainer:
             "rollout_expert_indices", None
         )
 
+        pixel_values = generator_output.get("pixel_values", None)
+        image_grid_thw = generator_output.get("image_grid_thw", None)
+        if pixel_values is not None:
+            assert len(pixel_values) == len(
+                image_grid_thw
+            ), "Number of pixel values should match number of image grid thw"
+            pixel_values = TensorList(pixel_values)
+            image_grid_thw = TensorList(image_grid_thw)
+
         (
             sequences_tensor,
             attention_masks_tensor,
@@ -650,6 +659,8 @@ class RayPPOTrainer:
                 "loss_mask": loss_masks_tensor,
                 "rollout_logprobs": rollout_logprobs_tensor,
                 "rollout_expert_indices": rollout_expert_indices_tensor,
+                "pixel_values": pixel_values,
+                "image_grid_thw": image_grid_thw,
                 "is_last_step": (
                     torch.tensor(generator_output["is_last_step"], dtype=torch.bool)
                     if generator_output.get("is_last_step", None) is not None
@@ -899,18 +910,25 @@ class RayPPOTrainer:
             return training_input
         for key, tensor in training_input.items():
             if tensor is not None:
-                additional_dims = tuple(tensor.shape[1:]) if len(tensor.shape) > 1 else ()
-
-                if key == "is_last_step":
+                if isinstance(tensor, TensorList):
+                    n = len(tensor)
+                    pad_indices = [i % n for i in range(pad_size)]
+                    padding = TensorList([tensor[i].clone() for i in pad_indices])
+                    new_tensors[key] = TensorList.cat([tensor, padding])
+                elif key == "is_last_step":
+                    additional_dims = tensor.shape[1:]
                     padding_tensor = torch.ones(pad_size, *additional_dims, dtype=tensor.dtype, device=tensor.device)
+                    new_tensors[key] = torch.cat([tensor, padding_tensor], dim=0)
                 elif key == "loss_mask":
                     # ensures that padding tensors don't count towards the loss
+                    additional_dims = tensor.shape[1:]
                     padding_tensor = torch.zeros(pad_size, *additional_dims, dtype=tensor.dtype, device=tensor.device)
+                    new_tensors[key] = torch.cat([tensor, padding_tensor], dim=0)
                 else:
                     # ensures all padding tensors are in a valid format by cloning `pad_size` from the original input
                     # `pad_size` is guaranteed to be smaller than batch_size
                     padding_tensor = tensor[:pad_size].clone()
-                new_tensors[key] = torch.cat([tensor, padding_tensor], dim=0)
+                    new_tensors[key] = torch.cat([tensor, padding_tensor], dim=0)
 
         new_training_input = TrainingInputBatch(new_tensors)
         new_training_input.metadata = {}


### PR DESCRIPTION
## Summary
Final PR addressing #1493 . This addresses the trainer changes required for compatibility with the new generator. 

- Add VLM (vision-language model) training support by propagating `pixel_values` and `image_grid_thw` through the trainer pipeline
- Extract vision inputs from generator output, wrap them in `TensorList` for variable-length handling, and pass them through to the training batch and forward pass
- Update padding logic to handle `TensorList` types by cloning and concatenating entries instead of using tensor padding
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
