### PR TITLE
Modify SkyRL Generator to Append Router Indices in Multi-Turn

### DIFF
--- a/examples/train/search/run_search_router_replay.sh
+++ b/examples/train/search/run_search_router_replay.sh
@@ -1,0 +1,139 @@
+set -x
+
+# follow the instructions in examples/train/search/README.md for setting up the
+# SearchR1 dataset and starting the local search server.
+#
+# R3 requires:
+#   * trainer.strategy=megatron (only backend that supports routing replay)
+#   * generator.inference_engine.distributed_executor_backend=mp
+#       - hangs related to Ray Compiled Graph occur with the default ray
+#         executor when vLLM returns routed_experts; see
+#         https://github.com/vllm-project/vllm/issues/36237
+#       - mp executor currently forces single-node serving per engine, which
+#         is why INFERENCE_ENGINE_TP is bounded by NUM_GPUS_PER_NODE.
+#   * an MoE base model (defaults to Qwen3-30B-A3B).
+#
+# Multi-turn search-r1 runs up to 4 turns, the generator merges R3
+# expert indices across turns using append-only. 
+#
+# Usage:
+#   export WANDB_API_KEY=<your_key_here>
+#   bash examples/train/search/run_search_router_replay.sh
+#
+# Configurable knobs (override via env vars or command-line args):
+#   USE_CONVERSATION_MULTI_TURN - "true" to use conversation multi-turn format
+#                                  (default: false, matches run_search.sh).
+#                                  STEP_WISE is unsupported with R3 and will
+#                                  error out in _validate_cfg if enabled.
+
+# Dataset path (shared storage across nodes, or local storage on each node)
+DATA_DIR="$HOME/data/searchR1"
+
+MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3-30B-A3B}"
+
+NUM_NODES=${NUM_NODES:-4}
+NUM_GPUS_PER_NODE=${NUM_GPUS_PER_NODE:-8}
+
+MEGATRON_TP=${MEGATRON_TP:-2}
+MEGATRON_PP=${MEGATRON_PP:-1}
+MEGATRON_CP=${MEGATRON_CP:-1}
+MEGATRON_EP=${MEGATRON_EP:-8}
+MEGATRON_ETP=${MEGATRON_ETP:-1}
+
+MICRO_TRAIN_BATCH_SIZE_PER_GPU=${MICRO_TRAIN_BATCH_SIZE_PER_GPU:-1}
+MICRO_FORWARD_BATCH_SIZE_PER_GPU=${MICRO_FORWARD_BATCH_SIZE_PER_GPU:-2}
+
+# mp executor requires single-node-per-engine; keep INFERENCE_ENGINE_TP <= NUM_GPUS_PER_NODE.
+NUM_INFERENCE_ENGINES=${NUM_INFERENCE_ENGINES:-4}
+INFERENCE_ENGINE_TP=${INFERENCE_ENGINE_TP:-8}
+
+# Router replay (R3) settings
+ROUTER_REPLAY=${ROUTER_REPLAY:-true}
+DISTRIBUTED_EXECUTOR_BACKEND="mp"
+
+# Multi-turn knobs (mirrored from run_search.sh; step-wise disallowed with R3)
+: "${USE_CONVERSATION_MULTI_TURN:=false}"
+
+MULTI_TURN_ARGS=""
+if [ "$USE_CONVERSATION_MULTI_TURN" = "true" ]; then
+  MULTI_TURN_ARGS="generator.use_conversation_multi_turn=true generator.append_eos_token_after_stop_str_in_multi_turn=true"
+else
+  MULTI_TURN_ARGS="generator.use_conversation_multi_turn=false"
+fi
+
+RUN_NAME="skyrl-search_r3_${MODEL_NAME//\//_}_tp${MEGATRON_TP}_pp${MEGATRON_PP}_ep${MEGATRON_EP}"
+
+SKYRL_RAY_PG_TIMEOUT_IN_S=300 uv run --isolated --frozen --extra megatron -m skyrl.train.entrypoints.main_base \
+  data.train_data="['${DATA_DIR}/train.parquet']" \
+  data.val_data="['${DATA_DIR}/validation.parquet']" \
+  trainer.algorithm.advantage_estimator="grpo" \
+  trainer.policy.optimizer_config.lr=1.0e-6 \
+  trainer.policy.optimizer_config.max_grad_norm=0.5 \
+  trainer.policy.optimizer_config.num_warmup_steps=94 \
+  trainer.algorithm.use_kl_loss=true \
+  trainer.algorithm.kl_loss_coef=0.001 \
+  trainer.policy.model.path=$MODEL_NAME \
+  trainer.placement.colocate_all=true \
+  trainer.strategy=megatron \
+  trainer.placement.policy_num_nodes=$NUM_NODES \
+  trainer.placement.ref_num_nodes=$NUM_NODES \
+  trainer.placement.policy_num_gpus_per_node=$NUM_GPUS_PER_NODE \
+  trainer.placement.ref_num_gpus_per_node=$NUM_GPUS_PER_NODE \
+  trainer.policy.megatron_config.tensor_model_parallel_size=$MEGATRON_TP \
+  trainer.policy.megatron_config.pipeline_model_parallel_size=$MEGATRON_PP \
+  trainer.policy.megatron_config.context_parallel_size=$MEGATRON_CP \
+  trainer.policy.megatron_config.expert_model_parallel_size=$MEGATRON_EP \
+  trainer.policy.megatron_config.expert_tensor_parallel_size=$MEGATRON_ETP \
+  trainer.policy.megatron_config.moe_enable_routing_replay=$ROUTER_REPLAY \
+  trainer.ref.megatron_config.tensor_model_parallel_size=$MEGATRON_TP \
+  trainer.ref.megatron_config.context_parallel_size=$MEGATRON_CP \
+  trainer.ref.megatron_config.pipeline_model_parallel_size=$MEGATRON_PP \
+  trainer.ref.megatron_config.expert_model_parallel_size=$MEGATRON_EP \
+  trainer.ref.megatron_config.expert_tensor_parallel_size=$MEGATRON_ETP \
+  generator.inference_engine.num_engines=$NUM_INFERENCE_ENGINES \
+  generator.inference_engine.tensor_parallel_size=$INFERENCE_ENGINE_TP \
+  generator.inference_engine.backend=vllm \
+  generator.inference_engine.run_engines_locally=true \
+  generator.inference_engine.weight_sync_backend=nccl \
+  generator.inference_engine.gpu_memory_utilization=0.6 \
+  generator.inference_engine.async_engine=true \
+  generator.inference_engine.enable_return_routed_experts=$ROUTER_REPLAY \
+  generator.inference_engine.distributed_executor_backend=$DISTRIBUTED_EXECUTOR_BACKEND \
+  trainer.use_sample_packing=true \
+  trainer.epochs=1 \
+  trainer.update_epochs_per_batch=1 \
+  trainer.train_batch_size=512 \
+  trainer.policy_mini_batch_size=256 \
+  trainer.micro_forward_batch_size_per_gpu=$MICRO_FORWARD_BATCH_SIZE_PER_GPU \
+  trainer.micro_train_batch_size_per_gpu=$MICRO_TRAIN_BATCH_SIZE_PER_GPU \
+  trainer.max_prompt_length=2048 \
+  generator.max_input_length=4096 \
+  generator.sampling_params.max_generate_length=500 \
+  generator.batched=false \
+  $MULTI_TURN_ARGS \
+  generator.n_samples_per_prompt=5 \
+  generator.max_turns=4 \
+  generator.sampling_params.temperature=1.0 \
+  generator.sampling_params.top_p=1.0 \
+  generator.sampling_params.stop='["</search>", "</answer>"]' \
+  environment.env_class="search" \
+  environment.skyrl_gym.max_env_workers=16 \
+  environment.skyrl_gym.search.log_requests=false \
+  environment.skyrl_gym.search.search_url="http://127.0.0.1:8000/retrieve" \
+  environment.skyrl_gym.search.topk=3 \
+  trainer.logger="wandb" \
+  trainer.project_name="skyrl-search-r3" \
+  trainer.run_name="${RUN_NAME}" \
+  trainer.ckpt_interval=20 \
+  trainer.hf_save_interval=100 \
+  trainer.max_ckpts_to_keep=5 \
+  trainer.resume_mode=null \
+  trainer.ckpt_path="$HOME/${RUN_NAME}" \
+  trainer.eval_batch_size=256 \
+  trainer.eval_before_train=false \
+  generator.eval_sampling_params.temperature=0 \
+  generator.eval_sampling_params.stop='["</search>", "</answer>"]' \
+  generator.eval_sampling_params.max_generate_length=500 \
+  trainer.export_path="$HOME/${RUN_NAME}/exports" \
+  trainer.eval_interval=50 \
+  $@

--- a/examples/train/search/run_search_router_replay.sh
+++ b/examples/train/search/run_search_router_replay.sh
@@ -29,9 +29,9 @@ set -x
 # Dataset path (shared storage across nodes, or local storage on each node)
 DATA_DIR="$HOME/data/searchR1"
 
-MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3-30B-A3B}"
+MODEL_NAME="/home/ray/models/Qwen3-30B-A3B"
 
-NUM_NODES=${NUM_NODES:-4}
+NUM_NODES=${NUM_NODES:-2}
 NUM_GPUS_PER_NODE=${NUM_GPUS_PER_NODE:-8}
 
 MEGATRON_TP=${MEGATRON_TP:-2}
@@ -44,7 +44,7 @@ MICRO_TRAIN_BATCH_SIZE_PER_GPU=${MICRO_TRAIN_BATCH_SIZE_PER_GPU:-1}
 MICRO_FORWARD_BATCH_SIZE_PER_GPU=${MICRO_FORWARD_BATCH_SIZE_PER_GPU:-2}
 
 # mp executor requires single-node-per-engine; keep INFERENCE_ENGINE_TP <= NUM_GPUS_PER_NODE.
-NUM_INFERENCE_ENGINES=${NUM_INFERENCE_ENGINES:-4}
+NUM_INFERENCE_ENGINES=${NUM_INFERENCE_ENGINES:-1}
 INFERENCE_ENGINE_TP=${INFERENCE_ENGINE_TP:-8}
 
 # Router replay (R3) settings
@@ -95,20 +95,20 @@ SKYRL_RAY_PG_TIMEOUT_IN_S=300 uv run --isolated --frozen --extra megatron -m sky
   generator.inference_engine.backend=vllm \
   generator.inference_engine.run_engines_locally=true \
   generator.inference_engine.weight_sync_backend=nccl \
-  generator.inference_engine.gpu_memory_utilization=0.6 \
+  generator.inference_engine.gpu_memory_utilization=0.35 \
   generator.inference_engine.async_engine=true \
   generator.inference_engine.enable_return_routed_experts=$ROUTER_REPLAY \
   generator.inference_engine.distributed_executor_backend=$DISTRIBUTED_EXECUTOR_BACKEND \
   trainer.use_sample_packing=true \
   trainer.epochs=1 \
   trainer.update_epochs_per_batch=1 \
-  trainer.train_batch_size=512 \
-  trainer.policy_mini_batch_size=256 \
+  trainer.train_batch_size=256 \
+  trainer.policy_mini_batch_size=128 \
   trainer.micro_forward_batch_size_per_gpu=$MICRO_FORWARD_BATCH_SIZE_PER_GPU \
   trainer.micro_train_batch_size_per_gpu=$MICRO_TRAIN_BATCH_SIZE_PER_GPU \
   trainer.max_prompt_length=2048 \
   generator.max_input_length=4096 \
-  generator.sampling_params.max_generate_length=500 \
+  generator.sampling_params.max_generate_length=256 \
   generator.batched=false \
   $MULTI_TURN_ARGS \
   generator.n_samples_per_prompt=5 \

--- a/examples/train/search/run_search_router_replay.sh
+++ b/examples/train/search/run_search_router_replay.sh
@@ -29,9 +29,9 @@ set -x
 # Dataset path (shared storage across nodes, or local storage on each node)
 DATA_DIR="$HOME/data/searchR1"
 
-MODEL_NAME="/home/ray/models/Qwen3-30B-A3B"
+MODEL_NAME=${MODEL_NAME:-"/home/ray/models/Moonlight-16B-A3B-Instruct"}
 
-NUM_NODES=${NUM_NODES:-2}
+NUM_NODES=${NUM_NODES:-1}
 NUM_GPUS_PER_NODE=${NUM_GPUS_PER_NODE:-8}
 
 MEGATRON_TP=${MEGATRON_TP:-2}
@@ -73,6 +73,7 @@ SKYRL_RAY_PG_TIMEOUT_IN_S=300 uv run --isolated --frozen --extra megatron -m sky
   trainer.algorithm.use_kl_loss=true \
   trainer.algorithm.kl_loss_coef=0.001 \
   trainer.policy.model.path=$MODEL_NAME \
+  trainer.flash_attn=false \
   trainer.placement.colocate_all=true \
   trainer.strategy=megatron \
   trainer.placement.policy_num_nodes=$NUM_NODES \

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -1072,13 +1072,14 @@ class SkyRLGymGenerator(GeneratorInterface):
             self.generator_cfg.inference_engine.enable_return_routed_experts
             and turn_output.rollout_expert_indices is not None
         ):
-            # overwrite the existing rollout inference indices, since the inference engine should
-            # return the expert indices for the entire sequence including each turn's input and observation tokens
-            # and the final response should not have an observation appended to it
+            # append the rollout expert indices for the current turn, including both
+            # the response and observation tokens
 
-            # TODO(Dev): append here for single-turn?
+            rollout_expert_indices_for_turn = turn_output.rollout_expert_indices[
+                : len(agent_loop_state.input_ids) - len(obs_ids_to_add)
+            ]
             agent_loop_state.rollout_expert_indices = append_rollout_expert_indices(
-                agent_loop_state.rollout_expert_indices, turn_output.rollout_expert_indices
+                agent_loop_state.rollout_expert_indices, rollout_expert_indices_for_turn
             )
 
         return agent_loop_state

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -35,6 +35,7 @@ from skyrl.train.generators.utils import (
     get_custom_chat_template,
     get_generation_prompt_ids,
     get_rollout_metrics,
+    append_rollout_expert_indices,
 )
 from skyrl_gym.envs.base_text_env import BaseTextEnvStepOutput
 
@@ -967,6 +968,8 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         # use the raw rollout expert indices without any appending of observation tokens
         # this will be overwritten each turn, so we don't need to append observation tokens to it
+
+        # TODO(Dev): append?
         rollout_expert_indices_for_turn = turn_output.rollout_expert_indices
 
         if self.generator_cfg.step_wise_trajectories:
@@ -988,7 +991,10 @@ class SkyRLGymGenerator(GeneratorInterface):
                 # overwrite the existing rollout inference indices, since the inference engine should
                 # return the expert indices for the entire sequence including each turn's input
                 # and the final response should not have an observation appended to it
-                agent_loop_state.rollout_expert_indices = rollout_expert_indices_for_turn
+                
+                ## append, not overwrite 
+                agent_loop_state.rollout_expert_indices = append_rollout_expert_indices(
+                    agent_loop_state.rollout_expert_indices, rollout_expert_indices_for_turn)
 
         return agent_loop_state
 
@@ -1066,6 +1072,9 @@ class SkyRLGymGenerator(GeneratorInterface):
             # overwrite the existing rollout inference indices, since the inference engine should
             # return the expert indices for the entire sequence including each turn's input and observation tokens
             # and the final response should not have an observation appended to it
-            agent_loop_state.rollout_expert_indices = turn_output.rollout_expert_indices
+
+            # TODO(Dev): append here for single-turn?
+            agent_loop_state.rollout_expert_indices = append_rollout_expert_indices(
+                agent_loop_state.rollout_expert_indices, turn_output.rollout_expert_indices)
 
         return agent_loop_state

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -31,11 +31,11 @@ from skyrl.train.generators.base import (
     TrajectoryID,
 )
 from skyrl.train.generators.utils import (
+    append_rollout_expert_indices,
     apply_overlong_filtering,
     get_custom_chat_template,
     get_generation_prompt_ids,
     get_rollout_metrics,
-    append_rollout_expert_indices,
 )
 from skyrl_gym.envs.base_text_env import BaseTextEnvStepOutput
 
@@ -990,13 +990,14 @@ class SkyRLGymGenerator(GeneratorInterface):
                 # overwrite the existing rollout inference indices, since the inference engine should
                 # return the expert indices for the entire sequence including each turn's input
                 # and the final response should not have an observation appended to it
-                
+
                 ## TODO(Dev): Fix comments above – prior-turn routings for positions the
                 # prior turn already decoded, append the new turn's routings for
-                # any new positions 
-                
+                # any new positions
+
                 agent_loop_state.rollout_expert_indices = append_rollout_expert_indices(
-                    agent_loop_state.rollout_expert_indices, rollout_expert_indices_for_turn)
+                    agent_loop_state.rollout_expert_indices, rollout_expert_indices_for_turn
+                )
 
         return agent_loop_state
 
@@ -1077,6 +1078,7 @@ class SkyRLGymGenerator(GeneratorInterface):
 
             # TODO(Dev): append here for single-turn?
             agent_loop_state.rollout_expert_indices = append_rollout_expert_indices(
-                agent_loop_state.rollout_expert_indices, turn_output.rollout_expert_indices)
+                agent_loop_state.rollout_expert_indices, turn_output.rollout_expert_indices
+            )
 
         return agent_loop_state

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -969,7 +969,6 @@ class SkyRLGymGenerator(GeneratorInterface):
         # use the raw rollout expert indices without any appending of observation tokens
         # this will be overwritten each turn, so we don't need to append observation tokens to it
 
-        # TODO(Dev): append?
         rollout_expert_indices_for_turn = turn_output.rollout_expert_indices
 
         if self.generator_cfg.step_wise_trajectories:
@@ -992,7 +991,10 @@ class SkyRLGymGenerator(GeneratorInterface):
                 # return the expert indices for the entire sequence including each turn's input
                 # and the final response should not have an observation appended to it
                 
-                ## append, not overwrite 
+                ## TODO(Dev): Fix comments above – prior-turn routings for positions the
+                # prior turn already decoded, append the new turn's routings for
+                # any new positions 
+                
                 agent_loop_state.rollout_expert_indices = append_rollout_expert_indices(
                     agent_loop_state.rollout_expert_indices, rollout_expert_indices_for_turn)
 

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -574,3 +574,14 @@ def get_response_ids_and_loss_mask_from_messages(
         assert len(rollout_logprobs) == len(response_ids) if rollout_logprobs is not None else True
 
     return response_ids, loss_mask, rollout_logprobs
+
+
+def append_rollout_expert_indices(
+    rollout_expert_indices: List[List[List[int]]],
+    new_rollout_expert_indices: List[List[List[int]]],
+) -> List[List[List[int]]]:
+
+    existing_len = len(rollout_expert_indices)
+    if existing_len < len(new_rollout_expert_indices):
+        return rollout_expert_indices + new_rollout_expert_indices[existing_len:]
+    return rollout_expert_indices

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_router_replay.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_router_replay.py
@@ -118,11 +118,7 @@ def build_training_input_from_text_samples(
     "max_turns,env_class",
     [
         pytest.param(1, "gsm8k", id="single_turn"),
-        # Multi-turn variant exercises the append-only R3 merge path: turn 2's
-        # vLLM call re-prefills turn 1's tokens, but our merge keeps turn 1's
-        # routings for those positions. With correct append semantics the
-        # logprob diff vs vLLM should still drop when routing replay is on.
-        pytest.param(2, "gsm8k_multi_turn", id="multi_turn_append_only"),
+        pytest.param(2, "gsm8k_multi_turn", id="multi_turn"),
     ],
 )
 async def test_logprobs(ray_init_fixture, tp, pp, cp, ep, etp, extra_tf_kwargs, max_turns, env_class):
@@ -141,9 +137,6 @@ async def test_logprobs(ray_init_fixture, tp, pp, cp, ep, etp, extra_tf_kwargs, 
         )
         cfg.generator.batched = False
         cfg.generator.max_turns = max_turns
-        # The multi-turn case must use conversation-style multi-turn so that
-        # `_update_agent_loop_state_with_multiturn_chat_template` is exercised
-        # and the append-only merge runs across turns.
         cfg.generator.use_conversation_multi_turn = True
 
         tokenizer = AutoTokenizer.from_pretrained(MOE_MODEL_NAME, trust_remote_code=True)

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_router_replay.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_router_replay.py
@@ -114,7 +114,18 @@ def build_training_input_from_text_samples(
         pytest.param(2, 2, 2, 4, 1, {"num_layers_in_first_pipeline_stage": 13}, id="max_parallelism"),
     ],
 )
-async def test_logprobs(ray_init_fixture, tp, pp, cp, ep, etp, extra_tf_kwargs):
+@pytest.mark.parametrize(
+    "max_turns,env_class",
+    [
+        pytest.param(1, "gsm8k", id="single_turn"),
+        # Multi-turn variant exercises the append-only R3 merge path: turn 2's
+        # vLLM call re-prefills turn 1's tokens, but our merge keeps turn 1's
+        # routings for those positions. With correct append semantics the
+        # logprob diff vs vLLM should still drop when routing replay is on.
+        pytest.param(2, "gsm8k_multi_turn", id="multi_turn_append_only"),
+    ],
+)
+async def test_logprobs(ray_init_fixture, tp, pp, cp, ep, etp, extra_tf_kwargs, max_turns, env_class):
     """
     Check that logprob diff is lower when using router replay. Requires full 8xH100 setup to do full forward pass.
     """
@@ -129,7 +140,11 @@ async def test_logprobs(ray_init_fixture, tp, pp, cp, ep, etp, extra_tf_kwargs):
             temperature=1.0,
         )
         cfg.generator.batched = False
-        cfg.generator.max_turns = 1
+        cfg.generator.max_turns = max_turns
+        # The multi-turn case must use conversation-style multi-turn so that
+        # `_update_agent_loop_state_with_multiturn_chat_template` is exercised
+        # and the append-only merge runs across turns.
+        cfg.generator.use_conversation_multi_turn = True
 
         tokenizer = AutoTokenizer.from_pretrained(MOE_MODEL_NAME, trust_remote_code=True)
 
@@ -157,7 +172,7 @@ async def test_logprobs(ray_init_fixture, tp, pp, cp, ep, etp, extra_tf_kwargs):
                 num_prompts=NUM_PROMPTS,
                 n_samples_per_prompt=N_SAMPLES_PER_PROMPT,
                 max_prompt_length=512,
-                env_class="gsm8k",
+                env_class=env_class,
             )
             input_batch["sampling_params"] = get_sampling_params_for_backend(
                 "vllm",

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py
@@ -482,12 +482,7 @@ async def test_generator_multi_turn_gsm8k_step_wise(ray_init_fixture):
 async def test_generator_multi_turn_gsm8k_router_replay(ray_init_fixture, use_conversation_multi_turn):
     """
     Test the generator with the multi-turn GSM8K environment for router replay.
-
-    Verifies both that R3 indices are returned in the expected shape and that
-    the multi-turn append-only merge preserves the vLLM length invariant
-    ``len(indices_i) == prompt_len_i + response_len_i - 1`` for every sample.
-    Runs with both conversation-style multi-turn (a new assistant message per
-    turn) and single-turn-chat-template (everything in one assistant message).
+    Runs with multi-turn and single-turn chat template.
     """
     num_prompts = 5
     n_samples_per_prompt = 2
@@ -525,12 +520,7 @@ async def test_generator_multi_turn_gsm8k_router_replay(ray_init_fixture, use_co
     assert len(rollout_expert_indices[0][0]) == 16  # 16 layers in OLMoE-1B-7B-0924
     assert len(rollout_expert_indices[0][0][0]) == 8  # 8 topk for each layer
 
-    # Append-only merge invariant: vLLM returns ``num_tokens - 1`` routings per
-    # request (the very last decoded token is never re-fed and has no routing).
-    # Across multi-turn append, the final accumulated length must equal the
-    # full sequence length minus 1 -- i.e. prompt + response - 1. If a turn
-    # had its EOS appended manually (single-turn chat template path), the
-    # generator pads one extra zero entry, giving exactly prompt + response.
+   
     for i in range(total_batch_size):
         prompt_len = len(prompt_token_ids[i])
         response_len = len(response_ids[i])

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py
@@ -520,7 +520,6 @@ async def test_generator_multi_turn_gsm8k_router_replay(ray_init_fixture, use_co
     assert len(rollout_expert_indices[0][0]) == 16  # 16 layers in OLMoE-1B-7B-0924
     assert len(rollout_expert_indices[0][0][0]) == 8  # 8 topk for each layer
 
-   
     for i in range(total_batch_size):
         prompt_len = len(prompt_token_ids[i])
         response_len = len(response_ids[i])

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_skyrl_gym_generator.py
@@ -471,9 +471,23 @@ async def test_generator_multi_turn_gsm8k_step_wise(ray_init_fixture):
 
 
 @pytest.mark.asyncio
-async def test_generator_multi_turn_gsm8k_router_replay(ray_init_fixture):
+@pytest.mark.parametrize(
+    "use_conversation_multi_turn",
+    [True, False],
+    ids=[
+        "test_generator_multi_turn_gsm8k_router_replay_conversation",
+        "test_generator_multi_turn_gsm8k_router_replay_singleturn_chat",
+    ],
+)
+async def test_generator_multi_turn_gsm8k_router_replay(ray_init_fixture, use_conversation_multi_turn):
     """
-    Test the generator with the multi-turn GSM8K environment for router replay
+    Test the generator with the multi-turn GSM8K environment for router replay.
+
+    Verifies both that R3 indices are returned in the expected shape and that
+    the multi-turn append-only merge preserves the vLLM length invariant
+    ``len(indices_i) == prompt_len_i + response_len_i - 1`` for every sample.
+    Runs with both conversation-style multi-turn (a new assistant message per
+    turn) and single-turn-chat-template (everything in one assistant message).
     """
     num_prompts = 5
     n_samples_per_prompt = 2
@@ -492,7 +506,7 @@ async def test_generator_multi_turn_gsm8k_router_replay(ray_init_fixture):
         env_class="gsm8k_multi_turn",
         num_prompts=num_prompts,
         max_turns=2,
-        use_conversation_multi_turn=True,
+        use_conversation_multi_turn=use_conversation_multi_turn,
         max_env_workers=0,
         is_step_wise=False,
         temperature=0,
@@ -502,9 +516,28 @@ async def test_generator_multi_turn_gsm8k_router_replay(ray_init_fixture):
 
     # check that the rollout expert indices are non-zero, and that the shape is (bs, seq_len, layer_num, topk)
     rollout_expert_indices = generator_output["rollout_expert_indices"]
+    prompt_token_ids = generator_output["prompt_token_ids"]
+    response_ids = generator_output["response_ids"]
     total_batch_size = num_prompts * n_samples_per_prompt
 
     assert len(rollout_expert_indices) == total_batch_size
     assert len(rollout_expert_indices[0]) < max_input_length
     assert len(rollout_expert_indices[0][0]) == 16  # 16 layers in OLMoE-1B-7B-0924
     assert len(rollout_expert_indices[0][0][0]) == 8  # 8 topk for each layer
+
+    # Append-only merge invariant: vLLM returns ``num_tokens - 1`` routings per
+    # request (the very last decoded token is never re-fed and has no routing).
+    # Across multi-turn append, the final accumulated length must equal the
+    # full sequence length minus 1 -- i.e. prompt + response - 1. If a turn
+    # had its EOS appended manually (single-turn chat template path), the
+    # generator pads one extra zero entry, giving exactly prompt + response.
+    for i in range(total_batch_size):
+        prompt_len = len(prompt_token_ids[i])
+        response_len = len(response_ids[i])
+        indices_len = len(rollout_expert_indices[i])
+        expected = prompt_len + response_len
+        assert indices_len in (expected - 1, expected), (
+            f"Sample {i}: rollout_expert_indices length {indices_len} != "
+            f"prompt+response-1 ({expected - 1}) or prompt+response ({expected}); "
+            f"prompt_len={prompt_len}, response_len={response_len}"
+        )

--- a/tests/train/generators/test_utils.py
+++ b/tests/train/generators/test_utils.py
@@ -8,7 +8,6 @@ import pytest
 from transformers import AutoTokenizer
 
 from skyrl.train.generators.utils import (
-    append_rollout_expert_indices,
     apply_overlong_filtering,
     encode_messages_subset,
     get_generation_prompt_ids,

--- a/tests/train/generators/test_utils.py
+++ b/tests/train/generators/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from skyrl.train.generators.utils import (
+    append_rollout_expert_indices,
     apply_overlong_filtering,
     encode_messages_subset,
     get_generation_prompt_ids,


### PR DESCRIPTION
vLLM returns new expert indices across prior turns which can often differ from the actual routing decisions that were used in earlier turns. 

Turn 1:
Input: [A] w/ R3 indices A_r
Output: [B] w/ R3 indices B_r
Observation: O

Record [A_r, B_r].

Turn 2:
Input: [A, B, O] w/ R3 indices [AB_r, O_r]
Output: [C] w/ R3 indices C_r

The previous approach was to override the recorded indices, but in the case that [AB_r, O_r] != [A_r, B_r], we need to instead append O and C to the original recorded indices instead. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
