### PR TITLE
fix(docker): optimize Dockerfile.megatron to reduce image size by 1.36 GB

### DIFF
--- a/docker/Dockerfile.megatron
+++ b/docker/Dockerfile.megatron
@@ -13,14 +13,6 @@ RUN wget https://developer.download.nvidia.com/compute/cuda/12.8.0/local_install
 RUN curl -LsSf https://astral.sh/uv/0.9.4/install.sh | sh
 RUN echo "export RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook" >> /home/ray/.bashrc
 
-# Repair openjdk-11-jre-headless from base image (missing /usr/share/binfmts)
-# JDK needs recommended packages (binfmt-support) to configure properly
-RUN sudo mkdir -p /usr/share/binfmts && \
-    sudo apt-get update -y && \
-    sudo apt-get install --fix-broken -y && \
-    sudo apt-get install -y default-jre-headless openjdk-8-jdk && \
-    sudo rm -rf /var/lib/apt/lists/*
-
 # Post-CUDA packages: networking, dev libs, and NCCL runtime
 RUN sudo apt-get update -y && \
     sudo apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.megatron
+++ b/docker/Dockerfile.megatron
@@ -1,6 +1,10 @@
 FROM anyscale/ray:2.51.1-slim-py312-cu128
 
-RUN sudo apt-get update -y && sudo apt-get install -y wget kmod libxml2 build-essential libnuma-dev
+# Pre-CUDA packages (needed for CUDA toolkit installer)
+RUN sudo apt-get update -y && \
+    sudo apt-get install -y --no-install-recommends \
+    wget kmod libxml2 build-essential libnuma-dev && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 # the cuda compiler here is needed for deepspeed
 RUN wget https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda_12.8.0_570.86.10_linux.run \
@@ -9,27 +13,28 @@ RUN wget https://developer.download.nvidia.com/compute/cuda/12.8.0/local_install
 RUN curl -LsSf https://astral.sh/uv/0.9.4/install.sh | sh
 RUN echo "export RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook" >> /home/ray/.bashrc
 
+# Repair openjdk-11-jre-headless from base image (missing /usr/share/binfmts)
+# JDK needs recommended packages (binfmt-support) to configure properly
+RUN sudo mkdir -p /usr/share/binfmts && \
+    sudo apt-get update -y && \
+    sudo apt-get install --fix-broken -y && \
+    sudo apt-get install -y default-jre-headless openjdk-8-jdk && \
+    sudo rm -rf /var/lib/apt/lists/*
 
-RUN sudo apt-get update \
-    && sudo apt-get install -y openssh-server iputils-ping net-tools iproute2 traceroute netcat \
-    libopenexr-dev libxi-dev libglfw3-dev libglew-dev libomp-dev libxinerama-dev libxcursor-dev tzdata \
-    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
-
-RUN sudo apt update && sudo apt install --fix-broken && sudo apt install -y default-jre-headless openjdk-8-jdk \
-    && sudo apt-get clean \
-    && sudo rm -rf /var/lib/apt/lists/*
-
-# build toolchain + nccl dev headers for transformer engine build
-RUN sudo apt-get update && sudo apt-get install -y \
-    cmake \
-    ninja-build \
+# Post-CUDA packages: networking, dev libs, and TE build toolchain
+RUN sudo apt-get update -y && \
+    sudo apt-get install -y --no-install-recommends \
+    openssh-server iputils-ping net-tools iproute2 traceroute netcat tzdata \
+    libopenexr-dev libxi-dev libglfw3-dev libglew-dev libomp-dev libxinerama-dev libxcursor-dev \
+    cmake ninja-build \
     libnccl-dev=2.25.1-1+cuda12.8 \
-    libnccl2=2.25.1-1+cuda12.8 \
-    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+    libnccl2=2.25.1-1+cuda12.8 && \
+    sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
 # ---------- PyTorch + cuDNN + Transformer Engine ----------
-# PyTorch + cuDNN + Transformer Engine
-RUN pip install --no-cache-dir "torch==2.7.1" "nvidia-cudnn-cu12>=9.3" && \
+RUN pip install --no-cache-dir \
+    "torch==2.7.1" "nvidia-cudnn-cu12>=9.3" \
+    nvidia-mathdx pybind11 setuptools wheel && \
     CUDNN_PATH="$(python -c 'import inspect, nvidia.cudnn as c, os; print(os.path.dirname(inspect.getfile(c)))')" && \
     sudo mkdir -p /opt && sudo ln -sfn "$CUDNN_PATH" /opt/cudnn && \
     echo "/opt/cudnn/lib" | sudo tee /etc/ld.so.conf.d/cudnn.conf >/dev/null && sudo ldconfig
@@ -37,14 +42,11 @@ RUN pip install --no-cache-dir "torch==2.7.1" "nvidia-cudnn-cu12>=9.3" && \
 ENV CUDNN_PATH=/opt/cudnn
 ENV CPATH=${CUDNN_PATH}/include:${CPATH}
 ENV LD_LIBRARY_PATH=${CUDNN_PATH}/lib:${LD_LIBRARY_PATH}
-
-RUN pip install --no-cache-dir \
-    nvidia-mathdx \
-    pybind11 \
-    setuptools \
-    wheel
-
 ENV CMAKE_ARGS=-DPython_EXECUTABLE=/home/ray/anaconda3/bin/python3
 
-RUN pip install --no-cache-dir --no-build-isolation "transformer_engine[pytorch]==2.9.0"
+RUN pip install --no-cache-dir --no-build-isolation "transformer_engine[pytorch]==2.9.0" && \
+    sudo apt-get purge -y cmake ninja-build libnccl-dev && \
+    sudo apt-get autoremove -y && \
+    sudo apt-get clean && \
+    rm -rf ~/.cache && sudo rm -rf /tmp/*
 # --------------------

--- a/docker/Dockerfile.megatron
+++ b/docker/Dockerfile.megatron
@@ -21,13 +21,11 @@ RUN sudo mkdir -p /usr/share/binfmts && \
     sudo apt-get install -y default-jre-headless openjdk-8-jdk && \
     sudo rm -rf /var/lib/apt/lists/*
 
-# Post-CUDA packages: networking, dev libs, and TE build toolchain
+# Post-CUDA packages: networking, dev libs, and NCCL runtime
 RUN sudo apt-get update -y && \
     sudo apt-get install -y --no-install-recommends \
     openssh-server iputils-ping net-tools iproute2 traceroute netcat tzdata \
     libopenexr-dev libxi-dev libglfw3-dev libglew-dev libomp-dev libxinerama-dev libxcursor-dev \
-    cmake ninja-build \
-    libnccl-dev=2.25.1-1+cuda12.8 \
     libnccl2=2.25.1-1+cuda12.8 && \
     sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
@@ -44,9 +42,14 @@ ENV CPATH=${CUDNN_PATH}/include:${CPATH}
 ENV LD_LIBRARY_PATH=${CUDNN_PATH}/lib:${LD_LIBRARY_PATH}
 ENV CMAKE_ARGS=-DPython_EXECUTABLE=/home/ray/anaconda3/bin/python3
 
-RUN pip install --no-cache-dir --no-build-isolation "transformer_engine[pytorch]==2.9.0" && \
+# Install TE build deps, compile, then purge -- all in one layer to avoid bloat
+RUN sudo apt-get update -y && \
+    sudo apt-get install -y --no-install-recommends \
+    cmake ninja-build libnccl-dev=2.25.1-1+cuda12.8 && \
+    pip install --no-cache-dir --no-build-isolation "transformer_engine[pytorch]==2.9.0" && \
     sudo apt-get purge -y cmake ninja-build libnccl-dev && \
     sudo apt-get autoremove -y && \
     sudo apt-get clean && \
-    rm -rf ~/.cache && sudo rm -rf /tmp/*
+    sudo rm -rf /var/lib/apt/lists/* /tmp/* && \
+    rm -rf ~/.cache
 # --------------------

--- a/docker/Dockerfile.megatron
+++ b/docker/Dockerfile.megatron
@@ -1,6 +1,10 @@
 FROM anyscale/ray:2.51.1-slim-py312-cu128
 
-RUN sudo apt-get update -y && sudo apt-get install -y wget kmod libxml2 build-essential libnuma-dev
+# Pre-CUDA packages (needed for CUDA toolkit installer)
+RUN sudo apt-get update -y && \
+    sudo apt-get install -y --no-install-recommends \
+    wget kmod libxml2 build-essential libnuma-dev && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 # the cuda compiler here is needed for deepspeed
 RUN wget https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda_12.8.0_570.86.10_linux.run \
@@ -9,27 +13,28 @@ RUN wget https://developer.download.nvidia.com/compute/cuda/12.8.0/local_install
 RUN curl -LsSf https://astral.sh/uv/0.9.4/install.sh | sh
 RUN echo "export RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook" >> /home/ray/.bashrc
 
+# Repair openjdk-11-jre-headless from base image (missing /usr/share/binfmts)
+# JDK needs recommended packages (binfmt-support) to configure properly
+RUN sudo mkdir -p /usr/share/binfmts && \
+    sudo apt-get update -y && \
+    sudo apt-get install --fix-broken -y && \
+    sudo apt-get install -y default-jre-headless openjdk-8-jdk && \
+    sudo rm -rf /var/lib/apt/lists/*
 
-RUN sudo apt-get update \
-    && sudo apt-get install -y openssh-server iputils-ping net-tools iproute2 traceroute netcat \
-    libopenexr-dev libxi-dev libglfw3-dev libglew-dev libomp-dev libxinerama-dev libxcursor-dev tzdata \
-    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
-
-RUN sudo apt update && sudo apt install --fix-broken && sudo apt install -y default-jre-headless openjdk-8-jdk \
-    && sudo apt-get clean \
-    && sudo rm -rf /var/lib/apt/lists/*
-
-# build toolchain + nccl dev headers for transformer engine build
-RUN sudo apt-get update && sudo apt-get install -y \
-    cmake \
-    ninja-build \
+# Post-CUDA packages: networking, dev libs, and TE build toolchain
+RUN sudo apt-get update -y && \
+    sudo apt-get install -y --no-install-recommends \
+    openssh-server iputils-ping net-tools iproute2 traceroute netcat tzdata \
+    libopenexr-dev libxi-dev libglfw3-dev libglew-dev libomp-dev libxinerama-dev libxcursor-dev \
+    cmake ninja-build \
     libnccl-dev=2.25.1-1+cuda12.8 \
-    libnccl2=2.25.1-1+cuda12.8 \
-    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+    libnccl2=2.25.1-1+cuda12.8 && \
+    sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
 # ---------- PyTorch + cuDNN + Transformer Engine ----------
-# PyTorch + cuDNN + Transformer Engine
-RUN uv pip install --system --no-cache-dir "torch==2.10.0" "nvidia-cudnn-cu12>=9.3" && \
+RUN uv pip install --system --no-cache-dir \
+    "torch==2.10.0" "nvidia-cudnn-cu12>=9.3" \
+    nvidia-mathdx pybind11 setuptools wheel && \
     CUDNN_PATH="$(python -c 'import nvidia.cudnn as c; print(c.__path__[0])')" && \
     sudo mkdir -p /opt && sudo ln -sfn "$CUDNN_PATH" /opt/cudnn && \
     echo "/opt/cudnn/lib" | sudo tee /etc/ld.so.conf.d/cudnn.conf >/dev/null && sudo ldconfig
@@ -37,18 +42,15 @@ RUN uv pip install --system --no-cache-dir "torch==2.10.0" "nvidia-cudnn-cu12>=9
 ENV CUDNN_PATH=/opt/cudnn
 ENV CPATH=${CUDNN_PATH}/include:${CPATH}
 ENV LD_LIBRARY_PATH=${CUDNN_PATH}/lib:${LD_LIBRARY_PATH}
-
-RUN uv pip install  --system --no-cache-dir \
-    nvidia-mathdx \
-    pybind11 \
-    setuptools \
-    wheel
-
 ENV CMAKE_ARGS=-DPython_EXECUTABLE=/home/ray/anaconda3/bin/python3
 
 RUN sudo mkdir /opt/wheels && sudo chown ray: /opt/wheels && \
-     pip wheel --no-cache-dir --no-build-isolation --no-deps \
-        -w /opt/wheels "transformer-engine-torch==2.10.0"
-RUN pip install --no-cache-dir --no-build-isolation --find-links /opt/wheels "transformer_engine[pytorch]==2.10.0"
+    pip wheel --no-cache-dir --no-build-isolation --no-deps \
+        -w /opt/wheels "transformer-engine-torch==2.10.0" && \
+    pip install --no-cache-dir --no-build-isolation --find-links /opt/wheels "transformer_engine[pytorch]==2.10.0" && \
+    sudo apt-get purge -y cmake ninja-build libnccl-dev && \
+    sudo apt-get autoremove -y && \
+    sudo apt-get clean && \
+    rm -rf ~/.cache && sudo rm -rf /tmp/*
 ENV UV_FIND_LINKS=/opt/wheels
 # --------------------


### PR DESCRIPTION
- Consolidate 4 apt-get blocks into 3 (pre-CUDA, JDK repair, post-CUDA)
- Add --no-install-recommends to non-JDK apt installs
- Add apt list cleanup to pre-CUDA block (was missing entirely)
- Merge torch+cudnn and mathdx+pybind11 pip installs into one RUN
- Purge cmake, ninja-build, and libnccl-dev after Transformer Engine build
- Clean /tmp and ~/.cache build artifacts after TE compilation
- Remove OpenJDK package as it is not needed.

Verified: image builds successfully and compressed size drops from 12.20 GB to 11.01 GB (1,359 MB or 10.9% reduction).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
