### PR TITLE
[qoc][workers] Unify offload/onload methods across roles and backend

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -117,9 +117,7 @@ class FSDPStrategy(DistributedStrategy):
 
         self.device_mesh = create_device_mesh(world_size=self.world_size, fsdp_size=self.fsdp_config.fsdp_size)
 
-    def offload_to_cpu(
-        self, model, optimizer, pin_memory=True, non_blocking=True, offload_optimizer=True, offload_model=True
-    ):
+    def offload_to_cpu(self, model, optimizer, offload_optimizer=True, offload_model=True):
         """
         Offload model weights and optimizer to CPU memory.
 
@@ -127,8 +125,6 @@ class FSDPStrategy(DistributedStrategy):
         """
         if isinstance(model, HFModelWrapper):
             model = model.model
-        else:
-            model = model
 
         if self.manual_offload:
             if offload_model:
@@ -140,12 +136,10 @@ class FSDPStrategy(DistributedStrategy):
         torch.cuda.synchronize()
         torch.cuda.empty_cache()
 
-    def backload_to_gpu(self, model, optimizer, non_blocking=True, backload_optimizer=True, backload_model=True):
+    def backload_to_gpu(self, model, optimizer, backload_optimizer=True, backload_model=True):
         """Reload model weights back to GPU."""
         if isinstance(model, HFModelWrapper):
             model = model.model
-        else:
-            model = model
 
         # if we are using fsdp 1 or cpu offload is off for fsdp2, then we need to manually backload weights/optimizer to gpu
         if self.manual_offload:

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -177,9 +177,7 @@ class MegatronStrategy(DistributedStrategy):
         self.set_seed(self.seed)
         self.world_size = dist.get_world_size()
 
-    def offload_to_cpu(
-        self, model, optimizer, pin_memory=True, non_blocking=True, offload_optimizer=True, offload_model=True
-    ):
+    def offload_to_cpu(self, model, optimizer, offload_optimizer=True, offload_model=True):
         """
         Offload model weights and optimizer to CPU memory.
         """
@@ -191,7 +189,7 @@ class MegatronStrategy(DistributedStrategy):
         torch.cuda.synchronize()
         torch.cuda.empty_cache()
 
-    def backload_to_gpu(self, model, optimizer, non_blocking=True, backload_optimizer=True, backload_model=True):
+    def backload_to_gpu(self, model, optimizer, backload_optimizer=True, backload_model=True):
         """Reload model weights back to GPU."""
         if backload_model:
             load_megatron_model_to_gpu(model)

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -152,15 +152,6 @@ class FSDPWeightExtractor(WeightExtractor):
 
 
 class FSDPPolicyWorkerBase(PolicyWorkerBase):
-    def offload_to_cpu(self, pin_memory=True, non_blocking=True, offload_optimizer=True, offload_model=True):
-        self._set_numa_affinity(torch.distributed.get_rank() % torch.cuda.device_count())
-        self.strategy.offload_to_cpu(
-            self.model, self.optimizer, pin_memory, non_blocking, offload_optimizer, offload_model
-        )
-
-    def backload_to_gpu(self, non_blocking=True, backload_optimizer=True, backload_model=True):
-        self.strategy.backload_to_gpu(self.model, self.optimizer, non_blocking, backload_optimizer, backload_model)
-
     def init_model(self, model_path, num_training_steps: int = None):
         assert self.cfg.strategy in ("fsdp", "fsdp2")
         strategy = FSDPStrategy(
@@ -330,15 +321,6 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
 
 
 class FSDPCriticWorkerBase(CriticWorkerBase):
-    def offload_to_cpu(self, pin_memory=True, non_blocking=True, offload_optimizer=True, offload_model=True):
-        self._set_numa_affinity(torch.distributed.get_rank() % torch.cuda.device_count())
-        self.strategy.offload_to_cpu(
-            self.model, self.optimizer, pin_memory, non_blocking, offload_optimizer, offload_model
-        )
-
-    def backload_to_gpu(self, non_blocking=True, backload_optimizer=True, backload_model=True):
-        self.strategy.backload_to_gpu(self.model, self.optimizer, non_blocking, backload_optimizer, backload_model)
-
     def init_model(self, model_path, num_training_steps: int = None):
         assert self.cfg.strategy in ("fsdp", "fsdp2")
         strategy = FSDPStrategy(
@@ -406,13 +388,6 @@ class FSDPCriticWorkerBase(CriticWorkerBase):
 
 
 class FSDPRefWorkerBase(RefWorkerBase):
-    def offload_to_cpu(self, pin_memory=True, non_blocking=True, **kwargs):
-        self._set_numa_affinity(torch.distributed.get_rank() % torch.cuda.device_count())
-        self.strategy.offload_to_cpu(self.model, None, pin_memory, non_blocking)
-
-    def backload_to_gpu(self, non_blocking=True, **kwargs):
-        self.strategy.backload_to_gpu(self.model, None, non_blocking)
-
     def init_model(self, model_path):
         assert self.cfg.strategy in ("fsdp", "fsdp2")
         strategy = FSDPStrategy(

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -529,6 +529,10 @@ class MegatronWorker:
             tokenizer=tokenizer,
         )
 
+    def _get_module_for_offload(self):
+        # The underlying offloadable module is `self.actor_module` instead of `self.model`.
+        return self.actor_module
+
 
 class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
     def __init__(self, **kwargs):
@@ -539,17 +543,6 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         self.optimizer: DistributedOptimizer = None
         self.profiler: Profiler = None
         self._is_lora = self.cfg.policy.model.lora.rank > 0
-
-    def offload_to_cpu(self, pin_memory=True, non_blocking=True, offload_optimizer=True, offload_model=True):
-        self._set_numa_affinity(torch.distributed.get_rank() % torch.cuda.device_count())
-        self.strategy.offload_to_cpu(
-            self.actor_module, self.optimizer, pin_memory, non_blocking, offload_optimizer, offload_model
-        )
-
-    def backload_to_gpu(self, non_blocking=True, backload_optimizer=True, backload_model=True):
-        self.strategy.backload_to_gpu(
-            self.actor_module, self.optimizer, non_blocking, backload_optimizer, backload_model
-        )
 
     def init_worker_process_group(self):
         """
@@ -934,13 +927,6 @@ class MegatronRefWorkerBase(MegatronWorker, RefWorkerBase):
         super().__init__(**kwargs)
         self.model: MegatronModelWrapper = None
         self.actor_module: List[nn.Module] = None
-
-    def offload_to_cpu(self, pin_memory=True, non_blocking=True, **kwargs):
-        self._set_numa_affinity(torch.distributed.get_rank() % torch.cuda.device_count())
-        self.strategy.offload_to_cpu(self.actor_module, None, pin_memory, non_blocking)
-
-    def backload_to_gpu(self, non_blocking=True, **kwargs):
-        self.strategy.backload_to_gpu(self.actor_module, None, non_blocking)
 
     def init_worker_process_group(self):
         """

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -123,7 +123,8 @@ class DistributedTorchRayActor:
 
         # setup device mesh
         # TODO: Support TP / PP for additional backends
-        # NOTE (sumanthrh): Device mesh and mesh rank are rank specific attributes. For the current way the strategy is defined, it is only meant to interact with worker state; not hold worker state. Thus, this should live outside the strategy object.
+        # NOTE (sumanthrh): Device mesh and mesh rank are rank specific attributes. For the current way the strategy is defined,
+        # it is only meant to interact with worker state; not hold worker state. Thus, this should live outside the strategy object.
         # This device mesh can be common across all the strategies we use
         dp_size = self._world_size // self.sequence_parallel_size
         device_mesh = torch.distributed.device_mesh.init_device_mesh(
@@ -247,24 +248,40 @@ class Worker(DistributedTorchRayActor):
         for key, value in kwargs.items():
             setattr(self.cfg.algorithm, key, value)
 
-    def offload_to_cpu(self, pin_memory=True, non_blocking=True):
+    def _get_module_for_offload(self):
+        """Return the model module(s) to be offloaded/backloaded. Megatron offloads `self.actor_module`. FSDP workers use `self.model` directly."""
+        return self.model
+
+    def offload_to_cpu(self, offload_optimizer=True, offload_model=True):
         """Offload all worker state to CPU.
 
-        After this function runs, only temporary reserved memory and torch's pre-loaded cuda kernels (~ GB) will remain
+        After this function runs, only temporary reserved memory and torch's pre-loaded cuda kernels (~ GB) will remain.
 
         Args:
-            pin_memory: Whether to use pinned/ paged-locked memory on CPU
-            non_blocking: Whether the operation is non-blocking
+            offload_optimizer: Whether to offload optimizer state (no-op when there is no optimizer, e.g. Ref worker).
+            offload_model: Whether to offload model parameters.
         """
-        raise NotImplementedError()
+        self._set_numa_affinity(torch.distributed.get_rank() % torch.cuda.device_count())
+        self.strategy.offload_to_cpu(
+            self._get_module_for_offload(),
+            self.optimizer,
+            offload_optimizer=offload_optimizer,
+            offload_model=offload_model,
+        )
 
-    def backload_to_gpu(self, non_blocking=True):
-        """Backload worker state to GPU
+    def backload_to_gpu(self, backload_optimizer=True, backload_model=True):
+        """Backload worker state to GPU.
 
         Args:
-            non_blocking: Whether the operation is non-blocking
+            backload_optimizer: Whether to backload optimizer state (no-op when there is no optimizer).
+            backload_model: Whether to backload model parameters.
         """
-        raise NotImplementedError()
+        self.strategy.backload_to_gpu(
+            self._get_module_for_offload(),
+            self.optimizer,
+            backload_optimizer=backload_optimizer,
+            backload_model=backload_model,
+        )
 
     def get_cuda_memory(self) -> Dict[str, Any]:
         """Get CUDA memory usage on worker's CUDA device."""
@@ -1116,6 +1133,9 @@ class RefWorkerBase(Worker):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.model: nn.Module = None
+        # Ref does not train. Expose ``None`` defaults so inherited methods (e.g. offload_to_cpu) work.
+        self.optimizer = None
+        self.scheduler = None
 
     def _forward_micro_batch(self, micro_batch: TrainingInputBatch) -> TrainingOutputBatch:
         device = torch.cuda.current_device()

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -260,10 +260,10 @@ def test_micro_batches_accumulated_initialized():
         def init_model(self, *args, **kwargs):
             pass
 
-        def offload_to_cpu(self, pin_memory=True, non_blocking=True):
+        def offload_to_cpu(self, offload_optimizer=True, offload_model=True):
             pass
 
-        def backload_to_gpu(self, non_blocking=True):
+        def backload_to_gpu(self, backload_optimizer=True, backload_model=True):
             pass
 
         def _forward_micro_batch(self, micro_batch):


### PR DESCRIPTION
Before this PR, we have a `offload_to_cpu`/`backload_to_gpu` method for `FSDPRef`, `FSDPCritic`, `FSDPPolicy`, `MegatronRef`, `MegatronPolicy` Workers. Those are 10 methods in total. There are also 2 abstract methods in the base `Worker` class.

Three observations:
1. PolicyWorker and CriticWorker have identical offload/backload in FSDP.
2. RefWorker only misses offload_optimizer=True, offload_model=True in the header, and passing in None for optimizer.
3. For FSDP and Megatron, the methods only differ by, the former uses `self.model`, and the latter uses `self.actor_module`

This PR lift it up the to base `Worker` class.

- For observation 2, we add `self.optimizer=None` to `RefWorker` base class so it will directly be passed in.
- For observation 3, we add a small `_get_module_for_offload()` method where `MegatronWorker` mixin overrides
- In addition, we had `pin_memory` and `non_blocking` args which are never used in the method implementation. We remove them in this PR.

The result is a removal of 10 methods in total.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/novasky-ai/skyrl/pull/1602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
