### PR TITLE
[fix][train] Fix Megatron weight syncing for new inference codepath

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -99,10 +99,10 @@ class MegatronWeightExtractor(WeightExtractor):
         self._buckets_initialized = False
 
     def _get_params_iterator(self):
-        """Single unified iterator that yields ALL HF params with conversion_tasks=None.
+        """Iterator that yields ALL HF params with conversion_tasks=None.
 
-        Used by both get_weight_metadata and extract_weights to avoid metadata/data
-        mismatches and unnecessary dtype conversions."""
+        Used by get_weight_metadata to collect names and shapes without
+        materializing dtype conversions."""
         return self.bridge.export_hf_weights(
             self.actor_module,
             show_progress=False,
@@ -232,9 +232,13 @@ class MegatronWeightExtractor(WeightExtractor):
         self._ensure_buckets_initialized()
         device = torch.cuda.current_device()
 
-        hf_params_generator = self._get_params_iterator()
-
         if not self.enable_bucketing:
+            # No bucketing: yield one chunk per parameter
+            hf_params_generator = self.bridge.export_hf_weights(
+                self.actor_module,
+                show_progress=False,
+                conversion_tasks=None,
+            )
 
             for name, tensor in hf_params_generator:
                 tensor = tensor.to(device=device, dtype=dtype, non_blocking=True)
@@ -246,42 +250,41 @@ class MegatronWeightExtractor(WeightExtractor):
                     tensors=[tensor],
                 )
         else:
-            # Size-based bucketing: batch tensors up to bucket_size_threshold_GB
-            # into a single chunk so the packed broadcast sends larger payloads
-            # instead of one-per-tensor.
-            threshold_bytes = int(self.bucket_size_threshold_GB * 1024**3)
+            # Build fresh tasks each sync so mapping objects have clean
+            # PP-collective caches; reuse the pre-computed bucket structure.
+            fresh_tasks = self.bridge.get_conversion_tasks(self.actor_module)
 
-            names: list[str] = []
-            dtypes_list: list[str] = []
-            shapes: list[list[int]] = []
-            tensors: list[torch.Tensor] = []
-            cur_bytes = 0
+            for index_group in self.bucket_index_groups:
+                bucket_tasks = [fresh_tasks[i] for i in index_group]
+                hf_params_generator = self.bridge.export_hf_weights(
+                    self.actor_module,
+                    show_progress=False,
+                    conversion_tasks=bucket_tasks,
+                )
 
-            for name, tensor in hf_params_generator:
-                tensor = tensor.to(device=device, dtype=dtype, non_blocking=True)
-                names.append(name)
-                dtypes_list.append(str(dtype))
-                shapes.append(list(tensor.shape))
-                tensors.append(tensor)
-                cur_bytes += tensor.numel() * tensor.element_size()
+                # Collect all parameters in this bucket into one chunk
+                names = []
+                dtypes_list = []
+                shapes = []
+                tensors = []
 
-                if cur_bytes >= threshold_bytes:
+                for name, tensor in hf_params_generator:
+                    # Move to device and convert dtype
+                    tensor = tensor.to(device=device, dtype=dtype, non_blocking=True)
+
+                    names.append(name)
+                    dtypes_list.append(str(dtype))
+                    shapes.append(list(tensor.shape))
+                    tensors.append(tensor)
+
+                # Yield one chunk containing all parameters in this bucket
+                if tensors:
                     yield WeightChunk(
                         names=names,
                         dtypes=dtypes_list,
                         shapes=shapes,
                         tensors=tensors,
                     )
-                    names, dtypes_list, shapes, tensors = [], [], [], []
-                    cur_bytes = 0
-
-            if tensors:
-                yield WeightChunk(
-                    names=names,
-                    dtypes=dtypes_list,
-                    shapes=shapes,
-                    tensors=tensors,
-                )
 
 
 class MegatronWorker:

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -182,9 +182,7 @@ class MegatronWeightExtractor(WeightExtractor):
     def get_weight_metadata(self, dtype: torch.dtype) -> dict:
         """Return weight metadata without keeping tensors in memory.
 
-        On first call, runs export_hf_weights to discover HF names and shapes
-        (tensors are discarded immediately). Result is cached for subsequent calls.
-        TODO (aaron): find a better way to get all metadata without materializing tensors.
+        TODO (sumanthrh): remove this once we move towards chunk-based update weights
         """
         if hasattr(self, "_weight_metadata_cache"):
             return self._weight_metadata_cache
@@ -193,17 +191,13 @@ class MegatronWeightExtractor(WeightExtractor):
         dtype_names = []
         shapes = []
         dtype_name = str(dtype).split(".")[-1]
-        device = torch.cuda.current_device()
-        for name, tensor in self.bridge.export_hf_weights(
-            self.actor_module,
-            show_progress=False,
-            conversion_tasks=None,
-        ):
-            tensor = tensor.to(device=device, dtype=dtype, non_blocking=True)
-            names.append(name)
-            dtype_names.append(dtype_name)
-            shapes.append(list(tensor.shape))
-            del tensor
+        # Iterate via the same extract_weights generator to get all weights
+        # This ensures that the metadata matches exactly
+        for chunk in self.extract_weights(dtype):
+            for name, shape in zip(chunk.names, chunk.shapes):
+                names.append(name)
+                dtype_names.append(dtype_name)
+                shapes.append(shape)
         self._weight_metadata_cache = {"names": names, "dtype_names": dtype_names, "shapes": shapes}
         return self._weight_metadata_cache
 
@@ -227,13 +221,16 @@ class MegatronWeightExtractor(WeightExtractor):
         self._ensure_buckets_initialized()
         device = torch.cuda.current_device()
 
+        # No bucketing: yield one chunk per parameter
+        # NOTE (sumanthrh): Always iterate with `conversation_tasks=None` to capture all parameters,
+        # even those without explicit Megatron-> HF conversion tasks like `router.expert_bias`
+        hf_params_generator = self.bridge.export_hf_weights(
+            self.actor_module,
+            show_progress=False,
+            conversion_tasks=None,
+        )
+
         if not self.enable_bucketing:
-            # No bucketing: yield one chunk per parameter
-            hf_params_generator = self.bridge.export_hf_weights(
-                self.actor_module,
-                show_progress=False,
-                conversion_tasks=None,
-            )
 
             for name, tensor in hf_params_generator:
                 tensor = tensor.to(device=device, dtype=dtype, non_blocking=True)
@@ -245,41 +242,42 @@ class MegatronWeightExtractor(WeightExtractor):
                     tensors=[tensor],
                 )
         else:
-            # Build fresh tasks each sync so mapping objects have clean
-            # PP-collective caches; reuse the pre-computed bucket structure.
-            fresh_tasks = self.bridge.get_conversion_tasks(self.actor_module)
+            # Size-based bucketing: batch tensors up to bucket_size_threshold_GB
+            # into a single chunk so the packed broadcast sends larger payloads
+            # instead of one-per-tensor.
+            threshold_bytes = int(self.bucket_size_threshold_GB * 1024**3)
 
-            for index_group in self.bucket_index_groups:
-                bucket_tasks = [fresh_tasks[i] for i in index_group]
-                hf_params_generator = self.bridge.export_hf_weights(
-                    self.actor_module,
-                    show_progress=False,
-                    conversion_tasks=bucket_tasks,
-                )
+            names: list[str] = []
+            dtypes_list: list[str] = []
+            shapes: list[list[int]] = []
+            tensors: list[torch.Tensor] = []
+            cur_bytes = 0
 
-                # Collect all parameters in this bucket into one chunk
-                names = []
-                dtypes_list = []
-                shapes = []
-                tensors = []
+            for name, tensor in hf_params_generator:
+                tensor = tensor.to(device=device, dtype=dtype, non_blocking=True)
+                names.append(name)
+                dtypes_list.append(str(dtype))
+                shapes.append(list(tensor.shape))
+                tensors.append(tensor)
+                cur_bytes += tensor.numel() * tensor.element_size()
 
-                for name, tensor in hf_params_generator:
-                    # Move to device and convert dtype
-                    tensor = tensor.to(device=device, dtype=dtype, non_blocking=True)
-
-                    names.append(name)
-                    dtypes_list.append(str(dtype))
-                    shapes.append(list(tensor.shape))
-                    tensors.append(tensor)
-
-                # Yield one chunk containing all parameters in this bucket
-                if tensors:
+                if cur_bytes >= threshold_bytes:
                     yield WeightChunk(
                         names=names,
                         dtypes=dtypes_list,
                         shapes=shapes,
                         tensors=tensors,
                     )
+                    names, dtypes_list, shapes, tensors = [], [], [], []
+                    cur_bytes = 0
+
+            if tensors:
+                yield WeightChunk(
+                    names=names,
+                    dtypes=dtypes_list,
+                    shapes=shapes,
+                    tensors=tensors,
+                )
 
 
 class MegatronWorker:

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -232,8 +232,6 @@ class MegatronWeightExtractor(WeightExtractor):
         self._ensure_buckets_initialized()
         device = torch.cuda.current_device()
 
-        # NOTE (sumanthrh): Always iterate with `conversion_tasks=None` to capture all parameters,
-        # even those without explicit Megatron-> HF conversion tasks like `router.expert_bias`
         hf_params_generator = self._get_params_iterator()
 
         if not self.enable_bucketing:

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -98,6 +98,17 @@ class MegatronWeightExtractor(WeightExtractor):
         self.bucket_index_groups = None
         self._buckets_initialized = False
 
+    def _get_params_iterator(self):
+        """Single unified iterator that yields ALL HF params with conversion_tasks=None.
+
+        Used by both get_weight_metadata and extract_weights to avoid metadata/data
+        mismatches and unnecessary dtype conversions."""
+        return self.bridge.export_hf_weights(
+            self.actor_module,
+            show_progress=False,
+            conversion_tasks=None,
+        )
+
     def _init_param_buckets(self):
         """Compute bucket boundaries (index groups) from parameter sizes.
 
@@ -182,6 +193,9 @@ class MegatronWeightExtractor(WeightExtractor):
     def get_weight_metadata(self, dtype: torch.dtype) -> dict:
         """Return weight metadata without keeping tensors in memory.
 
+        Uses _get_params_iterator() directly to collect names and shapes
+        without any dtype conversion or device transfer.
+
         TODO (sumanthrh): remove this once we move towards chunk-based update weights
         """
         if hasattr(self, "_weight_metadata_cache"):
@@ -191,13 +205,10 @@ class MegatronWeightExtractor(WeightExtractor):
         dtype_names = []
         shapes = []
         dtype_name = str(dtype).split(".")[-1]
-        # Iterate via the same extract_weights generator to get all weights
-        # This ensures that the metadata matches exactly
-        for chunk in self.extract_weights(dtype):
-            for name, shape in zip(chunk.names, chunk.shapes):
-                names.append(name)
-                dtype_names.append(dtype_name)
-                shapes.append(shape)
+        for name, tensor in self._get_params_iterator():
+            names.append(name)
+            dtype_names.append(dtype_name)
+            shapes.append(list(tensor.shape))
         self._weight_metadata_cache = {"names": names, "dtype_names": dtype_names, "shapes": shapes}
         return self._weight_metadata_cache
 
@@ -221,14 +232,9 @@ class MegatronWeightExtractor(WeightExtractor):
         self._ensure_buckets_initialized()
         device = torch.cuda.current_device()
 
-        # No bucketing: yield one chunk per parameter
-        # NOTE (sumanthrh): Always iterate with `conversation_tasks=None` to capture all parameters,
+        # NOTE (sumanthrh): Always iterate with `conversion_tasks=None` to capture all parameters,
         # even those without explicit Megatron-> HF conversion tasks like `router.expert_bias`
-        hf_params_generator = self.bridge.export_hf_weights(
-            self.actor_module,
-            show_progress=False,
-            conversion_tasks=None,
-        )
+        hf_params_generator = self._get_params_iterator()
 
         if not self.enable_bucketing:
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
@@ -124,7 +124,7 @@ def get_test_training_batch(batch_size=4) -> TrainingInputBatch:
         pytest.param(MODEL_NAME, True, 4, 2, 2, 1, None, False, marks=_skip_new_inference, id="colocate_all"),
         pytest.param(MODEL_NAME, False, 2, 2, 1, 1, None, False, id="non_colocated"),
         pytest.param(MODEL_NAME, True, 4, 2, 2, 1, None, True, marks=_skip_new_inference, id="colocate_all_lora"),
-        pytest.param(MOE_MODEL_NAME, True, 4, 2, 2, 1, None, False, id="colocate_all_moe"),
+        pytest.param(MOE_MODEL_NAME, False, 2, 2, 1, 1, None, False, id="non_colocated_moe"),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
@@ -40,6 +40,7 @@ MODEL_NAME = "Qwen/Qwen3-0.6B"
 # this might be a model specific mbridge issue - see if this persists when we transition to Megatron-Bridge
 # MOE_MODEL_NAME = "Qwen/Qwen1.5-MoE-A2.7B"
 MOE_MODEL_NAME = "Qwen/Qwen3-30B-A3B"
+SMALL_MOE_MODEL_NAME = "Qwen/Qwen1.5-MoE-A2.7B"
 
 
 def get_test_actor_config(model_name=MODEL_NAME) -> SkyRLTrainConfig:
@@ -119,23 +120,24 @@ def get_test_training_batch(batch_size=4) -> TrainingInputBatch:
 
 
 @pytest.mark.parametrize(
-    ("colocate_all", "inference_tp", "megatron_tp", "megatron_pp", "megatron_ep", "megatron_etp", "lora"),
+    ("model", "colocate_all", "inference_tp", "megatron_tp", "megatron_pp", "megatron_ep", "megatron_etp", "lora"),
     [
-        pytest.param(True, 4, 2, 2, 1, None, False, marks=_skip_new_inference, id="colocate_all"),
-        pytest.param(False, 2, 2, 1, 1, None, False, id="non_colocated"),
-        pytest.param(True, 4, 2, 2, 1, None, True, marks=_skip_new_inference, id="colocate_all_lora"),
+        pytest.param(MODEL_NAME, True, 4, 2, 2, 1, None, False, marks=_skip_new_inference, id="colocate_all"),
+        pytest.param(MODEL_NAME, False, 2, 2, 1, 1, None, False, id="non_colocated"),
+        pytest.param(MODEL_NAME, True, 4, 2, 2, 1, None, True, marks=_skip_new_inference, id="colocate_all_lora"),
+        pytest.param(SMALL_MOE_MODEL_NAME, True, 4, 2, 2, 1, None, True, id="colocate_all_moe"),
     ],
 )
 @pytest.mark.asyncio
 @pytest.mark.megatron
 async def test_megatron_policy_weight_sync(
-    ray_init_fixture, colocate_all, inference_tp, megatron_tp, megatron_pp, megatron_ep, megatron_etp, lora
+    ray_init_fixture, model, colocate_all, inference_tp, megatron_tp, megatron_pp, megatron_ep, megatron_etp, lora
 ):
     """
     Test that we can sync weights between policy and inference for megatron then run inference
     """
     try:
-        cfg = get_test_actor_config(model_name=MODEL_NAME)
+        cfg = get_test_actor_config(model_name=model)
         if lora:
             cfg.trainer.policy.model.lora = SkyRLLoraConfig(rank=16, alpha=16)
         cfg.trainer.placement.colocate_all = colocate_all
@@ -153,7 +155,7 @@ async def test_megatron_policy_weight_sync(
         # If colocate is True, this will load the engine, sleep, and wake up the engine
         async with InferenceEngineState.create(
             cfg=cfg,
-            model=MODEL_NAME,
+            model=model,
             use_local=True,
             backend="vllm",
             sleep_level=2,  # since we explicitly sync weights
@@ -191,9 +193,9 @@ async def test_megatron_policy_weight_sync(
                 cfg.generator.inference_engine.backend, cfg.generator.sampling_params
             )
             tokenizer = (
-                AutoTokenizer.from_pretrained(MODEL_NAME, trust_remote_code=True) if _SKYRL_USE_NEW_INFERENCE else None
+                AutoTokenizer.from_pretrained(model, trust_remote_code=True) if _SKYRL_USE_NEW_INFERENCE else None
             )
-            outputs = await run_inference(client, get_test_prompts(MODEL_NAME), sampling_params, tokenizer=tokenizer)
+            outputs = await run_inference(client, get_test_prompts(model), sampling_params, tokenizer=tokenizer)
 
             print(f"Example output: {outputs['responses'][0]}, {outputs['stop_reasons'][0]}")
     finally:

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
@@ -40,7 +40,6 @@ MODEL_NAME = "Qwen/Qwen3-0.6B"
 # this might be a model specific mbridge issue - see if this persists when we transition to Megatron-Bridge
 # MOE_MODEL_NAME = "Qwen/Qwen1.5-MoE-A2.7B"
 MOE_MODEL_NAME = "Qwen/Qwen3-30B-A3B"
-SMALL_MOE_MODEL_NAME = "Qwen/Qwen1.5-MoE-A2.7B"
 
 
 def get_test_actor_config(model_name=MODEL_NAME) -> SkyRLTrainConfig:
@@ -125,7 +124,7 @@ def get_test_training_batch(batch_size=4) -> TrainingInputBatch:
         pytest.param(MODEL_NAME, True, 4, 2, 2, 1, None, False, marks=_skip_new_inference, id="colocate_all"),
         pytest.param(MODEL_NAME, False, 2, 2, 1, 1, None, False, id="non_colocated"),
         pytest.param(MODEL_NAME, True, 4, 2, 2, 1, None, True, marks=_skip_new_inference, id="colocate_all_lora"),
-        pytest.param(SMALL_MOE_MODEL_NAME, True, 4, 2, 2, 1, None, True, id="colocate_all_moe"),
+        pytest.param(MOE_MODEL_NAME, True, 4, 2, 2, 1, None, False, id="colocate_all_moe"),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
@@ -119,24 +119,23 @@ def get_test_training_batch(batch_size=4) -> TrainingInputBatch:
 
 
 @pytest.mark.parametrize(
-    ("model", "colocate_all", "inference_tp", "megatron_tp", "megatron_pp", "megatron_ep", "megatron_etp", "lora"),
+    ("colocate_all", "inference_tp", "megatron_tp", "megatron_pp", "megatron_ep", "megatron_etp", "lora"),
     [
-        pytest.param(MODEL_NAME, True, 4, 2, 2, 1, None, False, marks=_skip_new_inference, id="colocate_all"),
-        pytest.param(MODEL_NAME, False, 2, 2, 1, 1, None, False, id="non_colocated"),
-        pytest.param(MODEL_NAME, True, 4, 2, 2, 1, None, True, marks=_skip_new_inference, id="colocate_all_lora"),
-        pytest.param(MOE_MODEL_NAME, False, 2, 2, 1, 1, None, False, id="non_colocated_moe"),
+        pytest.param(True, 4, 2, 2, 1, None, False, marks=_skip_new_inference, id="colocate_all"),
+        pytest.param(False, 2, 2, 1, 1, None, False, id="non_colocated"),
+        pytest.param(True, 4, 2, 2, 1, None, True, marks=_skip_new_inference, id="colocate_all_lora"),
     ],
 )
 @pytest.mark.asyncio
 @pytest.mark.megatron
 async def test_megatron_policy_weight_sync(
-    ray_init_fixture, model, colocate_all, inference_tp, megatron_tp, megatron_pp, megatron_ep, megatron_etp, lora
+    ray_init_fixture, colocate_all, inference_tp, megatron_tp, megatron_pp, megatron_ep, megatron_etp, lora
 ):
     """
     Test that we can sync weights between policy and inference for megatron then run inference
     """
     try:
-        cfg = get_test_actor_config(model_name=model)
+        cfg = get_test_actor_config(model_name=MODEL_NAME)
         if lora:
             cfg.trainer.policy.model.lora = SkyRLLoraConfig(rank=16, alpha=16)
         cfg.trainer.placement.colocate_all = colocate_all
@@ -154,7 +153,7 @@ async def test_megatron_policy_weight_sync(
         # If colocate is True, this will load the engine, sleep, and wake up the engine
         async with InferenceEngineState.create(
             cfg=cfg,
-            model=model,
+            model=MODEL_NAME,
             use_local=True,
             backend="vllm",
             sleep_level=2,  # since we explicitly sync weights
@@ -192,9 +191,9 @@ async def test_megatron_policy_weight_sync(
                 cfg.generator.inference_engine.backend, cfg.generator.sampling_params
             )
             tokenizer = (
-                AutoTokenizer.from_pretrained(model, trust_remote_code=True) if _SKYRL_USE_NEW_INFERENCE else None
+                AutoTokenizer.from_pretrained(MODEL_NAME, trust_remote_code=True) if _SKYRL_USE_NEW_INFERENCE else None
             )
-            outputs = await run_inference(client, get_test_prompts(model), sampling_params, tokenizer=tokenizer)
+            outputs = await run_inference(client, get_test_prompts(MODEL_NAME), sampling_params, tokenizer=tokenizer)
 
             print(f"Example output: {outputs['responses'][0]}, {outputs['stop_reasons'][0]}")
     finally:


### PR DESCRIPTION
# What does this PR do?

in #1271, we added support for using the native vLLM weight sync APis with Megatron. The implementation of `export_weights` can have some edge cases: We filtered by `conversion_tasks=bucket_tasks,` while calling `export_weights`. There is a corner case where user code can parametrize Megatron in a way that adds additional parameters -like adding router expert bias. This causes a mismatch between parameters from `.export_hf_weights(..., conversion_tasks=None)`  and `.export_hf_weights(..., conversion_tasks=self.bridge.get_conversion_tasks(self.actor_module))`. 