### PR TITLE
[CI] Fix timeout failures in E2E CI pipelines

### DIFF
--- a/.github/workflows/gpu_e2e_ci.yaml
+++ b/.github/workflows/gpu_e2e_ci.yaml
@@ -42,6 +42,6 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
           envsubst < ci/anyscale_gpu_e2e_test.yaml > ci/anyscale_gpu_e2e_test_envsubst.yaml
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_envsubst.yaml --timeout 4500
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test --timeout 4500
+          anyscale job submit -f ci/anyscale_gpu_e2e_test_envsubst.yaml --timeout 5000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test --timeout 5000
           rm -f ci/anyscale_gpu_e2e_test_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_fully_async.yaml
+++ b/.github/workflows/gpu_e2e_ci_fully_async.yaml
@@ -42,6 +42,6 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_fully_async.yaml > ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml --timeout 4500
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test-fully-async --timeout 4500
+          anyscale job submit -f ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml --timeout 5000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test-fully-async --timeout 5000
           rm -f ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml

--- a/ci/gpu_e2e_test_run_fully_async.sh
+++ b/ci/gpu_e2e_test_run_fully_async.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 export _SKYRL_USE_NEW_INFERENCE=1
-# Use onlt 2500 samples for the CI run
+# Use only 2500 samples for the CI run
 uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k --max_train_dataset_length 2500
 bash tests/train/gpu_e2e_test/gsm8k_fully_async.sh

--- a/ci/gpu_e2e_test_run_fully_async.sh
+++ b/ci/gpu_e2e_test_run_fully_async.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 export _SKYRL_USE_NEW_INFERENCE=1
-uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
+# Use onlt 2500 samples for the CI run
+uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k --max_train_dataset_length 2500
 bash tests/train/gpu_e2e_test/gsm8k_fully_async.sh


### PR DESCRIPTION
# what does this PR do?

Fixes timeout issues in E2E CI workflows

1. Sync E2E CI: Since Sept, this workflow takes close to 1h 12m to run, but the timeout value is 4500. This makes it very close to timing out and we've seen some failures in the pipeline recently because the run was a few minutes off. 
2. Fully async E2E CI: The batch sizes used in the default script are small and 1 epoch takes 3h 14m on a 4xL4 node ([internal Anyscale job link](https://console.anyscale.com/cld_hxkifz7xa22mwicp21nzkds1lw/prj_4b6c498rypyq6g7yhk6vzgjevt/jobs/prodjob_vqe8ewfy4bdlc9unaqap1m7zlu?job-tab=overview)). I don't think a full run is even needed here - so I'm switching to a smaller subset for now (compared to the sync runs). I triggered a job manually and this takes ~ 72 mins for completion now (took ~1m 30 s to start). So a timeout of 5000 s should be tight enough to catch regressions