### PR TITLE
[qoc][trainer] Remove unused PPORayActorGroup and Dispatch methods

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/dispatch.py
+++ b/skyrl/backends/skyrl_train/distributed/dispatch.py
@@ -1,9 +1,8 @@
 """Defines dispatch and collect logic for distributed training"""
 
-import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Tuple, Type
 
 import ray
 from ray import ObjectRef
@@ -64,7 +63,6 @@ class Dispatch(ABC):
 
     Dispatch types are responsible for:
     - dispatching method calls to actors handling data sharding if necessary
-    - collecting results from actors and concatenating results if necessary
     - validating arguments for dispatch
     """
 
@@ -72,20 +70,6 @@ class Dispatch(ABC):
     @abstractmethod
     def dispatch(cls, actor_infos: List[ActorInfo], method: str, *args, **kwargs) -> List[ObjectRef]:
         """Dispatches method calls to the actors with data sharding if necessary."""
-        pass
-
-    @classmethod
-    @abstractmethod
-    async def async_collect(
-        cls, actor_infos: List[ActorInfo], object_refs: List[ObjectRef]
-    ) -> Optional[TrainingOutputBatch]:
-        """Collects results from the actors asynchronously in an asyncio-compatible way."""
-        pass
-
-    @classmethod
-    @abstractmethod
-    def sync_collect(cls, actor_infos: List[ActorInfo], object_refs: List[ObjectRef]) -> Optional[TrainingOutputBatch]:
-        """Collects results from the actors synchronously and returns a `TrainingOutputBatch`."""
         pass
 
     @classmethod
@@ -110,19 +94,10 @@ class MeshDispatch(Dispatch):
     * The input data is chunked into `dp_size` equal chunks, where `dp_size` is the size of data parallelism.
     * Each actor with the same DP rank processes the same data chunk in parallel.
 
-    For data collection:
-
-    * Data is collected only from the primary rank of each model/sequence parallel group.
-    * The primary rank is defined as the rank with (SP=0, TP=0, PP=0).
-    * The collected chunks are concatenated in order of DP rank to reconstruct the full data.
-
     Example: For a world size of 8, with DP size=2, SP size=2, TP size=2, PP size=1:
 
     * Data dispatch: The data is chunked into 2 chunks. All actors with DP rank 0 process the first chunk,
       and all actors with DP rank 1 process the second chunk.
-    * Data collection: Only two actors contribute to the final output - the primary rank from each DP group:
-      (DP=0, SP=0, TP=0, PP=0) and (DP=1, SP=0, TP=0, PP=0). Their chunks are concatenated in order.
-
     """
 
     @classmethod
@@ -145,26 +120,6 @@ class MeshDispatch(Dispatch):
             chunk_ref = chunk_refs[actor_info.rank.dp]
             object_refs.append(getattr(actor_info.handle, method).remote(chunk_ref, **kwargs))
         return object_refs
-
-    @classmethod
-    async def async_collect(
-        cls, actor_infos: List[ActorInfo], object_refs: List[ObjectRef]
-    ) -> Optional[TrainingOutputBatch]:
-        assert len(actor_infos) == len(object_refs), "`actor_infos` and `object_refs` must have the same length"
-        all_objects = await asyncio.gather(*object_refs)
-        if len(all_objects) and all_objects[0] is not None:
-            return concatenate_outputs_after_mesh_dispatch(actor_infos, all_objects)
-        return
-
-    @classmethod
-    def sync_collect(cls, actor_infos: List[ActorInfo], object_refs: List[ObjectRef]) -> Optional[TrainingOutputBatch]:
-        assert len(actor_infos) == len(object_refs), "`actor_infos` and `object_refs` must have the same length"
-        all_objects = ray.get(object_refs)
-        if len(all_objects) and all_objects[0] is not None:
-            return concatenate_outputs_after_mesh_dispatch(actor_infos, all_objects)
-        # all should be none
-        assert all(obj is None for obj in all_objects), "Got a mix of `None` and non-`None` objects"
-        return
 
     @classmethod
     def stage_chunks(
@@ -265,27 +220,6 @@ class PassThroughDispatch(Dispatch):
     @classmethod
     def dispatch(cls, actor_infos: List[ActorInfo], method: str, *args, **kwargs) -> List[ObjectRef]:
         return [getattr(actor_info.handle, method).remote(*args, **kwargs) for actor_info in actor_infos]
-
-    @classmethod
-    async def async_collect(
-        cls, actor_infos: List[ActorInfo], object_refs: List[ObjectRef]
-    ) -> Optional[TrainingOutputBatch]:
-        all_objects = await asyncio.gather(*object_refs)
-        if len(all_objects) and all_objects[0] is not None:
-            return concatenate_outputs_after_mesh_dispatch(actor_infos, all_objects)
-        return
-
-    @classmethod
-    def sync_collect(cls, actor_infos: List[ActorInfo], object_refs: List[ObjectRef]) -> Optional[TrainingOutputBatch]:
-        data_batches = ray.get(object_refs)
-        if len(data_batches) > 0 and data_batches[0] is not None:
-            assert isinstance(
-                data_batches[0], TrainingOutputBatch
-            ), "data_batches must be a list of `TrainingOutputBatch` objects"
-            return concatenate_outputs_after_mesh_dispatch(actor_infos, data_batches)
-        # all should be none
-        assert all(obj is None for obj in data_batches), "Got a mix of `None` and non-`None` objects"
-        return
 
     @classmethod
     def validate_dispatch_args(cls, *args, **kwargs) -> Tuple[Tuple, Dict[str, Any]]:

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -602,30 +602,6 @@ class PPORayActorGroup:
             return refs
         return ray.get(refs)
 
-    def run_method(self, dispatch_type: str, method_name: str, *args, **kwargs) -> Optional[TrainingOutputBatch]:
-        """Run a method on all actors using specified dispatch type synchronously.
-
-        The method should either return `None` or a `TrainingOutputBatch` object.
-
-        Args:
-            dispatch_type: Type of dispatch to use ("mesh" or "pass_through")
-            method_name: Name of the method to call on actors
-            *args: Positional arguments to pass to the method
-            **kwargs: Keyword arguments to pass to the method
-
-        Returns:
-            Collect results from all the actors.
-        """
-        dispatch_class: Dispatch = DispatchRegistry.get(dispatch_type)
-        # validate the dispatch args to be sent to `.dispatch`
-        args, kwargs = dispatch_class.validate_dispatch_args(*args, **kwargs)
-
-        # Dispatch the method call
-        object_refs = dispatch_class.dispatch(self.actor_infos, method_name, *args, **kwargs)
-        # Collect results from all the actors
-        ret = dispatch_class.sync_collect(self.actor_infos, object_refs)
-        return ret
-
     def async_run_ray_method(self, dispatch_type: str, method_name: str, *args, **kwargs) -> List[ObjectRef]:
         """Run a method on all actors using specified dispatch type asynchronously.
 
@@ -645,28 +621,6 @@ class PPORayActorGroup:
         # Dispatch the method call
         object_refs = dispatch_class.dispatch(self.actor_infos, method_name, *args, **kwargs)
         return object_refs
-
-    async def async_run_method(
-        self, dispatch_type: str, method_name: str, *args, **kwargs
-    ) -> Optional[TrainingOutputBatch]:
-        """Run a method on all actors using specified dispatch type in an asyncio-compatible way.
-
-        Args:
-            dispatch_type: Type of dispatch to use ("mesh" or "pass_through")
-            method_name: Name of the method to call on actors
-            *args: Positional arguments to pass to the method
-            **kwargs: Keyword arguments to pass to the method
-
-        Returns:
-            TrainingOutputBatch: concatenated results from all actors
-        """
-        dispatch_class: Dispatch = DispatchRegistry.get(dispatch_type)
-        # validate the dispatch args to be sent to `.dispatch`
-        args, kwargs = dispatch_class.validate_dispatch_args(*args, **kwargs)
-
-        # Dispatch the method call
-        object_refs = dispatch_class.dispatch(self.actor_infos, method_name, *args, **kwargs)
-        return await dispatch_class.async_collect(self.actor_infos, object_refs)
 
 
 class PolicyWorkerBase(Worker):

--- a/tests/backends/skyrl_train/distributed/test_dispatch.py
+++ b/tests/backends/skyrl_train/distributed/test_dispatch.py
@@ -2,9 +2,8 @@
 uv run --isolated --extra dev pytest tests/backends/skyrl_train/distributed/test_dispatch.py
 """
 
-from typing import List, Optional, Union
+from typing import List
 
-import pytest
 import ray
 import torch
 from ray import ObjectRef
@@ -16,6 +15,7 @@ from skyrl.backends.skyrl_train.distributed.dispatch import (
     MeshDispatch,
     MeshRank,
     PassThroughDispatch,
+    concatenate_outputs_after_mesh_dispatch,
 )
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.train.dataset.preprocess import compute_prompt_mini_batch_boundaries
@@ -53,14 +53,12 @@ class RayActorGroup:
 
     def mesh_dispatch_and_collect(self, data: TrainingInputBatch):
         object_refs = MeshDispatch.dispatch(self.actor_infos, "do_work", data)
-        ret = MeshDispatch.sync_collect(self.actor_infos, object_refs)
-        return ret
+        return concatenate_outputs_after_mesh_dispatch(self.actor_infos, ray.get(object_refs))
 
     def pass_through_dispatch(self, a, b):
         # just pass values as is
         object_refs = PassThroughDispatch.dispatch(self.actor_infos, "dummy", a, b)
-        ret = PassThroughDispatch.sync_collect(self.actor_infos, object_refs)
-        return ret
+        return ray.get(object_refs)
 
 
 def test_mesh_dispatch():
@@ -104,7 +102,7 @@ def test_stage_chunks_and_dispatch_from_staged():
     )
 
     # Collect results (only sp=0 workers contribute, which are ranks 0,1,2,3)
-    results = MeshDispatch.sync_collect(actor_group.actor_infos, object_refs)
+    results = concatenate_outputs_after_mesh_dispatch(actor_group.actor_infos, ray.get(object_refs))
 
     # Expected: each dp_rank gets 2 elements, adds its rank
     # dp_rank 0 (rank 0): [8,9] + 0 = [8,9]
@@ -120,20 +118,7 @@ def test_pass_through_dispatch():
     num_actors = 8
     actor_group = RayActorGroup(num_actors)
     ret = actor_group.pass_through_dispatch(1, 2)
-    assert ret is None
-
-
-def test_mesh_dispatch_with_mixed():
-    num_actors = 8
-    actor_group = RayActorGroup(num_actors)
-    object_refs = MeshDispatch.dispatch(
-        actor_group.actor_infos,
-        "do_work",
-        TrainingInputBatch({"a": torch.tensor([1, 2, 3, 4])}),
-    )
-    object_refs[0] = ray.put(None)
-    with pytest.raises(AssertionError):
-        MeshDispatch.sync_collect(actor_group.actor_infos, object_refs)
+    assert ret == [None] * num_actors
 
 
 def test_dispatch_registry():
@@ -143,18 +128,6 @@ def test_dispatch_registry():
         class CustomDispatch(Dispatch):
             @classmethod
             def dispatch(cls, actor_infos: List[ActorInfo], method: str, *args, **kwargs) -> List[ObjectRef]:
-                pass
-
-            @classmethod
-            def sync_collect(
-                cls, actor_infos: List[ActorInfo], object_refs: List[ObjectRef], nonblocking: bool = False
-            ) -> Union[List[ObjectRef], TrainingInputBatch]:
-                pass
-
-            @classmethod
-            def async_collect(
-                cls, actor_infos: List[ActorInfo], object_refs: List[ObjectRef]
-            ) -> Optional[TrainingInputBatch]:
                 pass
 
         DispatchRegistry.register("custom", CustomDispatch)

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_worker_offload.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_worker_offload.py
@@ -8,7 +8,6 @@ import shutil
 import pytest
 import ray
 
-from skyrl.backends.skyrl_train.training_batch import TrainingOutputBatch
 from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.utils.utils import validate_cfg
 from tests.backends.skyrl_train.gpu.utils import (
@@ -211,7 +210,7 @@ async def test_fsdp_ref_offload_memory_and_correctness(ray_init_fixture, cfg, wo
 
         dummy_batch = make_dummy_tensorbatch()
         # Run forward pass
-        results: TrainingOutputBatch = actor_group.run_method("pass_through", "forward", dummy_batch)
+        results = ray.get(actor_group.async_run_ray_method("pass_through", "forward", dummy_batch))
 
         after_forward = get_rank_0_memory(actor_group, "After forward")
 
@@ -238,7 +237,7 @@ async def test_fsdp_ref_offload_memory_and_correctness(ray_init_fixture, cfg, wo
         get_rank_0_memory(actor_group, "After backload")
 
         # Run forward again and ensure output consistency
-        results_backload: TrainingOutputBatch = actor_group.run_method("pass_through", "forward", dummy_batch)
+        results_backload = ray.get(actor_group.async_run_ray_method("pass_through", "forward", dummy_batch))
 
         assert (
             results == results_backload


### PR DESCRIPTION
## Summary

Removes unused dispatch collect APIs that had no production callers:

- `PPORayActorGroup.run_method` / `async_run_method`
- Hence, `Dispatch.sync_collect` / `Dispatch.async_collect` and both implementations in `MeshDispatch` / `PassThroughDispatch`


The actual dispatch path used in production is `async_run_ray_method` + `ray.get` (or `concatenate_outputs_after_mesh_dispatch` for mesh-collected outputs); these removed helpers were a parallel API kept alive only by tests.

## Changes

- `dispatch.py`: drop `async_collect` / `sync_collect` from the `Dispatch` ABC and both subclasses; drop now-unused `asyncio` import and stale "data collection" docstrings.
- `worker.py`: drop `run_method` and `async_run_method` from `PPORayActorGroup`.
- `test_dispatch.py`: replace `sync_collect` calls with `concatenate_outputs_after_mesh_dispatch(actor_infos, ray.get(refs))` (the public helper used in `worker_dispatch.py` and other tests). Drop `test_mesh_dispatch_with_mixed` — its "mix of None / non-None" assertion was specific to `sync_collect` and not part of the helper's contract.
- `test_worker_offload.py`: switch the two `run_method("pass_through", "forward", ...)` calls to `ray.get(async_run_ray_method(...))`.

## Test plan

- [x] `uv run --isolated --extra fsdp --extra dev pytest tests/backends/skyrl_train/distributed/test_dispatch.py` — 4 passed
- [x] `uv run --isolated --extra fsdp --extra dev pytest tests/backends/skyrl_train/gpu/gpu_ci/test_worker_offload.py` — 11 passed
- [x] `grep` confirms no remaining references to the removed names in tracked source, tests, or docs.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
