### PR TITLE
Fix GPU assignment for Slurm-launched Ray clusters

### DIFF
--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -65,7 +65,6 @@ from skyrl.train.utils.utils import (
     ResolvedPlacementGroup,
     configure_ray_worker_logging,
     get_ray_pg_ready_with_timeout,
-    ray_noset_visible_devices,
 )
 
 _SET_AFFINITY = False
@@ -96,10 +95,11 @@ class DistributedTorchRayActor:
         os.environ["MASTER_PORT"] = str(self._master_port)
         os.environ["WORLD_SIZE"] = str(self._world_size)
         os.environ["RANK"] = str(self._rank)
-        # NOTE: Ray will automatically set the CUDA_VISIBLE_DEVICES
-        # environment variable for each actor, so always set device to 0
-        # os.environ["LOCAL_RANK"] = str(self._local_rank)
-        os.environ["LOCAL_RANK"] = str(ray.get_gpu_ids()[0]) if ray_noset_visible_devices() else "0"
+        # Narrow CUDA_VISIBLE_DEVICES to the Ray-assigned GPU so LOCAL_RANK="0"
+        # is correct regardless of whether Ray or Slurm set
+        # CUDA_VISIBLE_DEVICES before actor init
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(ray.get_gpu_ids()[0])
+        os.environ["LOCAL_RANK"] = "0"
         self.sequence_parallel_size: int = sequence_parallel_size
 
         self.record_memory = record_memory

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -98,8 +98,14 @@ class DistributedTorchRayActor:
         # Narrow CUDA_VISIBLE_DEVICES to the Ray-assigned GPU so LOCAL_RANK="0"
         # is correct regardless of whether Ray or Slurm set
         # CUDA_VISIBLE_DEVICES before actor init
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(ray.get_gpu_ids()[0])
-        os.environ["LOCAL_RANK"] = "0"
+        gpu_ids = ray.get_gpu_ids()
+        if gpu_ids:
+            assert len(gpu_ids) == 1, f"Expected 1 GPU per actor, got {gpu_ids}"
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_ids[0])
+            os.environ["LOCAL_RANK"] = "0"
+        else:
+            os.environ["LOCAL_RANK"] = str(self._local_rank)
+
         self.sequence_parallel_size: int = sequence_parallel_size
 
         self.record_memory = record_memory


### PR DESCRIPTION
 
Fixes #1577
 
## Problem
 
`DistributedTorchRayActor.__init__` assumed Ray always narrows `CUDA_VISIBLE_DEVICES` to a single GPU per actor, making `LOCAL_RANK="0"` safe. On Slurm clusters, Ray inherits `CUDA_VISIBLE_DEVICES="0,1,...,7"` from Slurm and never narrows it, so every worker calls `set_device(0)` and piles onto physical GPU 0, causing silent OOMs.
 
## Fix
 
```python
os.environ["CUDA_VISIBLE_DEVICES"] = str(ray.get_gpu_ids()[0])
os.environ["LOCAL_RANK"] = "0"
```
 
We explicitly narrow `CUDA_VISIBLE_DEVICES` to the Ray-assigned physical GPU, making `LOCAL_RANK="0"` unconditionally correct. This replaces the `ray_noset_visible_devices()` ternary which only checked whether the user disabled Ray's narrowing, not whether Ray actually performed it.
 
## Scenarios
 
| | CVD before init | CVD after fix | LOCAL_RANK |
|---|---|---|---|
| Ray default | `"3"` (Ray narrowed) | `"3"` (no-op) | `"0"` ✓ |
| Ray noset | `"0,1,...,7"` | `"3"` | `"0"` ✓ |
| Slurm | `"0,1,...,7"` | `"3"` | `"0"` ✓ |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
