### PR TITLE
Avoid blocking Ray registry lookups for policy loss resolution

### DIFF
--- a/skyrl/backends/skyrl_train/utils/ppo_utils.py
+++ b/skyrl/backends/skyrl_train/utils/ppo_utils.py
@@ -19,7 +19,7 @@
 from collections import defaultdict
 from enum import StrEnum
 from functools import wraps
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Iterable, List, Mapping, Optional, Tuple, Union
 
 import numpy as np
 import ray
@@ -342,6 +342,50 @@ class BaseFunctionRegistry:
         return cls._functions[name]
 
     @classmethod
+    def get_local(cls, name: Union[str, StrEnum]) -> Callable:
+        """Get a function from the local process registry without syncing with Ray."""
+        if isinstance(name, StrEnum):
+            name = name.value
+
+        if name not in cls._functions:
+            available = list(cls._functions.keys())
+            raise ValueError(f"Unknown local {cls._function_type.lower()} '{name}'. Available locally: {available}")
+        return cls._functions[name]
+
+    @classmethod
+    def snapshot_serialized(
+        cls,
+        names: Optional[Iterable[Union[str, StrEnum]]] = None,
+        *,
+        sync_with_actor: bool = True,
+    ) -> dict[str, bytes]:
+        """Create a serialized registry snapshot for worker-local installation.
+
+        This is intended for driver/control paths. When requested, it may sync with
+        the named Ray actor before serializing, but the resulting snapshot can be
+        installed in workers without any Ray actor calls.
+        """
+        if sync_with_actor and ray.is_initialized():
+            cls.sync_with_actor()
+
+        if names is None:
+            function_names = list(cls._functions.keys())
+        else:
+            function_names = [name.value if isinstance(name, StrEnum) else name for name in names]
+
+        return {name: cloudpickle.dumps(cls.get_local(name)) for name in function_names}
+
+    @classmethod
+    def install_serialized(cls, snapshot: Mapping[str, bytes]) -> None:
+        """Install a serialized registry snapshot locally without syncing with Ray."""
+        for name, func_serialized in snapshot.items():
+            try:
+                cls._functions[name] = cloudpickle.loads(func_serialized)
+            except Exception as e:
+                logger.error(f"Error deserializing {name} into local {cls._function_type} registry: {e}")
+                raise e
+
+    @classmethod
     def list_available(cls) -> List[str]:
         """List all registered functions."""
         # Try to sync with actor first if Ray is available
@@ -472,24 +516,32 @@ class PolicyLossRegistry(BaseFunctionRegistry):
     _function_type = "policy loss"
 
     @classmethod
+    def _default_policy_losses(cls) -> dict[str, tuple[PolicyLossType, Callable]]:
+        return {
+            "regular": (PolicyLossType.REGULAR, ppo_policy_loss),
+            "dual_clip": (PolicyLossType.DUAL_CLIP, ppo_policy_loss),
+            "gspo": (PolicyLossType.GSPO, gspo_policy_loss),
+            "clip_cov": (PolicyLossType.CLIP_COV, compute_policy_loss_clip_cov),
+            "kl_cov": (PolicyLossType.KL_COV, compute_policy_loss_kl_cov),
+            "sapo": (PolicyLossType.SAPO, sapo_policy_loss),
+            "cross_entropy": (PolicyLossType.CROSS_ENTROPY, cross_entropy_loss),
+            "importance_sampling": (PolicyLossType.IMPORTANCE_SAMPLING, importance_sampling_loss),
+            "rollout_is": (PolicyLossType.ROLLOUT_IS, rollout_is_policy_loss),
+        }
+
+    @classmethod
     def repopulate_registry(cls):
         """Repopulate the registry with default policy loss functions."""
         pl_avail = set(cls.list_available())
-        pl_types = {
-            "regular": [PolicyLossType.REGULAR, ppo_policy_loss],
-            "dual_clip": [PolicyLossType.DUAL_CLIP, ppo_policy_loss],
-            "gspo": [PolicyLossType.GSPO, gspo_policy_loss],
-            "clip_cov": [PolicyLossType.CLIP_COV, compute_policy_loss_clip_cov],
-            "kl_cov": [PolicyLossType.KL_COV, compute_policy_loss_kl_cov],
-            "sapo": [PolicyLossType.SAPO, sapo_policy_loss],
-            "cross_entropy": [PolicyLossType.CROSS_ENTROPY, cross_entropy_loss],
-            "importance_sampling": [PolicyLossType.IMPORTANCE_SAMPLING, importance_sampling_loss],
-            "rollout_is": [PolicyLossType.ROLLOUT_IS, rollout_is_policy_loss],
-        }
-
-        for pl_name, (pl_type, pl_func) in pl_types.items():
+        for pl_name, (pl_type, pl_func) in cls._default_policy_losses().items():
             if pl_name not in pl_avail:
                 cls.register(pl_type, pl_func)
+
+    @classmethod
+    def repopulate_local_registry(cls):
+        """Install default policy losses locally without syncing with Ray."""
+        for pl_name, (_, pl_func) in cls._default_policy_losses().items():
+            cls._functions.setdefault(pl_name, pl_func)
 
 
 def register_advantage_estimator(name: Union[str, AdvantageEstimator]):
@@ -527,6 +579,12 @@ def sync_registries():
     PolicyLossRegistry.sync_with_actor()
     AdvantageEstimatorRegistry.sync_with_actor()
     logger.info("Synced registries to ray actor")
+
+
+def snapshot_policy_loss_registry_for_workers() -> dict[str, bytes]:
+    """Snapshot policy losses so workers can look them up without actor sync."""
+    PolicyLossRegistry.repopulate_local_registry()
+    return PolicyLossRegistry.snapshot_serialized(sync_with_actor=True)
 
 
 @register_policy_loss(PolicyLossType.REGULAR)

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -21,10 +21,7 @@ from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
     from_parallel_logits_to_logprobs,
     vocab_parallel_entropy,
 )
-from skyrl.backends.skyrl_train.utils.ppo_utils import (
-    PolicyLossRegistry,
-    compute_approx_kl,
-)
+from skyrl.backends.skyrl_train.utils.ppo_utils import compute_approx_kl
 from skyrl.backends.skyrl_train.utils.replay_utils import (
     setup_per_microbatch_replay_backward,
     setup_per_microbatch_replay_forward,
@@ -40,11 +37,13 @@ class MegatronModelWrapper:
         actor_module: List[nn.Module],
         actor_optimizer: Optional[torch.optim.Optimizer] = None,
         policy_loss_fn: Optional[Callable] = None,
+        policy_loss_fn_resolver: Optional[Callable[[str], Callable]] = None,
     ):
         self.cfg = config
         self.actor_module = actor_module
         self.actor_optimizer = actor_optimizer
         self.policy_loss_fn = policy_loss_fn
+        self.policy_loss_fn_resolver = policy_loss_fn_resolver
         self.use_sample_packing = self.cfg.use_sample_packing
 
         config = get_model_config(self.actor_module[0])
@@ -225,7 +224,9 @@ class MegatronModelWrapper:
         # Resolve loss function
         resolved_loss_name = loss_fn if loss_fn is not None else self.cfg.algorithm.policy_loss_type
         if loss_fn is not None:
-            current_loss_fn = PolicyLossRegistry.get(loss_fn)
+            if self.policy_loss_fn_resolver is None:
+                raise ValueError("MegatronModelWrapper requires policy_loss_fn_resolver for loss overrides")
+            current_loss_fn = self.policy_loss_fn_resolver(loss_fn)
         else:
             current_loss_fn = self.policy_loss_fn
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -673,6 +673,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             actor_module=self.actor_module,
             actor_optimizer=self.optimizer,
             policy_loss_fn=self.policy_loss_fn,
+            policy_loss_fn_resolver=self._get_policy_loss_fn,
         )
 
         self.empty_cuda_cache = self.cfg.policy.megatron_config.empty_cuda_cache

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -5,7 +5,17 @@ import socket
 from collections import defaultdict
 from ctypes import CDLL, POINTER, Structure, c_char_p, c_int, c_ulong, c_void_p
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Type,
+    Union,
+)
 
 import ray
 import torch
@@ -486,6 +496,7 @@ class PPORayActorGroup:
         colocate_all: bool = False,
         sequence_parallel_size: int = 1,
         record_memory: bool = False,
+        worker_init_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Args:
@@ -504,6 +515,7 @@ class PPORayActorGroup:
         self.colocate_all = colocate_all
         self.sequence_parallel_size = sequence_parallel_size
         self.record_memory = record_memory
+        self.worker_init_kwargs = dict(worker_init_kwargs or {})
         self._initiate_actors(pg, num_gpus_per_actor)
 
     def _initiate_actors(self, pg: Optional[ResolvedPlacementGroup], num_gpus_per_actor: float):
@@ -572,16 +584,18 @@ class PPORayActorGroup:
         if sched is not None:
             actor_options["scheduling_strategy"] = sched
 
-        master_actor = self.ray_actor_type.options(**actor_options).remote(
-            cfg=self.cfg,
-            world_size=world_size,
-            rank=0,
-            local_rank=0,
-            master_addr=None,
-            master_port=None,
-            sequence_parallel_size=self.sequence_parallel_size,
-            record_memory=self.record_memory,
-        )
+        master_actor_kwargs = {
+            **self.worker_init_kwargs,
+            "cfg": self.cfg,
+            "world_size": world_size,
+            "rank": 0,
+            "local_rank": 0,
+            "master_addr": None,
+            "master_port": None,
+            "sequence_parallel_size": self.sequence_parallel_size,
+            "record_memory": self.record_memory,
+        }
+        master_actor = self.ray_actor_type.options(**actor_options).remote(**master_actor_kwargs)
         self._actor_handlers = [master_actor]
 
         if world_size > 1:
@@ -598,16 +612,18 @@ class PPORayActorGroup:
                 if sched is not None:
                     actor_options["scheduling_strategy"] = sched
 
-                worker_actor = self.ray_actor_type.options(**actor_options).remote(
-                    cfg=self.cfg,
-                    world_size=world_size,
-                    rank=rank,
-                    local_rank=local_rank,
-                    master_addr=master_addr,
-                    master_port=master_port,
-                    sequence_parallel_size=self.sequence_parallel_size,
-                    record_memory=self.record_memory,
-                )
+                worker_actor_kwargs = {
+                    **self.worker_init_kwargs,
+                    "cfg": self.cfg,
+                    "world_size": world_size,
+                    "rank": rank,
+                    "local_rank": local_rank,
+                    "master_addr": master_addr,
+                    "master_port": master_port,
+                    "sequence_parallel_size": self.sequence_parallel_size,
+                    "record_memory": self.record_memory,
+                }
+                worker_actor = self.ray_actor_type.options(**actor_options).remote(**worker_actor_kwargs)
                 self._actor_handlers.append(worker_actor)
 
         # Initialize process group
@@ -682,15 +698,31 @@ class PPORayActorGroup:
 
 
 class PolicyWorkerBase(Worker):
-    def __init__(self, **kwargs):
+    def __init__(self, policy_loss_registry_snapshot: Optional[Mapping[str, bytes]] = None, **kwargs):
         super().__init__(**kwargs)
+        if policy_loss_registry_snapshot is None:
+            PolicyLossRegistry.repopulate_local_registry()
+        else:
+            PolicyLossRegistry.install_serialized(policy_loss_registry_snapshot)
         self.model: nn.Module = None
         self.scheduler: LRScheduler = None
         self.optimizer: Optimizer = None
         self.strategy: DistributedStrategy = None
         self.record_memory: bool = False
         self.mesh_rank: MeshRank = None
-        self.policy_loss_fn: Callable = PolicyLossRegistry.get(self.cfg.algorithm.policy_loss_type)
+        self._policy_loss_fn_cache: Dict[str, Callable] = {}
+        self.policy_loss_fn: Callable = self._get_policy_loss_fn(self.cfg.algorithm.policy_loss_type)
+
+    def _get_policy_loss_fn(self, loss_name: str) -> Callable:
+        try:
+            if loss_name not in self._policy_loss_fn_cache:
+                self._policy_loss_fn_cache[loss_name] = PolicyLossRegistry.get_local(loss_name)
+            return self._policy_loss_fn_cache[loss_name]
+        except ValueError as e:
+            raise ValueError(
+                f"{e}. If this is a custom policy loss, register it before initialize_ray()/worker creation "
+                "so it is included in the policy-loss snapshot."
+            ) from e
 
     def forward_backward(
         self,
@@ -789,7 +821,7 @@ class PolicyWorkerBase(Worker):
         resolved_loss_name = loss_fn if loss_fn is not None else self.cfg.algorithm.policy_loss_type
         if loss_fn is not None:
             # Use the provided loss function (Tinker API style)
-            current_loss_fn = PolicyLossRegistry.get(loss_fn)
+            current_loss_fn = self._get_policy_loss_fn(loss_fn)
         else:
             # Fall back to config default
             current_loss_fn = self.policy_loss_fn

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -26,6 +26,9 @@ from skyrl.backends.skyrl_train.training_batch import (
     TrainingInputBatch,
     pad_training_input_batch,
 )
+from skyrl.backends.skyrl_train.utils.ppo_utils import (
+    snapshot_policy_loss_registry_for_workers,
+)
 from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
 from skyrl.backends.skyrl_train.workers.worker_dispatch import WorkerDispatch
 from skyrl.env_vars import _SKYRL_USE_NEW_INFERENCE, SKYRL_RAY_PG_TIMEOUT_IN_S
@@ -239,6 +242,9 @@ class SkyRLTrainBackend(AbstractBackend):
             colocate_all=colocate_all,
             sequence_parallel_size=cfg.trainer.policy.sequence_parallel_size,
             record_memory=cfg.trainer.policy.record_memory,
+            worker_init_kwargs={
+                "policy_loss_registry_snapshot": snapshot_policy_loss_registry_for_workers(),
+            },
         )
 
         # set to a large number for megatron scheduler init

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -34,6 +34,9 @@ from ray.util.placement_group import placement_group
 
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.backends.skyrl_train.utils.io import io
+from skyrl.backends.skyrl_train.utils.ppo_utils import (
+    snapshot_policy_loss_registry_for_workers,
+)
 from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
 from skyrl.backends.skyrl_train.workers.worker_dispatch import WorkerDispatch
 from skyrl.env_vars import SKYRL_RAY_PG_TIMEOUT_IN_S
@@ -388,6 +391,9 @@ class SFTTrainer:
             colocate_all=False,
             sequence_parallel_size=self.cfg.trainer.policy.sequence_parallel_size,
             record_memory=self.cfg.trainer.policy.record_memory,
+            worker_init_kwargs={
+                "policy_loss_registry_snapshot": snapshot_policy_loss_registry_for_workers(),
+            },
         )
         num_training_steps = (
             self.sft_cfg.dummy_run_max_steps if self.sft_cfg.dummy_run_full_ctx else self.sft_cfg.num_steps

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -395,6 +395,9 @@ class RayPPOTrainer:
         pg = None
 
         use_ref_model = cfg.trainer.algorithm.use_kl_loss or cfg.trainer.algorithm.use_kl_in_reward
+        policy_worker_init_kwargs = {
+            "policy_loss_registry_snapshot": ppo_utils.snapshot_policy_loss_registry_for_workers(),
+        }
 
         if cfg.trainer.placement.colocate_all:
             num_policy_gpus = cfg.trainer.placement.policy_num_gpus_per_node * cfg.trainer.placement.policy_num_nodes
@@ -422,6 +425,7 @@ class RayPPOTrainer:
                 colocate_all=True,
                 sequence_parallel_size=cfg.trainer.policy.sequence_parallel_size,
                 record_memory=cfg.trainer.policy.record_memory,
+                worker_init_kwargs=policy_worker_init_kwargs,
             )
             if use_ref_model:
                 assert (
@@ -484,6 +488,7 @@ class RayPPOTrainer:
                 num_gpus_per_actor=0.75 if pg else 1,
                 colocate_all=False,
                 sequence_parallel_size=cfg.trainer.policy.sequence_parallel_size,
+                worker_init_kwargs=policy_worker_init_kwargs,
             )
             if use_ref_model:
                 ref_model = PPORayActorGroup(

--- a/tests/backends/skyrl_train/utils/test_ppo_utils.py
+++ b/tests/backends/skyrl_train/utils/test_ppo_utils.py
@@ -7,6 +7,7 @@ import math
 
 import numpy as np
 import pytest
+import ray
 import torch
 
 from skyrl.backends.skyrl_train.utils.ppo_utils import (
@@ -25,6 +26,7 @@ from skyrl.backends.skyrl_train.utils.ppo_utils import (
     reduce_loss,
     register_advantage_estimator,
     register_policy_loss,
+    snapshot_policy_loss_registry_for_workers,
 )
 from skyrl.backends.skyrl_train.utils.torch_utils import masked_mean
 
@@ -445,6 +447,64 @@ def test_policy_loss_registry_specific():
 
     # Clean up
     PolicyLossRegistry.unregister("test_policy_decorator")
+
+
+def test_policy_loss_registry_get_local_does_not_sync(monkeypatch):
+    """Local lookup should never contact the Ray registry actor."""
+    PolicyLossRegistry.repopulate_registry()
+
+    def fail_sync():
+        pytest.fail("get_local should not sync with the registry actor")
+
+    monkeypatch.setattr(PolicyLossRegistry, "sync_with_actor", fail_sync)
+
+    assert PolicyLossRegistry.get_local("regular") is not None
+    with pytest.raises(ValueError, match="Unknown local policy loss"):
+        PolicyLossRegistry.get_local("missing_policy_loss")
+
+
+def test_policy_loss_registry_snapshot_install_round_trip():
+    """Serialized snapshots should install custom losses locally without actor sync."""
+    from skyrl.train.config import AlgorithmConfig
+
+    loss_name = "snapshot_round_trip_policy_loss"
+
+    def custom_policy_loss(log_probs, old_log_probs, advantages, config, loss_mask=None, rollout_logprobs=None):
+        return torch.tensor(4.0), {"clip_ratio": 0.7}
+
+    PolicyLossRegistry._functions.pop(loss_name, None)
+
+    try:
+        PolicyLossRegistry.register(loss_name, custom_policy_loss)
+        snapshot = PolicyLossRegistry.snapshot_serialized([loss_name], sync_with_actor=False)
+        PolicyLossRegistry.unregister(loss_name)
+
+        PolicyLossRegistry.install_serialized(snapshot)
+        retrieved = PolicyLossRegistry.get_local(loss_name)
+        loss, metrics = retrieved(
+            log_probs=torch.tensor([[0.1]]),
+            old_log_probs=torch.tensor([[0.2]]),
+            advantages=torch.tensor([[1.0]]),
+            config=AlgorithmConfig(policy_loss_type=loss_name),
+        )
+
+        assert loss.item() == 4.0
+        assert metrics["clip_ratio"] == 0.7
+    finally:
+        PolicyLossRegistry._functions.pop(loss_name, None)
+        if ray.is_initialized():
+            try:
+                actor = ray.get_actor("policy_loss_registry")
+                ray.get(actor.unregister.remote(loss_name))
+            except ValueError:
+                pass
+
+
+def test_snapshot_policy_loss_registry_for_workers_syncs_then_serializes():
+    snapshot = snapshot_policy_loss_registry_for_workers()
+
+    assert "regular" in snapshot
+    assert "cross_entropy" in snapshot
 
 
 def test_registry_cross_ray_process():

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -11,6 +11,11 @@ from jaxtyping import Float, Integer
 from pytest import approx
 
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
+from skyrl.backends.skyrl_train.utils.ppo_utils import (
+    PolicyLossRegistry,
+    repopulate_all_registries,
+    snapshot_policy_loss_registry_for_workers,
+)
 from skyrl.backends.skyrl_train.workers.worker import CriticWorkerBase, PolicyWorkerBase
 from skyrl.backends.skyrl_train.workers.worker_utils import BatchIterator
 from skyrl.train.config import SkyRLTrainConfig
@@ -60,6 +65,66 @@ def dummy_tokenizer():
 @pytest.fixture
 def dummy_generator():
     return MagicMock()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _ensure_default_registries_for_trainer_tests():
+    repopulate_all_registries()
+
+
+def test_policy_worker_uses_local_policy_loss_snapshot(monkeypatch, dummy_config):
+    dummy_config.trainer.algorithm.policy_loss_type = "regular"
+    snapshot = snapshot_policy_loss_registry_for_workers()
+
+    def fail_sync():
+        pytest.fail("policy workers should resolve losses from the local snapshot")
+
+    monkeypatch.setattr(PolicyLossRegistry, "sync_with_actor", fail_sync)
+
+    worker = PolicyWorkerBase(
+        cfg=dummy_config.trainer,
+        world_size=1,
+        rank=0,
+        local_rank=0,
+        master_addr="localhost",
+        master_port=12345,
+        sequence_parallel_size=1,
+        policy_loss_registry_snapshot=snapshot,
+    )
+
+    assert worker.policy_loss_fn is worker._get_policy_loss_fn("regular")
+    assert worker._get_policy_loss_fn("cross_entropy") is not None
+
+    with pytest.raises(ValueError, match="custom policy loss"):
+        worker._get_policy_loss_fn("missing_policy_loss")
+
+
+def test_policy_worker_repopulates_builtin_losses_without_actor_sync(monkeypatch, dummy_config):
+    dummy_config.trainer.algorithm.policy_loss_type = "regular"
+    saved_functions = dict(PolicyLossRegistry._functions)
+    PolicyLossRegistry._functions.clear()
+
+    def fail_sync():
+        pytest.fail("policy worker fallback should not sync with the registry actor")
+
+    monkeypatch.setattr(PolicyLossRegistry, "sync_with_actor", fail_sync)
+
+    try:
+        worker = PolicyWorkerBase(
+            cfg=dummy_config.trainer,
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            master_addr="localhost",
+            master_port=12345,
+            sequence_parallel_size=1,
+        )
+
+        assert worker.policy_loss_fn is not None
+        assert "regular" in PolicyLossRegistry._functions
+    finally:
+        PolicyLossRegistry._functions.clear()
+        PolicyLossRegistry._functions.update(saved_functions)
 
 
 def _get_test_data(trainer: RayPPOTrainer):


### PR DESCRIPTION
## Summary

Fixes #1485.

This PR removes policy-loss registry actor lookups from policy worker hot paths. Policy workers now receive a serialized policy-loss registry snapshot during construction and resolve both configured losses and request-time overrides from local process state.

## Root Cause

`PolicyWorkerBase` and the Megatron request-time loss override path called `PolicyLossRegistry.get(...)` inside Ray worker actors. When Ray is initialized, that method synchronizes with the named registry actor using blocking `ray.get(...)`, which triggers Ray's warning about using blocking calls inside async actors and can interfere with actor execution.

## Changes

- Add local-only registry lookup plus serialized snapshot/install helpers.
- Snapshot the policy-loss registry on control paths before policy worker actors are created.
- Pass the snapshot through PPO trainer, SFT trainer, and `SkyRLTrainBackend` policy actor construction.
- Resolve FSDP and Megatron policy losses through worker-local lookup instead of actor-backed lookup.
- Keep direct worker construction compatible by locally repopulating built-in policy losses without actor sync.
- Add regression coverage for local lookup, snapshot round-trip behavior, worker-local resolution, and registry-test isolation.

## Validation

- `uv run --isolated --extra skyrl-train --extra dev --with transformers==5.2.0 pytest tests/backends/skyrl_train/utils/test_ppo_utils.py tests/train/test_trainer.py`
  - `44 passed, 1 warning`
- `uv run --isolated --extra dev --with ruff ruff check skyrl/backends/skyrl_train/utils/ppo_utils.py skyrl/backends/skyrl_train/workers/worker.py skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py skyrl/backends/skyrl_train_backend.py skyrl/train/sft_trainer.py skyrl/train/trainer.py tests/backends/skyrl_train/utils/test_ppo_utils.py tests/train/test_trainer.py`
  - passed
- `git diff --check`
  - passed

The remaining warning is Ray's existing accelerator environment variable `FutureWarning`; it is not introduced by this change.
