### PR TITLE
[train] Support packing for CUDA IPC transfer with new inference codepath

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -84,13 +84,22 @@ class NewInferenceWorkerWrap:
         """
         Receive and load a single chunk of weights.
 
-        Delegates to the weight transfer engine's receive_weights, using
-        model.load_weights for checkpoint format or direct param.copy_ for
-        kernel format. Can be called multiple times between start and finish.
+        SkyRL packs each chunk's tensors into a single contiguous CUDA buffer
+        (see CudaIpcWeightTransferSender._send_chunks_vllm_native) and sends
+        one IPC handle per rank plus per-param `sizes` metadata. We rebuild
+        the packed tensor here, slice it per param, and hand the list to
+        model.load_weights (checkpoint format) or copy per-param directly
+        (kernel format). We intentionally bypass vLLM's IPCWeightTransferEngine
+        for the IPC unpack because its update_info schema enforces one handle
+        per param and does not support packed transfers.
 
         Args:
-            update_info: Dict with backend-specific update info (names,
-                dtypes, shapes, IPC handles or NCCL packed flag, etc.)
+            update_info: Dict with keys:
+                - names: list[str]
+                - dtype_names: list[str]
+                - shapes: list[list[int]]
+                - sizes: list[int]  (element count per param; used for slicing)
+                - ipc_handles_pickled: b64(pickle({gpu_uuid: (func, args)}))
         """
         if not getattr(self, "_skyrl_weight_update_active", False):
             raise RuntimeError("start_weight_update must be called before update_weights_chunk.")
@@ -100,29 +109,46 @@ class NewInferenceWorkerWrap:
                 "Weight transfer not configured. " "Please set weight_transfer_config to enable weight transfer."
             )
 
-        typed_update_info = self.weight_transfer_engine.parse_update_info(update_info)
-        model = self.model_runner.model
+        # --- unpack SkyRL packed CUDA IPC format ---
+        import base64
+        import pickle
 
+        names = update_info["names"]
+        shapes = update_info["shapes"]
+        sizes = update_info["sizes"]
+        pickled = update_info["ipc_handles_pickled"]
+        handles = pickle.loads(base64.b64decode(pickled))
+
+        device_index = torch.cuda.current_device()
+        physical_gpu_id = str(torch.cuda.get_device_properties(device_index).uuid)
+        if physical_gpu_id not in handles:
+            raise ValueError(f"IPC handle not found for GPU UUID {physical_gpu_id}. " f"Available: {list(handles)}")
+        func, args = handles[physical_gpu_id]
+        # Remap device index to the LOCAL current-device — mirrors the legacy
+        # receiver (CudaIpcWeightTransferReceiver.receive_weights). Without
+        # this, cross-device rebuilds on colocated runs silently corrupt or
+        # fail because logical and physical device indices can differ.
+        list_args = list(args)
+        list_args[6] = device_index
+        packed_tensor = func(*list_args)
+
+        weights: list[tuple[str, torch.Tensor]] = []
+        offset = 0
+        for name, shape, size in zip(names, shapes, sizes):
+            weights.append((name, packed_tensor[offset : offset + size].view(*shape)))
+            offset += size
+
+        model = self.model_runner.model
         with torch.device(self.device):
             if self._skyrl_is_checkpoint_format:
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=model.load_weights,
-                )
+                model.load_weights(weights=weights)
             else:
+                for name, weight in weights:
+                    param = model.get_parameter(name)
+                    param.copy_(weight)
 
-                def load_weights_direct(
-                    weights: list[tuple[str, torch.Tensor]],
-                ) -> None:
-                    for name, weight in weights:
-                        param = model.get_parameter(name)
-                        param.copy_(weight)
-
-                self.weight_transfer_engine.receive_weights(
-                    typed_update_info,
-                    load_weights=load_weights_direct,
-                )
-
+        # Ensure consumption of packed_tensor finishes before we return (and
+        # before the sender drops its reference on the next barrier).
         torch.accelerator.synchronize()
 
     def finish_weight_update(self) -> None:

--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -121,10 +121,7 @@ class NewInferenceWorkerWrap:
         if physical_gpu_id not in handles:
             raise ValueError(f"IPC handle not found for GPU UUID {physical_gpu_id}. " f"Available: {list(handles)}")
         func, args = handles[physical_gpu_id]
-        # Remap device index to the LOCAL current-device — mirrors the legacy
-        # receiver (CudaIpcWeightTransferReceiver.receive_weights). Without
-        # this, cross-device rebuilds on colocated runs silently corrupt or
-        # fail because logical and physical device indices can differ.
+        # Remap device index to the LOCAL current-device.
         list_args = list(args)
         list_args[6] = device_index
         packed_tensor = func(*list_args)

--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -84,14 +84,11 @@ class NewInferenceWorkerWrap:
         """
         Receive and load a single chunk of weights.
 
-        SkyRL packs each chunk's tensors into a single contiguous CUDA buffer
-        (see CudaIpcWeightTransferSender._send_chunks_vllm_native) and sends
+        SkyRL packs each chunk's tensors into a single contiguous CUDA buffer and sends
         one IPC handle per rank plus per-param `sizes` metadata. We rebuild
         the packed tensor here, slice it per param, and hand the list to
         model.load_weights (checkpoint format) or copy per-param directly
-        (kernel format). We intentionally bypass vLLM's IPCWeightTransferEngine
-        for the IPC unpack because its update_info schema enforces one handle
-        per param and does not support packed transfers.
+        (kernel format).
 
         Args:
             update_info: Dict with keys:

--- a/skyrl/backends/skyrl_train/weight_sync/cuda_ipc_strategy.py
+++ b/skyrl/backends/skyrl_train/weight_sync/cuda_ipc_strategy.py
@@ -177,15 +177,20 @@ class CudaIpcWeightTransferSender(WeightTransferSender):
     ) -> None:
         """Send weights chunk-by-chunk via vLLM native IPC (new inference path).
 
-        Uses the start/update/finish lifecycle to enable chunked transfers:
-        each chunk creates IPC handles for only its parameters, sends them,
-        and frees them before the next chunk. This bounds peak memory to one
-        chunk's worth of IPC handles rather than all parameters at once.
+        Uses the start/update/finish lifecycle to enable chunked transfers.
+        Per chunk, all tensors are packed into a single contiguous CUDA buffer
+        (one dtype per chunk, guaranteed by the weight extractor) and one IPC
+        handle is created for the packed buffer per rank. This mirrors the
+        legacy path and avoids the one-handle-per-param ceiling of vLLM's
+        default IPCWeightTransferEngine, which otherwise dominates latency
+        for models with many small parameters.
 
         All ranks iterate chunks (weight extraction may use collective ops).
-        Per chunk, each rank creates IPC handles, they are all-gathered so
-        rank 0 has handles for every GPU, and rank 0 sends them via
-        update_weights_chunk.
+        Per chunk, each rank packs + creates one IPC handle, handles are
+        all_gather_object'd into a single {gpu_uuid: handle} dict, and rank 0
+        sends the dict (plus per-param `sizes` metadata) via
+        update_weights_chunk. The receiver rebuilds the packed tensor, slices
+        it per param, and loads into vLLM.
 
         TODO: Once https://github.com/vllm-project/vllm/pull/39212 lands,
         replace update_weights_chunk with the native /update_weights endpoint
@@ -193,51 +198,70 @@ class CudaIpcWeightTransferSender(WeightTransferSender):
         """
         rank = torch.distributed.get_rank()
         world_size = torch.distributed.get_world_size()
-        gpu_uuid = str(torch.cuda.get_device_properties(torch.cuda.current_device()).uuid)
+        device = torch.cuda.current_device()
+        gpu_uuid = str(torch.cuda.get_device_properties(device).uuid)
+        dtype = str_to_torch_dtype(self._init_info.model_dtype_str)
+        dtype_name = self._init_info.model_dtype_str.split(".")[-1]
 
         if rank == 0:
             await self._inference_client.start_weight_update(is_checkpoint_format=True)
         torch.distributed.barrier()
 
         for chunk in chunks:
+            # --- pack all tensors in this chunk into one contiguous buffer ---
+            # Chunk tensors share a single dtype by construction (see
+            # weight_extractor_utils.py), so offsets in element units are safe.
             names: List[str] = []
             dtype_names: List[str] = []
             shapes: List[List[int]] = []
-            tensor_refs: List[torch.Tensor] = []
-            per_param_handles: List[Dict[str, IpcHandle]] = []
+            sizes: List[int] = []
 
-            for name, tensor in zip(chunk.names, chunk.tensors):
-                weight = tensor.detach().contiguous()
-                tensor_refs.append(weight)
-                handle = reduce_tensor(weight)
-                per_param_handles.append({gpu_uuid: handle})
+            total_numel = sum(t.numel() for t in chunk.tensors)
+            packed_tensor = torch.empty(
+                total_numel,
+                device=device,
+                dtype=dtype,
+                requires_grad=False,
+            )
+
+            offset = 0
+            for name, tensor, shape in zip(chunk.names, chunk.tensors, chunk.shapes):
+                size = tensor.numel()
+                packed_tensor[offset : offset + size].copy_(tensor.detach().reshape(-1))
+                offset += size
                 names.append(name)
-                dtype_names.append(str(weight.dtype).split(".")[-1])
-                shapes.append(list(weight.shape))
+                dtype_names.append(dtype_name)
+                shapes.append(list(shape) if not isinstance(shape, list) else shape)
+                sizes.append(size)
 
-            gathered: List[Optional[List[Dict[str, IpcHandle]]]] = [None] * world_size
-            torch.distributed.all_gather_object(gathered, per_param_handles)
+            # --- one IPC handle per rank for the packed buffer ---
+            ipc_handle: IpcHandle = reduce_tensor(packed_tensor)
+            local_handle_dict: Dict[str, IpcHandle] = {gpu_uuid: ipc_handle}
+            gathered: List[Optional[Dict[str, IpcHandle]]] = [None] * world_size
+            torch.distributed.all_gather_object(gathered, local_handle_dict)
 
             torch.distributed.barrier()
             torch.cuda.synchronize()
 
             if rank == 0:
-                merged_handles: List[Dict[str, IpcHandle]] = []
-                for param_idx in range(len(per_param_handles)):
-                    merged: Dict[str, IpcHandle] = {}
-                    for rank_handles in gathered:
-                        merged.update(rank_handles[param_idx])  # type: ignore[union-attr]
-                    merged_handles.append(merged)
+                merged_handles: Dict[str, IpcHandle] = {}
+                for d in gathered:
+                    if d is not None:
+                        merged_handles.update(d)
 
                 pickled = base64.b64encode(pickle.dumps(merged_handles)).decode("utf-8")
                 chunk_update_info: Dict[str, Any] = {
                     "names": names,
                     "dtype_names": dtype_names,
                     "shapes": shapes,
+                    "sizes": sizes,
                     "ipc_handles_pickled": pickled,
                 }
                 await self._inference_client.update_weights_chunk(chunk_update_info)
 
+            # Keep packed_tensor alive past the barrier so the receiver's
+            # rebuilt view has valid backing storage while it copies into
+            # the model. Post-barrier drops the local ref safely.
             torch.distributed.barrier()
             torch.cuda.ipc_collect()
             torch.cuda.synchronize()

--- a/skyrl/backends/skyrl_train/weight_sync/cuda_ipc_strategy.py
+++ b/skyrl/backends/skyrl_train/weight_sync/cuda_ipc_strategy.py
@@ -180,10 +180,7 @@ class CudaIpcWeightTransferSender(WeightTransferSender):
         Uses the start/update/finish lifecycle to enable chunked transfers.
         Per chunk, all tensors are packed into a single contiguous CUDA buffer
         (one dtype per chunk, guaranteed by the weight extractor) and one IPC
-        handle is created for the packed buffer per rank. This mirrors the
-        legacy path and avoids the one-handle-per-param ceiling of vLLM's
-        default IPCWeightTransferEngine, which otherwise dominates latency
-        for models with many small parameters.
+        handle is created for the packed buffer per rank.
 
         All ranks iterate chunks (weight extraction may use collective ops).
         Per chunk, each rank packs + creates one IPC handle, handles are


### PR DESCRIPTION
# What does this PR do?

Support for CUDA IPC based weight transfer for the new inference codepath was added in #1512 but it sent tensors one at a time. This PR packs tensors in the same chunk together. 


## Test Plan

I manually ran FSDP and Megatron colocated weight sync tests and they pass:

1. `uv run --isolated --extra megatron --extra dev -- pytest -s -vvv tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py::test_megatron_policy_weight_sync[colocate_all]`
2. `uv run --isolated --extra fsdp --extra dev -- pytest -s -vv tests/backends/skyrl_train/gpu/gpu_ci/test_policy_local_engines_e2e.py::test_policy_local_engines_e2e[colocate_nccl_fsdp2_vllm]`