### PR TITLE
[qoc][trainer] Use WorkerDispatch for weight sync instead of `policy_model`

### DIFF
--- a/docs/content/docs/tutorials/one_step_off_async.mdx
+++ b/docs/content/docs/tutorials/one_step_off_async.mdx
@@ -57,7 +57,7 @@ class AsyncRayPPOTrainer(RayPPOTrainer):
              if idx != len(self.train_dataloader) - 1:
                  await self.generation_ack.wait()
              # Synchronize weights after training.
-             await self.async_sync_policy_weights_to_inference_engines()
+             await self.dispatch.save_weights_for_sampler()
              # Signal that weight sync is done, ready for next round of generation.
              self.sync_finished.set()
              self.generation_ack.clear()

--- a/examples/train/async/async_trainer.py
+++ b/examples/train/async/async_trainer.py
@@ -34,7 +34,7 @@ class AsyncRayPPOTrainer(RayPPOTrainer):
 
         # sync weights to inference engines
         with Timer("sync_weights_to_inference_engines"):
-            await self.async_sync_policy_weights_to_inference_engines()
+            await self.dispatch.save_weights_for_sampler()
 
         # Eval before training
         if self.cfg.trainer.eval_interval > 0 and self.cfg.trainer.eval_before_train:
@@ -68,7 +68,7 @@ class AsyncRayPPOTrainer(RayPPOTrainer):
 
                     # sync weights
                     async with Timer("sync_weights", self.all_timings):
-                        await self.async_sync_policy_weights_to_inference_engines()
+                        await self.dispatch.save_weights_for_sampler()
 
                     self.sync_finished.set()
                     self.generation_ack.clear()
@@ -193,11 +193,3 @@ class AsyncRayPPOTrainer(RayPPOTrainer):
             logger.error(f"Generator errored out with exception: {e}")
             logger.error(f"Traceback: \n{traceback.format_exc()}")
             sys.exit(1)
-
-    async def async_sync_policy_weights_to_inference_engines(self):
-        return await self.policy_model.async_run_method(
-            "pass_through",
-            "broadcast_to_inference_engines",
-            self.inference_engine_client,
-            self.cfg.generator.inference_engine,
-        )

--- a/skyrl-agent/skyrl_agent/integrations/skyrl_train/trainer.py
+++ b/skyrl-agent/skyrl_agent/integrations/skyrl_train/trainer.py
@@ -286,24 +286,14 @@ class SkyRLAgentPPOTrainer(RayPPOTrainer):
         with Timer("init_weight_sync_state"):
             self.init_weight_sync_state()
 
-        # Load policy model to GPU before loading checkpoint.
-        if self.colocate_all:
-            self.policy_model.backload_to_gpu()
-
         # Load checkpoint state if resumption is enabled.
         if self.resume_mode != ResumeMode.NONE:
             with Timer("load_checkpoints"):
                 self.global_step, _ = self.load_checkpoints()
 
-        if self.colocate_all:
-            self.policy_model.offload_to_cpu(offload_optimizer=True, offload_model=False)
-            await self.inference_engine_client.wake_up(tags=["weights"])
+        # Prepare weights for sampling
         with Timer("sync_weights"):
-            ray.get(self.sync_policy_weights_to_inference_engines())
-        if self.colocate_all:
-            with Timer("offload_policy_model_to_cpu"):
-                self.policy_model.offload_to_cpu(offload_optimizer=False, offload_model=True)
-            await self.inference_engine_client.wake_up(tags=["kv_cache"])
+            await self.dispatch.save_weights_for_sampler()
 
         # Eval before training
         if self.cfg.trainer.eval_interval > 0 and self.cfg.trainer.eval_before_train:
@@ -413,15 +403,8 @@ class SkyRLAgentPPOTrainer(RayPPOTrainer):
                             self.update_ref_with_policy()
 
                     # 7. sync weights to inference engines
-                    if self.colocate_all:
-                        self.policy_model.offload_to_cpu(offload_optimizer=True, offload_model=False)
-                        await self.inference_engine_client.wake_up(tags=["weights"])
                     with Timer("sync_weights", self.all_timings):
-                        ray.get(self.sync_policy_weights_to_inference_engines())
-                    if self.colocate_all:
-                        with Timer("offload_policy_model_to_cpu"):
-                            self.policy_model.offload_to_cpu(offload_optimizer=False, offload_model=True)
-                        await self.inference_engine_client.wake_up(tags=["kv_cache"])
+                        await self.dispatch.save_weights_for_sampler()
 
                 # 8. set logs
                 logger.info(status)
@@ -453,7 +436,7 @@ class SkyRLAgentPPOTrainer(RayPPOTrainer):
         pbar.close()
         if self.colocate_all:
             await self.inference_engine_client.sleep()
-            self.policy_model.backload_to_gpu()
+
         if self.cfg.trainer.ckpt_interval > 0:
             with Timer("save_checkpoints", self.all_timings):
                 self.save_checkpoints()

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -369,73 +369,6 @@ class WorkerDispatch:
         self._gpu_state[model].model_on_gpu = True
         self._gpu_state[model].optimizer_on_gpu = model != "ref"  # ref has no optimizer
 
-    def init_weight_sync_state(self, inference_engine_client) -> None:
-        """Initialize weight sync state for policy model."""
-        ray.get(
-            self._actor_groups["policy"].async_run_ray_method(
-                "pass_through",
-                "init_weight_sync_state",
-                inference_engine_client,
-                self.cfg.generator.inference_engine,
-            )
-        )
-
-    def broadcast_to_inference_engines(self, inference_engine_client) -> None:
-        """Broadcast policy weights to inference engines."""
-        ray.get(
-            self._actor_groups["policy"].async_run_ray_method(
-                "pass_through",
-                "broadcast_to_inference_engines",
-                inference_engine_client,
-                self.cfg.generator.inference_engine,
-            )
-        )
-
-    def prepare_for_weight_sync(self) -> None:
-        """Prepare for weight sync: ensure policy model is on GPU, offload optimizer."""
-        if not self.colocate_all:
-            return
-        # Ensure policy model is on GPU (will offload others in colocation group)
-        self._ensure_on_gpu("policy", need_optimizer=False, need_model=True)
-        # Offload optimizer if it's on GPU
-        if self._gpu_state["policy"].optimizer_on_gpu:
-            self._offload("policy", offload_optimizer=True, offload_model=False)
-
-    def finish_weight_sync(self) -> None:
-        """Finish weight sync: offload model weights and optimizer state."""
-        if not self.colocate_all:
-            return
-        self._offload("policy", offload_optimizer=True, offload_model=True)
-
-    async def save_weights_for_sampler(self) -> None:
-        """
-        Tinker API method to prepare updated parameters for sampling.
-
-        Syncs weights to inference engine for sampling.
-        """
-        if self._inference_engine_client is None:
-            raise RuntimeError(
-                "Cannot save_weights_for_sampler: no inference_engine_client configured. "
-                "Pass inference_engine_client to WorkerDispatch constructor or call set_inference_engine_client()."
-            )
-
-        # Sync weights to inference engine
-        self.prepare_for_weight_sync()
-        if self.colocate_all:
-            await self._inference_engine_client.wake_up(tags=["weights"])
-            self.broadcast_to_inference_engines(self._inference_engine_client)
-            self.finish_weight_sync()
-            await self._inference_engine_client.wake_up(tags=["kv_cache"])
-        else:
-            # Non-colocated: pause generation to prevent in-flight requests from
-            # reading partially-updated weights during the NCCL broadcast.
-            await self._inference_engine_client.pause_generation()
-            try:
-                self.broadcast_to_inference_engines(self._inference_engine_client)
-                self.finish_weight_sync()
-            finally:
-                await self._inference_engine_client.resume_generation()
-
     def set_inference_engine_client(self, inference_engine_client: InferenceEngineClient) -> None:
         """Set the inference engine client for weight sync.
 
@@ -460,3 +393,74 @@ class WorkerDispatch:
             node_ids = ray.get(group.async_run_ray_method("pass_through", "get_ray_node_id"))
             all_node_ids.extend(node_ids)
         return list(set(all_node_ids))
+
+    # ----------------------------------
+    # Weight sync methods
+    # ----------------------------------
+
+    def init_weight_sync_state(self, inference_engine_client) -> None:
+        """Initialize weight sync state for policy model."""
+        ray.get(
+            self._actor_groups["policy"].async_run_ray_method(
+                "pass_through",
+                "init_weight_sync_state",
+                inference_engine_client,
+                self.cfg.generator.inference_engine,
+            )
+        )
+
+    def _broadcast_to_inference_engines(self, inference_engine_client) -> None:
+        """Broadcast policy weights to inference engines. Helper for save_weights_for_sampler."""
+        ray.get(
+            self._actor_groups["policy"].async_run_ray_method(
+                "pass_through",
+                "broadcast_to_inference_engines",
+                inference_engine_client,
+                self.cfg.generator.inference_engine,
+            )
+        )
+
+    def _prepare_for_weight_sync(self) -> None:
+        """Prepare for weight sync: ensure policy model is on GPU, offload optimizer. Helper for save_weights_for_sampler."""
+        if not self.colocate_all:
+            return
+        # Ensure policy model is on GPU (will offload others in colocation group)
+        self._ensure_on_gpu("policy", need_optimizer=False, need_model=True)
+        # Offload optimizer if it's on GPU
+        if self._gpu_state["policy"].optimizer_on_gpu:
+            self._offload("policy", offload_optimizer=True, offload_model=False)
+
+    def _finish_weight_sync(self) -> None:
+        """Finish weight sync: offload model weights and optimizer state. Helper for save_weights_for_sampler."""
+        if not self.colocate_all:
+            return
+        self._offload("policy", offload_optimizer=True, offload_model=True)
+
+    async def save_weights_for_sampler(self) -> None:
+        """
+        Tinker API method to prepare updated parameters for sampling.
+
+        Syncs weights to inference engine for sampling.
+        """
+        if self._inference_engine_client is None:
+            raise RuntimeError(
+                "Cannot save_weights_for_sampler: no inference_engine_client configured. "
+                "Pass inference_engine_client to WorkerDispatch constructor or call set_inference_engine_client()."
+            )
+
+        # Sync weights to inference engine
+        self._prepare_for_weight_sync()
+        if self.colocate_all:
+            await self._inference_engine_client.wake_up(tags=["weights"])
+            self._broadcast_to_inference_engines(self._inference_engine_client)
+            self._finish_weight_sync()
+            await self._inference_engine_client.wake_up(tags=["kv_cache"])
+        else:
+            # Non-colocated: pause generation to prevent in-flight requests from
+            # reading partially-updated weights during the NCCL broadcast.
+            await self._inference_engine_client.pause_generation()
+            try:
+                self._broadcast_to_inference_engines(self._inference_engine_client)
+                self._finish_weight_sync()
+            finally:
+                await self._inference_engine_client.resume_generation()

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -356,7 +356,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
 
         # sync weights to inference engines
         with Timer("sync_weights_to_inference_engines"):
-            await self.async_sync_policy_weights_to_inference_engines()
+            await self.dispatch.save_weights_for_sampler()
 
         # Eval before training
         if self.cfg.trainer.eval_interval > 0 and self.cfg.trainer.eval_before_train:
@@ -420,9 +420,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
 
                     # 4. After training: pause generation, sync weights, resume.
                     with Timer("sync_weights", self.all_timings):
-                        await self.inference_engine_client.pause_generation()
-                        await self.async_sync_policy_weights_to_inference_engines()
-                        await self.inference_engine_client.resume_generation()
+                        await self.dispatch.save_weights_for_sampler()
 
                 # 5. Set logs for this training step.
                 logger.info(status)
@@ -606,14 +604,6 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             if "slot_acquired" in locals() and slot_acquired:
                 raise RuntimeError("Generation workers should only run into error when they finish running.")
             sys.exit(1)
-
-    async def async_sync_policy_weights_to_inference_engines(self):
-        return await self.policy_model.async_run_method(
-            "pass_through",
-            "broadcast_to_inference_engines",
-            self.inference_engine_client,
-            self.cfg.generator.inference_engine,
-        )
 
     def convert_generation_group_mini_batch_to_training_input(
         self, cur_generation_group_mini_batch: List[GeneratedOutputGroup]

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -11,7 +11,6 @@ import ray
 import torch
 from jaxtyping import Float
 from loguru import logger
-from ray import ObjectRef
 from ray.util.placement_group import placement_group
 from tqdm import tqdm
 from transformers import AutoTokenizer
@@ -592,21 +591,6 @@ class RayPPOTrainer:
         """
         self.dispatch.init_weight_sync_state(self.inference_engine_client)
         logger.info("Initialized weight sync state for policy model and inference engines.")
-
-    def sync_policy_weights_to_inference_engines(self) -> List[ObjectRef]:
-        """Broadcast policy weights to inference engines.
-
-        Note: For new code, prefer using dispatch.save_weights_for_sampler() which
-        handles the full weight sync protocol including offload/backload.
-        This method is kept for backward compatibility with subclasses.
-        TODO(tgriggs): Remove this method when migration is complete.
-        """
-        return self.policy_model.async_run_ray_method(
-            "pass_through",
-            "broadcast_to_inference_engines",
-            self.inference_engine_client,
-            self.cfg.generator.inference_engine,
-        )
 
     def convert_to_training_input(self, generator_output: GeneratorOutput, uids: List[str]) -> TrainingInputBatch:
         """Converts lists to a padded batch of tensors for training

--- a/tests/backends/skyrl_train/distributed/test_megatron_correctness.py
+++ b/tests/backends/skyrl_train/distributed/test_megatron_correctness.py
@@ -125,14 +125,14 @@ class TestWeightSyncPauseFlush:
         dispatch = WorkerDispatch.__new__(WorkerDispatch)
         dispatch.colocate_all = False
         dispatch._inference_engine_client = AsyncMock()
-        dispatch.broadcast_to_inference_engines = MagicMock()
-        dispatch.prepare_for_weight_sync = MagicMock()
-        dispatch.finish_weight_sync = MagicMock()
+        dispatch._broadcast_to_inference_engines = MagicMock()
+        dispatch._prepare_for_weight_sync = MagicMock()
+        dispatch._finish_weight_sync = MagicMock()
 
         await dispatch.save_weights_for_sampler()
 
         dispatch._inference_engine_client.pause_generation.assert_awaited_once()
-        dispatch.broadcast_to_inference_engines.assert_called_once()
+        dispatch._broadcast_to_inference_engines.assert_called_once()
         dispatch._inference_engine_client.resume_generation.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -142,9 +142,9 @@ class TestWeightSyncPauseFlush:
         dispatch = WorkerDispatch.__new__(WorkerDispatch)
         dispatch.colocate_all = True
         dispatch._inference_engine_client = AsyncMock()
-        dispatch.broadcast_to_inference_engines = MagicMock()
-        dispatch.prepare_for_weight_sync = MagicMock()
-        dispatch.finish_weight_sync = MagicMock()
+        dispatch._broadcast_to_inference_engines = MagicMock()
+        dispatch._prepare_for_weight_sync = MagicMock()
+        dispatch._finish_weight_sync = MagicMock()
 
         await dispatch.save_weights_for_sampler()
 
@@ -163,9 +163,9 @@ class TestWeightSyncPauseFlush:
         dispatch._inference_engine_client = AsyncMock()
         dispatch._inference_engine_client.pause_generation = AsyncMock(side_effect=lambda: call_order.append("pause"))
         dispatch._inference_engine_client.resume_generation = AsyncMock(side_effect=lambda: call_order.append("resume"))
-        dispatch.broadcast_to_inference_engines = MagicMock(side_effect=lambda _: call_order.append("broadcast"))
-        dispatch.prepare_for_weight_sync = MagicMock()
-        dispatch.finish_weight_sync = MagicMock()
+        dispatch._broadcast_to_inference_engines = MagicMock(side_effect=lambda _: call_order.append("broadcast"))
+        dispatch._prepare_for_weight_sync = MagicMock()
+        dispatch._finish_weight_sync = MagicMock()
 
         await dispatch.save_weights_for_sampler()
 
@@ -179,9 +179,9 @@ class TestWeightSyncPauseFlush:
         dispatch = WorkerDispatch.__new__(WorkerDispatch)
         dispatch.colocate_all = False
         dispatch._inference_engine_client = AsyncMock()
-        dispatch.broadcast_to_inference_engines = MagicMock(side_effect=RuntimeError("broadcast failed"))
-        dispatch.prepare_for_weight_sync = MagicMock()
-        dispatch.finish_weight_sync = MagicMock()
+        dispatch._broadcast_to_inference_engines = MagicMock(side_effect=RuntimeError("broadcast failed"))
+        dispatch._prepare_for_weight_sync = MagicMock()
+        dispatch._finish_weight_sync = MagicMock()
 
         with pytest.raises(RuntimeError, match="broadcast failed"):
             await dispatch.save_weights_for_sampler()


### PR DESCRIPTION
Address "Remove weight sync logic from trainer. This should not be explicitly triggered by the trainer" item in #859, where we remove `sync_policy_weights_to_inference_engines()` from `RayPPOTrainer`.

Subclasses that call this method can directly use `await self.dispatch.save_weights_for_sampler()` which will also handle colocating logics.

Specifically, we modify `skyrl-agent`'s `trainer.py`, `async_trainer.py` (one-step off), and `fully_async_trainer.py`.

In addition, re-organize `dispatch.py` a bit to have the private methods start with underscore `_`:

```py
        broadcast_to_inference_engines --> _broadcast_to_inference_engines
        prepare_for_weight_sync --> _prepare_for_weight_sync
        finish_weight_sync --> _finish_weight_sync
```

### Testings

Ran `fully_async`, one-step-off `async`, and sync `run_gsm8k.sh` (colocated and uncolocated). Claude code checked infra log and made sure there is no extra sleeps.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
