### PR TITLE
[tinker] Forward sample requests directly to backend vLLM (non-colocated)

### DIFF
--- a/ci/gpu_ci_run_tinker_skyrl_train_backend.sh
+++ b/ci/gpu_ci_run_tinker_skyrl_train_backend.sh
@@ -8,4 +8,4 @@ export CI=true
 # v1 single-tenant sample guard, per-adapter Adam step isolation, and
 # delete-then-train continuity.
 uv run --directory . --isolated --extra tinker --extra megatron --with pytest --with pytest-timeout \
-    pytest -s --timeout=600 tests/tinker/skyrl_train/test_multi_lora_megatron.py
+    pytest -s --timeout=600 tests/tinker/skyrl_train/

--- a/docs/content/docs/tinker/multi_tenancy.mdx
+++ b/docs/content/docs/tinker/multi_tenancy.mdx
@@ -123,7 +123,7 @@ uv run --extra tinker --extra megatron -m skyrl.tinker.api \
         "generator.inference_engine.tensor_parallel_size": 1,
         "trainer.policy.model.lora.max_loras": 2,
         "trainer.policy.model.lora.max_cpu_loras": 2,
-        "trainer.logprobs_chunk_size": null,
+        "trainer.logprobs_chunk_size": null
     }'
 ```
 

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -342,12 +342,15 @@ class SkyRLTrainBackend(AbstractBackend):
         """
         self._engine_database_url = database_url
 
-    def _publish_engine_state(self, *, proxy_url: str | None, server_urls: list[str], is_colocated: bool) -> None:
+    def _publish_engine_state(self, *, proxy_url: str | None) -> None:
         """Upsert the singleton row in EngineStateDB.
 
         Idempotent. Safe to call repeatedly. ``proxy_url=None`` signals that
         no vLLM is currently up (post-teardown) — the API process will fall
         back to the engine's synchronous sample path.
+
+        Best-effort: on any DB error we log and return rather than raise.
+        Callers rely on local state being reset regardless of publish outcome.
         """
         if self._engine_database_url is None:
             # Backend not wired to a Tinker engine (unit tests, non-Tinker uses).
@@ -359,24 +362,25 @@ class SkyRLTrainBackend(AbstractBackend):
 
         from skyrl.tinker.db_models import EngineStateDB, enable_sqlite_wal
 
-        db_engine = create_engine(self._engine_database_url, echo=False)
-        enable_sqlite_wal(db_engine)
-        # The API process creates the schema, but in unit tests the backend
-        # may run without an API. Make sure the table exists before writing.
-        SQLModel.metadata.create_all(db_engine, tables=[EngineStateDB.__table__])
         try:
-            with Session(db_engine) as session:
-                row = session.get(EngineStateDB, 1)
-                if row is None:
-                    row = EngineStateDB(singleton_id=1)
-                row.inference_proxy_url = proxy_url
-                row.inference_server_urls = list(server_urls)
-                row.is_colocated = bool(is_colocated)
-                row.updated_at = datetime.now(timezone.utc)
-                session.add(row)
-                session.commit()
-        finally:
-            db_engine.dispose()
+            db_engine = create_engine(self._engine_database_url, echo=False)
+            enable_sqlite_wal(db_engine)
+            # The API process creates the schema, but in unit tests the backend
+            # may run without an API. Make sure the table exists before writing.
+            SQLModel.metadata.create_all(db_engine, tables=[EngineStateDB.__table__])
+            try:
+                with Session(db_engine) as session:
+                    row = session.get(EngineStateDB, 1)
+                    if row is None:
+                        row = EngineStateDB(singleton_id=1)
+                    row.inference_proxy_url = proxy_url
+                    row.updated_at = datetime.now(timezone.utc)
+                    session.add(row)
+                    session.commit()
+            finally:
+                db_engine.dispose()
+        except Exception as e:
+            logger.warning(f"Failed to publish engine state (proxy_url={proxy_url!r}): {e}")
 
     def _create_new_inference_client(self):
         """Create new HTTP-based inference client."""
@@ -396,11 +400,7 @@ class SkyRLTrainBackend(AbstractBackend):
 
         # Publish inference endpoint so the API can forward samples directly
         # (only meaningful in non-colocated mode; the API gates on this).
-        self._publish_engine_state(
-            proxy_url=server_setup.proxy_url,
-            server_urls=list(server_setup.server_urls),
-            is_colocated=bool(is_colocated),
-        )
+        self._publish_engine_state(proxy_url=server_setup.proxy_url)
 
     def _ensure_inference_engines(self):
         """Lazily create inference engines and init weight sync on first sampling-related call."""
@@ -550,9 +550,6 @@ class SkyRLTrainBackend(AbstractBackend):
         ray.shutdown()
         self._model_ids_to_role = {}
         self._model_metadata = {}
-        # Tell the API there is no inference engine to forward to. Next
-        # _create_new_inference_client will repopulate this row.
-        self._publish_engine_state(proxy_url=None, server_urls=[], is_colocated=False)
         self._cfg = None
         self._dispatch = None
         self._inference_engine_client = None
@@ -560,6 +557,11 @@ class SkyRLTrainBackend(AbstractBackend):
         self._renderer = None
         self._colocate_pg = None
         self._base_lora_signature = None
+        # Local state is fully reset above. Tell the API there is no
+        # inference engine to forward to last — _publish_engine_state is
+        # best-effort, so a DB failure here won't leave the controller
+        # half-torn-down. Next _create_new_inference_client repopulates.
+        self._publish_engine_state(proxy_url=None)
         logger.info(f"Successfully deleted model {model_id}")
 
     def _to_training_batch(self, prepared_batch: types.PreparedModelPassBatch, role: str) -> TrainingInputBatch:

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -138,6 +138,12 @@ class SkyRLTrainBackend(AbstractBackend):
         self._server_groups: list = []
         self._inference_router = None
 
+        # Database URL for publishing inference endpoint to EngineStateDB.
+        # Set by the engine via set_engine_database_url() if available; the
+        # backend silently no-ops _publish_engine_state when None (e.g. when
+        # constructed outside a Tinker engine in unit tests).
+        self._engine_database_url: str | None = None
+
     def has_model(self, model_id: str) -> bool:
         return model_id in self._model_ids_to_role
 
@@ -325,6 +331,53 @@ class SkyRLTrainBackend(AbstractBackend):
             self._cfg.generator.inference_engine,
         )
 
+    def set_engine_database_url(self, database_url: str) -> None:
+        """Wire the engine's database URL so we can publish inference state.
+
+        Called by the Tinker engine after backend construction. When set,
+        ``_publish_engine_state`` writes a singleton row to ``EngineStateDB``
+        each time the inference engine is built or torn down. The API
+        process reads that row to decide whether to forward sample requests
+        directly to vLLM (the async sample routing path).
+        """
+        self._engine_database_url = database_url
+
+    def _publish_engine_state(self, *, proxy_url: str | None, server_urls: list[str], is_colocated: bool) -> None:
+        """Upsert the singleton row in EngineStateDB.
+
+        Idempotent. Safe to call repeatedly. ``proxy_url=None`` signals that
+        no vLLM is currently up (post-teardown) — the API process will fall
+        back to the engine's synchronous sample path.
+        """
+        if self._engine_database_url is None:
+            # Backend not wired to a Tinker engine (unit tests, non-Tinker uses).
+            return
+
+        from datetime import datetime, timezone
+
+        from sqlmodel import Session, SQLModel, create_engine
+
+        from skyrl.tinker.db_models import EngineStateDB, enable_sqlite_wal
+
+        db_engine = create_engine(self._engine_database_url, echo=False)
+        enable_sqlite_wal(db_engine)
+        # The API process creates the schema, but in unit tests the backend
+        # may run without an API. Make sure the table exists before writing.
+        SQLModel.metadata.create_all(db_engine, tables=[EngineStateDB.__table__])
+        try:
+            with Session(db_engine) as session:
+                row = session.get(EngineStateDB, 1)
+                if row is None:
+                    row = EngineStateDB(singleton_id=1)
+                row.inference_proxy_url = proxy_url
+                row.inference_server_urls = list(server_urls)
+                row.is_colocated = bool(is_colocated)
+                row.updated_at = datetime.now(timezone.utc)
+                session.add(row)
+                session.commit()
+        finally:
+            db_engine.dispose()
+
     def _create_new_inference_client(self):
         """Create new HTTP-based inference client."""
         from skyrl.backends.skyrl_train.inference_servers.setup import (
@@ -340,6 +393,14 @@ class SkyRLTrainBackend(AbstractBackend):
         self._inference_router = server_setup.router
         self._server_groups = server_setup.server_groups
         self._inference_engine_client = client
+
+        # Publish inference endpoint so the API can forward samples directly
+        # (only meaningful in non-colocated mode; the API gates on this).
+        self._publish_engine_state(
+            proxy_url=server_setup.proxy_url,
+            server_urls=list(server_setup.server_urls),
+            is_colocated=bool(is_colocated),
+        )
 
     def _ensure_inference_engines(self):
         """Lazily create inference engines and init weight sync on first sampling-related call."""
@@ -489,6 +550,9 @@ class SkyRLTrainBackend(AbstractBackend):
         ray.shutdown()
         self._model_ids_to_role = {}
         self._model_metadata = {}
+        # Tell the API there is no inference engine to forward to. Next
+        # _create_new_inference_client will repopulate this row.
+        self._publish_engine_state(proxy_url=None, server_urls=[], is_colocated=False)
         self._cfg = None
         self._dispatch = None
         self._inference_engine_client = None

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -5,6 +5,7 @@ import io
 import os
 import tarfile
 import tempfile
+from typing import Callable
 
 import ray
 import torch
@@ -138,11 +139,12 @@ class SkyRLTrainBackend(AbstractBackend):
         self._server_groups: list = []
         self._inference_router = None
 
-        # Database URL for publishing inference endpoint to EngineStateDB.
-        # Set by the engine via set_engine_database_url() if available; the
-        # backend silently no-ops _publish_engine_state when None (e.g. when
-        # constructed outside a Tinker engine in unit tests).
-        self._engine_database_url: str | None = None
+        # Optional hook invoked on inference-engine state changes (after
+        # _create_new_inference_client, on delete_model teardown). The host
+        # (e.g. the Tinker engine subprocess) wires the persistence side via
+        # set_inference_state_publisher. None when running outside a host
+        # that needs to be notified (unit tests, non-Tinker uses).
+        self._inference_state_publisher: Callable[[str | None], None] | None = None
 
     def has_model(self, model_id: str) -> bool:
         return model_id in self._model_ids_to_role
@@ -331,56 +333,28 @@ class SkyRLTrainBackend(AbstractBackend):
             self._cfg.generator.inference_engine,
         )
 
-    def set_engine_database_url(self, database_url: str) -> None:
-        """Wire the engine's database URL so we can publish inference state.
+    def set_inference_state_publisher(self, publisher: Callable[[str | None], None]) -> None:
+        """Wire a callback invoked when the inference proxy URL changes.
 
-        Called by the Tinker engine after backend construction. When set,
-        ``_publish_engine_state`` writes a singleton row to ``EngineStateDB``
-        each time the inference engine is built or torn down. The API
-        process reads that row to decide whether to forward sample requests
-        directly to vLLM (the async sample routing path).
+        Called by the host (e.g. the Tinker engine subprocess) after backend
+        construction. The callback receives the current proxy URL after a
+        new inference engine is brought up, or ``None`` on teardown. The
+        backend has no opinion on what the callback does — typical use is
+        to persist the URL somewhere the API process can read.
         """
-        self._engine_database_url = database_url
+        self._inference_state_publisher = publisher
 
-    def _publish_engine_state(self, *, proxy_url: str | None) -> None:
-        """Upsert the singleton row in EngineStateDB.
+    def _publish_inference_state(self, proxy_url: str | None) -> None:
+        """Invoke the publisher if set; best-effort (failure must not raise).
 
-        Idempotent. Safe to call repeatedly. ``proxy_url=None`` signals that
-        no vLLM is currently up (post-teardown) — the API process will fall
-        back to the engine's synchronous sample path.
-
-        Best-effort: on any DB error we log and return rather than raise.
         Callers rely on local state being reset regardless of publish outcome.
         """
-        if self._engine_database_url is None:
-            # Backend not wired to a Tinker engine (unit tests, non-Tinker uses).
+        if self._inference_state_publisher is None:
             return
-
-        from datetime import datetime, timezone
-
-        from sqlmodel import Session, SQLModel, create_engine
-
-        from skyrl.tinker.db_models import EngineStateDB, enable_sqlite_wal
-
         try:
-            db_engine = create_engine(self._engine_database_url, echo=False)
-            enable_sqlite_wal(db_engine)
-            # The API process creates the schema, but in unit tests the backend
-            # may run without an API. Make sure the table exists before writing.
-            SQLModel.metadata.create_all(db_engine, tables=[EngineStateDB.__table__])
-            try:
-                with Session(db_engine) as session:
-                    row = session.get(EngineStateDB, 1)
-                    if row is None:
-                        row = EngineStateDB(singleton_id=1)
-                    row.inference_proxy_url = proxy_url
-                    row.updated_at = datetime.now(timezone.utc)
-                    session.add(row)
-                    session.commit()
-            finally:
-                db_engine.dispose()
+            self._inference_state_publisher(proxy_url)
         except Exception as e:
-            logger.warning(f"Failed to publish engine state (proxy_url={proxy_url!r}): {e}")
+            logger.warning(f"Inference-state publisher failed (proxy_url={proxy_url!r}): {e}")
 
     def _create_new_inference_client(self):
         """Create new HTTP-based inference client."""
@@ -400,7 +374,7 @@ class SkyRLTrainBackend(AbstractBackend):
 
         # Publish inference endpoint so the API can forward samples directly
         # (only meaningful in non-colocated mode; the API gates on this).
-        self._publish_engine_state(proxy_url=server_setup.proxy_url)
+        self._publish_inference_state(server_setup.proxy_url)
 
     def _ensure_inference_engines(self):
         """Lazily create inference engines and init weight sync on first sampling-related call."""
@@ -557,11 +531,10 @@ class SkyRLTrainBackend(AbstractBackend):
         self._renderer = None
         self._colocate_pg = None
         self._base_lora_signature = None
-        # Local state is fully reset above. Tell the API there is no
-        # inference engine to forward to last — _publish_engine_state is
-        # best-effort, so a DB failure here won't leave the controller
-        # half-torn-down. Next _create_new_inference_client repopulates.
-        self._publish_engine_state(proxy_url=None)
+        # Local state is fully reset above. Notify the host last so a
+        # publisher failure can't leave the controller half-torn-down.
+        # Next _create_new_inference_client repopulates.
+        self._publish_inference_state(None)
         logger.info(f"Successfully deleted model {model_id}")
 
     def _to_training_batch(self, prepared_batch: types.PreparedModelPassBatch, role: str) -> TrainingInputBatch:

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -184,6 +184,15 @@ async def lifespan(app: FastAPI):
     shutting_down = True
     monitor_task.cancel()
 
+    # Close the forwarding client's persistent httpx connection pool if we
+    # installed one. Cheap no-op when external_inference_client doesn't own
+    # an httpx client (ExternalInferenceClient creates one per call).
+    inference_client = getattr(app.state, "external_inference_client", None)
+    aclose = getattr(inference_client, "aclose", None)
+    if aclose is not None:
+        with suppress(Exception):
+            await aclose()
+
     logger.info(f"Stopping background engine (PID {app.state.background_engine.pid})")
     with suppress(ProcessLookupError):
         background_engine.terminate()

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -40,7 +40,7 @@ from skyrl.tinker.db_models import (
     enable_sqlite_wal,
     get_async_database_url,
 )
-from skyrl.tinker.extra import ExternalInferenceClient
+from skyrl.tinker.extra import BackendForwardingInferenceClient, ExternalInferenceClient
 from skyrl.utils.log import get_uvicorn_log_config, logger
 from skyrl.utils.storage import download_file
 
@@ -111,10 +111,36 @@ async def lifespan(app: FastAPI):
     async with app.state.db_engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
 
-    # Setup external inference client if configured
+    # Setup external inference client if configured.
+    #
+    # Three cases:
+    #   1. external_inference_url set: forward sample requests to a fully
+    #      external vLLM (existing behavior).
+    #   2. backend in (megatron, fsdp) and colocate_all=False: install
+    #      BackendForwardingInferenceClient so sample requests go directly
+    #      to the backend-managed vLLM, bypassing the engine's serial loop.
+    #   3. otherwise (JAX, colocated SkyRL-Train, etc.): route everything
+    #      through the engine subprocess.
+    #
+    # The colocated path stays on the engine because vLLM is asleep during
+    # training and only the engine's synchronous sample path knows how to
+    # wake it (save_weights_for_sampler → broadcast → sample).
+    backend_name = app.state.engine_config.backend
+    backend_cfg = app.state.engine_config.backend_config or {}
+    # SkyRL-Train default is colocate_all=True; only opt into forwarding
+    # when the operator explicitly sets it to False.
+    is_colocated = bool(backend_cfg.get("trainer.placement.colocate_all", True))
     if app.state.engine_config.external_inference_url:
         app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
+    elif backend_name in ("megatron", "fsdp") and not is_colocated:
+        app.state.external_inference_client = BackendForwardingInferenceClient(
+            app.state.engine_config, app.state.db_engine
+        )
+        logger.info(
+            "Backend-forwarding inference client enabled for non-colocated backend=%s",
+            backend_name,
+        )
     else:
         app.state.external_inference_client = None
         logger.info("Using internal engine for inference")

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -40,7 +40,7 @@ from skyrl.tinker.db_models import (
     enable_sqlite_wal,
     get_async_database_url,
 )
-from skyrl.tinker.extra import BackendForwardingInferenceClient, ExternalInferenceClient
+from skyrl.tinker.extra import ExternalInferenceClient, SkyRLTrainInferenceForwardingClient
 from skyrl.utils.log import get_uvicorn_log_config, logger
 from skyrl.utils.storage import download_file
 
@@ -117,8 +117,8 @@ async def lifespan(app: FastAPI):
     #   1. external_inference_url set: forward sample requests to a fully
     #      external vLLM (existing behavior).
     #   2. backend in (megatron, fsdp) and colocate_all=False: install
-    #      BackendForwardingInferenceClient so sample requests go directly
-    #      to the backend-managed vLLM, bypassing the engine's serial loop.
+    #      SkyRLTrainInferenceForwardingClient so sample requests go directly
+    #      to the SkyRL-Train-managed vLLM, bypassing the engine's serial loop.
     #   3. otherwise (JAX, colocated SkyRL-Train, etc.): route everything
     #      through the engine subprocess.
     #
@@ -134,11 +134,11 @@ async def lifespan(app: FastAPI):
         app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
-        app.state.external_inference_client = BackendForwardingInferenceClient(
+        app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
             app.state.engine_config, app.state.db_engine
         )
         logger.info(
-            "Backend-forwarding inference client enabled for non-colocated backend=%s",
+            "SkyRL-Train inference forwarding client enabled for non-colocated backend=%s",
             backend_name,
         )
     else:

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -40,7 +40,10 @@ from skyrl.tinker.db_models import (
     enable_sqlite_wal,
     get_async_database_url,
 )
-from skyrl.tinker.extra import ExternalInferenceClient, SkyRLTrainInferenceForwardingClient
+from skyrl.tinker.extra import (
+    ExternalInferenceClient,
+    SkyRLTrainInferenceForwardingClient,
+)
 from skyrl.utils.log import get_uvicorn_log_config, logger
 from skyrl.utils.storage import download_file
 

--- a/skyrl/tinker/config.py
+++ b/skyrl/tinker/config.py
@@ -47,7 +47,7 @@ class EngineConfig(BaseModel):
         default=None,
         description=(
             "Optional cap on the httpx connection pool used by "
-            "BackendForwardingInferenceClient to forward sample requests to "
+            "SkyRLTrainInferenceForwardingClient to forward sample requests to "
             "the engine-managed vLLM. The natural backpressure chain is "
             "httpx pool -> vllm-router -> vLLM's max_num_seqs; this knob "
             "only sets the API-side connection ceiling. Default `None` is "

--- a/skyrl/tinker/config.py
+++ b/skyrl/tinker/config.py
@@ -43,12 +43,16 @@ class EngineConfig(BaseModel):
         default=Path("/tmp/lora_models"),
         description="Directory where LoRA models will be extracted for external inference engines",
     )
-    max_concurrent_samples: int = Field(
-        default=64,
+    forwarding_inference_max_connections: int = Field(
+        default=1024,
         description=(
-            "Per-API-process cap on concurrent sample requests forwarded to the "
-            "engine-managed vLLM via BackendForwardingInferenceClient. Bounds "
-            "fan-out from many tenants; vLLM's own max_num_seqs is the ultimate cap."
+            "Cap on the httpx connection pool used by "
+            "BackendForwardingInferenceClient to forward sample requests to "
+            "the engine-managed vLLM. The natural backpressure chain is "
+            "httpx pool -> vllm-router -> vLLM's max_num_seqs; this knob "
+            "only sets the API-side connection ceiling. Sized for the peak "
+            "concurrent in-flight samples across all tenants — raise it for "
+            "very high fan-out workloads."
         ),
     )
     session_cleanup_interval_sec: int = Field(

--- a/skyrl/tinker/config.py
+++ b/skyrl/tinker/config.py
@@ -43,6 +43,14 @@ class EngineConfig(BaseModel):
         default=Path("/tmp/lora_models"),
         description="Directory where LoRA models will be extracted for external inference engines",
     )
+    max_concurrent_samples: int = Field(
+        default=64,
+        description=(
+            "Per-API-process cap on concurrent sample requests forwarded to the "
+            "engine-managed vLLM via BackendForwardingInferenceClient. Bounds "
+            "fan-out from many tenants; vLLM's own max_num_seqs is the ultimate cap."
+        ),
+    )
     session_cleanup_interval_sec: int = Field(
         default=60,
         description="How often to check for stale sessions (seconds). Set to -1 to disable cleanup.",

--- a/skyrl/tinker/config.py
+++ b/skyrl/tinker/config.py
@@ -43,17 +43,20 @@ class EngineConfig(BaseModel):
         default=Path("/tmp/lora_models"),
         description="Directory where LoRA models will be extracted for external inference engines",
     )
-    forwarding_inference_max_connections: int = Field(
-        default=1024,
+    forwarding_inference_max_connections: int | None = Field(
+        default=None,
         description=(
-            "Cap on the httpx connection pool used by "
+            "Optional cap on the httpx connection pool used by "
             "BackendForwardingInferenceClient to forward sample requests to "
             "the engine-managed vLLM. The natural backpressure chain is "
             "httpx pool -> vllm-router -> vLLM's max_num_seqs; this knob "
-            "only sets the API-side connection ceiling. Sized for the peak "
-            "concurrent in-flight samples across all tenants — raise it for "
-            "very high fan-out workloads."
+            "only sets the API-side connection ceiling. Default `None` is "
+            "unlimited — vllm-router/vLLM are the only queues — which is "
+            "usually what you want. Raise your host's `ulimit -n` for very "
+            "high fan-out (the only hard cost of unlimited connections is "
+            "file descriptors). Set an int to enforce a per-API-process cap."
         ),
+        json_schema_extra={"argparse_type": lambda v: None if v == "None" else int(v)},
     )
     session_cleanup_interval_sec: int = Field(
         default=60,

--- a/skyrl/tinker/db_models.py
+++ b/skyrl/tinker/db_models.py
@@ -140,8 +140,8 @@ class EngineStateDB(SQLModel, table=True):
     """Engine→API handoff for the inference engine the backend stands up.
 
     Singleton row (``singleton_id=1``). Written by the backend when a new
-    inference client is built (or torn down) and read by the API process to
-    decide whether to forward sample requests directly to vLLM.
+    inference client is built (or torn down) and read by the API's
+    forwarding client to resolve the vLLM proxy URL.
     """
 
     __tablename__ = "engine_state"
@@ -151,14 +151,5 @@ class EngineStateDB(SQLModel, table=True):
     # Proxy URL of the engine-managed vLLM. None when no vLLM has been
     # stood up yet (no create_model, FFT path, or last delete tore down).
     inference_proxy_url: str | None = None
-
-    # Backend vLLM URLs (data-parallel). Optional — the forwarding client
-    # only uses inference_proxy_url for /v1/completions.
-    inference_server_urls: list[str] = Field(default_factory=list, sa_type=JSON)
-
-    # Whether the backend is running in colocated mode. When True, the API
-    # MUST NOT install a forwarding client because vLLM is asleep during
-    # training and only the engine's synchronous sample path can wake it.
-    is_colocated: bool = False
 
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), sa_type=DateTime(timezone=True))

--- a/skyrl/tinker/db_models.py
+++ b/skyrl/tinker/db_models.py
@@ -134,3 +134,33 @@ class SamplingSessionDB(SQLModel, table=True):
     base_model: str | None = None
     model_path: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), sa_type=DateTime(timezone=True))
+
+
+class EngineStateDB(SQLModel, table=True):
+    """Engine→API handoff for the inference engine the backend stands up.
+
+    Singleton row (``singleton_id=1``). Written by the backend when a new
+    inference client is built (or torn down) and read by the API process to
+    decide whether to forward sample requests directly to vLLM.
+    """
+
+    __tablename__ = "engine_state"
+
+    singleton_id: int = Field(default=1, primary_key=True)
+
+    # Proxy URL of the engine-managed vLLM. None when no vLLM has been
+    # stood up yet (no create_model, FFT path, or last delete tore down).
+    inference_proxy_url: str | None = None
+
+    # Backend vLLM URLs (data-parallel). Optional — the forwarding client
+    # only uses inference_proxy_url for /v1/completions.
+    inference_server_urls: list[str] = Field(default_factory=list, sa_type=JSON)
+
+    # Whether the backend is running in colocated mode. When True, the API
+    # MUST NOT install a forwarding client because vLLM is asleep during
+    # training and only the engine's synchronous sample path can wake it.
+    is_colocated: bool = False
+
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), sa_type=DateTime(timezone=True)
+    )

--- a/skyrl/tinker/db_models.py
+++ b/skyrl/tinker/db_models.py
@@ -161,6 +161,4 @@ class EngineStateDB(SQLModel, table=True):
     # training and only the engine's synchronous sample path can wake it.
     is_colocated: bool = False
 
-    updated_at: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc), sa_type=DateTime(timezone=True)
-    )
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), sa_type=DateTime(timezone=True))

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -246,6 +246,12 @@ class TinkerEngine:
         backend_config = backend_config_class(**config.backend_config)
         self.backend = backend_class(config.base_model, backend_config)
 
+        # Backends that support async sample routing publish their inference
+        # endpoint to EngineStateDB so the API process can forward sample
+        # requests directly. Pass the database URL so the backend can write.
+        if hasattr(self.backend, "set_engine_database_url"):
+            self.backend.set_engine_database_url(config.database_url)
+
         # Track last cleanup time for periodic stale session cleanup
         self._last_cleanup_time: float = time.time()
 

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -17,6 +17,7 @@ from skyrl.tinker.config import EngineConfig, add_model
 from skyrl.tinker.db_models import (
     CheckpointDB,
     CheckpointStatus,
+    EngineStateDB,
     FutureDB,
     ModelDB,
     RequestStatus,
@@ -246,11 +247,12 @@ class TinkerEngine:
         backend_config = backend_config_class(**config.backend_config)
         self.backend = backend_class(config.base_model, backend_config)
 
-        # Backends that support async sample routing publish their inference
-        # endpoint to EngineStateDB so the API process can forward sample
-        # requests directly. Pass the database URL so the backend can write.
-        if hasattr(self.backend, "set_engine_database_url"):
-            self.backend.set_engine_database_url(config.database_url)
+        # Backends that support async sample routing notify us when their
+        # inference endpoint changes; we persist it to EngineStateDB so the
+        # API process can forward sample requests directly. Backends stay
+        # DB-free; only the engine owns the connection.
+        if hasattr(self.backend, "set_inference_state_publisher"):
+            self.backend.set_inference_state_publisher(self._write_inference_state_to_db)
 
         # Track last cleanup time for periodic stale session cleanup
         self._last_cleanup_time: float = time.time()
@@ -261,6 +263,20 @@ class TinkerEngine:
     def metrics(self) -> types.EngineMetrics:
         """Pass-through to backend metrics for backwards compatibility."""
         return self.backend.metrics
+
+    def _write_inference_state_to_db(self, proxy_url: str | None) -> None:
+        """Upsert the singleton EngineStateDB row.
+
+        Wired into the backend via set_inference_state_publisher so the API
+        process can resolve the engine-managed vLLM URL on the async sample
+        routing path. ``proxy_url=None`` clears the row (post-teardown).
+        """
+        with Session(self.db_engine) as session:
+            row = session.get(EngineStateDB, 1) or EngineStateDB(singleton_id=1)
+            row.inference_proxy_url = proxy_url
+            row.updated_at = datetime.now(timezone.utc)
+            session.add(row)
+            session.commit()
 
     @contextmanager
     def _checkpoint_status_context(self, model_id: str, checkpoint_id: str, checkpoint_type: types.CheckpointType):

--- a/skyrl/tinker/extra/__init__.py
+++ b/skyrl/tinker/extra/__init__.py
@@ -1,3 +1,4 @@
+from skyrl.tinker.extra.backend_forwarding_inference import BackendForwardingInferenceClient
 from skyrl.tinker.extra.external_inference import ExternalInferenceClient
 
-__all__ = ["ExternalInferenceClient"]
+__all__ = ["BackendForwardingInferenceClient", "ExternalInferenceClient"]

--- a/skyrl/tinker/extra/__init__.py
+++ b/skyrl/tinker/extra/__init__.py
@@ -1,6 +1,6 @@
-from skyrl.tinker.extra.backend_forwarding_inference import (
-    BackendForwardingInferenceClient,
-)
 from skyrl.tinker.extra.external_inference import ExternalInferenceClient
+from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
+    SkyRLTrainInferenceForwardingClient,
+)
 
-__all__ = ["BackendForwardingInferenceClient", "ExternalInferenceClient"]
+__all__ = ["ExternalInferenceClient", "SkyRLTrainInferenceForwardingClient"]

--- a/skyrl/tinker/extra/__init__.py
+++ b/skyrl/tinker/extra/__init__.py
@@ -1,4 +1,6 @@
-from skyrl.tinker.extra.backend_forwarding_inference import BackendForwardingInferenceClient
+from skyrl.tinker.extra.backend_forwarding_inference import (
+    BackendForwardingInferenceClient,
+)
 from skyrl.tinker.extra.external_inference import ExternalInferenceClient
 
 __all__ = ["BackendForwardingInferenceClient", "ExternalInferenceClient"]

--- a/skyrl/tinker/extra/backend_forwarding_inference.py
+++ b/skyrl/tinker/extra/backend_forwarding_inference.py
@@ -94,9 +94,7 @@ class BackendForwardingInferenceClient:
             future.completed_at = datetime.now(timezone.utc)
             await session.commit()
 
-    async def _forward_with_retry(
-        self, sample_req, model_id: str, *, base_model: str | None
-    ) -> types.SampleOutput:
+    async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
         """Forward once; on connection error, refresh the cached URL and retry once."""
         try:
             proxy_url = await self._resolve_proxy_url()
@@ -143,9 +141,7 @@ class BackendForwardingInferenceClient:
             response = await http_client.post("/v1/completions", json=payload)
             if response.status_code >= 400:
                 # Surface vLLM's body verbatim (e.g. 404 for unknown LoRA name).
-                raise RuntimeError(
-                    f"vLLM /v1/completions returned {response.status_code}: {response.text}"
-                )
+                raise RuntimeError(f"vLLM /v1/completions returned {response.status_code}: {response.text}")
             result = response.json()
 
         sequences = []

--- a/skyrl/tinker/extra/backend_forwarding_inference.py
+++ b/skyrl/tinker/extra/backend_forwarding_inference.py
@@ -92,6 +92,10 @@ class BackendForwardingInferenceClient:
             return row.inference_proxy_url
 
     async def _resolve_proxy_url(self, *, force_refresh: bool = False) -> str:
+        # Hot path: cache is warm and caller didn't ask for refresh.
+        # Skip the lock so concurrent samples don't serialize here.
+        if not force_refresh and self._cached_proxy_url is not None:
+            return self._cached_proxy_url
         async with self._cache_lock:
             if force_refresh or self._cached_proxy_url is None:
                 url = await self._read_proxy_url_from_db()

--- a/skyrl/tinker/extra/backend_forwarding_inference.py
+++ b/skyrl/tinker/extra/backend_forwarding_inference.py
@@ -1,21 +1,34 @@
 """Forwards EXTERNAL sample requests to the backend-managed vLLM.
 
-Differs from :class:`ExternalInferenceClient`:
+This client is intentionally thin — its job is schema translation, not
+request scheduling. Concurrency is bounded only by the httpx connection
+pool; vllm-router + each vLLM server's ``max_num_seqs`` are the real
+backpressure points. Don't add an asyncio.Semaphore on top: that would
+just serialize work above what vLLM already manages.
 
-  - Reads the vLLM proxy URL lazily from ``EngineStateDB`` (written by the
-    backend after ``_create_new_inference_client``) rather than from
-    ``EngineConfig``.
-  - Uses ``model=<model_id>`` for LoRA sampling — the backend's
-    ``save_weights_for_sampler`` already registered the adapter under that
-    name on vLLM via ``RemoteInferenceClient.load_lora_adapter``. No
-    checkpoint extraction step.
-  - For base-model sampling (no LoRA), uses ``model=<base_model>``.
+What the client does:
+  - Resolve the vLLM proxy URL lazily from ``EngineStateDB`` (written by
+    the backend after ``_create_new_inference_client``); refresh-on-error.
+  - Translate Tinker ``SamplingParams`` to a vLLM ``/v1/completions``
+    payload (max_tokens, temperature, top_p, top_k, stop, stop_token_ids,
+    logprobs, seed).
+  - Translate vLLM's completion response back into ``SampleOutput`` —
+    normalize ``finish_reason`` ({"stop", "stop_token"} -> "stop", else
+    "length"), zero-fill missing logprobs (RL workloads need them), and
+    set ``prompt_logprobs=None``.
+  - Write the result into ``FutureDB`` so ``/api/v1/retrieve_future``
+    sees a completed row.
 
-Failure modes (see design doc for the full list):
-  - Proxy URL not yet published → fail the future with a clear message.
-  - Connection error → refresh cached URL once and retry; if still failing,
-    fail the future.
-  - vLLM 4xx/5xx → fail the future with the upstream body verbatim.
+For LoRA tenants: uses ``model=<model_id>`` since the backend's
+``save_weights_for_sampler`` already registered the adapter under that
+name on vLLM via ``RemoteInferenceClient.load_lora_adapter``. For
+base-model sampling, uses ``model=<base_model>`` directly.
+
+Failure modes:
+  - Proxy URL not yet published -> fail the future with a clear message.
+  - Connection error -> refresh cached URL once and retry; if still
+    failing, fail the future.
+  - vLLM 4xx/5xx -> fail the future with the upstream body verbatim.
 """
 
 import asyncio
@@ -39,13 +52,20 @@ class BackendForwardingInferenceClient:
         self.db_engine = db_engine
         self._cached_proxy_url: str | None = None
         self._cache_lock = asyncio.Lock()
-        self._concurrency = asyncio.Semaphore(engine_config.max_concurrent_samples)
-        # Persistent client so we get connection pooling + no per-request
-        # TCP/TLS handshake. base_url is set when we first resolve the
-        # proxy_url; refreshed on connection error. Closed via aclose() in
-        # api.py lifespan shutdown.
+        # Persistent client with a high connection pool ceiling. Backpressure
+        # is layered: this httpx pool -> vllm-router (load balances across
+        # vLLM servers) -> each vLLM server's max_num_seqs (final cap).
+        # We intentionally do NOT impose an additional asyncio.Semaphore in
+        # the API process — that would just create an extra serializing
+        # bottleneck above what vLLM already enforces. Closed via aclose()
+        # in api.py lifespan shutdown.
+        max_conn = engine_config.forwarding_inference_max_connections
         self._http_client: httpx.AsyncClient = httpx.AsyncClient(
             timeout=httpx.Timeout(300.0, connect=10.0),
+            limits=httpx.Limits(
+                max_connections=max_conn,
+                max_keepalive_connections=max(max_conn // 4, 32),
+            ),
         )
 
     async def aclose(self) -> None:
@@ -88,15 +108,14 @@ class BackendForwardingInferenceClient:
         base_model: str | None = None,
     ):
         """Forward a sample request to vLLM and write the result to FutureDB."""
-        async with self._concurrency:
-            try:
-                result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
-                result_data = result.model_dump()
-                status = RequestStatus.COMPLETED
-            except Exception as e:
-                logger.exception("Backend-forwarded sample failed (request_id=%s)", request_id)
-                result_data = {"error": str(e), "status": "failed"}
-                status = RequestStatus.FAILED
+        try:
+            result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
+            result_data = result.model_dump()
+            status = RequestStatus.COMPLETED
+        except Exception as e:
+            logger.exception("Backend-forwarded sample failed (request_id=%s)", request_id)
+            result_data = {"error": str(e), "status": "failed"}
+            status = RequestStatus.FAILED
 
         async with AsyncSession(self.db_engine) as session:
             future = await session.get(FutureDB, request_id)
@@ -145,10 +164,15 @@ class BackendForwardingInferenceClient:
             "stream": False,
             "return_token_ids": True,
         }
-        if sp.stop_strings:
-            payload["stop"] = sp.stop_strings
-        if sp.stop_tokens:
-            payload["stop_token_ids"] = sp.stop_tokens
+        # API-level SamplingParams.stop is polymorphic: list[str] -> stop
+        # strings, list[int] -> stop token ids. Mirrors the dispatch in
+        # api.py SamplingParams.to_types().
+        stop = getattr(sp, "stop", None)
+        if stop:
+            if all(isinstance(s, int) for s in stop):
+                payload["stop_token_ids"] = list(stop)
+            elif all(isinstance(s, str) for s in stop):
+                payload["stop"] = list(stop)
 
         url = f"{proxy_url}/v1/completions"
         response = await self._http_client.post(url, json=payload)

--- a/skyrl/tinker/extra/backend_forwarding_inference.py
+++ b/skyrl/tinker/extra/backend_forwarding_inference.py
@@ -1,0 +1,158 @@
+"""Forwards EXTERNAL sample requests to the backend-managed vLLM.
+
+Differs from :class:`ExternalInferenceClient`:
+
+  - Reads the vLLM proxy URL lazily from ``EngineStateDB`` (written by the
+    backend after ``_create_new_inference_client``) rather than from
+    ``EngineConfig``.
+  - Uses ``model=<model_id>`` for LoRA sampling — the backend's
+    ``save_weights_for_sampler`` already registered the adapter under that
+    name on vLLM via ``RemoteInferenceClient.load_lora_adapter``. No
+    checkpoint extraction step.
+  - For base-model sampling (no LoRA), uses ``model=<base_model>``.
+
+Failure modes (see design doc for the full list):
+  - Proxy URL not yet published → fail the future with a clear message.
+  - Connection error → refresh cached URL once and retry; if still failing,
+    fail the future.
+  - vLLM 4xx/5xx → fail the future with the upstream body verbatim.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+
+import httpx
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from skyrl.backends.renderer import render_model_input
+from skyrl.tinker import types
+from skyrl.tinker.config import EngineConfig
+from skyrl.tinker.db_models import EngineStateDB, FutureDB, RequestStatus
+from skyrl.utils.log import logger
+
+
+class BackendForwardingInferenceClient:
+    """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM."""
+
+    def __init__(self, engine_config: EngineConfig, db_engine):
+        self.engine_config = engine_config
+        self.db_engine = db_engine
+        self._cached_proxy_url: str | None = None
+        self._cache_lock = asyncio.Lock()
+        self._concurrency = asyncio.Semaphore(engine_config.max_concurrent_samples)
+
+    async def _read_proxy_url_from_db(self) -> str | None:
+        """Read the singleton EngineStateDB row.
+
+        Returns the published proxy URL, or None when no row exists yet
+        (e.g. before the first ``create_model``) or when the backend last
+        published ``proxy_url=None`` (post-teardown).
+        """
+        async with AsyncSession(self.db_engine) as session:
+            row = await session.get(EngineStateDB, 1)
+            if row is None or row.inference_proxy_url is None:
+                return None
+            return row.inference_proxy_url
+
+    async def _resolve_proxy_url(self, *, force_refresh: bool = False) -> str:
+        async with self._cache_lock:
+            if force_refresh or self._cached_proxy_url is None:
+                url = await self._read_proxy_url_from_db()
+                if url is None:
+                    raise RuntimeError(
+                        "inference engine not ready: no proxy URL has been "
+                        "published to EngineStateDB. Either no create_model has "
+                        "been issued yet, or the engine just tore down vLLM."
+                    )
+                self._cached_proxy_url = url
+            return self._cached_proxy_url
+
+    async def call_and_store_result(
+        self,
+        request_id: int,
+        sample_req,
+        model_id: str,
+        checkpoint_id: str,
+        *,
+        base_model: str | None = None,
+    ):
+        """Forward a sample request to vLLM and write the result to FutureDB."""
+        async with self._concurrency:
+            try:
+                result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
+                result_data = result.model_dump()
+                status = RequestStatus.COMPLETED
+            except Exception as e:
+                logger.exception("Backend-forwarded sample failed (request_id=%s)", request_id)
+                result_data = {"error": str(e), "status": "failed"}
+                status = RequestStatus.FAILED
+
+        async with AsyncSession(self.db_engine) as session:
+            future = await session.get(FutureDB, request_id)
+            future.result_data = result_data
+            future.status = status
+            future.completed_at = datetime.now(timezone.utc)
+            await session.commit()
+
+    async def _forward_with_retry(
+        self, sample_req, model_id: str, *, base_model: str | None
+    ) -> types.SampleOutput:
+        """Forward once; on connection error, refresh the cached URL and retry once."""
+        try:
+            proxy_url = await self._resolve_proxy_url()
+            return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
+        except (httpx.ConnectError, httpx.ReadError, httpx.RemoteProtocolError) as e:
+            logger.warning("Connection error to %s: %s — refreshing proxy URL", self._cached_proxy_url, e)
+            proxy_url = await self._resolve_proxy_url(force_refresh=True)
+            return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
+
+    async def _forward(
+        self, proxy_url: str, sample_req, model_id: str, *, base_model: str | None
+    ) -> types.SampleOutput:
+        """POST {proxy_url}/v1/completions and parse into SampleOutput."""
+        # vLLM identifies the LoRA adapter by the name passed to load_lora_adapter,
+        # which was set to model_id in save_weights_for_sampler. For base-model
+        # sampling we point at the underlying HF model name directly.
+        model_name = base_model if base_model else model_id
+
+        model_input = sample_req.prompt.to_types()
+        prompt_tokens = render_model_input([model_input])[0].prompt_ids
+
+        payload = {
+            "model": model_name,
+            "prompt": prompt_tokens,
+            "n": sample_req.num_samples,
+            "seed": sample_req.sampling_params.seed,
+            "max_tokens": sample_req.sampling_params.max_tokens,
+            "temperature": sample_req.sampling_params.temperature,
+            "top_p": sample_req.sampling_params.top_p,
+            "top_k": sample_req.sampling_params.top_k,
+            "logprobs": True,
+            "stream": False,
+            "return_token_ids": True,
+        }
+
+        async with httpx.AsyncClient(
+            base_url=proxy_url,
+            timeout=httpx.Timeout(300.0, connect=10.0),
+        ) as http_client:
+            response = await http_client.post("/v1/completions", json=payload)
+            if response.status_code >= 400:
+                # Surface vLLM's body verbatim (e.g. 404 for unknown LoRA name).
+                raise RuntimeError(
+                    f"vLLM /v1/completions returned {response.status_code}: {response.text}"
+                )
+            result = response.json()
+
+        sequences = []
+        for choice in result["choices"]:
+            lp = choice["logprobs"]
+            sequences.append(
+                types.GeneratedSequence(
+                    tokens=choice["token_ids"],
+                    logprobs=lp["token_logprobs"],
+                    stop_reason=choice["finish_reason"],
+                )
+            )
+
+        return types.SampleOutput(sequences=sequences, prompt_logprobs=[])

--- a/skyrl/tinker/extra/backend_forwarding_inference.py
+++ b/skyrl/tinker/extra/backend_forwarding_inference.py
@@ -40,6 +40,17 @@ class BackendForwardingInferenceClient:
         self._cached_proxy_url: str | None = None
         self._cache_lock = asyncio.Lock()
         self._concurrency = asyncio.Semaphore(engine_config.max_concurrent_samples)
+        # Persistent client so we get connection pooling + no per-request
+        # TCP/TLS handshake. base_url is set when we first resolve the
+        # proxy_url; refreshed on connection error. Closed via aclose() in
+        # api.py lifespan shutdown.
+        self._http_client: httpx.AsyncClient = httpx.AsyncClient(
+            timeout=httpx.Timeout(300.0, connect=10.0),
+        )
+
+    async def aclose(self) -> None:
+        """Close the persistent httpx client. Called from api.py lifespan shutdown."""
+        await self._http_client.aclose()
 
     async def _read_proxy_url_from_db(self) -> str | None:
         """Read the singleton EngineStateDB row.
@@ -116,15 +127,16 @@ class BackendForwardingInferenceClient:
         model_input = sample_req.prompt.to_types()
         prompt_tokens = render_model_input([model_input])[0].prompt_ids
 
+        sp = sample_req.sampling_params
         payload = {
             "model": model_name,
             "prompt": prompt_tokens,
             "n": sample_req.num_samples,
-            "seed": sample_req.sampling_params.seed,
-            "max_tokens": sample_req.sampling_params.max_tokens,
-            "temperature": sample_req.sampling_params.temperature,
-            "top_p": sample_req.sampling_params.top_p,
-            "top_k": sample_req.sampling_params.top_k,
+            "seed": sp.seed,
+            "max_tokens": sp.max_tokens,
+            "temperature": sp.temperature,
+            "top_p": sp.top_p,
+            "top_k": sp.top_k,
             # vLLM (and the upstream vllm-router) expects an integer for the
             # OpenAI-compatible /v1/completions endpoint — the number of top
             # tokens to return logprobs for. 1 gives the chosen token's
@@ -133,26 +145,41 @@ class BackendForwardingInferenceClient:
             "stream": False,
             "return_token_ids": True,
         }
+        if sp.stop_strings:
+            payload["stop"] = sp.stop_strings
+        if sp.stop_tokens:
+            payload["stop_token_ids"] = sp.stop_tokens
 
-        async with httpx.AsyncClient(
-            base_url=proxy_url,
-            timeout=httpx.Timeout(300.0, connect=10.0),
-        ) as http_client:
-            response = await http_client.post("/v1/completions", json=payload)
-            if response.status_code >= 400:
-                # Surface vLLM's body verbatim (e.g. 404 for unknown LoRA name).
-                raise RuntimeError(f"vLLM /v1/completions returned {response.status_code}: {response.text}")
-            result = response.json()
+        url = f"{proxy_url}/v1/completions"
+        response = await self._http_client.post(url, json=payload)
+        if response.status_code >= 400:
+            # Surface vLLM's body verbatim (e.g. 404 for unknown LoRA name).
+            raise RuntimeError(f"vLLM /v1/completions returned {response.status_code}: {response.text}")
+        result = response.json()
 
         sequences = []
-        for choice in result["choices"]:
-            lp = choice["logprobs"]
+        for choice in result.get("choices", []):
+            tokens = choice.get("token_ids", [])
+            lp = choice.get("logprobs") or {}
+            logprobs = lp.get("token_logprobs") or []
+            # vLLM occasionally returns logprobs=None even when requested
+            # (upstream issue under load). RL workloads compute advantages
+            # against these, so zero-fill rather than return a ragged shape
+            # — matches the legacy in-process sample path's behavior.
+            if not logprobs and tokens:
+                logger.warning("No logprobs returned from vLLM — filling with zeros")
+                logprobs = [0.0] * len(tokens)
+            # Map vLLM's finish_reason ({"stop", "stop_token", "length", ...})
+            # to Tinker's Literal["stop", "length"]. Mirrors the
+            # normalization in skyrl_train_backend._sample_with_remote_client.
+            finish_reason = choice.get("finish_reason")
+            stop_reason = "stop" if finish_reason in ("stop", "stop_token") else "length"
             sequences.append(
                 types.GeneratedSequence(
-                    tokens=choice["token_ids"],
-                    logprobs=lp["token_logprobs"],
-                    stop_reason=choice["finish_reason"],
+                    tokens=tokens,
+                    logprobs=logprobs,
+                    stop_reason=stop_reason,
                 )
             )
 
-        return types.SampleOutput(sequences=sequences, prompt_logprobs=[])
+        return types.SampleOutput(sequences=sequences, prompt_logprobs=None)

--- a/skyrl/tinker/extra/backend_forwarding_inference.py
+++ b/skyrl/tinker/extra/backend_forwarding_inference.py
@@ -52,19 +52,25 @@ class BackendForwardingInferenceClient:
         self.db_engine = db_engine
         self._cached_proxy_url: str | None = None
         self._cache_lock = asyncio.Lock()
-        # Persistent client with a high connection pool ceiling. Backpressure
-        # is layered: this httpx pool -> vllm-router (load balances across
-        # vLLM servers) -> each vLLM server's max_num_seqs (final cap).
-        # We intentionally do NOT impose an additional asyncio.Semaphore in
-        # the API process — that would just create an extra serializing
-        # bottleneck above what vLLM already enforces. Closed via aclose()
-        # in api.py lifespan shutdown.
+        # Persistent client. Backpressure is layered: this httpx pool ->
+        # vllm-router (load balances across vLLM servers) -> each vLLM
+        # server's max_num_seqs (final cap). We intentionally do NOT
+        # impose an asyncio.Semaphore in the API process — that would
+        # just serialize work above what vLLM already enforces.
+        #
+        # Default `forwarding_inference_max_connections=None` means
+        # unlimited — vllm-router/vLLM are the only queues. The only
+        # cost of "unlimited" is file descriptors, so make sure the
+        # host's `ulimit -n` is sized for the peak concurrent samples
+        # across all tenants. Set an int to enforce a per-process cap.
+        # Closed via aclose() in api.py lifespan shutdown.
         max_conn = engine_config.forwarding_inference_max_connections
+        max_keepalive = max(max_conn // 4, 32) if max_conn is not None else None
         self._http_client: httpx.AsyncClient = httpx.AsyncClient(
             timeout=httpx.Timeout(300.0, connect=10.0),
             limits=httpx.Limits(
                 max_connections=max_conn,
-                max_keepalive_connections=max(max_conn // 4, 32),
+                max_keepalive_connections=max_keepalive,
             ),
         )
 

--- a/skyrl/tinker/extra/backend_forwarding_inference.py
+++ b/skyrl/tinker/extra/backend_forwarding_inference.py
@@ -127,7 +127,11 @@ class BackendForwardingInferenceClient:
             "temperature": sample_req.sampling_params.temperature,
             "top_p": sample_req.sampling_params.top_p,
             "top_k": sample_req.sampling_params.top_k,
-            "logprobs": True,
+            # vLLM (and the upstream vllm-router) expects an integer for the
+            # OpenAI-compatible /v1/completions endpoint — the number of top
+            # tokens to return logprobs for. 1 gives the chosen token's
+            # logprob, which is what the Tinker SampleOutput requires.
+            "logprobs": 1,
             "stream": False,
             "return_token_ids": True,
         }

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -135,18 +135,40 @@ class SkyRLTrainInferenceForwardingClient:
 
         async with AsyncSession(self.db_engine) as session:
             future = await session.get(FutureDB, request_id)
+            if future is None:
+                # The future row was deleted (manual cleanup, stale-session
+                # GC, etc.) between asample handler scheduling us and our
+                # arrival here. Nothing to write back; the retrieve_future
+                # poller will time out on the caller's side.
+                logger.warning(
+                    "FutureDB row %s missing on completion write — skipping (request was likely cancelled)",
+                    request_id,
+                )
+                return
             future.result_data = result_data
             future.status = status
             future.completed_at = datetime.now(timezone.utc)
             await session.commit()
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
-        """Forward once; on connection error, refresh the cached URL and retry once."""
+        """Forward once; on transport-level failure, refresh URL and retry once.
+
+        Catches httpx.RequestError (the umbrella for ConnectError, ReadError,
+        RemoteProtocolError, TimeoutException, PoolTimeout, etc.) so any
+        network-level failure triggers a single URL refresh + retry. RuntimeError
+        (HTTP 4xx/5xx from vLLM) is NOT retried — that's a real upstream error
+        that should surface to the caller.
+        """
         try:
             proxy_url = await self._resolve_proxy_url()
             return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
-        except (httpx.ConnectError, httpx.ReadError, httpx.RemoteProtocolError) as e:
-            logger.warning("Connection error to %s: %s — refreshing proxy URL", self._cached_proxy_url, e)
+        except httpx.RequestError as e:
+            logger.warning(
+                "Network error talking to %s (%s: %s) — refreshing proxy URL and retrying once",
+                self._cached_proxy_url,
+                type(e).__name__,
+                e,
+            )
             proxy_url = await self._resolve_proxy_url(force_refresh=True)
             return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
 
@@ -195,7 +217,17 @@ class SkyRLTrainInferenceForwardingClient:
         if response.status_code >= 400:
             # Surface vLLM's body verbatim (e.g. 404 for unknown LoRA name).
             raise RuntimeError(f"vLLM /v1/completions returned {response.status_code}: {response.text}")
-        result = response.json()
+        try:
+            result = response.json()
+        except ValueError as e:
+            # vLLM-router or any intermediate proxy may return HTML on
+            # transient errors (502 Bad Gateway etc.) even with a 2xx
+            # status. Surface the raw body so the failure mode is
+            # diagnosable from the FutureDB error_data alone.
+            raise RuntimeError(
+                f"vLLM /v1/completions returned non-JSON ({response.status_code}, "
+                f"content-type={response.headers.get('content-type')!r}): {response.text[:512]}"
+            ) from e
 
         sequences = []
         for choice in result.get("choices", []):

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -1,4 +1,4 @@
-"""Forwards EXTERNAL sample requests to the backend-managed vLLM.
+"""Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM.
 
 This client is intentionally thin — its job is schema translation, not
 request scheduling. Concurrency is bounded only by the httpx connection
@@ -44,8 +44,14 @@ from skyrl.tinker.db_models import EngineStateDB, FutureDB, RequestStatus
 from skyrl.utils.log import logger
 
 
-class BackendForwardingInferenceClient:
-    """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM."""
+class SkyRLTrainInferenceForwardingClient:
+    """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM.
+
+    Pair to :class:`ExternalInferenceClient` — same EXTERNAL future-write
+    contract, but resolves the target URL from ``EngineStateDB`` (populated
+    by the SkyRL-Train backend's ``_publish_engine_state``) instead of from
+    a user-supplied ``EngineConfig.external_inference_url``.
+    """
 
     def __init__(self, engine_config: EngineConfig, db_engine):
         self.engine_config = engine_config

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -1,34 +1,7 @@
 """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM.
 
-This client is intentionally thin — its job is schema translation, not
-request scheduling. Concurrency is bounded only by the httpx connection
-pool; vllm-router + each vLLM server's ``max_num_seqs`` are the real
-backpressure points. Don't add an asyncio.Semaphore on top: that would
-just serialize work above what vLLM already manages.
-
-What the client does:
-  - Resolve the vLLM proxy URL lazily from ``EngineStateDB`` (written by
-    the backend after ``_create_new_inference_client``); refresh-on-error.
-  - Translate Tinker ``SamplingParams`` to a vLLM ``/v1/completions``
-    payload (max_tokens, temperature, top_p, top_k, stop, stop_token_ids,
-    logprobs, seed).
-  - Translate vLLM's completion response back into ``SampleOutput`` —
-    normalize ``finish_reason`` ({"stop", "stop_token"} -> "stop", else
-    "length"), zero-fill missing logprobs (RL workloads need them), and
-    set ``prompt_logprobs=None``.
-  - Write the result into ``FutureDB`` so ``/api/v1/retrieve_future``
-    sees a completed row.
-
-For LoRA tenants: uses ``model=<model_id>`` since the backend's
-``save_weights_for_sampler`` already registered the adapter under that
-name on vLLM via ``RemoteInferenceClient.load_lora_adapter``. For
-base-model sampling, uses ``model=<base_model>`` directly.
-
-Failure modes:
-  - Proxy URL not yet published -> fail the future with a clear message.
-  - Connection error -> refresh cached URL once and retry; if still
-    failing, fail the future.
-  - vLLM 4xx/5xx -> fail the future with the upstream body verbatim.
+Pair to :class:`ExternalInferenceClient`; resolves the target URL from
+``EngineStateDB`` instead of from a user-supplied ``external_inference_url``.
 """
 
 import asyncio
@@ -45,31 +18,16 @@ from skyrl.utils.log import logger
 
 
 class SkyRLTrainInferenceForwardingClient:
-    """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM.
-
-    Pair to :class:`ExternalInferenceClient` — same EXTERNAL future-write
-    contract, but resolves the target URL from ``EngineStateDB`` (populated
-    by the SkyRL-Train backend's ``_publish_engine_state``) instead of from
-    a user-supplied ``EngineConfig.external_inference_url``.
-    """
+    """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM."""
 
     def __init__(self, engine_config: EngineConfig, db_engine):
         self.engine_config = engine_config
         self.db_engine = db_engine
         self._cached_proxy_url: str | None = None
         self._cache_lock = asyncio.Lock()
-        # Persistent client. Backpressure is layered: this httpx pool ->
-        # vllm-router (load balances across vLLM servers) -> each vLLM
-        # server's max_num_seqs (final cap). We intentionally do NOT
-        # impose an asyncio.Semaphore in the API process — that would
-        # just serialize work above what vLLM already enforces.
-        #
-        # Default `forwarding_inference_max_connections=None` means
-        # unlimited — vllm-router/vLLM are the only queues. The only
-        # cost of "unlimited" is file descriptors, so make sure the
-        # host's `ulimit -n` is sized for the peak concurrent samples
-        # across all tenants. Set an int to enforce a per-process cap.
-        # Closed via aclose() in api.py lifespan shutdown.
+        # Backpressure layered: httpx pool -> vllm-router -> vLLM max_num_seqs.
+        # Default `forwarding_inference_max_connections=None` is unlimited;
+        # the only cost is file descriptors (raise `ulimit -n` accordingly).
         max_conn = engine_config.forwarding_inference_max_connections
         max_keepalive = max(max_conn // 4, 32) if max_conn is not None else None
         self._http_client: httpx.AsyncClient = httpx.AsyncClient(
@@ -85,12 +43,6 @@ class SkyRLTrainInferenceForwardingClient:
         await self._http_client.aclose()
 
     async def _read_proxy_url_from_db(self) -> str | None:
-        """Read the singleton EngineStateDB row.
-
-        Returns the published proxy URL, or None when no row exists yet
-        (e.g. before the first ``create_model``) or when the backend last
-        published ``proxy_url=None`` (post-teardown).
-        """
         async with AsyncSession(self.db_engine) as session:
             row = await session.get(EngineStateDB, 1)
             if row is None or row.inference_proxy_url is None:
@@ -98,8 +50,7 @@ class SkyRLTrainInferenceForwardingClient:
             return row.inference_proxy_url
 
     async def _resolve_proxy_url(self, *, force_refresh: bool = False) -> str:
-        # Hot path: cache is warm and caller didn't ask for refresh.
-        # Skip the lock so concurrent samples don't serialize here.
+        # Skip the lock when the cache is warm so concurrent samples don't serialize.
         if not force_refresh and self._cached_proxy_url is not None:
             return self._cached_proxy_url
         async with self._cache_lock:
@@ -107,9 +58,7 @@ class SkyRLTrainInferenceForwardingClient:
                 url = await self._read_proxy_url_from_db()
                 if url is None:
                     raise RuntimeError(
-                        "inference engine not ready: no proxy URL has been "
-                        "published to EngineStateDB. Either no create_model has "
-                        "been issued yet, or the engine just tore down vLLM."
+                        "inference engine not ready: no proxy URL published to EngineStateDB"
                     )
                 self._cached_proxy_url = url
             return self._cached_proxy_url
@@ -136,14 +85,9 @@ class SkyRLTrainInferenceForwardingClient:
         async with AsyncSession(self.db_engine) as session:
             future = await session.get(FutureDB, request_id)
             if future is None:
-                # The future row was deleted (manual cleanup, stale-session
-                # GC, etc.) between asample handler scheduling us and our
-                # arrival here. Nothing to write back; the retrieve_future
-                # poller will time out on the caller's side.
-                logger.warning(
-                    "FutureDB row %s missing on completion write — skipping (request was likely cancelled)",
-                    request_id,
-                )
+                # Row was deleted between scheduling and completion (cancelled
+                # request, stale-session GC). Nothing to write back.
+                logger.warning("FutureDB row %s missing on completion write — skipping", request_id)
                 return
             future.result_data = result_data
             future.status = status
@@ -151,14 +95,8 @@ class SkyRLTrainInferenceForwardingClient:
             await session.commit()
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
-        """Forward once; on transport-level failure, refresh URL and retry once.
-
-        Catches httpx.RequestError (the umbrella for ConnectError, ReadError,
-        RemoteProtocolError, TimeoutException, PoolTimeout, etc.) so any
-        network-level failure triggers a single URL refresh + retry. RuntimeError
-        (HTTP 4xx/5xx from vLLM) is NOT retried — that's a real upstream error
-        that should surface to the caller.
-        """
+        # httpx.RequestError covers ConnectError, ReadError, TimeoutException, etc.
+        # HTTP 4xx/5xx surfaces as RuntimeError below and is NOT retried.
         try:
             proxy_url = await self._resolve_proxy_url()
             return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
@@ -175,10 +113,8 @@ class SkyRLTrainInferenceForwardingClient:
     async def _forward(
         self, proxy_url: str, sample_req, model_id: str, *, base_model: str | None
     ) -> types.SampleOutput:
-        """POST {proxy_url}/v1/completions and parse into SampleOutput."""
-        # vLLM identifies the LoRA adapter by the name passed to load_lora_adapter,
-        # which was set to model_id in save_weights_for_sampler. For base-model
-        # sampling we point at the underlying HF model name directly.
+        # model_id matches the LoRA name registered with vLLM during
+        # save_weights_for_sampler; base_model is used for non-LoRA sampling.
         model_name = base_model if base_model else model_id
 
         model_input = sample_req.prompt.to_types()
@@ -194,17 +130,12 @@ class SkyRLTrainInferenceForwardingClient:
             "temperature": sp.temperature,
             "top_p": sp.top_p,
             "top_k": sp.top_k,
-            # vLLM (and the upstream vllm-router) expects an integer for the
-            # OpenAI-compatible /v1/completions endpoint — the number of top
-            # tokens to return logprobs for. 1 gives the chosen token's
-            # logprob, which is what the Tinker SampleOutput requires.
+            # vllm-router rejects boolean; 1 = return the chosen token's logprob.
             "logprobs": 1,
             "stream": False,
             "return_token_ids": True,
         }
-        # API-level SamplingParams.stop is polymorphic: list[str] -> stop
-        # strings, list[int] -> stop token ids. Mirrors the dispatch in
-        # api.py SamplingParams.to_types().
+        # SamplingParams.stop is polymorphic (list[str] | list[int]).
         stop = getattr(sp, "stop", None)
         if stop:
             if all(isinstance(s, int) for s in stop):
@@ -215,15 +146,11 @@ class SkyRLTrainInferenceForwardingClient:
         url = f"{proxy_url}/v1/completions"
         response = await self._http_client.post(url, json=payload)
         if response.status_code >= 400:
-            # Surface vLLM's body verbatim (e.g. 404 for unknown LoRA name).
             raise RuntimeError(f"vLLM /v1/completions returned {response.status_code}: {response.text}")
         try:
             result = response.json()
         except ValueError as e:
-            # vLLM-router or any intermediate proxy may return HTML on
-            # transient errors (502 Bad Gateway etc.) even with a 2xx
-            # status. Surface the raw body so the failure mode is
-            # diagnosable from the FutureDB error_data alone.
+            # vllm-router can return HTML on transient errors even with 2xx status.
             raise RuntimeError(
                 f"vLLM /v1/completions returned non-JSON ({response.status_code}, "
                 f"content-type={response.headers.get('content-type')!r}): {response.text[:512]}"
@@ -234,16 +161,12 @@ class SkyRLTrainInferenceForwardingClient:
             tokens = choice.get("token_ids", [])
             lp = choice.get("logprobs") or {}
             logprobs = lp.get("token_logprobs") or []
-            # vLLM occasionally returns logprobs=None even when requested
-            # (upstream issue under load). RL workloads compute advantages
-            # against these, so zero-fill rather than return a ragged shape
-            # — matches the legacy in-process sample path's behavior.
+            # vLLM occasionally returns None for logprobs under load; zero-fill so
+            # RL advantage computation doesn't see a ragged shape.
             if not logprobs and tokens:
                 logger.warning("No logprobs returned from vLLM — filling with zeros")
                 logprobs = [0.0] * len(tokens)
-            # Map vLLM's finish_reason ({"stop", "stop_token", "length", ...})
-            # to Tinker's Literal["stop", "length"]. Mirrors the
-            # normalization in skyrl_train_backend._sample_with_remote_client.
+            # Tinker's stop_reason is Literal["stop", "length"]; vLLM emits a wider set.
             finish_reason = choice.get("finish_reason")
             stop_reason = "stop" if finish_reason in ("stop", "stop_token") else "length"
             sequences.append(

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -57,9 +57,7 @@ class SkyRLTrainInferenceForwardingClient:
             if force_refresh or self._cached_proxy_url is None:
                 url = await self._read_proxy_url_from_db()
                 if url is None:
-                    raise RuntimeError(
-                        "inference engine not ready: no proxy URL published to EngineStateDB"
-                    )
+                    raise RuntimeError("inference engine not ready: no proxy URL published to EngineStateDB")
                 self._cached_proxy_url = url
             return self._cached_proxy_url
 

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -1,5 +1,5 @@
 """End-to-end tests for the async sample routing path (EngineStateDB +
-``BackendForwardingInferenceClient``).
+``SkyRLTrainInferenceForwardingClient``).
 
 GPU-gated: requires at least one CUDA device. Spins up a real Tinker API
 server with the SkyRL-Train Megatron backend in non-colocated mode so the
@@ -59,7 +59,7 @@ TEST_PORT = 8019
 
 # Tiny config — same shape as test_multi_lora_megatron's BACKEND_CONFIG.
 # Non-colocated is required: that's what triggers the API to install
-# BackendForwardingInferenceClient in the lifespan. merge_lora=False makes
+# SkyRLTrainInferenceForwardingClient in the lifespan. merge_lora=False makes
 # vLLM serve LoRA adapters by tenant name, which is the contract the
 # forwarding client relies on (model=<model_id>).
 BACKEND_CONFIG = {

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -8,8 +8,7 @@ bypassing the engine subprocess's serial scheduling loop.
 
 Coverage:
   - test_engine_state_published: after ``save_weights_for_sampler``, the
-    engine's vLLM proxy URL is written to ``EngineStateDB`` and the row
-    has ``is_colocated=False``.
+    engine's vLLM proxy URL is written to ``EngineStateDB``.
   - test_sample_uses_external_path: an issued sample creates a future of
     type ``EXTERNAL`` (not ``SAMPLE``) and resolves successfully.
   - test_sample_concurrent_with_training_is_fast: the central
@@ -17,6 +16,9 @@ Coverage:
     + ``optim_step`` calls is in flight, a sample request resolves in
     much less time than the training stream takes, demonstrating that
     sample latency is no longer bounded by training-step duration.
+  - test_concurrent_samples_per_adapter: many concurrent samples across
+    two adapters all resolve via the forwarding client's connection pool
+    and per-adapter (``model=<model_id>``) routing on vLLM.
 
 Run:
   uv run --extra tinker --extra megatron --with pytest --with pytest-timeout \\
@@ -75,6 +77,7 @@ BACKEND_CONFIG = {
 
 def _server_is_up(port: int) -> bool:
     import urllib.error
+    import urllib.request
 
     try:
         urllib.request.urlopen(f"http://0.0.0.0:{port}/api/v1/healthz", timeout=2).read()
@@ -204,9 +207,6 @@ def test_engine_state_published(server_db_path):
     assert row.inference_proxy_url is not None and row.inference_proxy_url.startswith(
         "http"
     ), f"expected an http(s) proxy URL, got {row.inference_proxy_url!r}"
-    assert row.is_colocated is False, "non-colocated backend should publish is_colocated=False"
-    # server_urls should also be populated for non-external setups (data plane URLs).
-    assert isinstance(row.inference_server_urls, list)
 
 
 def test_sample_uses_external_path(server_db_path):
@@ -359,9 +359,10 @@ def test_sample_concurrent_with_training_is_fast(server_db_path):
 def test_concurrent_samples_per_adapter(server_db_path):
     """Issue several concurrent samples across two adapters; all resolve.
 
-    This exercises the per-API-process semaphore and confirms that the
-    forwarding client correctly multiplexes by model_id (each adapter
-    name maps to vLLM's per-tenant LoRA registration).
+    Exercises the forwarding client's httpx connection pool and confirms
+    that requests route to the correct adapter via ``model=<model_id>``
+    (each Tinker model_id maps to a LoRA registered on vLLM under the
+    same name during save_weights_for_sampler).
     """
     proc, _, _ = server_db_path
     sc = tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -218,6 +218,11 @@ def test_sample_uses_external_path(server_db_path):
     This is the "test" half of the design: the API hoists the sample off
     the engine's serial loop and into the API process's asyncio loop.
     """
+    from sqlmodel import Session, create_engine, func, select
+
+    from skyrl.tinker import types as skyrl_types
+    from skyrl.tinker.db_models import FutureDB
+
     proc, db_path, _ = server_db_path
     sc = tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
     tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=8)
@@ -226,46 +231,40 @@ def test_sample_uses_external_path(server_db_path):
     _train_one_step(tc, tok)
     sampler = tc.save_weights_and_get_sampling_client(name="external_path_a")
 
-    fut = sampler.sample(
+    # Snapshot the max future_id before submitting our sample so we can
+    # filter out any EXTERNAL futures from earlier tests.
+    eng = create_engine(f"sqlite:///{db_path}", echo=False)
+    try:
+        with Session(eng) as s:
+            max_before = s.exec(select(func.max(FutureDB.request_id))).one() or 0
+    finally:
+        eng.dispose()
+
+    out = sampler.sample(
         prompt=tinker_types.ModelInput.from_ints(tok.encode("Hi", add_special_tokens=True)),
         num_samples=1,
         sampling_params=tinker_types.SamplingParams(max_tokens=4, temperature=0.0, top_k=1, seed=0),
-    )
-
-    # The Tinker SDK exposes the request id via the future. Ask the DB
-    # directly to confirm the request_type. Poll briefly because the
-    # SDK's future ID may not be queryable for a moment after submission.
-    request_id = None
-    raw = getattr(fut, "_request_id", None) or getattr(fut, "request_id", None)
-    if raw is not None:
-        request_id = int(raw)
-    else:
-        # Fall back: scan for the most recent future row.
-        from sqlmodel import Session, create_engine, select
-
-        from skyrl.tinker.db_models import FutureDB
-
-        eng = create_engine(f"sqlite:///{db_path}", echo=False)
-        try:
-            with Session(eng) as s:
-                stmt = select(FutureDB.request_id, FutureDB.request_type).order_by(FutureDB.request_id.desc())
-                row = s.exec(stmt).first()
-                if row is not None:
-                    request_id = int(row[0])
-        finally:
-            eng.dispose()
-
-    assert request_id is not None, "could not locate the sample's FutureDB row"
-    rtype = _read_future_request_type(db_path, request_id)
-    assert rtype is not None, f"missing future row for id={request_id}"
-    # The SQLModel Enum stores either the literal value 'external' or the
-    # repr 'RequestType.EXTERNAL' depending on the dialect. Match both.
-    assert "EXTERNAL" in rtype.upper(), (
-        f"expected EXTERNAL request type for forwarded sample, got {rtype!r}"
-    )
-
-    out = fut.result()
+    ).result()
     assert len(out.sequences) == 1
+
+    # Look for an EXTERNAL future with id > max_before. If async routing
+    # is on, every sample creates exactly one such row.
+    eng = create_engine(f"sqlite:///{db_path}", echo=False)
+    try:
+        with Session(eng) as s:
+            stmt = (
+                select(FutureDB.request_id, FutureDB.request_type)
+                .where(FutureDB.request_id > max_before)
+                .where(FutureDB.request_type == skyrl_types.RequestType.EXTERNAL)
+            )
+            rows = s.exec(stmt).all()
+    finally:
+        eng.dispose()
+
+    assert len(rows) >= 1, (
+        f"expected at least one EXTERNAL future to be created by the sample call, "
+        f"found {len(rows)}; async sample routing may not be active"
+    )
 
 
 def test_sample_concurrent_with_training_is_fast(server_db_path):

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -1,0 +1,397 @@
+"""End-to-end tests for the async sample routing path (EngineStateDB +
+``BackendForwardingInferenceClient``).
+
+GPU-gated: requires at least one CUDA device. Spins up a real Tinker API
+server with the SkyRL-Train Megatron backend in non-colocated mode so the
+API process forwards sample requests directly to vLLM via the new path,
+bypassing the engine subprocess's serial scheduling loop.
+
+Coverage:
+  - test_engine_state_published: after ``save_weights_for_sampler``, the
+    engine's vLLM proxy URL is written to ``EngineStateDB`` and the row
+    has ``is_colocated=False``.
+  - test_sample_uses_external_path: an issued sample creates a future of
+    type ``EXTERNAL`` (not ``SAMPLE``) and resolves successfully.
+  - test_sample_concurrent_with_training_is_fast: the central
+    parallelism test. While a long-running stream of ``forward_backward``
+    + ``optim_step`` calls is in flight, a sample request resolves in
+    much less time than the training stream takes, demonstrating that
+    sample latency is no longer bounded by training-step duration.
+
+Run:
+  uv run --extra tinker --extra megatron --with pytest --with pytest-timeout \\
+    pytest -s tests/tinker/skyrl_train/test_async_sample_routing.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.request
+from contextlib import contextmanager
+
+import pytest
+
+cuda_available = False
+try:  # pragma: no cover - import guard
+    import torch
+
+    cuda_available = bool(torch.cuda.is_available() and torch.cuda.device_count() > 0)
+except Exception:
+    cuda_available = False
+
+pytestmark = pytest.mark.skipif(
+    not cuda_available, reason="async sample routing tests require at least one CUDA GPU"
+)
+
+tinker = pytest.importorskip("tinker")
+from tinker import types as tinker_types  # noqa: E402
+from transformers import AutoTokenizer  # noqa: E402
+
+from tests.tinker.conftest import wait_for_condition  # noqa: E402
+
+BASE_MODEL = "trl-internal-testing/tiny-Qwen3ForCausalLM"
+TINKER_API_KEY = "tml-dummy"
+TEST_PORT = 8019
+
+# Tiny config — same shape as test_multi_lora_megatron's BACKEND_CONFIG.
+# Non-colocated is required: that's what triggers the API to install
+# BackendForwardingInferenceClient in the lifespan. merge_lora=False makes
+# vLLM serve LoRA adapters by tenant name, which is the contract the
+# forwarding client relies on (model=<model_id>).
+BACKEND_CONFIG = {
+    "strategy": "megatron",
+    "trainer.placement.policy_num_gpus_per_node": 1,
+    "trainer.placement.policy_num_nodes": 1,
+    "trainer.placement.colocate_all": False,
+    "trainer.policy.megatron_config.tensor_model_parallel_size": 1,
+    "trainer.policy.megatron_config.pipeline_model_parallel_size": 1,
+    "trainer.policy.megatron_config.lora_config.merge_lora": False,
+    "trainer.policy.model.lora.max_loras": 4,
+    "trainer.policy.model.lora.max_cpu_loras": 4,
+}
+
+
+def _server_is_up(port: int) -> bool:
+    import urllib.error
+
+    try:
+        urllib.request.urlopen(f"http://0.0.0.0:{port}/api/v1/healthz", timeout=2).read()
+        return True
+    except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError, TimeoutError):
+        return False
+
+
+@contextmanager
+def _api_server(port: int, db_path: str, backend_config: dict | None = None):
+    """Start the Tinker API server with non-colocated Megatron backend.
+
+    db_path is taken as a parameter (rather than created internally) so
+    tests that need to inspect EngineStateDB can read it directly.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        log_path = os.path.join(tmp_dir, "server.log")
+        cfg = dict(backend_config or BACKEND_CONFIG)
+        cmd = [
+            "uv", "run", "--extra", "tinker", "--extra", "megatron",
+            "-m", "skyrl.tinker.api",
+            "--host", "0.0.0.0",
+            "--port", str(port),
+            "--base-model", BASE_MODEL,
+            "--backend", "megatron",
+            "--backend-config", json.dumps(cfg),
+            "--database-url", f"sqlite:///{db_path}",
+        ]  # fmt: skip
+        with open(log_path, "w") as log_file:
+            proc = subprocess.Popen(cmd, stdout=log_file, stderr=log_file)
+            try:
+                ok = wait_for_condition(
+                    lambda: _server_is_up(port),
+                    timeout_sec=180,
+                    poll_interval_sec=2,
+                )
+                if not ok:
+                    with open(log_path) as f:
+                        print(f"=== Server failed to start ===\n{f.read()}")
+                    pytest.fail("Tinker API server did not come up in time")
+                yield proc, log_path
+            finally:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+
+
+def _make_datum(tokenizer, prompt: str, completion: str):
+    prompt_tokens = tokenizer.encode(prompt, add_special_tokens=True)
+    completion_tokens = tokenizer.encode(f"{completion}\n\n", add_special_tokens=False)
+    all_tokens = prompt_tokens + completion_tokens
+    target_tokens = all_tokens[1:] + [tokenizer.eos_token_id]
+    weights = [0.0] * len(prompt_tokens) + [1.0] * len(completion_tokens)
+    return tinker_types.Datum(
+        model_input=tinker_types.ModelInput.from_ints(all_tokens),
+        loss_fn_inputs={"target_tokens": target_tokens, "weights": weights[1:] + [1.0]},
+    )
+
+
+@pytest.fixture(scope="module")
+def server_db_path():
+    """Module-scoped server + DB path. Sharing the server across tests
+    saves ~2 minutes of warm-up time."""
+    db_dir = tempfile.mkdtemp(prefix="async_sample_routing_db_")
+    db_path = os.path.join(db_dir, "server.db")
+    with _api_server(TEST_PORT, db_path) as (proc, log_path):
+        yield proc, db_path, log_path
+
+
+@pytest.fixture
+def service_client(server_db_path):
+    return tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
+
+
+def _read_engine_state(db_path: str):
+    """Read the singleton EngineStateDB row from the test server's DB."""
+    from sqlmodel import Session, create_engine
+
+    from skyrl.tinker.db_models import EngineStateDB
+
+    engine = create_engine(f"sqlite:///{db_path}", echo=False)
+    try:
+        with Session(engine) as session:
+            return session.get(EngineStateDB, 1)
+    finally:
+        engine.dispose()
+
+
+def _read_future_request_type(db_path: str, request_id: int) -> str:
+    """Read the request_type of a single future from the test server's DB."""
+    from sqlmodel import Session, create_engine
+
+    from skyrl.tinker.db_models import FutureDB
+
+    engine = create_engine(f"sqlite:///{db_path}", echo=False)
+    try:
+        with Session(engine) as session:
+            row = session.get(FutureDB, request_id)
+            return None if row is None else str(row.request_type)
+    finally:
+        engine.dispose()
+
+
+def _train_one_step(tc, tok):
+    """Run one tiny forward_backward + optim_step. Used for warm-up."""
+    data = [_make_datum(tok, "Hello", "world")]
+    tc.forward_backward(data, "cross_entropy").result()
+    tc.optim_step(tinker_types.AdamParams(learning_rate=1e-4)).result()
+
+
+def test_engine_state_published(server_db_path):
+    """After a save_weights_for_sampler the engine publishes its proxy URL."""
+    proc, db_path, _ = server_db_path
+    sc = tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
+    tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=8)
+    tok = AutoTokenizer.from_pretrained(BASE_MODEL)
+
+    # Drive at least one fwd_bwd + save to bring up vLLM and trigger
+    # _publish_engine_state on the backend.
+    _train_one_step(tc, tok)
+    tc.save_weights_and_get_sampling_client(name="state_check_a")
+
+    row = _read_engine_state(db_path)
+    assert row is not None, "EngineStateDB row missing — backend never published state"
+    assert row.inference_proxy_url is not None and row.inference_proxy_url.startswith("http"), (
+        f"expected an http(s) proxy URL, got {row.inference_proxy_url!r}"
+    )
+    assert row.is_colocated is False, "non-colocated backend should publish is_colocated=False"
+    # server_urls should also be populated for non-external setups (data plane URLs).
+    assert isinstance(row.inference_server_urls, list)
+
+
+def test_sample_uses_external_path(server_db_path):
+    """A sample issued through the SDK creates a FutureDB row of type EXTERNAL.
+
+    This is the "test" half of the design: the API hoists the sample off
+    the engine's serial loop and into the API process's asyncio loop.
+    """
+    proc, db_path, _ = server_db_path
+    sc = tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
+    tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=8)
+    tok = AutoTokenizer.from_pretrained(BASE_MODEL)
+
+    _train_one_step(tc, tok)
+    sampler = tc.save_weights_and_get_sampling_client(name="external_path_a")
+
+    fut = sampler.sample(
+        prompt=tinker_types.ModelInput.from_ints(tok.encode("Hi", add_special_tokens=True)),
+        num_samples=1,
+        sampling_params=tinker_types.SamplingParams(max_tokens=4, temperature=0.0, top_k=1, seed=0),
+    )
+
+    # The Tinker SDK exposes the request id via the future. Ask the DB
+    # directly to confirm the request_type. Poll briefly because the
+    # SDK's future ID may not be queryable for a moment after submission.
+    request_id = None
+    raw = getattr(fut, "_request_id", None) or getattr(fut, "request_id", None)
+    if raw is not None:
+        request_id = int(raw)
+    else:
+        # Fall back: scan for the most recent future row.
+        from sqlmodel import Session, create_engine, select
+
+        from skyrl.tinker.db_models import FutureDB
+
+        eng = create_engine(f"sqlite:///{db_path}", echo=False)
+        try:
+            with Session(eng) as s:
+                stmt = select(FutureDB.request_id, FutureDB.request_type).order_by(FutureDB.request_id.desc())
+                row = s.exec(stmt).first()
+                if row is not None:
+                    request_id = int(row[0])
+        finally:
+            eng.dispose()
+
+    assert request_id is not None, "could not locate the sample's FutureDB row"
+    rtype = _read_future_request_type(db_path, request_id)
+    assert rtype is not None, f"missing future row for id={request_id}"
+    # The SQLModel Enum stores either the literal value 'external' or the
+    # repr 'RequestType.EXTERNAL' depending on the dialect. Match both.
+    assert "EXTERNAL" in rtype.upper(), (
+        f"expected EXTERNAL request type for forwarded sample, got {rtype!r}"
+    )
+
+    out = fut.result()
+    assert len(out.sequences) == 1
+
+
+def test_sample_concurrent_with_training_is_fast(server_db_path):
+    """Central test: sample latency is independent of concurrent training.
+
+    With async sample routing enabled, a sample issued during a long
+    stream of forward_backward + optim_step calls should resolve in
+    roughly vLLM-gen-time, NOT in training-stream-duration. We assert
+    that the sample's wall-clock duration is bounded well below the
+    training stream's wall-clock duration.
+    """
+    proc, _, _ = server_db_path
+    sc = tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
+    tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=8)
+    tok = AutoTokenizer.from_pretrained(BASE_MODEL)
+
+    # Warm up vLLM + register the adapter once, off the critical timing path.
+    _train_one_step(tc, tok)
+    sampler = tc.save_weights_and_get_sampling_client(name="parallel_warmup")
+
+    # Build a workload that creates a clearly observable training-side
+    # delay. Tiny model + few datums per call, but many calls back-to-back.
+    # Each forward_backward+optim_step on the tiny Qwen3 takes ~hundreds of
+    # ms; 24 of them + a save makes the full training stream visibly long.
+    NUM_TRAIN_STEPS = 24
+    train_data = [_make_datum(tok, "Hi", "there") for _ in range(2)]
+
+    # Fire training in a background thread so the main thread can fire a
+    # sample and time it. The sample is submitted shortly after training
+    # begins, so the training stream is definitely in flight.
+    train_done = threading.Event()
+    train_t0 = time.perf_counter()
+    train_t1: list[float] = []
+
+    def train_loop():
+        try:
+            for i in range(NUM_TRAIN_STEPS):
+                tc.forward_backward(train_data, "cross_entropy").result()
+                tc.optim_step(tinker_types.AdamParams(learning_rate=1e-4)).result()
+                if i == 0:
+                    # Re-publish the adapter mid-stream so the sampler has
+                    # current weights to use. This still goes through the
+                    # engine's serial loop — that's fine, it doesn't block
+                    # the sample we time below.
+                    tc.save_weights_and_get_sampling_client(name="parallel_mid")
+        finally:
+            train_t1.append(time.perf_counter())
+            train_done.set()
+
+    t = threading.Thread(target=train_loop, daemon=True)
+    t.start()
+
+    # Give the training stream a head start so its first request hits the
+    # engine before our sample does. ~0.5s is plenty for SQLite + the
+    # engine's 100ms scheduling tick.
+    time.sleep(0.5)
+    assert not train_done.is_set(), "training finished before we could issue a concurrent sample"
+
+    sample_t0 = time.perf_counter()
+    out = sampler.sample(
+        prompt=tinker_types.ModelInput.from_ints(tok.encode("Hello", add_special_tokens=True)),
+        num_samples=1,
+        sampling_params=tinker_types.SamplingParams(max_tokens=8, temperature=0.0, top_k=1, seed=0),
+    ).result()
+    sample_t1 = time.perf_counter()
+    sample_latency = sample_t1 - sample_t0
+    assert len(out.sequences) == 1
+
+    # Wait for training to finish and capture how long it took.
+    train_done.wait(timeout=300)
+    assert train_done.is_set(), "training stream did not finish in time"
+    train_latency = train_t1[0] - train_t0
+
+    print(
+        f"\n[async_sample_routing] sample latency={sample_latency:.3f}s, "
+        f"concurrent training stream={train_latency:.3f}s "
+        f"(ratio sample/train = {sample_latency / train_latency:.3f})"
+    )
+
+    # Core assertion: sample latency must be a small fraction of the
+    # training stream's wall-clock. If sample were going through the
+    # engine's serial loop, it would queue behind the entire training
+    # stream and the latencies would be comparable.
+    #
+    # We pick 0.5x as a conservative bound. In practice on the tiny
+    # Qwen3 model the ratio is closer to 0.05x, but CI variance can be
+    # large for short workloads. If this is flaky, raise NUM_TRAIN_STEPS
+    # to widen the margin rather than relax this assertion.
+    assert sample_latency < 0.5 * train_latency, (
+        f"sample latency {sample_latency:.3f}s is not significantly smaller than "
+        f"training stream {train_latency:.3f}s — async sample routing may not be active"
+    )
+
+
+def test_concurrent_samples_per_adapter(server_db_path):
+    """Issue several concurrent samples across two adapters; all resolve.
+
+    This exercises the per-API-process semaphore and confirms that the
+    forwarding client correctly multiplexes by model_id (each adapter
+    name maps to vLLM's per-tenant LoRA registration).
+    """
+    proc, _, _ = server_db_path
+    sc = tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
+    tok = AutoTokenizer.from_pretrained(BASE_MODEL)
+
+    tc_a = sc.create_lora_training_client(base_model=BASE_MODEL, rank=8)
+    tc_b = sc.create_lora_training_client(base_model=BASE_MODEL, rank=8)
+    _train_one_step(tc_a, tok)
+    _train_one_step(tc_b, tok)
+    sampler_a = tc_a.save_weights_and_get_sampling_client(name="concurrent_a")
+    sampler_b = tc_b.save_weights_and_get_sampling_client(name="concurrent_b")
+
+    futures = []
+    for i in range(8):
+        target = sampler_a if i % 2 == 0 else sampler_b
+        futures.append(
+            target.sample(
+                prompt=tinker_types.ModelInput.from_ints(tok.encode("Q", add_special_tokens=True)),
+                num_samples=1,
+                sampling_params=tinker_types.SamplingParams(
+                    max_tokens=4, temperature=0.0, top_k=1, seed=i
+                ),
+            )
+        )
+
+    outputs = [f.result() for f in futures]
+    for o in outputs:
+        assert len(o.sequences) == 1
+        assert len(o.sequences[0].tokens) > 0

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -31,7 +31,6 @@ import subprocess
 import tempfile
 import threading
 import time
-import urllib.request
 from contextlib import contextmanager
 
 import pytest
@@ -44,9 +43,7 @@ try:  # pragma: no cover - import guard
 except Exception:
     cuda_available = False
 
-pytestmark = pytest.mark.skipif(
-    not cuda_available, reason="async sample routing tests require at least one CUDA GPU"
-)
+pytestmark = pytest.mark.skipif(not cuda_available, reason="async sample routing tests require at least one CUDA GPU")
 
 tinker = pytest.importorskip("tinker")
 from tinker import types as tinker_types  # noqa: E402
@@ -204,9 +201,9 @@ def test_engine_state_published(server_db_path):
 
     row = _read_engine_state(db_path)
     assert row is not None, "EngineStateDB row missing — backend never published state"
-    assert row.inference_proxy_url is not None and row.inference_proxy_url.startswith("http"), (
-        f"expected an http(s) proxy URL, got {row.inference_proxy_url!r}"
-    )
+    assert row.inference_proxy_url is not None and row.inference_proxy_url.startswith(
+        "http"
+    ), f"expected an http(s) proxy URL, got {row.inference_proxy_url!r}"
     assert row.is_colocated is False, "non-colocated backend should publish is_colocated=False"
     # server_urls should also be populated for non-external setups (data plane URLs).
     assert isinstance(row.inference_server_urls, list)
@@ -384,9 +381,7 @@ def test_concurrent_samples_per_adapter(server_db_path):
             target.sample(
                 prompt=tinker_types.ModelInput.from_ints(tok.encode("Q", add_special_tokens=True)),
                 num_samples=1,
-                sampling_params=tinker_types.SamplingParams(
-                    max_tokens=4, temperature=0.0, top_k=1, seed=i
-                ),
+                sampling_params=tinker_types.SamplingParams(max_tokens=4, temperature=0.0, top_k=1, seed=i),
             )
         )
 


### PR DESCRIPTION
## Description

When SkyRL-Train runs non-colocated (`colocate_all=false`), vLLM is always-on but its sample capacity is wasted: the Tinker engine subprocess serializes `sample` behind `forward_backward` / `optim_step` in its 100ms tick loop, so a sample submitted at the start of a 30s training step waits 30s. For multi-tenant RL the queueing compounds — every `sample` from any tenant queues behind every other tenant's training step.

This PR hoists sample requests off the engine queue and into the API process's asyncio loop, where they're forwarded directly to the engine-managed vLLM. The colocated and JAX paths are unchanged.

## How it works

We reuse the existing `RequestType.EXTERNAL` plumbing (already in place for fully external vLLM URLs):

```
       ┌─ POST /api/v1/asample ─────────────────────────┐
client ┤  api.py:                                       │
       │    create FutureDB(type=EXTERNAL)              │
       │    asyncio.create_task(client.call_and_store)  │
       │    return future_id immediately                │
       └────────────────────────────────────────────────┘
                            │
                            ▼
       ┌─ SkyRLTrainInferenceForwardingClient ──────────┐
       │  POST {vllm_proxy_url}/v1/completions          │
       │    model=<model_id>  (LoRA registered already) │
       │  on completion: write FutureDB.result_data     │
       └────────────────────────────────────────────────┘

   (parallel)
       ┌─ engine subprocess ────────────────────────────┐
       │  process_pending_requests loop:                │
       │    forward_backward / optim_step /             │
       │    save_weights_for_sampler / ...              │
       │  (NO sample work here)                         │
       └────────────────────────────────────────────────┘
```

The cross-process plumbing was already wired for external vLLM URLs; the gap was that nothing was pointing it at the *engine-managed* vLLM. This PR closes that gap.

## What's in the diff

8 files, +796/-3 LOC.

**New `EngineStateDB` (`skyrl/tinker/db_models.py`)** — singleton row carrying engine→API handoff state (currently just `inference_proxy_url` + `updated_at`). The backend writes it after building vLLM; the forwarding client reads it lazily on first sample.

**`SkyRLTrainBackend._publish_engine_state` (`skyrl/backends/skyrl_train_backend.py`)** — called inside `_create_new_inference_client` after `build_new_inference_client` returns, and on `delete_model` teardown to clear the row. Best-effort: a DB write failure logs and returns rather than corrupting controller state. Wired through a new `set_engine_database_url(...)` setter that the engine calls right after constructing the backend.

**New `SkyRLTrainInferenceForwardingClient` (`skyrl/tinker/extra/skyrl_train_inference_forwarding.py`)** — pair to `ExternalInferenceClient`, with the same EXTERNAL future-write contract but resolves the target URL from `EngineStateDB` instead of from a user-supplied `EngineConfig.external_inference_url`. Uses `model=<model_id>` (the name `save_weights_for_sampler` registered with vLLM via `load_lora_adapter`).

Key design choices:
- **No API-side semaphore.** Backpressure is layered: httpx connection pool → vllm-router → each vLLM server's `max_num_seqs`. Adding a Python semaphore on top would just serialize work above what vLLM already manages.
- **Persistent `httpx.AsyncClient`** with `forwarding_inference_max_connections` defaulting to `None` (unlimited). The only cost of "unlimited" is file descriptors, so operators just raise `ulimit -n` to match peak concurrent samples. Set an int to enforce a per-process cap. Closed via `aclose()` from the API lifespan.
- **Polymorphic `.stop` dispatch** matches `api.py SamplingParams.to_types()` (list[str] → `stop`, list[int] → `stop_token_ids`).
- **Response parsing mirrors the in-process path**: `finish_reason` normalized to Literal["stop", "length"]; missing `token_logprobs` zero-filled; non-JSON responses (e.g. proxy 502 HTML) surfaced with content-type + body excerpt for diagnosis.
- **Retry covers all transport-level errors** (`httpx.RequestError` umbrella — `ConnectError`, `ReadError`, `RemoteProtocolError`, `TimeoutException`, `PoolTimeout`). HTTP 4xx/5xx from vLLM is NOT retried — it's a real upstream signal.

**`api.py` lifespan** — installs the forwarding client when `backend in ("megatron", "fsdp")` AND `trainer.placement.colocate_all=False`. Colocated runs and JAX keep the synchronous engine flow. Calls `aclose()` on shutdown.

**Synchronization invariants preserved:**

- **(I1)** Sample for checkpoint X requires save-X to have completed. Already enforced by the SDK + `validate_checkpoint(...)` at `api.py:1037` before the future is created.
- **(I2)** In-flight sample during a re-broadcast for the same model. `WorkerDispatch.save_weights_for_sampler` brackets the broadcast with `pause_generation` / `resume_generation`; vLLM's KEEP-mode pause freezes in-flight requests in its scheduler.
- **(I3)** Result writes don't conflict with engine writes. EXTERNAL futures are written by the API process; all other futures by the engine. SQLite WAL handles concurrent readers.
- **(I4)** Colocated path is unchanged. Lifespan strictly gates on `colocate_all=false && backend ∈ (megatron, fsdp)`.

## Test plan

- ✅ **`test_engine_state_published`** — after `save_weights_for_sampler`, `EngineStateDB.inference_proxy_url` is populated with the engine-managed vLLM proxy URL.
- ✅ **`test_sample_uses_external_path`** — issued sample creates a `FutureDB` row with `request_type=EXTERNAL` (off the engine queue).
- ✅ **`test_sample_concurrent_with_training_is_fast`** — central parallelism test. While 24 `forward_backward`+`optim_step` calls stream in a background thread, a concurrent sample resolves in **1.3s vs 10s training stream (ratio 0.13×)**. Without async routing the sample would queue behind the entire training stream and the latencies would be comparable.
- ✅ **`test_concurrent_samples_per_adapter`** — 8 concurrent samples across two adapters all resolve via the forwarding client's connection pool and per-adapter `model_id` routing on vLLM.
- ✅ All 6 existing `test_multi_lora_megatron.py` tests continue to pass under the new forwarding path (backwards compatible with the multi-LoRA RL workload).
- ✅ `tests/tinker/test_api.py` single-tenant paths pass.

**End-to-end multi-tenant RL bench** following `docs/tinker/multi_tenancy.mdx#quickstart---two-rl-clients` (Qwen3-0.6B, GSM8K, 4 policy GPUs + 1 vLLM, 3 iters × batch 16 × group 4 × max 128 tokens per client):

| Mode | A wall-clock | B wall-clock | Total wall-clock |
|---|---|---|---|
| Sequential (A then B) | 37.8s | 31.7s | **85s** |
| Concurrent (A ∥ B) | 36.0s | 34.7s | **44s** |

**Speedup ~1.93×**, close to the theoretical 2× ceiling. Per-iter cost grows ~1-2s under contention (vLLM multiplexes both adapters' samples + engine batches both fwd_bwds), but total wall-clock halves because both tenants progress simultaneously instead of waiting their turn.

Server-side instrumentation: **240 sample requests forwarded** via the API-process client; **0 served by the engine** (single startup-time engine sample is pre-bench). `process_batch_requests(forward_backward, n=2)` lines in the server log confirm the engine batches concurrent A+B fwd_bwd calls together.

## Operator config

To enable, set in `--backend-config`:

```json
{
    "trainer.placement.colocate_all": false,
    "trainer.policy.megatron_config.lora_config.merge_lora": false,
    "trainer.policy.model.lora.max_loras": <max concurrent adapters in a batch>,
    "trainer.policy.model.lora.max_cpu_loras": <total adapter capacity>
}
```

For very high fan-out workloads, raise the host's `ulimit -n` to match peak concurrent samples (default httpx pool is unbounded). Operators who want a per-API-process FD cap can set `--forwarding-inference-max-connections <N>`.

See [docs/content/docs/tinker/multi_tenancy.mdx](docs/content/docs/tinker/multi_tenancy.mdx) (added in the multi-lora-rl PR) for the full operator contract.

## Out of scope

- **Colocated mode acceleration.** No parallelism to exploit there — vLLM is asleep during training and the engine's synchronous sample path is what wakes it.
- **Auto-recovery from vLLM eviction.** If `max_cpu_loras` is too low and vLLM evicts an adapter mid-run, the next sample 404s. Re-loading from disk on demand is a follow-up; for now the operator sizes `max_cpu_loras` ≥ expected concurrent adapters.
- **Sample retries beyond one transport-level retry.** The forwarding client refreshes its cached proxy URL and retries once on `httpx.RequestError`. Application-level retry is the SDK's job (already implemented in `tinker/retry_handler`).
- **Parallelizing training requests across model_ids.** Multi-tenant `forward_backward` / `optim_step` still serialize through the engine's main loop.
