### PR TITLE
[stepwise] Plumb through step-wise training for fully async

### DIFF
--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -623,11 +623,13 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         uids = []
         stalenesses = []
         staleness_violation_count = 0
-        group_size = len(cur_generation_group_mini_batch[0].generator_output["response_ids"])
         for cur_generated_output_group in cur_generation_group_mini_batch:
             cur_staleness = self.global_step - cur_generated_output_group.global_step_when_scheduled
             stalenesses.append(cur_staleness)
             generator_outputs.append(cur_generated_output_group.generator_output)
+            # NOTE(Charlie): for step-wise training each group can contain a variable number of entries
+            # (n_samples_per_prompt * variable turns_per_trajectory), so the uid fanout is per-group.
+            group_size = len(cur_generated_output_group.generator_output["response_ids"])
             uids.extend([cur_generated_output_group.uid] * group_size)
 
             # Check staleness violation.
@@ -642,7 +644,9 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 )
                 staleness_violation_count += 1
 
-        generator_output = concatenate_generator_outputs(generator_outputs)
+        generator_output = concatenate_generator_outputs(
+            generator_outputs, step_wise=self.cfg.generator.step_wise_trajectories
+        )
         assert generator_output["rollout_metrics"] is not None, "Rollout metrics should be non-null."
         self.all_metrics.update(generator_output["rollout_metrics"])
 

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -233,12 +233,17 @@ def _flatten_field(generator_outputs: List[GeneratorOutput], key: str) -> list:
     return flat
 
 
-def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput]) -> GeneratorOutput:
+def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput], step_wise: bool = False) -> GeneratorOutput:
     """
-    Concatenate the generator outputs of multiple batches.
+    Concatenate the generator outputs of multiple batches. Then validate the concatenated result.
 
     We only aggregate rollout metrics the can deduced by responses and rewards, but not
     those that use `env_metrics` or `env_classes`.
+
+    Args:
+        generator_outputs: Per-batch generator outputs to concatenate.
+        step_wise: If True, validate step-wise specific fields on the concatenated result
+            (e.g. `is_last_step`, `trajectory_ids`, contiguous trajectory ordering).
     """
     assert len(generator_outputs) > 0
     has_rollout_logprobs = [output.get("rollout_logprobs") is not None for output in generator_outputs]
@@ -276,7 +281,7 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput]) -> G
     from skyrl.train.utils.trainer_utils import validate_generator_output
 
     num_prompts = len(result["prompt_token_ids"])
-    validate_generator_output(num_prompts, result)
+    validate_generator_output(num_prompts, result, step_wise=step_wise)
 
     return result
 


### PR DESCRIPTION
Some minimal changes to enable step-wise training + fully async.

The only change needed is to make `uids.extend([cur_generated_output_group.uid] * group_size)`'s `group_size` per-group. Since each group can have variable number of generator output entries as the number of turns vary.

In addition, we add `step_wise` flag to `concatenate_generator_outputs` so that the `validate_generator_output` call can validate `step_wise` constraints when applicable.

We ran search-r1 with fully async and step-wise, with the following commands on 1x8xH100s

```bash
STEP_WISE=true \
USE_CONVERSATION_MULTI_TURN=true \
bash examples/train/search/run_search_fully_async.sh
```

Retrieval server (launched first, on GPUs 0-3):

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 python
  examples/train/search/retriever/retrieval_server.py \
  --index_path /path/to/searchR1/e5_Flat.index \
  --corpus_path /path/to/searchR1/wiki-18.jsonl \
  --topk 3 --retriever_name e5 --retriever_model intfloat/e5-base-v2 --faiss_gpu
```

The grey curve is what we have above. 

<img width="559" height="305" alt="image" src="https://github.com/user-attachments/assets/f3571659-21c1-4e63-ba52-fb951e8d5df5" />

This is compared against the curves we had in #1529. The curve grows slower because the grey one has `train_batch_size=256` while the other ones have `512`. So the learning is at a similar pace.

