### PR TITLE
[bug][tinker] Fix data_parallel_size > 1 in SkyRLTrainBackend

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/setup.py
+++ b/skyrl/backends/skyrl_train/inference_servers/setup.py
@@ -159,6 +159,7 @@ def create_inference_servers(
             router=router,
             proxy_url=proxy_url,
             server_urls=server_urls,
+            server_groups=prefill_server_groups + decode_server_groups,
             prefill_server_groups=prefill_server_groups,
             decode_server_groups=decode_server_groups,
         )

--- a/skyrl/backends/skyrl_train/inference_servers/setup.py
+++ b/skyrl/backends/skyrl_train/inference_servers/setup.py
@@ -22,6 +22,7 @@ from .vllm_router import VLLMRouter
 NIXL_SIDE_CHANNEL_BASE_PORT = 5600
 VLLM_START_PORT = 8000
 
+# Fixed LoRA adapter name used for generation requests when LoRA is active.
 _SKYRL_LORA_ADAPTER_NAME = "skyrl-lora"
 
 

--- a/skyrl/backends/skyrl_train/inference_servers/setup.py
+++ b/skyrl/backends/skyrl_train/inference_servers/setup.py
@@ -28,12 +28,10 @@ _SKYRL_LORA_ADAPTER_NAME = "skyrl-lora"
 
 @dataclass
 class InferenceServerSetup:
-    """Result of :func:`create_inference_servers` and
-    :func:`build_new_inference_client` (paired with the client in the
-    latter).
+    """Inference server setup result with optional router and groups.
 
-    ``router`` is ``None`` when the caller reuses a fully-external proxy
-    as-is (no internal :class:`VLLMRouter` is started). The three
+    ``router`` is ``None`` when the caller reuses a fully-external
+    proxy (no internal ``VLLMRouter`` is started). The three
     server-group lists default to empty when servers are external or
     when the relevant branch (PD vs non-PD) is not active.
     """
@@ -215,33 +213,28 @@ def build_new_inference_client(
     tokenizer,
     placement_group: Optional[ResolvedPlacementGroup] = None,
 ) -> Tuple[RemoteInferenceClient, InferenceServerSetup]:
-    """Build the new HTTP-based inference client and any supporting state.
+    """Build the new HTTP-based inference client and supporting state.
 
     Resolves the ``(external_proxy_url, external_server_urls)`` matrix:
-
-    - Both set: fully external — reuse both as-is, no internal router/groups.
-    - Proxy only: external proxy serves both data and control planes.
-    - Servers only: spawn an internal ``VLLMRouter`` over the external servers.
-    - Neither: spawn internal server groups + router via
-      :func:`create_inference_servers`.
-
-    Then builds the :class:`RemoteInferenceClient` against the resolved
-    endpoints.
+    both set means fully external (reuse both as-is); proxy only means
+    the external proxy serves both data and control planes; servers
+    only spawns an internal router over the external servers; neither
+    spawns internal server groups + router via
+    ``create_inference_servers``. Then builds the
+    ``RemoteInferenceClient`` against the resolved endpoints.
 
     Args:
         cfg: SkyRL train config.
         tokenizer: HF tokenizer for the policy model.
         placement_group: Resolved placement group when colocated, ``None``
-            otherwise. Passed through to :func:`create_inference_servers` in
+            otherwise. Passed through to ``create_inference_servers`` in
             the internal-servers branch; ignored on external branches.
 
     Returns:
-        ``(client, server_setup)`` — the constructed
-        :class:`RemoteInferenceClient` and the :class:`InferenceServerSetup`
-        describing whatever router and server groups (if any) were
-        internally started. ``server_setup.router`` is ``None`` for fully
-        external setups; the three group lists are empty when servers are
-        external or when their PD branch is inactive.
+        Tuple of (client, server_setup). ``server_setup.router`` is
+        ``None`` for fully external setups; the three group lists are
+        empty when servers are external or when their PD branch is
+        inactive.
     """
     ie_cfg = cfg.generator.inference_engine
     external_proxy_url = ie_cfg.external_proxy_url

--- a/skyrl/backends/skyrl_train/inference_servers/setup.py
+++ b/skyrl/backends/skyrl_train/inference_servers/setup.py
@@ -1,37 +1,48 @@
 import copy
 from argparse import Namespace
-from dataclasses import dataclass
-from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
 
 import ray
 from loguru import logger
 from ray.util.placement_group import placement_group as ray_placement_group
 
 from skyrl.env_vars import SKYRL_RAY_PG_TIMEOUT_IN_S
-from skyrl.train.config import InferenceEngineConfig
+from skyrl.train.config import InferenceEngineConfig, SkyRLTrainConfig
 from skyrl.train.utils.utils import (
     ResolvedPlacementGroup,
     get_ray_pg_ready_with_timeout,
 )
 
+from .remote_inference_client import RemoteInferenceClient
 from .server_group import ServerGroup
-from .utils import build_router_args, get_pd_cli_args
+from .utils import build_router_args, build_vllm_cli_args, get_pd_cli_args
 from .vllm_router import VLLMRouter
 
 NIXL_SIDE_CHANNEL_BASE_PORT = 5600
 VLLM_START_PORT = 8000
 
+_SKYRL_LORA_ADAPTER_NAME = "skyrl-lora"
+
 
 @dataclass
 class InferenceServerSetup:
-    """Simple dataclass for inference server setup result."""
+    """Result of :func:`create_inference_servers` and
+    :func:`build_new_inference_client` (paired with the client in the
+    latter).
 
-    router: "VLLMRouter"
+    ``router`` is ``None`` when the caller reuses a fully-external proxy
+    as-is (no internal :class:`VLLMRouter` is started). The three
+    server-group lists default to empty when servers are external or
+    when the relevant branch (PD vs non-PD) is not active.
+    """
+
     proxy_url: str
     server_urls: List[str]
-    server_groups: Optional[List["ServerGroup"]] = None
-    prefill_server_groups: Optional[List["ServerGroup"]] = None
-    decode_server_groups: Optional[List["ServerGroup"]] = None
+    router: Optional[VLLMRouter] = None
+    server_groups: List[ServerGroup] = field(default_factory=list)
+    prefill_server_groups: List[ServerGroup] = field(default_factory=list)
+    decode_server_groups: List[ServerGroup] = field(default_factory=list)
 
 
 def create_inference_servers(
@@ -196,3 +207,90 @@ def create_inference_servers(
             server_urls=server_urls,
             server_groups=server_groups,
         )
+
+
+def build_new_inference_client(
+    cfg: SkyRLTrainConfig,
+    tokenizer,
+    placement_group: Optional[ResolvedPlacementGroup] = None,
+) -> Tuple[RemoteInferenceClient, InferenceServerSetup]:
+    """Build the new HTTP-based inference client and any supporting state.
+
+    Resolves the ``(external_proxy_url, external_server_urls)`` matrix:
+
+    - Both set: fully external — reuse both as-is, no internal router/groups.
+    - Proxy only: external proxy serves both data and control planes.
+    - Servers only: spawn an internal ``VLLMRouter`` over the external servers.
+    - Neither: spawn internal server groups + router via
+      :func:`create_inference_servers`.
+
+    Then builds the :class:`RemoteInferenceClient` against the resolved
+    endpoints.
+
+    Args:
+        cfg: SkyRL train config.
+        tokenizer: HF tokenizer for the policy model.
+        placement_group: Resolved placement group when colocated, ``None``
+            otherwise. Passed through to :func:`create_inference_servers` in
+            the internal-servers branch; ignored on external branches.
+
+    Returns:
+        ``(client, server_setup)`` — the constructed
+        :class:`RemoteInferenceClient` and the :class:`InferenceServerSetup`
+        describing whatever router and server groups (if any) were
+        internally started. ``server_setup.router`` is ``None`` for fully
+        external setups; the three group lists are empty when servers are
+        external or when their PD branch is inactive.
+    """
+    ie_cfg = cfg.generator.inference_engine
+    external_proxy_url = ie_cfg.external_proxy_url
+    external_server_urls = ie_cfg.external_server_urls
+    has_external_proxy = external_proxy_url is not None
+    has_external_servers = external_server_urls is not None
+
+    if has_external_proxy and has_external_servers:
+        proxy_url = external_proxy_url
+        server_urls = list(external_server_urls)
+        logger.info(
+            f"HTTP Inference: Using fully external setup - " f"proxy_url={proxy_url}, server_urls={server_urls}"
+        )
+        server_setup = InferenceServerSetup(proxy_url=proxy_url, server_urls=server_urls)
+    elif has_external_proxy and not has_external_servers:
+        proxy_url = external_proxy_url
+        server_urls = [proxy_url]
+        logger.info(f"HTTP Inference: Using external proxy for both data and " f"control plane - proxy_url={proxy_url}")
+        server_setup = InferenceServerSetup(proxy_url=proxy_url, server_urls=server_urls)
+    elif has_external_servers and not has_external_proxy:
+        server_urls = list(external_server_urls)
+        router_args = build_router_args(ie_cfg, server_urls=server_urls)
+        router = VLLMRouter(router_args, log_path=cfg.trainer.log_path)
+        proxy_url = router.start()
+        logger.info(
+            f"HTTP Inference: Created router over external servers - "
+            f"server_urls={server_urls}, proxy_url={proxy_url}"
+        )
+        server_setup = InferenceServerSetup(proxy_url=proxy_url, server_urls=server_urls, router=router)
+    else:
+        cli_args = build_vllm_cli_args(cfg)
+        server_setup = create_inference_servers(
+            ie_cfg,
+            cli_args,
+            log_path=cfg.trainer.log_path,
+            placement_group=placement_group,
+        )
+
+    lora_cfg = cfg.trainer.policy.model.lora
+    active_lora_name = (
+        _SKYRL_LORA_ADAPTER_NAME if lora_cfg and lora_cfg.rank > 0 and cfg.trainer.strategy != "megatron" else None
+    )
+    client = RemoteInferenceClient(
+        proxy_url=server_setup.proxy_url,
+        server_urls=server_setup.server_urls,
+        model_name=cfg.trainer.policy.model.path,
+        enable_return_routed_experts=ie_cfg.enable_return_routed_experts,
+        active_lora_name=active_lora_name,
+        data_parallel_size=ie_cfg.data_parallel_size,
+        tokenizer=tokenizer,
+    )
+
+    return client, server_setup

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -322,9 +322,7 @@ class SkyRLTrainBackend(AbstractBackend):
             placement_group=self._colocate_pg if is_colocated else None,
         )
         self._inference_router = server_setup.router
-        self._server_groups = list(
-            server_setup.server_groups + server_setup.prefill_server_groups + server_setup.decode_server_groups
-        )
+        self._server_groups = server_setup.server_groups
         self._inference_engine_client = client
 
     def _ensure_inference_engines(self):

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -38,8 +38,6 @@ from skyrl.train.utils.utils import (
 from skyrl.utils.log import logger
 from skyrl.utils.tok import get_tokenizer
 
-# Fixed LoRA adapter name used for generation requests when LoRA is active.
-
 
 class SkyRLTrainBackendOverrides(BaseModel, extra="allow"):
     """Configuration overrides for the SkyRL-Train backend.

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -20,15 +20,6 @@ from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import
 from skyrl.backends.skyrl_train.inference_engines.ray_wrapped_inference_engine import (
     create_ray_wrapped_inference_engines,
 )
-from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
-    RemoteInferenceClient,
-)
-from skyrl.backends.skyrl_train.inference_servers.setup import create_inference_servers
-from skyrl.backends.skyrl_train.inference_servers.utils import (
-    build_router_args,
-    build_vllm_cli_args,
-)
-from skyrl.backends.skyrl_train.inference_servers.vllm_router import VLLMRouter
 from skyrl.backends.skyrl_train.training_batch import (
     TensorList,
     TrainingInputBatch,
@@ -48,7 +39,6 @@ from skyrl.utils.log import logger
 from skyrl.utils.tok import get_tokenizer
 
 # Fixed LoRA adapter name used for generation requests when LoRA is active.
-_SKYRL_LORA_ADAPTER_NAME = "skyrl-lora"
 
 
 class SkyRLTrainBackendOverrides(BaseModel, extra="allow"):
@@ -322,73 +312,22 @@ class SkyRLTrainBackend(AbstractBackend):
         )
 
     def _create_new_inference_client(self):
-        """Create new HTTP-based inference client.
+        """Create new HTTP-based inference client."""
+        from skyrl.backends.skyrl_train.inference_servers.setup import (
+            build_new_inference_client,
+        )
 
-        Possible config combinations:
-        - Both external_proxy_url and external_server_urls → fully external setup
-        - external_proxy_url only → proxy for both data + control plane
-        - external_server_urls only → create internal router over them
-        - Neither → build servers and router internally
-        """
-        ie_cfg = self._cfg.generator.inference_engine
         is_colocated = self._cfg.trainer.placement.colocate_all
-        external_proxy_url = ie_cfg.external_proxy_url
-        external_server_urls = ie_cfg.external_server_urls
-
-        has_external_proxy = external_proxy_url is not None
-        has_external_servers = external_server_urls is not None
-
-        if has_external_proxy and has_external_servers:
-            proxy_url = external_proxy_url
-            server_urls = list(external_server_urls)
-            logger.info(
-                f"HTTP Inference: Using fully external setup - proxy_url={proxy_url}, server_urls={server_urls}"
-            )
-
-        elif has_external_proxy and not has_external_servers:
-            proxy_url = external_proxy_url
-            server_urls = [proxy_url]
-            logger.info(f"HTTP Inference: Using external proxy for both data and control plane - proxy_url={proxy_url}")
-
-        elif has_external_servers and not has_external_proxy:
-            server_urls = list(external_server_urls)
-            router_args = build_router_args(ie_cfg, server_urls=server_urls)
-            self._inference_router = VLLMRouter(router_args, log_path=self._cfg.trainer.log_path)
-            proxy_url = self._inference_router.start()
-            logger.info(
-                f"HTTP Inference: Created router over external servers - "
-                f"server_urls={server_urls}, proxy_url={proxy_url}"
-            )
-
-        else:
-            cli_args = build_vllm_cli_args(self._cfg)
-            setup = create_inference_servers(
-                ie_cfg,
-                cli_args,
-                log_path=self._cfg.trainer.log_path,
-                placement_group=self._colocate_pg if is_colocated else None,
-            )
-            self._inference_router = setup.router
-            self._server_groups = list(
-                (setup.server_groups or []) + (setup.prefill_server_groups or []) + (setup.decode_server_groups or [])
-            )
-            proxy_url = setup.proxy_url
-            server_urls = setup.server_urls
-
-        lora_cfg = self._cfg.trainer.policy.model.lora
-        active_lora_name = (
-            _SKYRL_LORA_ADAPTER_NAME
-            if lora_cfg and lora_cfg.rank > 0 and self._cfg.trainer.strategy != "megatron"
-            else None
+        client, server_setup = build_new_inference_client(
+            self._cfg,
+            self._tokenizer,
+            placement_group=self._colocate_pg if is_colocated else None,
         )
-        self._inference_engine_client = RemoteInferenceClient(
-            proxy_url=proxy_url,
-            server_urls=server_urls,
-            model_name=self._cfg.trainer.policy.model.path,
-            active_lora_name=active_lora_name,
-            data_parallel_size=ie_cfg.data_parallel_size,
-            tokenizer=self._tokenizer,
+        self._inference_router = server_setup.router
+        self._server_groups = list(
+            server_setup.server_groups + server_setup.prefill_server_groups + server_setup.decode_server_groups
         )
+        self._inference_engine_client = client
 
     def _ensure_inference_engines(self):
         """Lazily create inference engines and init weight sync on first sampling-related call."""

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -23,7 +23,7 @@ from skyrl.backends.skyrl_train.inference_engines.ray_wrapped_inference_engine i
 from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
     RemoteInferenceClient,
 )
-from skyrl.backends.skyrl_train.inference_servers.server_group import ServerGroup
+from skyrl.backends.skyrl_train.inference_servers.setup import create_inference_servers
 from skyrl.backends.skyrl_train.inference_servers.utils import (
     build_router_args,
     build_vllm_cli_args,
@@ -141,7 +141,7 @@ class SkyRLTrainBackend(AbstractBackend):
         self._renderer = None
 
         # New inference infrastructure
-        self._server_group = None
+        self._server_groups: list = []
         self._inference_router = None
 
     def has_model(self, model_id: str) -> bool:
@@ -362,24 +362,18 @@ class SkyRLTrainBackend(AbstractBackend):
 
         else:
             cli_args = build_vllm_cli_args(self._cfg)
-
-            self._server_group = ServerGroup(
-                cli_args=cli_args,
-                num_servers=ie_cfg.num_engines,
+            setup = create_inference_servers(
+                ie_cfg,
+                cli_args,
+                log_path=self._cfg.trainer.log_path,
                 placement_group=self._colocate_pg if is_colocated else None,
-                enable_dp=ie_cfg.data_parallel_size > 1,
-                distributed_executor_backend=ie_cfg.distributed_executor_backend,
             )
-            server_infos = self._server_group.start()
-            server_urls = [info.url for info in server_infos]
-
-            router_args = build_router_args(ie_cfg, server_urls=server_urls)
-            self._inference_router = VLLMRouter(router_args, log_path=self._cfg.trainer.log_path)
-            proxy_url = self._inference_router.start()
-            logger.info(
-                f"HTTP Inference: Built servers and router internally - "
-                f"proxy_url={proxy_url}, server_urls={server_urls}, colocated={is_colocated}"
+            self._inference_router = setup.router
+            self._server_groups = list(
+                (setup.server_groups or []) + (setup.prefill_server_groups or []) + (setup.decode_server_groups or [])
             )
+            proxy_url = setup.proxy_url
+            server_urls = setup.server_urls
 
         lora_cfg = self._cfg.trainer.policy.model.lora
         active_lora_name = (
@@ -479,9 +473,9 @@ class SkyRLTrainBackend(AbstractBackend):
         # deleting any model tears down the whole backend and it will be
         # re-initialized on the next create_model() call.
         logger.info(f"Deleting model {model_id}, shutting down shared SkyRL-Train runtime...")
-        if self._server_group:
-            self._server_group.shutdown()
-            self._server_group = None
+        for group in self._server_groups:
+            group.shutdown()
+        self._server_groups = []
         if self._inference_router:
             self._inference_router.shutdown()
             self._inference_router = None

--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -21,7 +21,6 @@ from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import
 from skyrl.backends.skyrl_train.inference_engines.remote_inference_engine import (
     create_remote_inference_engines,
 )
-from skyrl.backends.skyrl_train.inference_servers.utils import build_vllm_cli_args
 from skyrl.env_vars import _SKYRL_USE_NEW_INFERENCE, SKYRL_RAY_PG_TIMEOUT_IN_S
 from skyrl.train.config import SkyRLTrainConfig, get_config_as_yaml_str
 from skyrl.train.dataset import PromptDataset
@@ -35,9 +34,6 @@ from skyrl.train.utils.utils import (
     initialize_ray,
 )
 from skyrl.utils.tok import get_tokenizer
-
-# Fixed LoRA adapter name used for generation requests when LoRA is active.
-_SKYRL_LORA_ADAPTER_NAME = "skyrl-lora"
 
 # NOTE (sumanthrh): We use ray heavily and thus disable `fork` start method.
 # forking within ray leads to undefined behaviour and often causes hard to debug
@@ -316,95 +312,23 @@ class BasePPOExp:
     def _get_new_inference_client(self):
         """New inference client using HTTP endpoints.
 
-        Config combinations:
-        - Colocated + external URLs → ERROR (validated earlier)
-        - Neither set → Build servers internally
-        - external_server_urls only → Create router over external servers
-        - external_proxy_url only → Use proxy for both data + control plane
-        - Both set → Fully external (proxy for data plane, servers for control plane)
-
         Returns:
             RemoteInferenceClient: The new inference client.
         """
-        from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
-            RemoteInferenceClient,
-        )
         from skyrl.backends.skyrl_train.inference_servers.setup import (
-            create_inference_servers,
-        )
-        from skyrl.backends.skyrl_train.inference_servers.utils import (
-            build_router_args,
-        )
-        from skyrl.backends.skyrl_train.inference_servers.vllm_router import (
-            VLLMRouter,
+            build_new_inference_client,
         )
 
-        ie_cfg = self.cfg.generator.inference_engine
         is_colocated = self.cfg.trainer.placement.colocate_all
-        external_proxy_url = ie_cfg.external_proxy_url
-        external_server_urls = ie_cfg.external_server_urls
-
-        has_external_proxy = external_proxy_url is not None
-        has_external_servers = external_server_urls is not None
-
-        if has_external_proxy and has_external_servers:
-            # Case: Both external - fully external setup
-            proxy_url = external_proxy_url
-            server_urls = list(external_server_urls)
-            logger.info(
-                f"HTTP Inference: Using fully external setup - " f"proxy_url={proxy_url}, server_urls={server_urls}"
-            )
-
-        elif has_external_proxy and not has_external_servers:
-            # Case: Proxy only - assume proxy handles control plane too
-            proxy_url = external_proxy_url
-            server_urls = [proxy_url]
-            logger.info(
-                f"HTTP Inference: Using external proxy for both data and " f"control plane - proxy_url={proxy_url}"
-            )
-
-        elif has_external_servers and not has_external_proxy:
-            # Case: Servers only - create internal router over them
-            server_urls = list(external_server_urls)
-            router_args = build_router_args(self.cfg.generator.inference_engine, server_urls=server_urls)
-            self._inference_router = VLLMRouter(router_args, log_path=self.cfg.trainer.log_path)
-            proxy_url = self._inference_router.start()
-            logger.info(
-                f"HTTP Inference: Created router over external "
-                f"servers - server_urls={server_urls}, proxy_url={proxy_url}"
-            )
-
-        else:
-            # Case: Neither - build servers and router internally
-            cli_args = build_vllm_cli_args(self.cfg)
-            setup = create_inference_servers(
-                self.cfg.generator.inference_engine,
-                cli_args,
-                log_path=self.cfg.trainer.log_path,
-                placement_group=self.colocate_pg if is_colocated else None,
-            )
-            self._inference_router = setup.router
-            self._server_groups = setup.server_groups
-            self._prefill_server_groups = setup.prefill_server_groups
-            self._decode_server_groups = setup.decode_server_groups
-            proxy_url = setup.proxy_url
-            server_urls = setup.server_urls
-
-        lora_cfg = self.cfg.trainer.policy.model.lora
-        active_lora_name = (
-            _SKYRL_LORA_ADAPTER_NAME
-            if lora_cfg and lora_cfg.rank > 0 and self.cfg.trainer.strategy != "megatron"
-            else None
+        client, server_setup = build_new_inference_client(
+            self.cfg,
+            self.tokenizer,
+            placement_group=self.colocate_pg if is_colocated else None,
         )
-        client = RemoteInferenceClient(
-            proxy_url=proxy_url,
-            server_urls=server_urls,
-            model_name=self.cfg.trainer.policy.model.path,
-            enable_return_routed_experts=ie_cfg.enable_return_routed_experts,
-            active_lora_name=active_lora_name,
-            data_parallel_size=ie_cfg.data_parallel_size,
-            tokenizer=self.tokenizer,
-        )
+        self._inference_router = server_setup.router
+        self._server_groups = server_setup.server_groups
+        self._prefill_server_groups = server_setup.prefill_server_groups
+        self._decode_server_groups = server_setup.decode_server_groups
 
         if is_colocated:
             # Callers must invoke get_inference_client() from a sync context (no running event loop).

--- a/tests/backends/skyrl_train/gpu/utils.py
+++ b/tests/backends/skyrl_train/gpu/utils.py
@@ -442,7 +442,13 @@ class InferenceEngineState:
         """
         if self.router is not None:
             self.router.shutdown()
-        for group_list in (self.server_groups, self.prefill_server_groups, self.decode_server_groups):
+        # Handle shutdown for prefill and decode server groups separately
+        group_lists = (
+            [self.server_groups]
+            if not self.prefill_server_groups
+            else [self.prefill_server_groups, self.decode_server_groups]
+        )
+        for group_list in group_lists:
             if group_list is not None:
                 for group in group_list:
                     group.shutdown()


### PR DESCRIPTION
Fixes #1575


## Test Plan

Ran a Tinker rl loop example with dp > 1

### Server 

```bash
  uv run --python 3.12 --extra tinker --extra fsdp -m skyrl.tinker.api \
    --base-model "Qwen/Qwen1.5-MoE-A2.7B" \
    --backend fsdp \
    --backend-config '{"trainer.placement.policy_num_gpus_per_node": 2, "generator.inference_engine.num_engines": 2, "generator.inference_engine.data_parallel_size": 2, "trainer.placement.colocate_all": false}'
```

### Client

```bash
TINKER_API_KEY=tml-dummy uv run --python 3.12 --extra tinker --extra fsdp \
    python -m tinker_cookbook.recipes.rl_loop \
      --base-url http://localhost:8000 \
      --model-name "Qwen/Qwen1.5-MoE-A2.7B"
```