### PR TITLE
[fix] Add trailing slash to local directory for uploads to existing cloud directory with fsspec

### DIFF
--- a/skyrl/backends/skyrl_train/utils/io/io.py
+++ b/skyrl/backends/skyrl_train/utils/io/io.py
@@ -129,6 +129,10 @@ def upload_directory(local_path: str, cloud_path: str) -> None:
         raise ValueError(f"Destination must be a cloud path, got: {cloud_path}")
 
     fs = _get_filesystem(cloud_path)
+    # NOTE (sumanthrh): While uploading files in a directory `src` to an existing directory `dst` with fsspec,
+    # we need to ensure that the file path ends in a trailing slash. otherwise, fsspec will create a subdirectory
+    # `dst/src` instead of directly syncing contents of `src` into the root `dst` directory
+    local_path = f"{local_path}/" if not local_path.endswith("/") else local_path
     if cloud_path.startswith("s3://"):
         call_with_s3_retry(fs, fs.put, local_path, fs._strip_protocol(cloud_path), recursive=True)
     else:

--- a/skyrl/backends/skyrl_train/utils/io/io.py
+++ b/skyrl/backends/skyrl_train/utils/io/io.py
@@ -132,7 +132,7 @@ def upload_directory(local_path: str, cloud_path: str) -> None:
     # NOTE (sumanthrh): While uploading files in a directory `src` to an existing directory `dst` with fsspec,
     # we need to ensure that the file path ends in a trailing slash. otherwise, fsspec will create a subdirectory
     # `dst/src` instead of directly syncing contents of `src` into the root `dst` directory
-    local_path = f"{local_path}/" if not local_path.endswith("/") else local_path
+    local_path = os.path.join(local_path, "")
     if cloud_path.startswith("s3://"):
         call_with_s3_retry(fs, fs.put, local_path, fs._strip_protocol(cloud_path), recursive=True)
     else:


### PR DESCRIPTION
# What does this PR do?

Fixes an issue with checkpoint upload format with LoRA. With LoRA, we make multiple calls to `io.local_work_dir` , which in turn calls `io.upload_directory` . Each time, we write checkpoint files to a temporary file and then upload them to directory in cloud storage. Currently, subsequent calls to `io.upload_directory` leads to nesting of ckpt contents:


```bash
 aws s3 ls <my_remote_path>/global_step_40/policy/
                           PRE tmp8uxmdhfx/
                           PRE tmpbbhsijnu/
                           PRE tmpd3xtpaoz/
                           PRE tmpeag11l_c/
                           PRE tmppg5zt9uh/
                           PRE tmpqplxqem5/
2026-05-01 00:01:40      14885 extra_state_world_size_8_rank_6.pt
2026-05-01 00:01:40      14885 extra_state_world_size_8_rank_7.pt
2026-05-01 00:01:40  860448401 model_world_size_8_rank_6.pt
2026-05-01 00:01:40  860448401 model_world_size_8_rank_7.pt
2026-05-01 00:01:40 1720907321 optim_world_size_8_rank_6.pt
2026-05-01 00:01:40 1720907321 optim_world_size_8_rank_7.pt
```

The root cause is that with `fsspec`, while uploading files in a directory `src` to an existing directory `dst` with fsspec, we need to ensure that the file path ends in a trailing slash. otherwise, fsspec will create a subdirectory `dst/src` instead of directly syncing contents of `src` into the root `dst` directory


