### PR TITLE
[fix][CI] Fix cleanup for `test_weight_sync`

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/server_group.py
+++ b/skyrl/backends/skyrl_train/inference_servers/server_group.py
@@ -250,3 +250,7 @@ class ServerGroup:
         if self._pool:
             logger.info("Shutting down servers...")
             self._pool.shutdown()
+
+        if self._internal_pg:
+            # created pg internally, teardown
+            ray.util.remove_placement_group(self._internal_pg)

--- a/skyrl/backends/skyrl_train/inference_servers/server_pool.py
+++ b/skyrl/backends/skyrl_train/inference_servers/server_pool.py
@@ -5,6 +5,7 @@ Generic server actor pool.
 from typing import Any, List, Union
 
 import ray
+from loguru import logger
 
 from skyrl.backends.skyrl_train.inference_servers.common import ServerInfo
 
@@ -72,4 +73,7 @@ class ServerActorPool:
         shutdown_refs = [actor.shutdown.remote() for actor in self._actors]
         ray.get(shutdown_refs)
         for actor in self._actors:
-            ray.kill(actor)
+            try:
+                ray.kill(actor)
+            except Exception as e:
+                logger.info(f"Encountered exception while cleaning up actor {actor}: {e}")

--- a/skyrl/backends/skyrl_train/inference_servers/server_pool.py
+++ b/skyrl/backends/skyrl_train/inference_servers/server_pool.py
@@ -71,3 +71,5 @@ class ServerActorPool:
         """Shutdown all actors."""
         shutdown_refs = [actor.shutdown.remote() for actor in self._actors]
         ray.get(shutdown_refs)
+        for actor in self._actors:
+            ray.kill(actor)

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -431,7 +431,6 @@ async def ipc_weight_update_env(class_scoped_ray_init_fixture, request):
             "router_url": engines.client.proxy_url,
         }
 
-        print("Running cleanup")
         await engines.client.teardown()
         ray.kill(trainer)
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -180,7 +180,6 @@ async def weight_update_env(class_scoped_ray_init_fixture, request):
             "router_url": engines.client.proxy_url,
         }
 
-        print("Entering clenaup right now")
         await engines.client.teardown()
         ray.kill(trainer)
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -119,7 +119,7 @@ class Trainer:
 @pytest_asyncio.fixture(
     params=[
         pytest.param({"enable_pd": False}, id="no_pd"),
-        pytest.param( 
+        pytest.param(
             {"enable_pd": True, "num_prefill": 1, "num_decode": 1},
             id="pd_1P1D_non_colocated",
         ),

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -363,57 +363,19 @@ class IpcTrainer:
         }
 
 
-@pytest_asyncio.fixture(
-    scope="class",
-    params=[
-        pytest.param({"enable_pd": False}, id="no_pd"),
-        pytest.param(
-            {"enable_pd": True, "num_prefill": 1, "num_decode": 1},
-            id="pd_1P1D_colocated",
-        ),
-    ],
-)
-async def ipc_weight_update_env(class_scoped_ray_init_fixture, request):
-    """
-    Create environment for colocated IPC weight update testing.
-
-    Colocated setup with TP=1:
-    - no_pd: Trainer and server share the same GPU via placement group (1 GPU).
-    - pd_1P1D_colocated: 1P1D (2 engines, TP=1), both colocated (2 GPUs).
-    """
-    pd_cfg = request.param
-    enable_pd = pd_cfg["enable_pd"]
+@pytest_asyncio.fixture(scope="class")
+async def ipc_weight_update_env(class_scoped_ray_init_fixture):
+    """Create environment for colocated IPC weight update testing."""
     cfg = SkyRLTrainConfig()
     cfg.trainer.policy.model.path = MODEL
-
-    if enable_pd:
-        num_prefill = pd_cfg["num_prefill"]
-        num_decode = pd_cfg["num_decode"]
-        create_kwargs = dict(
-            model=MODEL,
-            tp_size=1,
-            num_inference_engines=num_prefill + num_decode,
-            colocate_all=True,
-            gpu_memory_utilization=0.5,
-            use_new_inference_servers=True,
-            engine_init_kwargs={
-                "load_format": "dummy",
-                "kv_transfer_config": {
-                    "kv_connector": "NixlConnector",
-                },
-            },
-            enable_pd=True,
-            num_prefill=num_prefill,
-        )
-    else:
-        create_kwargs = dict(
-            model=MODEL,
-            tp_size=1,
-            colocate_all=True,
-            gpu_memory_utilization=0.5,
-            use_new_inference_servers=True,
-            engine_init_kwargs={"load_format": "dummy"},
-        )
+    create_kwargs = dict(
+        model=MODEL,
+        tp_size=1,
+        colocate_all=True,
+        gpu_memory_utilization=0.5,
+        use_new_inference_servers=True,
+        engine_init_kwargs={"load_format": "dummy"},
+    )
 
     async with InferenceEngineState.create(cfg, **create_kwargs) as engines:
         # Trainer on same PG bundle as server (colocated) with fractional GPU

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -182,6 +182,7 @@ async def weight_update_env(class_scoped_ray_init_fixture, request):
 
         await engines.client.teardown()
         ray.kill(trainer)
+    # cleanup manually in colocated case
     if engines.pg:
         ray.util.remove_placement_group(engines.pg)
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -117,6 +117,7 @@ class Trainer:
 
 
 @pytest_asyncio.fixture(
+    scope="class",
     params=[
         pytest.param({"enable_pd": False}, id="no_pd"),
         pytest.param(
@@ -125,7 +126,7 @@ class Trainer:
         ),
     ],
 )
-async def weight_update_env(ray_init_fixture, request):
+async def weight_update_env(class_scoped_ray_init_fixture, request):
     """
     Create environment for weight update testing (non-colocated, NCCL broadcast).
 
@@ -179,14 +180,15 @@ async def weight_update_env(ray_init_fixture, request):
             "router_url": engines.client.proxy_url,
         }
 
+        print("Entering clenaup right now")
         await engines.client.teardown()
         ray.kill(trainer)
 
 
+@pytest.mark.asyncio(loop_scope="class")
 class TestWeightUpdateFlow:
     """Tests for weight synchronization from trainer to inference server (non-colocated)."""
 
-    @pytest.mark.asyncio
     async def test_update_weights_flow(self, weight_update_env):
         """
         Full E2E weight sync test (non-colocated, NCCL broadcast):
@@ -360,6 +362,7 @@ class IpcTrainer:
 
 
 @pytest_asyncio.fixture(
+    scope="class",
     params=[
         pytest.param({"enable_pd": False}, id="no_pd"),
         pytest.param(
@@ -368,7 +371,7 @@ class IpcTrainer:
         ),
     ],
 )
-async def ipc_weight_update_env(ray_init_fixture, request):
+async def ipc_weight_update_env(class_scoped_ray_init_fixture, request):
     """
     Create environment for colocated IPC weight update testing.
 
@@ -429,14 +432,15 @@ async def ipc_weight_update_env(ray_init_fixture, request):
             "router_url": engines.client.proxy_url,
         }
 
+        print("Running cleanup")
         await engines.client.teardown()
         ray.kill(trainer)
 
 
+@pytest.mark.asyncio(loop_scope="class")
 class TestColocatedIpcWeightUpdateFlow:
     """Tests for weight synchronization via CUDA IPC (colocated, TP=1)."""
 
-    @pytest.mark.asyncio
     async def test_update_weights_ipc(self, ipc_weight_update_env):
         """
         Full E2E weight sync test (colocated, CUDA IPC):

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -182,6 +182,8 @@ async def weight_update_env(class_scoped_ray_init_fixture, request):
 
         await engines.client.teardown()
         ray.kill(trainer)
+    if engines.pg:
+        ray.util.remove_placement_group(engines.pg)
 
 
 @pytest.mark.asyncio(loop_scope="class")
@@ -433,6 +435,9 @@ async def ipc_weight_update_env(class_scoped_ray_init_fixture, request):
 
         await engines.client.teardown()
         ray.kill(trainer)
+    # cleanup manually in colocated case
+    if engines.pg:
+        ray.util.remove_placement_group(engines.pg)
 
 
 @pytest.mark.asyncio(loop_scope="class")

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_weight_sync.py
@@ -117,16 +117,15 @@ class Trainer:
 
 
 @pytest_asyncio.fixture(
-    scope="class",
     params=[
         pytest.param({"enable_pd": False}, id="no_pd"),
-        pytest.param(
+        pytest.param( 
             {"enable_pd": True, "num_prefill": 1, "num_decode": 1},
             id="pd_1P1D_non_colocated",
         ),
     ],
 )
-async def weight_update_env(class_scoped_ray_init_fixture, request):
+async def weight_update_env(ray_init_fixture, request):
     """
     Create environment for weight update testing (non-colocated, NCCL broadcast).
 
@@ -181,12 +180,13 @@ async def weight_update_env(class_scoped_ray_init_fixture, request):
         }
 
         await engines.client.teardown()
+        ray.kill(trainer)
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestWeightUpdateFlow:
     """Tests for weight synchronization from trainer to inference server (non-colocated)."""
 
+    @pytest.mark.asyncio
     async def test_update_weights_flow(self, weight_update_env):
         """
         Full E2E weight sync test (non-colocated, NCCL broadcast):
@@ -360,7 +360,6 @@ class IpcTrainer:
 
 
 @pytest_asyncio.fixture(
-    scope="class",
     params=[
         pytest.param({"enable_pd": False}, id="no_pd"),
         pytest.param(
@@ -369,7 +368,7 @@ class IpcTrainer:
         ),
     ],
 )
-async def ipc_weight_update_env(class_scoped_ray_init_fixture, request):
+async def ipc_weight_update_env(ray_init_fixture, request):
     """
     Create environment for colocated IPC weight update testing.
 
@@ -431,12 +430,13 @@ async def ipc_weight_update_env(class_scoped_ray_init_fixture, request):
         }
 
         await engines.client.teardown()
+        ray.kill(trainer)
 
 
-@pytest.mark.asyncio(loop_scope="class")
 class TestColocatedIpcWeightUpdateFlow:
     """Tests for weight synchronization via CUDA IPC (colocated, TP=1)."""
 
+    @pytest.mark.asyncio
     async def test_update_weights_ipc(self, ipc_weight_update_env):
         """
         Full E2E weight sync test (colocated, CUDA IPC):

--- a/tests/backends/skyrl_train/gpu/utils.py
+++ b/tests/backends/skyrl_train/gpu/utils.py
@@ -449,6 +449,10 @@ class InferenceEngineState:
                     group.shutdown()
                 if self._cleanup_pg:
                     if len(group_list):
+                        # TODO (sumanthrh): This is a bit hacky, this assumes pg is the same
+                        # for groups in the group list - which is true for creation in
+                        # `create_inference_servers`
+                        # we should have a better way for cleaning up pg state
                         group = group_list[0]
                         try:
                             ray.util.remove_placement_group(group._get_placement_group())

--- a/tests/backends/skyrl_train/gpu/utils.py
+++ b/tests/backends/skyrl_train/gpu/utils.py
@@ -432,6 +432,7 @@ class InferenceEngineState:
         # internal attribute to track if the inference engines need a wake_up()
         # call before generation
         self._needs_wake_up = False
+        self._cleanup_pg = False
 
     def _close_common(self):
         """Shutdown router, server_group, and Ray actors (sync resources).
@@ -446,6 +447,13 @@ class InferenceEngineState:
             if group_list is not None:
                 for group in group_list:
                     group.shutdown()
+                if self._cleanup_pg:
+                    if len(group_list):
+                        group = group_list[0]
+                        try:
+                            ray.util.remove_placement_group(group._get_placement_group())
+                        except Exception as e:
+                            logger.info(f"Encountered error at pg cleanup: {e}")
 
         if isinstance(self.client, InferenceEngineClient):
             for engine in self.client.engines:
@@ -653,6 +661,7 @@ class InferenceEngineState:
             decode_server_groups=decode_server_groups,
         )
         state._needs_wake_up = needs_wake_up
+        state._cleanup_pg = not shared_pg
         return state
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes cleanup for `test_weight_sync.py`. #1467  added P/D support and this led to weight sync hanging - the root cause was that cleanup logic was incomplete - we had not killed the ray actors explicitly. 

This PR kilsl the trainer actors and fixes serverpool cleanup to kill the vllm server actors. 

Also removed colocated P/D test which is not required

Tests pass with these fixes

