### PR TITLE
[feat][megatron] Add freeze_moe_router config to skip router parameters

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -101,11 +101,6 @@ def freeze_moe_router(model):
                 layer.mlp.router.weight.requires_grad = False
             if getattr(layer.mlp.router, "bias", None) is not None:
                 layer.mlp.router.bias.requires_grad = False
-        if hasattr(layer.mlp, "shared_experts"):
-            if getattr(layer.mlp.shared_experts, "gate_weight", None) is not None:
-                layer.mlp.shared_experts.gate_weight.requires_grad = False
-            if getattr(layer.mlp.shared_experts, "gate_bias", None) is not None:
-                layer.mlp.shared_experts.gate_bias.requires_grad = False
 
 
 @torch.no_grad()

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -95,10 +95,6 @@ def get_model_size(model: nn.Module, scale="auto"):
 
 
 def freeze_moe_router(model):
-    # Unwrap common Megatron/Torch DDP + Float16Module wrappers so callers can
-    # pass a wrapped chunk (e.g. ``DDP(Float16Module(GPTModel))``) directly.
-    while hasattr(model, "module"):
-        model = model.module
     for layer in model.decoder.layers:
         if hasattr(layer.mlp, "router"):
             if getattr(layer.mlp.router, "weight", None) is not None:

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -95,16 +95,20 @@ def get_model_size(model: nn.Module, scale="auto"):
 
 
 def freeze_moe_router(model):
+    # Unwrap common Megatron/Torch DDP + Float16Module wrappers so callers can
+    # pass a wrapped chunk (e.g. ``DDP(Float16Module(GPTModel))``) directly.
+    while hasattr(model, "module"):
+        model = model.module
     for layer in model.decoder.layers:
         if hasattr(layer.mlp, "router"):
-            if hasattr(layer.mlp.router, "weight"):
+            if getattr(layer.mlp.router, "weight", None) is not None:
                 layer.mlp.router.weight.requires_grad = False
-            if hasattr(layer.mlp.router, "bias"):
+            if getattr(layer.mlp.router, "bias", None) is not None:
                 layer.mlp.router.bias.requires_grad = False
         if hasattr(layer.mlp, "shared_experts"):
-            if hasattr(layer.mlp.shared_experts, "gate_weight"):
+            if getattr(layer.mlp.shared_experts, "gate_weight", None) is not None:
                 layer.mlp.shared_experts.gate_weight.requires_grad = False
-            if hasattr(layer.mlp.shared_experts, "gate_bias"):
+            if getattr(layer.mlp.shared_experts, "gate_bias", None) is not None:
                 layer.mlp.shared_experts.gate_bias.requires_grad = False
 
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -935,12 +935,6 @@ class MegatronRefWorkerBase(MegatronWorker, RefWorkerBase):
         if self._rank == 0:
             print_model_size(self.actor_module[0])
 
-        # Mirror policy hook for symmetry; ref builds no optimizer so this is a no-op for
-        # grad flow but keeps the config surface consistent.
-        if self.cfg.ref.megatron_config.freeze_moe_router:
-            for chunk in self.actor_module:
-                freeze_moe_router(chunk)
-
         # create worker model
         self.model = MegatronModelWrapper(config=self.cfg, actor_module=self.actor_module)
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed
 import torch.nn as nn
 from huggingface_hub import snapshot_download
+from loguru import logger
 from megatron.bridge import AutoBridge
 from megatron.bridge.peft.canonical_lora import CanonicalLoRA
 from megatron.bridge.peft.lora import LoRA
@@ -23,6 +24,7 @@ from skyrl.backends.skyrl_train.distributed.megatron.megatron_strategy import (
 )
 from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
     broadcast_object_across_pp_ranks,
+    freeze_moe_router,
     print_model_size,
 )
 from skyrl.backends.skyrl_train.distributed.megatron.optimizer import (
@@ -618,6 +620,14 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         if self.cfg.policy.megatron_config.torch_profiler_config.enable:
             self.profiler = Profiler(self.cfg.policy.megatron_config.torch_profiler_config)
 
+        # Freeze MoE router and shared-expert gate params before optimizer build.
+        # Megatron's DistributedOptimizer reads requires_grad at construction.
+        if self.cfg.policy.megatron_config.freeze_moe_router:
+            if self._rank == 0:
+                logger.info("freeze_moe_router=True: freezing MoE router and shared-expert gate params")
+            for chunk in self.actor_module:
+                freeze_moe_router(chunk)
+
         # create optimizer
         optim_config = init_megatron_optim_config(
             self.cfg.policy.optimizer_config, self.cfg.policy.megatron_config.optimizer_config_kwargs
@@ -925,6 +935,12 @@ class MegatronRefWorkerBase(MegatronWorker, RefWorkerBase):
         # load weights
         if self._rank == 0:
             print_model_size(self.actor_module[0])
+
+        # Mirror policy hook for symmetry; ref builds no optimizer so this is a no-op for
+        # grad flow but keeps the config surface consistent.
+        if self.cfg.ref.megatron_config.freeze_moe_router:
+            for chunk in self.actor_module:
+                freeze_moe_router(chunk)
 
         # create worker model
         self.model = MegatronModelWrapper(config=self.cfg, actor_module=self.actor_module)

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -625,8 +625,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         if self.cfg.policy.megatron_config.freeze_moe_router:
             if self._rank == 0:
                 logger.info("freeze_moe_router=True: freezing MoE router and shared-expert gate params")
-            for chunk in self.actor_module:
-                freeze_moe_router(chunk)
+            self.provider.register_pre_wrap_hook(freeze_moe_router)
 
         # create optimizer
         optim_config = init_megatron_optim_config(

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -172,6 +172,10 @@ class MegatronConfig(BaseConfig):
     empty_cuda_cache: Optional[bool] = None
     model_config_kwargs: dict = field(default_factory=dict)
     dist_ckpt_optim_fully_reshardable: bool = False
+    freeze_moe_router: bool = False
+    """If True, freeze MoE router (and shared-expert gate) parameters after model load,
+    before optimizer construction, so they are not updated during training. No-op on
+    non-MoE models."""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backends/skyrl_train/distributed/test_freeze_moe_router.py
+++ b/tests/backends/skyrl_train/distributed/test_freeze_moe_router.py
@@ -64,16 +64,6 @@ def test_freeze_moe_router_freezes_router_params():
         assert layer.mlp.router.bias.requires_grad is False
 
 
-def test_freeze_moe_router_freezes_shared_expert_gate():
-    m = _Model()
-
-    freeze_moe_router(m)
-
-    for layer in m.decoder.layers:
-        assert layer.mlp.shared_experts.gate_weight.requires_grad is False
-        assert layer.mlp.shared_experts.gate_bias.requires_grad is False
-
-
 def test_freeze_moe_router_leaves_other_params_trainable():
     m = _Model()
 
@@ -82,16 +72,8 @@ def test_freeze_moe_router_leaves_other_params_trainable():
     for layer in m.decoder.layers:
         assert layer.mlp.linear_fc1.weight.requires_grad is True
         assert layer.mlp.linear_fc1.bias.requires_grad is True
-
-
-def test_freeze_moe_router_handles_missing_shared_experts():
-    m = _Model(with_shared_experts=False)
-
-    # Should not raise when shared_experts attribute is absent.
-    freeze_moe_router(m)
-
-    for layer in m.decoder.layers:
-        assert layer.mlp.router.weight.requires_grad is False
+        assert layer.mlp.shared_experts.gate_weight.requires_grad is True
+        assert layer.mlp.shared_experts.gate_bias.requires_grad is True
 
 
 def test_freeze_moe_router_handles_layer_without_router():
@@ -123,7 +105,7 @@ def test_freeze_moe_router_no_bias():
             self.router = nn.Linear(8, 4, bias=False)  # router.bias is None
             self.shared_experts = nn.Module()
             self.shared_experts.gate_weight = nn.Parameter(torch.randn(4, 8))
-            # deliberately no gate_bias attr on shared_experts
+            # no gate_bias attr on shared_experts
             self.linear_fc1 = nn.Linear(8, 16)
 
     class _MoELayer(nn.Module):
@@ -140,5 +122,5 @@ def test_freeze_moe_router_no_bias():
     m = _Model()
     freeze_moe_router(m)  # should NOT raise
     assert not m.decoder.layers[0].mlp.router.weight.requires_grad
-    assert not m.decoder.layers[0].mlp.shared_experts.gate_weight.requires_grad
+    assert m.decoder.layers[0].mlp.shared_experts.gate_weight.requires_grad
     assert m.decoder.layers[0].mlp.linear_fc1.weight.requires_grad

--- a/tests/backends/skyrl_train/distributed/test_freeze_moe_router.py
+++ b/tests/backends/skyrl_train/distributed/test_freeze_moe_router.py
@@ -142,31 +142,3 @@ def test_freeze_moe_router_no_bias():
     assert not m.decoder.layers[0].mlp.router.weight.requires_grad
     assert not m.decoder.layers[0].mlp.shared_experts.gate_weight.requires_grad
     assert m.decoder.layers[0].mlp.linear_fc1.weight.requires_grad
-
-
-def test_freeze_moe_router_two_level_wrap():
-    """
-    Under Megatron's ``bf16=True`` path, chunks are wrapped as
-    ``DDP(Float16Module(GPTModel))``. This tests whether `freeze_moe_router`
-    can handle 2 levels of wrapping.
-    """
-    inner_model = _Model()
-
-    class FakeFloat16Module(nn.Module):
-        def __init__(self, m):
-            super().__init__()
-            self.module = m
-
-    class FakeDDP(nn.Module):
-        def __init__(self, m):
-            super().__init__()
-            self.module = m
-
-    wrapped = FakeDDP(FakeFloat16Module(inner_model))
-
-    # Pass the wrapped chunk directly — the helper must unwrap internally.
-    freeze_moe_router(wrapped)
-
-    for layer in inner_model.decoder.layers:
-        assert not layer.mlp.router.weight.requires_grad
-        assert layer.mlp.linear_fc1.weight.requires_grad

--- a/tests/backends/skyrl_train/distributed/test_freeze_moe_router.py
+++ b/tests/backends/skyrl_train/distributed/test_freeze_moe_router.py
@@ -1,0 +1,172 @@
+"""CPU-only smoke tests for the ``freeze_moe_router`` helper.
+
+The helper walks ``model.decoder.layers`` and flips ``requires_grad`` on
+router weights/biases and the shared-expert gate weight/bias. These tests
+build minimal mock modules that mimic Megatron-Core's attribute layout
+without importing Megatron.
+"""
+
+import torch
+import torch.nn as nn
+
+from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
+    freeze_moe_router,
+)
+
+
+class _SharedExperts(nn.Module):
+    def __init__(self, in_features: int = 8, hidden: int = 4, with_bias: bool = True):
+        super().__init__()
+        self.gate_weight = nn.Parameter(torch.randn(hidden, in_features))
+        if with_bias:
+            self.gate_bias = nn.Parameter(torch.randn(hidden))
+
+
+class _MLP(nn.Module):
+    def __init__(self, with_shared_experts: bool = True):
+        super().__init__()
+        # Mimic Megatron's TopKRouter: a module with ``weight`` (and optional ``bias``)
+        # Parameters. We use nn.Linear here because it has the right attribute layout.
+        self.router = nn.Linear(8, 4, bias=True)
+        if with_shared_experts:
+            self.shared_experts = _SharedExperts(in_features=8, hidden=4, with_bias=True)
+        # Non-router param that must remain trainable.
+        self.linear_fc1 = nn.Linear(8, 16)
+
+
+class _Layer(nn.Module):
+    def __init__(self, **mlp_kwargs):
+        super().__init__()
+        self.mlp = _MLP(**mlp_kwargs)
+
+
+class _Decoder(nn.Module):
+    def __init__(self, n_layers: int = 2, **mlp_kwargs):
+        super().__init__()
+        self.layers = nn.ModuleList([_Layer(**mlp_kwargs) for _ in range(n_layers)])
+
+
+class _Model(nn.Module):
+    def __init__(self, n_layers: int = 2, **mlp_kwargs):
+        super().__init__()
+        self.decoder = _Decoder(n_layers=n_layers, **mlp_kwargs)
+
+
+def test_freeze_moe_router_freezes_router_params():
+    m = _Model()
+    # sanity: all params start trainable
+    assert all(p.requires_grad for p in m.parameters())
+
+    freeze_moe_router(m)
+
+    for layer in m.decoder.layers:
+        assert layer.mlp.router.weight.requires_grad is False
+        assert layer.mlp.router.bias.requires_grad is False
+
+
+def test_freeze_moe_router_freezes_shared_expert_gate():
+    m = _Model()
+
+    freeze_moe_router(m)
+
+    for layer in m.decoder.layers:
+        assert layer.mlp.shared_experts.gate_weight.requires_grad is False
+        assert layer.mlp.shared_experts.gate_bias.requires_grad is False
+
+
+def test_freeze_moe_router_leaves_other_params_trainable():
+    m = _Model()
+
+    freeze_moe_router(m)
+
+    for layer in m.decoder.layers:
+        assert layer.mlp.linear_fc1.weight.requires_grad is True
+        assert layer.mlp.linear_fc1.bias.requires_grad is True
+
+
+def test_freeze_moe_router_handles_missing_shared_experts():
+    m = _Model(with_shared_experts=False)
+
+    # Should not raise when shared_experts attribute is absent.
+    freeze_moe_router(m)
+
+    for layer in m.decoder.layers:
+        assert layer.mlp.router.weight.requires_grad is False
+
+
+def test_freeze_moe_router_handles_layer_without_router():
+    # PP/VPP stages without MoE layers: layer.mlp has no .router attribute.
+    class _NonMoEMLP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_fc1 = nn.Linear(8, 16)
+
+    class _NonMoELayer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mlp = _NonMoEMLP()
+
+    m = _Model()
+    m.decoder.layers = nn.ModuleList([_NonMoELayer(), _NonMoELayer()])
+
+    # Should be a no-op without raising.
+    freeze_moe_router(m)
+
+    for layer in m.decoder.layers:
+        assert layer.mlp.linear_fc1.weight.requires_grad is True
+
+
+def test_freeze_moe_router_no_bias():
+    class _MoEMLP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.router = nn.Linear(8, 4, bias=False)  # router.bias is None
+            self.shared_experts = nn.Module()
+            self.shared_experts.gate_weight = nn.Parameter(torch.randn(4, 8))
+            # deliberately no gate_bias attr on shared_experts
+            self.linear_fc1 = nn.Linear(8, 16)
+
+    class _MoELayer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mlp = _MoEMLP()
+
+    class _Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Module()
+            self.decoder.layers = nn.ModuleList([_MoELayer()])
+
+    m = _Model()
+    freeze_moe_router(m)  # should NOT raise
+    assert not m.decoder.layers[0].mlp.router.weight.requires_grad
+    assert not m.decoder.layers[0].mlp.shared_experts.gate_weight.requires_grad
+    assert m.decoder.layers[0].mlp.linear_fc1.weight.requires_grad
+
+
+def test_freeze_moe_router_two_level_wrap():
+    """
+    Under Megatron's ``bf16=True`` path, chunks are wrapped as
+    ``DDP(Float16Module(GPTModel))``. This tests whether `freeze_moe_router`
+    can handle 2 levels of wrapping.
+    """
+    inner_model = _Model()
+
+    class FakeFloat16Module(nn.Module):
+        def __init__(self, m):
+            super().__init__()
+            self.module = m
+
+    class FakeDDP(nn.Module):
+        def __init__(self, m):
+            super().__init__()
+            self.module = m
+
+    wrapped = FakeDDP(FakeFloat16Module(inner_model))
+
+    # Pass the wrapped chunk directly — the helper must unwrap internally.
+    freeze_moe_router(wrapped)
+
+    for layer in inner_model.decoder.layers:
+        assert not layer.mlp.router.weight.requires_grad
+        assert layer.mlp.linear_fc1.weight.requires_grad


### PR DESCRIPTION
# What does this PR do?

Adds `MegatronConfig.freeze_moe_router` (default False). When `True`, the Megatron policy/ref workers call the existing freeze_moe_router helper after model load and before optimizer construction, setting requires_grad=False on router parameters. The Megatron DistributedOptimizer reads requires_grad at construction, so frozen params are excluded from its reduce buckets and param groups.

Also fixed a bug:
- hasattr(x, "bias") returns True for nn.Linear(bias=False) where bias is None, matching Megatron's TopKRouter(add_bias_linear=False) default. Swap to getattr(x, name, None) is not None.

## Test plan

 New `tests/backends/skyrl_train/distributed/test_freeze_moe_router.py` covering default behaviour, testing the `bias=None` case and the wrapped models
 
 TODO:

- [x] E2E run 