### PR TITLE
[feat][megatron] Add freeze_moe_router config to skip router parameters

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -21,6 +21,7 @@
 # limitations under the License.
 
 import gc
+from typing import List, Union
 
 import torch
 import torch.nn as nn
@@ -94,7 +95,7 @@ def get_model_size(model: nn.Module, scale="auto"):
     return n_params, scale
 
 
-def freeze_moe_router(model_or_models):
+def freeze_moe_router(model_or_models: Union[nn.Module, List[nn.Module]]):
     models = model_or_models
     if not isinstance(model_or_models, list):
         models = [model_or_models]

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -94,18 +94,20 @@ def get_model_size(model: nn.Module, scale="auto"):
     return n_params, scale
 
 
-def freeze_moe_router(model):
-    for layer in model.decoder.layers:
-        if hasattr(layer.mlp, "router"):
-            if hasattr(layer.mlp.router, "weight"):
-                layer.mlp.router.weight.requires_grad = False
-            if hasattr(layer.mlp.router, "bias"):
-                layer.mlp.router.bias.requires_grad = False
-        if hasattr(layer.mlp, "shared_experts"):
-            if hasattr(layer.mlp.shared_experts, "gate_weight"):
-                layer.mlp.shared_experts.gate_weight.requires_grad = False
-            if hasattr(layer.mlp.shared_experts, "gate_bias"):
-                layer.mlp.shared_experts.gate_bias.requires_grad = False
+def freeze_moe_router(model_or_models):
+    models = model_or_models
+    if not isinstance(model_or_models, list):
+        models = [model_or_models]
+
+    for model in models:
+        for layer in model.decoder.layers:
+            if hasattr(layer.mlp, "router"):
+                if getattr(layer.mlp.router, "weight", None) is not None:
+                    layer.mlp.router.weight.requires_grad = False
+                if getattr(layer.mlp.router, "bias", None) is not None:
+                    layer.mlp.router.bias.requires_grad = False
+    # modified in-place
+    return model_or_models
 
 
 @torch.no_grad()

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed
 import torch.nn as nn
 from huggingface_hub import snapshot_download
+from loguru import logger
 from megatron.bridge import AutoBridge
 from megatron.bridge.peft.canonical_lora import CanonicalLoRA
 from megatron.bridge.peft.lora import LoRA
@@ -23,6 +24,7 @@ from skyrl.backends.skyrl_train.distributed.megatron.megatron_strategy import (
 )
 from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
     broadcast_object_across_pp_ranks,
+    freeze_moe_router,
     print_model_size,
 )
 from skyrl.backends.skyrl_train.distributed.megatron.optimizer import (
@@ -595,6 +597,13 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             )
 
             patch_topk_router_layer_number()
+
+        # Freeze MoE router params before optimizer build.
+        # Megatron's DistributedOptimizer reads requires_grad at construction.
+        if self.cfg.policy.megatron_config.freeze_moe_router:
+            if self._rank == 0:
+                logger.info("freeze_moe_router=True: freezing MoE router params")
+            self.provider.register_pre_wrap_hook(freeze_moe_router)
 
         # wrap with DDP for training
         self.actor_module = self.make_megatron_module(

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -172,6 +172,9 @@ class MegatronConfig(BaseConfig):
     empty_cuda_cache: Optional[bool] = None
     model_config_kwargs: dict = field(default_factory=dict)
     dist_ckpt_optim_fully_reshardable: bool = False
+    freeze_moe_router: bool = False
+    """If True, freeze MoE router parameters so they are not updated during training. No-op on
+    non-MoE models."""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backends/skyrl_train/distributed/test_freeze_moe_router.py
+++ b/tests/backends/skyrl_train/distributed/test_freeze_moe_router.py
@@ -1,0 +1,141 @@
+"""CPU-only smoke tests for the ``freeze_moe_router`` helper.
+
+The helper walks ``model.decoder.layers`` and flips ``requires_grad`` on
+router weights/biases. These tests build minimal mock modules that mimic Megatron-Core's attribute layout
+without importing Megatron.
+"""
+
+import torch
+import torch.nn as nn
+
+from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
+    freeze_moe_router,
+)
+
+
+class _SharedExperts(nn.Module):
+    def __init__(self, in_features: int = 8, hidden: int = 4, with_bias: bool = True):
+        super().__init__()
+        self.gate_weight = nn.Parameter(torch.randn(hidden, in_features))
+        if with_bias:
+            self.gate_bias = nn.Parameter(torch.randn(hidden))
+
+
+class _MLP(nn.Module):
+    def __init__(self, with_shared_experts: bool = True):
+        super().__init__()
+        # Mimic Megatron's TopKRouter: a module with ``weight`` (and optional ``bias``)
+        # Parameters. We use nn.Linear here because it has the right attribute layout.
+        self.router = nn.Linear(8, 4, bias=True)
+        if with_shared_experts:
+            self.shared_experts = _SharedExperts(in_features=8, hidden=4, with_bias=True)
+        # Non-router param that must remain trainable.
+        self.linear_fc1 = nn.Linear(8, 16)
+
+
+class _Layer(nn.Module):
+    def __init__(self, **mlp_kwargs):
+        super().__init__()
+        self.mlp = _MLP(**mlp_kwargs)
+
+
+class _Decoder(nn.Module):
+    def __init__(self, n_layers: int = 2, **mlp_kwargs):
+        super().__init__()
+        self.layers = nn.ModuleList([_Layer(**mlp_kwargs) for _ in range(n_layers)])
+
+
+class _Model(nn.Module):
+    def __init__(self, n_layers: int = 2, **mlp_kwargs):
+        super().__init__()
+        self.decoder = _Decoder(n_layers=n_layers, **mlp_kwargs)
+
+
+def test_freeze_moe_router_freezes_router_params():
+    m = _Model()
+    # sanity: all params start trainable
+    assert all(p.requires_grad for p in m.parameters())
+
+    ret = freeze_moe_router(m)
+    assert ret is not None
+    assert ret == m
+
+    for layer in m.decoder.layers:
+        assert layer.mlp.router.weight.requires_grad is False
+        assert layer.mlp.router.bias.requires_grad is False
+
+
+def test_freeze_moe_router_leaves_other_params_trainable():
+    m = _Model()
+
+    freeze_moe_router(m)
+
+    for layer in m.decoder.layers:
+        assert layer.mlp.linear_fc1.weight.requires_grad is True
+        assert layer.mlp.linear_fc1.bias.requires_grad is True
+        assert layer.mlp.shared_experts.gate_weight.requires_grad is True
+        assert layer.mlp.shared_experts.gate_bias.requires_grad is True
+
+
+def test_freeze_moe_router_handles_layer_without_router():
+    # PP/VPP stages without MoE layers: layer.mlp has no .router attribute.
+    class _NonMoEMLP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_fc1 = nn.Linear(8, 16)
+
+    class _NonMoELayer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mlp = _NonMoEMLP()
+
+    m = _Model()
+    m.decoder.layers = nn.ModuleList([_NonMoELayer(), _NonMoELayer()])
+
+    # Should be a no-op without raising.
+    freeze_moe_router(m)
+
+    for layer in m.decoder.layers:
+        assert layer.mlp.linear_fc1.weight.requires_grad is True
+
+
+def test_freeze_moe_router_no_bias():
+    class _MoEMLP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.router = nn.Linear(8, 4, bias=False)  # router.bias is None
+            self.shared_experts = nn.Module()
+            self.shared_experts.gate_weight = nn.Parameter(torch.randn(4, 8))
+            # no gate_bias attr on shared_experts
+            self.linear_fc1 = nn.Linear(8, 16)
+
+    class _MoELayer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mlp = _MoEMLP()
+
+    class _Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Module()
+            self.decoder.layers = nn.ModuleList([_MoELayer()])
+
+    m = _Model()
+    freeze_moe_router(m)  # should NOT raise
+    assert not m.decoder.layers[0].mlp.router.weight.requires_grad
+    assert m.decoder.layers[0].mlp.shared_experts.gate_weight.requires_grad
+    assert m.decoder.layers[0].mlp.linear_fc1.weight.requires_grad
+
+
+def test_freeze_moe_router_list():
+    m = _Model()
+    # sanity: all params start trainable
+    assert all(p.requires_grad for p in m.parameters())
+
+    ret = freeze_moe_router([m])
+    assert isinstance(ret, list)
+    assert len(ret) == 1
+
+    for layer in m.decoder.layers:
+        assert layer.mlp.router.weight.requires_grad is False
+        assert layer.mlp.router.bias.requires_grad is False

--- a/tests/backends/skyrl_train/distributed/test_freeze_moe_router.py
+++ b/tests/backends/skyrl_train/distributed/test_freeze_moe_router.py
@@ -105,8 +105,8 @@ def test_freeze_moe_router_no_bias():
             super().__init__()
             self.router = nn.Linear(8, 4, bias=False)  # router.bias is None
             self.shared_experts = nn.Module()
-            self.shared_experts.gate_weight = nn.Parameter(torch.randn(4, 8))
             # no gate_bias attr on shared_experts
+            self.shared_experts.gate_weight = nn.Parameter(torch.randn(4, 8))
             self.linear_fc1 = nn.Linear(8, 16)
 
     class _MoELayer(nn.Module):

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_freeze_moe_router.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_freeze_moe_router.py
@@ -1,8 +1,11 @@
-"""CPU-only smoke tests for the ``freeze_moe_router`` helper.
+"""Smoke tests for the ``freeze_moe_router`` helper.
 
 The helper walks ``model.decoder.layers`` and flips ``requires_grad`` on
 router weights/biases. These tests build minimal mock modules that mimic Megatron-Core's attribute layout
 without importing Megatron.
+
+Run with:
+uv run --isolated --extra dev --extra megatron -- pytest -s tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_freeze_moe_router.py
 """
 
 import torch

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
@@ -1,6 +1,6 @@
 """
 Run with:
-uv run --isolated --extra dev --extra megatron -- pytest -s tests/backends/skyrl_train/gpu/gpu_ci/test_megatron_worker.py
+uv run --isolated --extra dev --extra megatron -- pytest -s tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
 """
 
 import pytest

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py
@@ -136,7 +136,7 @@ def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardabl
 
         # For Megatron, build training batches and reuse the second one pre/post checkpoint resume
         if "megatron" in strategy:
-            from tests.backends.skyrl_train.gpu.gpu_ci.test_megatron_worker import (
+            from tests.backends.skyrl_train.gpu.gpu_ci.megatron.test_megatron_worker import (
                 get_test_training_batch,
             )
 
@@ -271,7 +271,7 @@ def test_save_load_checkpoint_cloud(ray_init_fixture):
 
         dp_size = actor_group.actor_infos[0].rank.dp_size
 
-        from tests.backends.skyrl_train.gpu.gpu_ci.test_megatron_worker import (
+        from tests.backends.skyrl_train.gpu.gpu_ci.megatron.test_megatron_worker import (
             get_test_training_batch,
         )
 

--- a/tests/backends/skyrl_train/gpu/test_save_load_model.py
+++ b/tests/backends/skyrl_train/gpu/test_save_load_model.py
@@ -5,7 +5,7 @@ For FSDP and FSDP2, run with:
 uv run --isolated --extra dev -- pytest tests/backends/skyrl_train/gpu/test_save_load_model.py -m "not megatron"
 
 For Megatron, run with:
-uv run --isolated --extra dev --extra mcore -- pytest tests/backends/skyrl_train/gpu/test_save_load_model.py -m "megatron"
+uv run --isolated --extra dev --extra megatron -- pytest tests/backends/skyrl_train/gpu/test_save_load_model.py -m "megatron"
 """
 
 import json
@@ -94,7 +94,7 @@ def test_save_load_hf_model(ray_init_fixture, strategy):
         # Prepare training input and run one training step
         dp_size = actor_group_1.actor_infos[0].rank.dp_size
         if "megatron" in strategy:
-            from tests.backends.skyrl_train.gpu.gpu_ci.test_megatron_worker import (
+            from tests.backends.skyrl_train.gpu.gpu_ci.megatron.test_megatron_worker import (
                 get_test_training_batch,
             )
 


### PR DESCRIPTION
# What does this PR do?

Adds `MegatronConfig.freeze_moe_router` (default False). When `True`, the Megatron policy/ref workers call the existing freeze_moe_router helper after model load and before optimizer construction, setting requires_grad=False on router parameters. The Megatron DistributedOptimizer reads requires_grad at construction, so frozen params are excluded from its reduce buckets and param groups.

Also fixed a bug:
- hasattr(x, "bias") returns True for nn.Linear(bias=False) where bias is None, matching Megatron's TopKRouter(add_bias_linear=False) default. Swap to getattr(x, name, None) is not None.

## Test plan

 New `tests/backends/skyrl_train/distributed/test_freeze_moe_router.py` covering default behaviour, testing the `bias=None` case and the wrapped models
 
 TODO:

- [x] E2E run 

Re-opening since I missed a commit and the bots keep yelling