### PR TITLE
[bug] Lora bug fixes + port collision fix

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/common.py
+++ b/skyrl/backends/skyrl_train/inference_servers/common.py
@@ -13,6 +13,12 @@ import ray
 
 logger = logging.getLogger(__name__)
 
+# Stride between successive server actors' (or groups') start_port values.
+# Each actor's `find_and_reserve_port` increments by 1 on conflict, so this
+# stride must be larger than the max number of conflicts an actor could see
+# inside its window.
+SERVER_PORT_STRIDE = 100
+
 
 @dataclass
 class ServerInfo:
@@ -85,8 +91,9 @@ def find_and_reserve_port(start_port: int) -> Tuple[int, socket.socket]:
         (port, socket) -- caller must close the socket before rebinding.
     """
     port = start_port
+    end_port = start_port + SERVER_PORT_STRIDE
     sock: socket.socket | None = None
-    while True:
+    while port < end_port:
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -97,5 +104,7 @@ def find_and_reserve_port(start_port: int) -> Tuple[int, socket.socket]:
             if sock:
                 sock.close()
             port += 1
-            if port > 65535:
-                raise RuntimeError(f"No available port found starting from {start_port}")
+    raise RuntimeError(
+        f"No available port found in [{start_port}, {end_port}). "
+        f"Free up the port range or raise SERVER_PORT_STRIDE."
+    )

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -1140,7 +1140,7 @@ class RemoteInferenceClient:
                 if resp.status >= 400:
                     body = await resp.json()
                     raise_for_status(resp, body)
-                return server_url, {"status": resp.status, "body": await resp.json()}
+                return server_url, {"status": resp.status, "body": await resp.text()}
 
         results = await asyncio.gather(*[_load_on_server(url) for url in self.server_urls])
 

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -1140,7 +1140,7 @@ class RemoteInferenceClient:
                 if resp.status >= 400:
                     body = await resp.json()
                     raise_for_status(resp, body)
-                return server_url, await resp.json()
+                return server_url, {"status": resp.status, "body": await resp.json()}
 
         results = await asyncio.gather(*[_load_on_server(url) for url in self.server_urls])
 

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -1100,16 +1100,26 @@ class RemoteInferenceClient:
         lora_path: str,
     ) -> Dict[str, Any]:
         """
-        Update LoRA adapter weights by loading from disk on all backend servers via /v1/load_lora_adapter.
+        Update LoRA adapter weights by loading from disk on all backend servers
+        via the SkyRL custom /skyrl/v1/load_lora_adapter endpoint.
 
-        Always loads under self.active_lora_name so the same slot is reused across
-        weight syncs.
+        Always loads under self.active_lora_name so the same lora_int_id slot
+        is reused across weight syncs.
 
-        After loading, generation requests will automatically use the LoRA adapter
-        by setting the model name to the LoRA adapter name.
+        TODO(aaron): switch back to /v1/load_lora_adapter (with "load_inplace": True)
+        once the upstream fix in https://github.com/vllm-project/vllm/pull/41482
+        lands in a vLLM release we depend on.
 
-        TODO(aaron): remove _unload_on_server and add back "load_inplace": True to payload after
-        vllm lora disk load bug is fixed.
+        The custom endpoint (defined in vllm_server_actor.py) wraps add_lora
+        with load_inplace=True (so the engine reloads the freshly-written
+        safetensors) and then resets the cached LoRARequest's load_inplace=False
+        (so subsequent generates don't reload from disk on every step). This
+        avoids two vLLM 0.19.0 bugs that surface under colocate_all + tp=1 +
+        num_engines>=2 — see vllm_server_actor.py:_skyrl_load_lora_adapter for
+        the detailed explanation.
+
+        After loading, generation requests will automatically use the LoRA
+        adapter by setting the model name to the LoRA adapter name.
 
         Args:
             lora_path: Path to the LoRA adapter on disk (must be accessible from servers).
@@ -1121,30 +1131,17 @@ class RemoteInferenceClient:
             raise ValueError("active_lora_name must be set on RemoteInferenceClient before loading a LoRA adapter.")
 
         lora_name = self.active_lora_name
-        # Both endpoints return plain text on success or JSON ErrorResponse on failure,
-        # so we use a session.post directly rather than _call_all_servers (which expects JSON).
         session = await self._get_session()
 
-        async def _unload_on_server(server_url: str) -> None:
-            """Remove the cached LoRARequest server-side. 404 on the first sync is expected."""
-            url = f"{server_url}/v1/unload_lora_adapter"
-            async with session.post(url, json={"lora_name": lora_name}) as resp:
-                if resp.status == 404:
-                    return
-                if resp.status >= 400:
-                    body = await resp.json()
-                    raise_for_status(resp, body)
-
         async def _load_on_server(server_url: str):
-            url = f"{server_url}/v1/load_lora_adapter"
+            url = f"{server_url}/skyrl/v1/load_lora_adapter"
             payload = {"lora_name": lora_name, "lora_path": lora_path}
             async with session.post(url, json=payload) as resp:
                 if resp.status >= 400:
                     body = await resp.json()
                     raise_for_status(resp, body)
-                return server_url, {"status": resp.status, "body": await resp.text()}
+                return server_url, await resp.json()
 
-        await asyncio.gather(*[_unload_on_server(url) for url in self.server_urls])
         results = await asyncio.gather(*[_load_on_server(url) for url in self.server_urls])
 
         logger.info(f"Loaded LoRA adapter '{lora_name}' from {lora_path}")

--- a/skyrl/backends/skyrl_train/inference_servers/server_group.py
+++ b/skyrl/backends/skyrl_train/inference_servers/server_group.py
@@ -11,6 +11,7 @@ from ray.util.placement_group import PlacementGroup, placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from skyrl.backends.skyrl_train.inference_servers.common import (
+    SERVER_PORT_STRIDE,
     ServerInfo,
 )
 from skyrl.backends.skyrl_train.inference_servers.protocols import ServerActorProtocol
@@ -184,7 +185,7 @@ class ServerGroup:
 
             actor = ServerActorClass.remote(
                 self._cli_args,
-                self._start_port + server_idx,
+                self._start_port + server_idx * SERVER_PORT_STRIDE,
                 server_idx=server_idx,
                 bundle_indices=bundle_indices,
                 dp_size=self._num_servers if self._enable_dp else -1,

--- a/skyrl/backends/skyrl_train/inference_servers/setup.py
+++ b/skyrl/backends/skyrl_train/inference_servers/setup.py
@@ -14,6 +14,7 @@ from skyrl.train.utils.utils import (
     get_ray_pg_ready_with_timeout,
 )
 
+from .common import SERVER_PORT_STRIDE
 from .remote_inference_client import RemoteInferenceClient
 from .server_group import ServerGroup
 from .utils import (
@@ -107,7 +108,7 @@ def create_inference_servers(
             ServerGroup(
                 cli_args=copy.deepcopy(pd_cli_args),
                 num_servers=ie_cfg.data_parallel_size,
-                start_port=VLLM_START_PORT + i * servers_per_group,
+                start_port=VLLM_START_PORT + i * servers_per_group * SERVER_PORT_STRIDE,
                 placement_group=prefill_pg,
                 placement_group_bundle_offset=i * gpus_per_server * servers_per_group,
                 enable_dp=ie_cfg.data_parallel_size > 1,
@@ -125,7 +126,7 @@ def create_inference_servers(
             ServerGroup(
                 cli_args=copy.deepcopy(pd_cli_args),
                 num_servers=ie_cfg.data_parallel_size,
-                start_port=VLLM_START_PORT + (num_prefill + i) * servers_per_group,
+                start_port=VLLM_START_PORT + (num_prefill + i) * servers_per_group * SERVER_PORT_STRIDE,
                 placement_group=decode_pg,
                 placement_group_bundle_offset=decode_bundle_offset + i * gpus_per_server * servers_per_group,
                 enable_dp=ie_cfg.data_parallel_size > 1,
@@ -183,7 +184,7 @@ def create_inference_servers(
                 cli_args=cli_args,
                 num_servers=ie_cfg.data_parallel_size,
                 placement_group=placement_group,
-                start_port=VLLM_START_PORT + i * ie_cfg.data_parallel_size,
+                start_port=VLLM_START_PORT + i * ie_cfg.data_parallel_size * SERVER_PORT_STRIDE,
                 enable_dp=ie_cfg.data_parallel_size > 1,
                 distributed_executor_backend=ie_cfg.distributed_executor_backend,
                 placement_group_bundle_offset=i * gpus_per_server * ie_cfg.data_parallel_size,

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -22,6 +22,7 @@ from vllm.entrypoints.openai.api_server import (
     init_app_state,
 )
 from vllm.inputs import TokensPrompt
+from vllm.lora.request import LoRARequest
 from vllm.sampling_params import SamplingParams as VLLMSamplingParams
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import random_uuid
@@ -359,6 +360,47 @@ class VLLMServerActor(ServerActorProtocol):
             """Reset the prefix cache."""
             await engine.reset_prefix_cache()
             return {"status": "ok"}
+
+        @app.post("/skyrl/v1/load_lora_adapter")
+        async def _skyrl_load_lora_adapter(request: Request):
+            """Load a LoRA adapter from disk, replacing any existing adapter
+            under the same name in place. Used by RemoteInferenceClient.update_lora_from_disk.
+
+            TODO(aaron): remove this endpoint and route update_lora_from_disk back
+            through /v1/load_lora_adapter once the upstream fix in
+            https://github.com/vllm-project/vllm/pull/41482 lands in a vLLM release we depend on.
+            """
+            body = await request.json()
+            lora_name = body.get("lora_name")
+            lora_path = body.get("lora_path")
+            if not lora_name or not lora_path:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Both 'lora_name' and 'lora_path' must be provided.",
+                )
+
+            models = request.app.state.openai_serving_models
+            async with models.lora_resolver_lock[lora_name]:
+                lora_int_id = (
+                    models.lora_requests[lora_name].lora_int_id
+                    if lora_name in models.lora_requests
+                    else models.lora_id_counter.inc(1)
+                )
+                lora_request = LoRARequest(
+                    lora_name=lora_name,
+                    lora_int_id=lora_int_id,
+                    lora_path=lora_path,
+                    load_inplace=True,
+                )
+                await models.engine_client.add_lora(lora_request)
+                lora_request.load_inplace = False
+                models.lora_requests[lora_name] = lora_request
+
+            return {
+                "status": "ok",
+                "lora_name": lora_name,
+                "lora_int_id": lora_int_id,
+            }
 
         # NOTE (sumanthrh): We use a custom generate endpoint /skyrl/v1/generate because the native
         # endpoint /inference/v1/generate does not support returning routed expert IDs.


### PR DESCRIPTION
Bug fixes found in https://github.com/NovaSky-AI/SkyRL/pull/1616

While testing out the tinker CI, found a port collision bug.

async def _run_server(self) -> None:
    """Internal method to run the HTTP server."""
    # Release the port reservation right before vLLM rebinds.
    if self._port_reservation is not None:
        self._port_reservation.close()                          # ← step A
        self._port_reservation = None
    ...
    sock_addr = (self._cli_args.host, self._cli_args.port)
    sock = create_server_socket(sock_addr)
There exists a window of time where we free port so vllm can take it, but other actors can also. Fixed this by allocating a specific, non-overlapping port range for each actor.

Additionally, changed the disk reloading workaround https://github.com/NovaSky-AI/SkyRL/pull/1606 created here to more closely mirror the upstream change https://github.com/vllm-project/vllm/pull/41482, adding a new custom endpoint with the load_inplace override.