### PR TITLE
[CI] Migrate E2E CI to use new inference

### DIFF
--- a/ci/gpu_e2e_test_run.sh
+++ b/ci/gpu_e2e_test_run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export _SKYRL_USE_NEW_INFERENCE=1
 uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 bash tests/train/gpu_e2e_test/gsm8k_colocate.sh

--- a/ci/gpu_e2e_test_run_fully_async.sh
+++ b/ci/gpu_e2e_test_run_fully_async.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export _SKYRL_USE_NEW_INFERENCE=1
 uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
 bash tests/train/gpu_e2e_test/gsm8k_fully_async.sh

--- a/ci/gpu_e2e_test_run_megatron.sh
+++ b/ci/gpu_e2e_test_run_megatron.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export _SKYRL_USE_NEW_INFERENCE=1
 uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k --max_train_dataset_length 1280
 bash tests/train/gpu_e2e_test/gsm8k_colocate_megatron.sh


### PR DESCRIPTION
# What does this PR do?

Migrates E2E CI to use new inference codepath

TODO: 
- [x] Trigger E2E CI jobs and ensure they pass

All runs are passing:
1. FSDP Sync: https://console.anyscale.com/jobs/prodjob_p3ie4y9za5hptj94gc64vzkb8l
2. Fully Async: https://console.anyscale.com/jobs/prodjob_vqe8ewfy4bdlc9unaqap1m7zlu 
3. Megatron Sync:  https://console.anyscale.com/jobs/prodjob_kbhil9lumj8diak7s9guptpsmf