### PR TITLE
[bug] Fix `AttributeError` on `MambaLayer` in `freeze_moe_router`

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -102,7 +102,7 @@ def freeze_moe_router(model_or_models: Union[nn.Module, List[nn.Module]]):
 
     for model in models:
         for layer in model.decoder.layers:
-            if hasattr(layer.mlp, "router"):
+            if hasattr(layer, "mlp") and hasattr(layer.mlp, "router"):
                 if getattr(layer.mlp.router, "weight", None) is not None:
                     layer.mlp.router.weight.requires_grad = False
                 if getattr(layer.mlp.router, "bias", None) is not None:


### PR DESCRIPTION
# What does this PR do?

Fixes a bug in `freeze_moe_router` when used with models with `MambaLayer`, like `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`


```bash
File "/home/flytekit/workspace/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1965, in __getattr__
        raise AttributeError(
    AttributeError: 'MambaLayer' object has no attribute 'mlp'
```
