### PR TITLE
[chore] Redirect output to infrastructure logs for `VLLMServerActor`

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -123,6 +123,10 @@ class VLLMServerActor(ServerActorProtocol):
                 per-server placement group. Only used when
                 ``distributed_executor_backend="mp"`` and TP*PP > 1.
         """
+        from skyrl.train.utils.ray_logging import redirect_actor_output_to_file
+
+        redirect_actor_output_to_file()
+
         self._cli_args = vllm_cli_args
         self._ip = get_node_ip()
         self._port, self._port_reservation = find_and_reserve_port(start_port)


### PR DESCRIPTION
# What does this PR do?

Redirects logs from `VLLMServerActor` to a log file if `SKYRL_DUMP_INFRA_LOG_TO_STDOUT=0`. This change already made it to the 0.2.0 release, replicating on `main`. 