### PR TITLE
Stabilize Qwen3 MoE LoRA mixed-scale test

### DIFF
--- a/tests/tx/models/test_qwen3.py
+++ b/tests/tx/models/test_qwen3.py
@@ -65,6 +65,32 @@ def load_moe_base_weights(jax_moe_layer: Qwen3MoeSparseMoeBlock, hf_moe_layer: H
     )
 
 
+def assert_allclose_mixed_scale(
+    actual,
+    expected,
+    *,
+    rtol: float = 1e-3,
+    base_atol: float = 1e-3,
+    scale_atol: float = 1e-6,
+    err_msg: str = "",
+) -> None:
+    actual_arr = np.asarray(actual)
+    expected_arr = np.asarray(expected)
+    if not np.isfinite(actual_arr).all() or not np.isfinite(expected_arr).all():
+        raise AssertionError(f"{err_msg}\nNon-finite values found in MoE LoRA comparison.")
+
+    max_abs = max(float(np.max(np.abs(actual_arr))), float(np.max(np.abs(expected_arr))), 1.0)
+    atol = max(base_atol, scale_atol * max_abs)
+    np.testing.assert_allclose(
+        actual_arr,
+        expected_arr,
+        rtol=rtol,
+        atol=atol,
+        equal_nan=False,
+        err_msg=f"{err_msg}\nmax_abs={max_abs:.6g}, atol={atol:.6g}",
+    )
+
+
 @pytest.mark.parametrize("ep,tp", [(1, 1), (1, 2), (2, 1)])
 def test_qwen3_moe_layer(ep: int, tp: int):
     model_name = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
@@ -130,7 +156,8 @@ def test_qwen3_moe_layer_lora(ep: int, tp: int):
     config = Qwen3Config(base_config, max_lora_adapters=3, max_lora_rank=4, shard_attention_heads=True)
 
     hf_moe_layer = hf_model.model.layers[0].mlp
-    x = torch.randn(3, 4, config.hidden_size)
+    torch_rng = torch.Generator().manual_seed(0)
+    x = torch.randn(3, 4, config.hidden_size, generator=torch_rng)
 
     mesh = jax.make_mesh((1, ep, tp), ("fsdp", "ep", "tp"), axis_types=(jax.sharding.AxisType.Auto,) * 3)
     with jax.set_mesh(mesh):
@@ -177,7 +204,14 @@ def test_qwen3_moe_layer_lora(ep: int, tp: int):
             x_sample = x[sample_idx : sample_idx + 1].numpy()
             output_merged, _ = moe_layer_merged(x_sample, return_router_logits=True)
 
-            assert np.allclose(output_with_lora[sample_idx : sample_idx + 1], output_merged, rtol=1e-3, atol=1e-3)
+            assert_allclose_mixed_scale(
+                output_with_lora[sample_idx : sample_idx + 1],
+                output_merged,
+                rtol=1e-3,
+                base_atol=1e-3,
+                scale_atol=1e-6,
+                err_msg=f"MoE LoRA merged-weight mismatch for sample_idx={sample_idx}, adapter_idx={adapter_idx}",
+            )
 
 
 def test_qwen3_lora():


### PR DESCRIPTION
## Summary

- Stabilizes the flaky Qwen3 MoE LoRA comparison reported in #1604 by making this test input deterministic.
- Replaces the fixed absolute tolerance at the flaky assertion with a local mixed-scale assertion helper that preserves the existing relative tolerance while scaling absolute tolerance with the output dynamic range.
- Adds explicit non-finite checks and a richer failure message so future failures report the adapter, sample, dynamic range, and effective tolerance.

## Root Cause

Issue #1604 reports that tests/tx/models/test_qwen3.py::test_qwen3_moe_layer_lora compares tensors whose values span from small numbers to roughly 1e4. A fixed atol=1e-3 can make numerically equivalent JAX fused-LoRA and merged-weight paths fail on small-magnitude entries when the layer output has a much larger dynamic range.

## Changes

- Seed only this test input with a local torch.Generator so the flaky random input is reproducible without changing global RNG state.
- Add assert_allclose_mixed_scale for this activation-level comparison.
- Keep the assertion local to the Qwen3 MoE LoRA test and avoid production MoE/LoRA behavior changes.

## Validation

- git diff --check -- tests/tx/models/test_qwen3.py
- uv run --with ruff ruff check tests/tx/models/test_qwen3.py
- .venv/bin/python -m pytest -q tests/tx/models/test_qwen3.py::test_qwen3_moe_layer_lora - 3 passed
- OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES .venv/bin/python -m pytest -q --forked tests/tx/models/test_qwen3.py::test_qwen3_moe_layer_lora - 3 passed

Fixes #1604