### PR TITLE
[fix] Fix old inference generate path to take in model as an optional Arg

### DIFF
--- a/skyrl/backends/skyrl_train/inference_engines/base.py
+++ b/skyrl/backends/skyrl_train/inference_engines/base.py
@@ -49,7 +49,11 @@ class InferenceEngineOutput(TypedDict):
 class InferenceEngineInterface(ABC):
 
     @abstractmethod
-    async def generate(self, input_batch: InferenceEngineInput) -> InferenceEngineOutput:
+    async def generate(
+        self,
+        input_batch: InferenceEngineInput,
+        model: Optional[str] = None,
+    ) -> InferenceEngineOutput:
         raise NotImplementedError
 
     async def sample(

--- a/skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py
@@ -89,7 +89,17 @@ class InferenceEngineClient(InferenceEngineInterface):
         awaitables = [getattr(engine, method_name)(*args, **kwargs) for engine in self.engines]
         return await asyncio.gather(*awaitables)
 
-    async def generate(self, input_batch: InferenceEngineInput) -> InferenceEngineOutput:
+    async def generate(
+        self,
+        input_batch: InferenceEngineInput,
+        model: Optional[str] = None,
+    ) -> InferenceEngineOutput:
+        # `model` is accepted for signature parity with `RemoteInferenceClient.generate`
+        # (added in #1579 for multi-LoRA routing). The legacy path only supports a single
+        # LoRA via the `LoraLoadRequest` smuggling mechanism, so per-call routing is a no-op
+        # here — we just need to tolerate the kwarg.
+        del model
+
         # 0. Extract input
         prompts = input_batch.get("prompts")
         prompt_token_ids = input_batch.get("prompt_token_ids")

--- a/skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py
@@ -94,11 +94,6 @@ class InferenceEngineClient(InferenceEngineInterface):
         input_batch: InferenceEngineInput,
         model: Optional[str] = None,
     ) -> InferenceEngineOutput:
-        # `model` is accepted for signature parity with `RemoteInferenceClient.generate`
-        # (added in #1579 for multi-LoRA routing). The legacy path only supports a single
-        # LoRA via the `LoraLoadRequest` smuggling mechanism, so per-call routing is a no-op
-        # here — we just need to tolerate the kwarg.
-        del model
 
         # 0. Extract input
         prompts = input_batch.get("prompts")

--- a/skyrl/backends/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/remote_inference_engine.py
@@ -147,7 +147,12 @@ class RemoteInferenceEngine(InferenceEngineInterface):
     def ep_size(self) -> int:
         return self._ep_size
 
-    async def generate(self, input_batch: InferenceEngineInput) -> InferenceEngineOutput:
+    async def generate(
+        self,
+        input_batch: InferenceEngineInput,
+        model: Optional[str] = None,
+    ) -> InferenceEngineOutput:
+
         # 1. Prepare inputs
         prompts = input_batch.get("prompts")
         prompt_token_ids: Optional[List[List[int]]] = input_batch.get("prompt_token_ids")


### PR DESCRIPTION
## Issue
PR #1579 ([feat] Multi-LoRA serving for RemoteInferenceClient) added a required-by-callsite model= kwarg at every inference_engine_client.generate(...) callsite in the generators (e.g. skyrl_gym_generator.py:681, skyrl_gym_generator.py:348, skyrl_vlm_generator.py:152), but only widened the new RemoteInferenceClient.generate() signature. The legacy InferenceEngineClient.generate() (used when _SKYRL_USE_NEW_INFERENCE=0, which run_megatron_dapo_qwen3.5_35b_a3b.sh sets) was left with the old signature, so it raised TypeError: InferenceEngineClient.generate() got an unexpected keyword argument 'model'. The PR description explicitly flagged this gap ("the legacy InferenceEngineClient (Ray-wrapped) path is not updated for multi-LoRA").
## Fix
Added model: Optional[str] = None to InferenceEngineClient.generate() in skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py and to the abstract InferenceEngineInterface.generate() in skyrl/backends/skyrl_train/inference_engines/base.py. The legacy single-LoRA flow already routes via the LoraLoadRequest smuggling mechanism, so the kwarg is accepted as a no-op on this path — exactly matching the PR's stated contract that legacy is single-LoRA only. No callsite changes needed.