### PR TITLE
[skyrl] Pass through profiler_config to vLLM engine

### DIFF
--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -502,6 +502,9 @@ class InferenceEngineConfig(BaseConfig):
     """Pass-through kwargs applied to ``RouterArgs`` for the vllm-router.
     Names must match ``vllm_router.RouterArgs`` fields (e.g. ``policy``, ``request_timeout_secs``)."""
 
+    profiler_config: Dict[str, Any] = field(default_factory=dict)
+    """Pass through profiler config to vLLM engine."""
+
 
 # ---------------------------------------------------------------------------
 # Generator


### PR DESCRIPTION
Can be used like
```
"generator":{"inference_engine":{"tensor_parallel_size":4, "profiler_config":"{\"profiler\":\"torch\",\"torch_profiler_dir\":\"/mnt/shared_storage/vllm_profile\"}"}}}'
```