### PR TITLE
[CI] Add `pull_request` trigger to GPU CI workflows

### DIFF
--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -31,13 +31,16 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
-        (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
         !github.event.pull_request.draft &&
         contains(github.event.pull_request.labels.*.name, 'run_train_gpu_ci') &&
         (
           github.event.pull_request.author_association == 'MEMBER' ||
           github.event.pull_request.author_association == 'OWNER' ||
           github.event.pull_request.author_association == 'COLLABORATOR'
+        ) &&
+        (
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) ||
+          (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
         )
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -31,7 +31,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
-        github.event_name == 'pull_request_target' &&
+        (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
         !github.event.pull_request.draft &&
         contains(github.event.pull_request.labels.*.name, 'run_train_gpu_ci') &&
         (

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -13,8 +13,6 @@ on:
       - '!docs/**'
       - '!examples/**'
       - '.github/workflows/**'
-  pull_request:
-    types: [labeled]
   pull_request_target:
     types: [labeled]
   workflow_dispatch:
@@ -31,16 +29,11 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
-        !github.event.pull_request.draft &&
         contains(github.event.pull_request.labels.*.name, 'run_train_gpu_ci') &&
         (
           github.event.pull_request.author_association == 'MEMBER' ||
           github.event.pull_request.author_association == 'OWNER' ||
           github.event.pull_request.author_association == 'COLLABORATOR'
-        ) &&
-        (
-          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) ||
-          (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
         )
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -13,6 +13,8 @@ on:
       - '!docs/**'
       - '!examples/**'
       - '.github/workflows/**'
+  pull_request:
+    types: [labeled]
   pull_request_target:
     types: [labeled]
   workflow_dispatch:

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -15,6 +15,8 @@ on:
       - '!docs/**'
       - '!examples/**'
       - '.github/workflows/**'
+  pull_request:
+    types: [labeled]
   pull_request_target:
     types: [labeled]
   workflow_dispatch:

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -33,7 +33,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
-        github.event_name == 'pull_request_target' &&
+        (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
         !github.event.pull_request.draft &&
         contains(github.event.pull_request.labels.*.name, 'run_train_megatron_gpu_ci') &&
         (

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -33,13 +33,16 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
-        (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
         !github.event.pull_request.draft &&
         contains(github.event.pull_request.labels.*.name, 'run_train_megatron_gpu_ci') &&
         (
           github.event.pull_request.author_association == 'MEMBER' ||
           github.event.pull_request.author_association == 'OWNER' ||
           github.event.pull_request.author_association == 'COLLABORATOR'
+        ) &&
+        (
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) ||
+          (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
         )
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add `pull_request` alongside `pull_request_target` as a trigger event for the skyrl-train-gpu-ci and skyrl-train-megatron-gpu-ci workflows. The job gating condition is unchanged — only `pull_request_target` events with the appropriate label from a trusted author run the tests.