### PR TITLE
[megatron] Forward adam_betas in init_megatron_optim_config

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/optimizer.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/optimizer.py
@@ -32,12 +32,20 @@ from skyrl.train.config import OptimizerConfig as SkyRLOptimizerConfig
 def init_megatron_optim_config(
     optim_config: Union[SkyRLOptimizerConfig, DictConfig], optimizer_config_kwargs: dict
 ) -> OptimizerConfig:
+    # SkyRL's OptimizerConfig stores betas as a single list (matches the
+    # FSDP path's torch.optim.AdamW signature); Megatron's OptimizerConfig
+    # splits them into adam_beta1 / adam_beta2. Translate here so users
+    # don't silently get Megatron's defaults (0.9, 0.999) regardless of
+    # what they set. See https://github.com/NovaSky-AI/SkyRL/issues/1646.
+    adam_betas = getattr(optim_config, "adam_betas", (0.9, 0.999))
     optim_args = {
         "optimizer": getattr(optim_config, "optimizer", "adam"),
         "lr": getattr(optim_config, "lr", 1e-6),
         "min_lr": getattr(optim_config, "min_lr", 0.0),
         "clip_grad": getattr(optim_config, "max_grad_norm", 1.0),
         "weight_decay": getattr(optim_config, "weight_decay", 1e-2),
+        "adam_beta1": float(adam_betas[0]),
+        "adam_beta2": float(adam_betas[1]),
         "bf16": True,
         "params_dtype": torch.bfloat16,
         "use_distributed_optimizer": True,

--- a/skyrl/backends/skyrl_train/distributed/megatron/optimizer.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/optimizer.py
@@ -32,11 +32,6 @@ from skyrl.train.config import OptimizerConfig as SkyRLOptimizerConfig
 def init_megatron_optim_config(
     optim_config: Union[SkyRLOptimizerConfig, DictConfig], optimizer_config_kwargs: dict
 ) -> OptimizerConfig:
-    # SkyRL's OptimizerConfig stores betas as a single list (matches the
-    # FSDP path's torch.optim.AdamW signature); Megatron's OptimizerConfig
-    # splits them into adam_beta1 / adam_beta2. Translate here so users
-    # don't silently get Megatron's defaults (0.9, 0.999) regardless of
-    # what they set. See https://github.com/NovaSky-AI/SkyRL/issues/1646.
     adam_betas = getattr(optim_config, "adam_betas", (0.9, 0.999))
     optim_args = {
         "optimizer": getattr(optim_config, "optimizer", "adam"),


### PR DESCRIPTION
Fix #1646. init_megatron_optim_config picked optimizer/lr/min_lr/ weight_decay/clip_grad from the SkyRL OptimizerConfig but never read adam_betas, so all Megatron runs silently used Megatron's defaults (0.9, 0.999) no matter what the user configured. The FSDP path (fsdp_strategy.py:289) forwards betas correctly via torch.optim.AdamW's betas= kwarg; Megatron's OptimizerConfig splits them into adam_beta1 / adam_beta2, so we translate at the boundary.

Callers can still override via optimizer_config_kwargs since the .update() runs after.