### PR TITLE
[harbor] Use old inference codepath for harbor

### DIFF
--- a/examples/train_integrations/harbor/run_codecontest.sh
+++ b/examples/train_integrations/harbor/run_codecontest.sh
@@ -62,7 +62,7 @@ TRAJECTORIES_PER_SECOND=5  # Maximum trajectories per second (must be >= 1.0, fr
 MAX_CONCURRENCY=512        # Maximum concurrent trial.run() calls allowed (must be >= 1). null or omit to disable concurrency limiting
 
 # Run SkyRL command
-uv run --isolated --extra fsdp --extra harbor -m examples.train_integrations.harbor.entrypoints.main_harbor \
+_SKYRL_USE_NEW_INFERENCE=0 uv run --isolated --extra fsdp --extra harbor -m examples.train_integrations.harbor.entrypoints.main_harbor \
   data.train_data=$TRAIN_DATA \
   data.val_data=$EVAL_DATA \
   trainer.policy.model.path=Qwen/Qwen3-8B \

--- a/examples/train_integrations/harbor/run_codecontest_fully_async.sh
+++ b/examples/train_integrations/harbor/run_codecontest_fully_async.sh
@@ -72,7 +72,7 @@ TRAJECTORIES_PER_SECOND=5  # Maximum trajectories per second (must be >= 1.0, fr
 MAX_CONCURRENCY=128        # Maximum concurrent trial.run() calls allowed (must be >= 1). null or omit to disable concurrency limiting
 
 # Run SkyRL command
-uv run --isolated --extra fsdp --extra harbor -m examples.train_integrations.harbor.entrypoints.main_harbor_fully_async \
+_SKYRL_USE_NEW_INFERENCE=0 uv run --isolated --extra fsdp --extra harbor -m examples.train_integrations.harbor.entrypoints.main_harbor_fully_async \
   data.train_data=$TRAIN_DATA \
   data.val_data=$EVAL_DATA \
   trainer.policy.model.path=Qwen/Qwen3-8B \


### PR DESCRIPTION
There are still some gaps for the new inference codepath especially for agentic RL. As described here #1591

So we will toggle the flag to use the old path for the harbor scripts