### PR TITLE
[cleanup] Remove NCCL_CUMEM_ENABLE=0 from `prepare_runtime_environment` 

### DIFF
--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -612,11 +612,6 @@ def prepare_runtime_environment(cfg: SkyRLTrainConfig) -> dict[str, str]:
     # TODO(sumanthrh): introduce a debug mode and add debugging flags like `CUDA_LAUNCH_BLOCKING` here
     env_vars = {}
 
-    # NOTE (charlie): See https://github.com/vllm-project/vllm/blob/c6b0a7d3ba03ca414be1174e9bd86a97191b7090/vllm/worker/worker_base.py#L445
-    # and https://docs.vllm.ai/en/v0.9.2/usage/troubleshooting.html?h=nccl_cumem_enable#known-issues
-    if cfg.generator.inference_engine.weight_sync_backend == "nccl":
-        env_vars["NCCL_CUMEM_ENABLE"] = "0"
-
     if cfg.trainer.strategy == "megatron":
         # this is needed for megatron-core >= 0.15.0, which requires devices to be visible while importing megatron.core
         env_vars["RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO"] = "0"


### PR DESCRIPTION
We previously had the following snippet in `prepare_runtime_environment`

```python
# NOTE (charlie): See https://github.com/vllm-project/vllm/blob/c6b0a7d3ba03ca414be1174e9bd86a97191b7090/vllm/worker/worker_base.py#L445
# and https://docs.vllm.ai/en/v0.9.2/usage/troubleshooting.html?h=nccl_cumem_enable#known-issues
    if cfg.generator.inference_engine.weight_sync_backend == "nccl":
        env_vars["NCCL_CUMEM_ENABLE"] = "0"
```

The NCCL bug that required this was resolved in NCCL 2.22.3, and this override was removed from vLLM:

NCCL: https://github.com/NVIDIA/nccl/issues/1234
vLLM: https://github.com/vllm-project/vllm/pull/24141

Since the resolved NCCL version is shipped with PyTorch, and we are pinned to 2.10.0 (NCCL 2.26.2), it seems safe to remove this env var for older NCCL versions.

In fact, Nemo-RL actually sets this env-var to 1 ([link](https://github.com/NVIDIA-NeMo/RL/blob/cf0c7b45b2fbb5ce20fb51d034d7e4b73a20199b/nemo_rl/models/policy/workers/dtensor_policy_worker.py#L209)).

Verified that GSM8K still works with this flag removed both colocated and non-colocated, and with vllm tp=2

We see that max gpu memory utilization is also slightly lower with this env var removed, as it enables newer NCCL version memory optimizations (as mentioned in https://github.com/vllm-project/vllm/pull/24141):

<img width="1135" height="824" alt="image" src="https://github.com/user-attachments/assets/8f0c5b1f-338c-476e-b05d-cc0286c39ee1" />




<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
