### PR TITLE
[megatron] Fix failing CI test for megatron chunked logprobs + entropy loss

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
@@ -572,10 +572,8 @@ class _VocabParallelEntropy(torch.autograd.Function):
         # NOTE: do NOT mutate vocab_parallel_logits in-place. The same logits tensor may also
         # be saved for backward by ChunkedDistributedLogprob; even the "sub_ then add_" restore
         # pattern bumps the storage version counter and trips that Function's version check.
-        centered_logits = vocab_parallel_logits.sub(sum_softmax_times_logits)
-        softmax_logits.mul_(centered_logits)
+        softmax_logits.mul_(sum_softmax_times_logits - vocab_parallel_logits)
         softmax_logits.mul_(grad_output.unsqueeze(dim=-1))
-        softmax_logits.mul_(-1)
         return softmax_logits
 
 

--- a/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
@@ -568,12 +568,13 @@ class _VocabParallelEntropy(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
         vocab_parallel_logits, softmax_logits, sum_softmax_times_logits = ctx.saved_tensors
-        # reuse softmax_logits as grad
-        vocab_parallel_logits.sub_(sum_softmax_times_logits)
-        softmax_logits.mul_(vocab_parallel_logits)
+        # grad = softmax * (sum_softmax_times_logits - vocab_parallel_logits) * grad_output
+        # NOTE: do NOT mutate vocab_parallel_logits in-place. The same logits tensor may also
+        # be saved for backward by ChunkedDistributedLogprob; even the "sub_ then add_" restore
+        # pattern bumps the storage version counter and trips that Function's version check.
+        centered_logits = vocab_parallel_logits.sub(sum_softmax_times_logits)
+        softmax_logits.mul_(centered_logits)
         softmax_logits.mul_(grad_output.unsqueeze(dim=-1))
-        # recover vocab_parallel_logits
-        vocab_parallel_logits.add_(sum_softmax_times_logits)
         softmax_logits.mul_(-1)
         return softmax_logits
 


### PR DESCRIPTION
### What

  `tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py::test_megatron_train[tp2_pp2_policy_seq_packing_with_entropy_loss]` has been failing since #1610 made
  chunked logprobs the default for Megatron, with:

```bash
  RuntimeError: one of the variables needed for gradient computation has been modified by an
  inplace operation: [torch.cuda.FloatTensor [1, 31, 75968]], which is output 0 of
  torch::autograd::CopySlices, is at version 3; expected version 1 instead.
```
  ### Why

  Two `autograd.Function`s save the same `vocab_parallel_logits` tensor for backward:

  - `ChunkedDistributedLogprob.forward` saves it directly (the input logits).
  - `_VocabParallelEntropy.forward` saves `action_logits = logits[:, -num_actions-1:-1, :]`, which is a view of the same storage.

  `_VocabParallelEntropy.backward` used a `sub_` + `add_` "modify-then-restore" trick on its saved tensor to avoid an allocation. The restore makes the values correct, but each
  in-place op still bumps the storage version counter (1 → 2 → 3). When `ChunkedDistributedLogprob.backward` later reads `ctx.saved_tensors`, its version check fails.

  Before #1610, the non-chunked `DistributedLogprob` saved `softmax_output` rather than the input logits, so the two Functions didn't share storage and the version bump went
  unnoticed.

  ### Fix

  `skyrl/backends/skyrl_train/distributed/megatron/model_utils.py` — replace the in-place `sub_`/`add_` pair with one out-of-place `vocab_parallel_logits.sub(...)`. Same math, no
  mutation of the saved tensor. Costs one temporary the size of the action-logits slice during entropy backward; freed when backward returns. Only on the `use_entropy_loss=True`
  path (default is `False`).

  ### Test plan

  - [x] Repro'd the original failure locally.
  - [x] `tp2_pp2_policy_seq_packing_with_entropy_loss` passes after fix.
  - [x] `tp2_pp2_policy_seq_packing` (non-entropy sibling) still passes.