### PR TITLE
[qoc] Remove unused TrainingInputBatch.metadata["trajectory_ids"]

### DIFF
--- a/skyrl/backends/skyrl_train/training_batch.py
+++ b/skyrl/backends/skyrl_train/training_batch.py
@@ -469,8 +469,8 @@ class TrainingInput(TypedDict, total=False):
     rewards: Optional[Float[torch.Tensor, "batch_size seq_len"]]
     rollout_logprobs: Optional[Float[torch.Tensor, "batch_size seq_len"]]
     rollout_expert_indices: Optional[Integer[torch.Tensor, "batch_size seq_len layer_num topk"]]
-    pixel_values: Optional[TensorList]  # list of [num_patches_i, dim]
-    image_grid_thw: Optional[TensorList]  # list of [num_images_i, 3]
+    pixel_values: Optional[TensorList]  # list of `batch_size` [num_patches_i, dim] tensors
+    image_grid_thw: Optional[TensorList]  # list of `batch_size` [num_images_i, 3] tensors
 
 
 class TrainingInputBatch(TensorBatch[TrainingInput]):

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -277,6 +277,7 @@ class RayPPOTrainer:
                         for key in ["rewards"]:
                             training_input.pop(key)
                         training_input.metadata.pop("uids")
+                        training_input.metadata.pop("is_last_step")
 
                     if self.cfg.trainer.dump_data_batch:
                         # dump data to file
@@ -664,14 +665,9 @@ class RayPPOTrainer:
                 "rollout_expert_indices": rollout_expert_indices_tensor,
                 "pixel_values": pixel_values,
                 "image_grid_thw": image_grid_thw,
-                "is_last_step": (
-                    torch.tensor(generator_output["is_last_step"], dtype=torch.bool)
-                    if generator_output.get("is_last_step", None) is not None
-                    else None
-                ),
             },
         )
-        training_input.metadata = {"uids": uids}
+        training_input.metadata = {"uids": uids, "is_last_step": generator_output.get("is_last_step", None)}
         # padded response length
         training_input.metadata["response_length"] = response_masks_tensor.shape[1]
         batch_num_seq, batch_padded_seq_len = sequences_tensor.shape
@@ -801,6 +797,7 @@ class RayPPOTrainer:
             - `["values"]`: Float[torch.Tensor, "batch_size seqlen"]
             - `["rewards"]`: Float[torch.Tensor, "batch_size seqlen"]
             - `.metadata["uids"]`: List[str]
+            - `.metadata["is_last_step"]`: List[bool] for step-wise training
 
         Adds:
             - `["advantages"]`: Float[torch.Tensor, "batch_size seqlen"]
@@ -809,7 +806,7 @@ class RayPPOTrainer:
         token_level_rewards = data["rewards"]
 
         if self.cfg.generator.step_wise_trajectories:
-            is_last_step = data["is_last_step"].bool()
+            is_last_step = torch.tensor(data.metadata["is_last_step"], dtype=torch.bool)
             index = np.array(data.metadata["uids"])
             values = data["values"]
             # Step-wise only supports outcome-based estimators (GRPO, RLOO, MAXRL); ensured by `validate_cfg`.
@@ -868,7 +865,7 @@ class RayPPOTrainer:
 
         return_sums = token_level_rewards.sum(dim=-1)[: num_samples - pad_size]
         if self.cfg.generator.step_wise_trajectories:
-            avg_rewards: float = return_sums[data["is_last_step"][: num_samples - pad_size]].mean().item()
+            avg_rewards: float = return_sums[is_last_step[: num_samples - pad_size]].mean().item()
         else:
             avg_rewards: float = return_sums.mean().item()
 
@@ -927,10 +924,6 @@ class RayPPOTrainer:
                     pad_indices = [i % n for i in range(pad_size)]
                     padding = TensorList([tensor[i].clone() for i in pad_indices])
                     new_tensors[key] = TensorList.cat([tensor, padding])
-                elif key == "is_last_step":
-                    additional_dims = tensor.shape[1:]
-                    padding_tensor = torch.ones(pad_size, *additional_dims, dtype=tensor.dtype, device=tensor.device)
-                    new_tensors[key] = torch.cat([tensor, padding_tensor], dim=0)
                 elif key == "loss_mask":
                     # ensures that padding tensors don't count towards the loss
                     additional_dims = tensor.shape[1:]
@@ -949,6 +942,10 @@ class RayPPOTrainer:
             if key == "uids":
                 new_training_input.metadata["uids"] = training_input.metadata["uids"] + [
                     f"pad{i}" for i in range(pad_size)
+                ]
+            elif key == "is_last_step":
+                new_training_input.metadata["is_last_step"] = training_input.metadata["is_last_step"] + [
+                    True for i in range(pad_size)
                 ]
             else:
                 new_training_input.metadata[key] = copy.deepcopy(value)

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -277,7 +277,7 @@ class RayPPOTrainer:
                         for key in ["rewards"]:
                             training_input.pop(key)
                         training_input.metadata.pop("uids")
-                        training_input.metadata.pop("is_last_step")
+                        training_input.metadata.pop("is_last_step", None)
 
                     if self.cfg.trainer.dump_data_batch:
                         # dump data to file
@@ -667,7 +667,10 @@ class RayPPOTrainer:
                 "image_grid_thw": image_grid_thw,
             },
         )
-        training_input.metadata = {"uids": uids, "is_last_step": generator_output.get("is_last_step", None)}
+        training_input.metadata = {"uids": uids}
+        if generator_output.get("is_last_step", None) is not None:
+            training_input.metadata["is_last_step"] = generator_output["is_last_step"]
+
         # padded response length
         training_input.metadata["response_length"] = response_masks_tensor.shape[1]
         batch_num_seq, batch_padded_seq_len = sequences_tensor.shape

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -686,9 +686,6 @@ class RayPPOTrainer:
             assert (
                 "trajectory_ids" in generator_output
             ), "Expected `trajectory_ids` in generator output for step wise training"
-            training_input.metadata["trajectory_ids"] = [
-                trajectory_id.to_string() for trajectory_id in generator_output["trajectory_ids"]
-            ]
         training_input.metadata["avg_response_length"] = sum(
             len(sample_response_ids) for sample_response_ids in response_ids
         ) / len(response_ids)
@@ -948,13 +945,12 @@ class RayPPOTrainer:
 
         new_training_input = TrainingInputBatch(new_tensors)
         new_training_input.metadata = {}
-        new_training_input.metadata["uids"] = training_input.metadata["uids"] + [f"pad{i}" for i in range(pad_size)]
-        if "trajectory_ids" in training_input.metadata:
-            new_training_input.metadata["trajectory_ids"] = training_input.metadata["trajectory_ids"] + [
-                f"pad{i}" for i in range(pad_size)
-            ]
         for key, value in training_input.metadata.items():
-            if key not in ["uids", "trajectory_ids"]:
+            if key == "uids":
+                new_training_input.metadata["uids"] = training_input.metadata["uids"] + [
+                    f"pad{i}" for i in range(pad_size)
+                ]
+            else:
                 new_training_input.metadata[key] = copy.deepcopy(value)
         return new_training_input
 

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -623,6 +623,12 @@ def validate_generator_output(num_prompts: int, generator_output: GeneratorOutpu
             "loss_masks",
             "rewards",
             "rollout_logprobs",
+            "stop_reasons",
+            "trajectory_ids",
+            "rollout_expert_indices",
+            "is_last_step",
+            "pixel_values",
+            "image_grid_thw",
         ]:
             assert len(generator_output[key]) == len(generator_output["response_ids"]), (
                 f"Generator output {key} length must be equal to response_ids length, "

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -213,7 +213,7 @@ def test_calc_advantages_and_returns_step_wise_broadcast(dummy_config):
     # position where that step's response_mask is 1. Traj A -> 2.0, Traj B -> 0.0.
     rewards = torch.zeros(batch_size, seqlen)
     rewards[1, -1] = 2.0
-    is_last_step = torch.tensor([False, True, False, True])
+    is_last_step = [False, True, False, True]
 
     data = TrainingInputBatch(
         {
@@ -223,7 +223,6 @@ def test_calc_advantages_and_returns_step_wise_broadcast(dummy_config):
             "response_mask": response_mask,
             "rewards": rewards,
             "values": torch.zeros(batch_size, seqlen),
-            "is_last_step": is_last_step,
         },
     )
     # Both trajectories share a GRPO group so the group has the 2 samples needed to produce a mean.
@@ -231,6 +230,7 @@ def test_calc_advantages_and_returns_step_wise_broadcast(dummy_config):
         "uids": np.array(["grp0", "grp0", "grp0", "grp0"]),
         "response_length": seqlen,
         "avg_response_length": (4 + 1 + 3 + 2) / 4,
+        "is_last_step": is_last_step,
     }
 
     data = trainer.compute_advantages_and_returns(data)


### PR DESCRIPTION
Remove unused `TrainingInputBatch.metadata["trajectory_ids"]` from `trainer.py`'s `convert_to_training_input` and hence `pad_batch()` logics.

Also add more length checkings for fields in `validate_generator_output()`.

Move `is_last_step` from `TrainingInput` to `metadata` as well.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
