### PR TITLE
[lora][tinker] Add pause and resume for multi-tenant lora 

### DIFF
--- a/skyrl/backends/skyrl_train/inference_engines/base.py
+++ b/skyrl/backends/skyrl_train/inference_engines/base.py
@@ -165,13 +165,22 @@ class InferenceEngineInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def pause_generation(self) -> None:
-        """Pause generation, freezing in-flight requests so they can be resumed later."""
+    async def pause_generation(self, lora_name: Optional[str] = None) -> None:
+        """Pause generation, freezing in-flight requests so they can be resumed later.
+
+        When ``lora_name`` is None (default), pauses all generation globally
+        (vLLM keep-mode pause). When ``lora_name`` is provided, only requests
+        targeting that specific LoRA adapter are paused (HTTP path only).
+        """
         raise NotImplementedError
 
     @abstractmethod
-    async def resume_generation(self) -> None:
-        """Resume generation after a pause, continuing any frozen in-flight requests."""
+    async def resume_generation(self, lora_name: Optional[str] = None) -> None:
+        """Resume generation after a pause, continuing any frozen in-flight requests.
+
+        ``lora_name`` must match the value used in the corresponding
+        ``pause_generation`` call.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py
@@ -366,21 +366,29 @@ class InferenceEngineClient(InferenceEngineInterface):
     # ----------------------------
     # Generation pause and resume
     # ----------------------------
-    async def pause_generation(self) -> None:
+    async def pause_generation(self, lora_name: Optional[str] = None) -> None:
         """
         Pauses generation for all engines using vLLM's native keep mode.
 
         In-flight requests are frozen (not aborted) and will resume from where they left off
         when `resume_generation()` is called. New requests are blocked until resume.
+
+        ``lora_name`` is accepted for interface parity with the HTTP path but
+        targeted (per-LoRA) pause is HTTP-only; passing a non-None value
+        raises ``NotImplementedError``.
         """
+        if lora_name is not None:
+            raise NotImplementedError("targeted pause is HTTP-only")
         await self._run_on_all_engines("pause_generation")
 
-    async def resume_generation(self) -> None:
+    async def resume_generation(self, lora_name: Optional[str] = None) -> None:
         """
         Resumes generation for all engines after a keep-mode pause.
 
         Frozen in-flight requests continue from where they left off, and new requests are unblocked.
         """
+        if lora_name is not None:
+            raise NotImplementedError("targeted pause is HTTP-only")
         await self._run_on_all_engines("resume_generation")
 
     # ----------------------------

--- a/skyrl/backends/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import ray
 from packaging import version
@@ -76,10 +76,14 @@ class RayWrappedInferenceEngine(InferenceEngineInterface):
     async def completion(self, request_payload: Dict[str, Any]) -> Dict[str, Any]:
         return await self.inference_engine_actor.completion.remote(request_payload)
 
-    async def pause_generation(self) -> None:
+    async def pause_generation(self, lora_name: Optional[str] = None) -> None:
+        if lora_name is not None:
+            raise NotImplementedError("targeted pause is HTTP-only")
         return await self.inference_engine_actor.pause_generation.remote()
 
-    async def resume_generation(self) -> None:
+    async def resume_generation(self, lora_name: Optional[str] = None) -> None:
+        if lora_name is not None:
+            raise NotImplementedError("targeted pause is HTTP-only")
         return await self.inference_engine_actor.resume_generation.remote()
 
 

--- a/skyrl/backends/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/remote_inference_engine.py
@@ -282,8 +282,10 @@ class RemoteInferenceEngine(InferenceEngineInterface):
                 "body": text,
             }
 
-    async def pause_generation(self) -> None:
+    async def pause_generation(self, lora_name: Optional[str] = None) -> None:
         """Pause generation using vLLM's native keep mode, freezing in-flight requests."""
+        if lora_name is not None:
+            raise NotImplementedError("targeted pause is HTTP-only")
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 f"{self.url}/pause",
@@ -293,8 +295,10 @@ class RemoteInferenceEngine(InferenceEngineInterface):
                 if resp.status != 200:
                     raise RuntimeError(f"Failed to pause generation: {result.get('error', result)}")
 
-    async def resume_generation(self) -> None:
+    async def resume_generation(self, lora_name: Optional[str] = None) -> None:
         """Resume generation after a keep-mode pause."""
+        if lora_name is not None:
+            raise NotImplementedError("targeted pause is HTTP-only")
         async with aiohttp.ClientSession() as session:
             async with session.post(f"{self.url}/resume") as resp:
                 result = await resp.json()

--- a/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -216,10 +216,10 @@ class BaseVLLMInferenceEngine(InferenceEngineInterface):
         """Reset the prefix cache. Subclasses override for async version."""
         return self.llm.llm_engine.reset_prefix_cache()
 
-    async def pause_generation(self, clear_cache: bool = False) -> None:
+    async def pause_generation(self, lora_name: Optional[str] = None, clear_cache: bool = False) -> None:
         raise NotImplementedError("pause_generation is only supported for AsyncVLLMInferenceEngine.")
 
-    async def resume_generation(self) -> None:
+    async def resume_generation(self, lora_name: Optional[str] = None) -> None:
         raise NotImplementedError("resume_generation is only supported for AsyncVLLMInferenceEngine.")
 
 
@@ -648,14 +648,18 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
         """
         return await self._handle_openai_request(request_payload, endpoint="/completions")
 
-    async def pause_generation(self, clear_cache: bool = False) -> None:
+    async def pause_generation(self, lora_name: Optional[str] = None, clear_cache: bool = False) -> None:
         """Pause generation using vLLM's native keep mode, freezing in-flight requests."""
+        if lora_name is not None:
+            raise NotImplementedError("targeted pause is HTTP-only")
         engine = self._get_engine()
         await engine.pause_generation(mode="keep", clear_cache=clear_cache)
         logger.info("pause_generation(mode='keep') finished")
 
-    async def resume_generation(self) -> None:
+    async def resume_generation(self, lora_name: Optional[str] = None) -> None:
         """Resume generation after a keep-mode pause."""
+        if lora_name is not None:
+            raise NotImplementedError("targeted pause is HTTP-only")
         engine = self._get_engine()
         await engine.resume_generation()
         logger.info("resume_generation() finished")

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -785,8 +785,15 @@ class RemoteInferenceClient:
           ``max_tokens`` decremented by the accumulated length. Repeat until
           a non-abort stop reason or ``max_tokens`` exhausts.
 
-        Only supports ``num_samples == 1`` (matches every current Tinker
-        caller in ``_sample_with_remote_client``).
+        Requires:
+            - ``num_samples == 1`` (matches every current Tinker caller in
+              ``_sample_with_remote_client``).
+            - ``sampling_params["max_tokens"]`` set to a positive int. The
+              retry loop decrements this budget on each iteration so the
+              total generation is bounded; without it we'd over-generate
+              (each retry would use the server's default budget on top of
+              accumulated tokens) and potentially loop forever on persistent
+              aborts.
 
         TRANSIENT: delete this method and revert the multi-LoRA call site
         back to ``sample`` when vLLM ships native per-LoRA pause.
@@ -803,6 +810,11 @@ class RemoteInferenceClient:
 
         sp_template = dict(body.get("sampling_params") or {})
         original_max_tokens = sp_template.get("max_tokens")
+        if not isinstance(original_max_tokens, int) or original_max_tokens <= 0:
+            raise ValueError(
+                "sample_with_retry requires sampling_params['max_tokens'] to be a positive int; "
+                f"got {original_max_tokens!r}"
+            )
 
         accum_tokens: List[int] = []
         accum_logprobs: List[float] = []
@@ -817,12 +829,11 @@ class RemoteInferenceClient:
                 if ev is not None:
                     await ev.wait()
 
-            if original_max_tokens is not None:
-                remaining = original_max_tokens - len(accum_tokens)
-                if remaining <= 0:
-                    stop_reason = "length"
-                    break
-                body["sampling_params"] = {**sp_template, "max_tokens": remaining}
+            remaining = original_max_tokens - len(accum_tokens)
+            if remaining <= 0:
+                stop_reason = "length"
+                break
+            body["sampling_params"] = {**sp_template, "max_tokens": remaining}
 
             cur_token_ids = token_ids + accum_tokens
             final = await self._sample_with_rendered_tokens(
@@ -846,20 +857,29 @@ class RemoteInferenceClient:
             if new_logprobs:
                 accum_logprobs.extend(new_logprobs)
 
-        if final is None:
-            # Only reachable if max_tokens was already 0 before the first
-            # dispatch — degenerate but worth handling.
-            return {
-                "type": "sample",
-                "sequences": [{"tokens": [], "logprobs": None, "stop_reason": "length"}],
-                "prompt_logprobs": None,
-                "topk_prompt_logprobs": None,
-            }
+        # Since we required max_tokens > 0 at entry, the loop must have
+        # dispatched at least once and ``final`` is bound.
+        assert final is not None, "sample_with_retry exited the loop without dispatching"
 
         # Merge accumulators into the final response.
         final["sequences"][0]["tokens"] = accum_tokens
         final["sequences"][0]["logprobs"] = accum_logprobs if accum_logprobs else None
         final["sequences"][0]["stop_reason"] = stop_reason
+
+        # When a retry fires, we resubmit with ``cur_token_ids = original_prompt +
+        # accum_tokens`` so the server computes prompt_logprobs over that
+        # extended prompt. The final response's prompt_logprobs therefore has
+        # entries for the accumulated tokens too — but the caller asked about
+        # the original prompt only. Truncate back to ``len(token_ids)``
+        # (the rendered original prompt length, never reassigned across
+        # retries). For positions in the original prompt the autoregressive
+        # logprobs are identical regardless of what follows in the prompt,
+        # so this is a lossless truncation.
+        if final.get("prompt_logprobs") is not None:
+            final["prompt_logprobs"] = final["prompt_logprobs"][: len(token_ids)]
+        if final.get("topk_prompt_logprobs") is not None:
+            final["topk_prompt_logprobs"] = final["topk_prompt_logprobs"][: len(token_ids)]
+
         return final
 
     async def chat_completion(

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -1503,6 +1503,8 @@ class RemoteInferenceClient:
         state["_gen_sem"] = None
         state["_detok_sem"] = None
         state["_sem_loop"] = None
+        state["_lora_pause_events"] = {}
+        state["_lora_events_loop"] = None
         return state
 
     def __setstate__(self, state: dict) -> None:
@@ -1512,6 +1514,8 @@ class RemoteInferenceClient:
         self._gen_sem = None
         self._detok_sem = None
         self._sem_loop = None
+        self._lora_pause_events = {}
+        self._lora_events_loop = None
 
     async def aclose(self):
         if self._session is not None:

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -79,6 +79,13 @@ from skyrl.env_vars import (
 
 _DATA_PLANE_RETRIES = 30
 
+# Grace period between setting the per-LoRA pause gate and asking the server
+# to abort that LoRA's in-flight requests. Gives requests that the client
+# has already sent (but vLLM hasn't yet admitted to its scheduler) time to
+# land, so the abort fan-out catches them. Mirrors the pre-removal
+# ABORT_GENERATION_GRACE_PERIOD_SECONDS in inference_engine_client.py.
+ABORT_GENERATION_GRACE_PERIOD_SECONDS = 5
+
 SKYRL_LORA_ADAPTER_NAME = "skyrl-lora"
 """Default LoRA adapter name used for single-LoRA training inside SkyRL."""
 
@@ -224,6 +231,13 @@ class RemoteInferenceClient:
     _gen_sem: Optional[asyncio.Semaphore] = field(default=None, repr=False)
     _detok_sem: Optional[asyncio.Semaphore] = field(default=None, repr=False)
     _sem_loop: Optional[asyncio.AbstractEventLoop] = field(default=None, repr=False)
+    # Per-LoRA pause gates for targeted (multi-tenant) pause/resume. Convention:
+    # event SET = open (running), CLEAR = paused (waiters block on .wait()).
+    # Like the semaphores above, these are event-loop-bound — recreate when the
+    # running loop changes. Read only by sample_with_retry().
+    # TRANSIENT: delete with sample_with_retry() when vLLM ships native per-LoRA pause.
+    _lora_pause_events: Dict[str, asyncio.Event] = field(default_factory=dict, repr=False)
+    _lora_events_loop: Optional[asyncio.AbstractEventLoop] = field(default=None, repr=False)
 
     def __post_init__(self):
         if self.data_parallel_size <= 0:
@@ -260,6 +274,27 @@ class RemoteInferenceClient:
                 self._detok_sem = None
             self._sem_loop = current_loop
         return self._gen_sem, self._detok_sem
+
+    def _get_lora_pause_event(self, lora_name: str) -> asyncio.Event:
+        """Return the per-LoRA pause event for the current running loop.
+
+        Events are bound to the loop they're first awaited on (Python 3.10+);
+        if the running loop has changed since the events were created, wipe
+        the dict and recreate. Mirrors ``_get_semaphores`` above.
+
+        TRANSIENT: delete with ``sample_with_retry`` when vLLM ships native
+        per-LoRA pause.
+        """
+        loop = asyncio.get_running_loop()
+        if self._lora_events_loop is not loop:
+            self._lora_pause_events = {}
+            self._lora_events_loop = loop
+        ev = self._lora_pause_events.get(lora_name)
+        if ev is None:
+            ev = asyncio.Event()
+            ev.set()  # SET = open (not paused)
+            self._lora_pause_events[lora_name] = ev
+        return ev
 
     async def _get_session(self) -> aiohttp.ClientSession:
         """Get or create the aiohttp session."""
@@ -606,8 +641,35 @@ class RemoteInferenceClient:
         body["model"] = model
 
         prompt = body.get("prompt", {})
+
+        # Render prompt: flatten text tokens and, if images are present,
+        # call the render endpoint to get placeholder tokens + features.
+        token_ids, mm_features = await self._render_for_sample(prompt, session_id, model=model)
+
+        return await self._sample_with_rendered_tokens(
+            token_ids=token_ids,
+            mm_features=mm_features,
+            body=body,
+            session_id=session_id,
+            model=model,
+        )
+
+    async def _sample_with_rendered_tokens(
+        self,
+        token_ids: List[int],
+        mm_features: Optional[MultiModalFeatures],
+        body: Dict[str, Any],
+        session_id: Optional[str],
+        model: str,
+    ) -> SampleResponse:
+        """Dispatch a single rendered sample request to /inference/v1/generate.
+
+        Shared between ``sample`` (one shot) and ``sample_with_retry`` (loops
+        on this method with accumulating ``token_ids`` and decremented
+        ``max_tokens``). No retry, no LoRA gating; those live in the caller.
+        """
         num_samples = body.get("num_samples", 1)
-        tinker_params = body.get("sampling_params", {})
+        tinker_params = body.get("sampling_params", {}) or {}
 
         # Note: Tinker SampleRequest uses "prompt_logprobs" (bool), while
         # SamplingClient.sample() uses "include_prompt_logprobs".
@@ -618,10 +680,6 @@ class RemoteInferenceClient:
         prompt_logprobs_sp = None
         if include_prompt_logprobs:
             prompt_logprobs_sp = topk_prompt_logprobs_k if topk_prompt_logprobs_k > 0 else 0
-
-        # Render prompt: flatten text tokens and, if images are present,
-        # call the render endpoint to get placeholder tokens + features.
-        token_ids, mm_features = await self._render_for_sample(prompt, session_id, model=model)
 
         # Map Tinker SamplingParams → vLLM format
         sampling_params: Dict[str, Any] = {
@@ -707,6 +765,102 @@ class RemoteInferenceClient:
             "prompt_logprobs": result_prompt_logprobs,
             "topk_prompt_logprobs": result_topk_prompt_logprobs,
         }
+
+    async def sample_with_retry(
+        self,
+        request_payload: SampleRequestPayload,
+    ) -> SampleResponse:
+        """Sample with abort-and-retry, gated on a per-LoRA pause event.
+
+        Used by the multi-tenant LoRA training path so that pausing one
+        LoRA's generation (to swap weights) doesn't freeze unrelated LoRAs.
+
+        Flow:
+        - Render the prompt once.
+        - Dispatch ``_sample_with_rendered_tokens``.
+        - If the returned ``stop_reason == "abort"``, accumulate the partial
+          tokens, ``await`` the per-LoRA pause event (so we don't busy-loop
+          while the trainer is still loading new weights), then resubmit
+          with ``token_ids = original_prompt + accumulated`` and
+          ``max_tokens`` decremented by the accumulated length. Repeat until
+          a non-abort stop reason or ``max_tokens`` exhausts.
+
+        Only supports ``num_samples == 1`` (matches every current Tinker
+        caller in ``_sample_with_remote_client``).
+
+        TRANSIENT: delete this method and revert the multi-LoRA call site
+        back to ``sample`` when vLLM ships native per-LoRA pause.
+        """
+        session_id, body = _extract_session_id_and_body(request_payload)
+        model = self._resolve_model(body.get("model"), "sample_with_retry")
+        body["model"] = model
+
+        if body.get("num_samples", 1) != 1:
+            raise ValueError("sample_with_retry only supports num_samples=1")
+
+        # Render the prompt once; the retry loop only re-dispatches.
+        token_ids, mm_features = await self._render_for_sample(body.get("prompt", {}), session_id, model=model)
+
+        sp_template = dict(body.get("sampling_params") or {})
+        original_max_tokens = sp_template.get("max_tokens")
+
+        accum_tokens: List[int] = []
+        accum_logprobs: List[float] = []
+        final: Optional[SampleResponse] = None
+        stop_reason: Optional[str] = "abort"
+
+        while stop_reason == "abort":
+            # Wait if this LoRA is paused. No-op if no event has been
+            # created yet (i.e. the LoRA was never paused for this loop).
+            if self._lora_events_loop is asyncio.get_running_loop():
+                ev = self._lora_pause_events.get(model)
+                if ev is not None:
+                    await ev.wait()
+
+            if original_max_tokens is not None:
+                remaining = original_max_tokens - len(accum_tokens)
+                if remaining <= 0:
+                    stop_reason = "length"
+                    break
+                body["sampling_params"] = {**sp_template, "max_tokens": remaining}
+
+            cur_token_ids = token_ids + accum_tokens
+            final = await self._sample_with_rendered_tokens(
+                token_ids=cur_token_ids,
+                mm_features=mm_features,
+                body=body,
+                session_id=session_id,
+                model=model,
+            )
+            seq = final["sequences"][0]
+            stop_reason = seq.get("stop_reason") or "abort"
+
+            new_tokens = seq.get("tokens") or []
+            if not new_tokens and stop_reason == "abort":
+                # Aborted with no progress (e.g. the abort fan-out caught
+                # this request before it generated anything). Just retry.
+                continue
+
+            accum_tokens.extend(new_tokens)
+            new_logprobs = seq.get("logprobs")
+            if new_logprobs:
+                accum_logprobs.extend(new_logprobs)
+
+        if final is None:
+            # Only reachable if max_tokens was already 0 before the first
+            # dispatch — degenerate but worth handling.
+            return {
+                "type": "sample",
+                "sequences": [{"tokens": [], "logprobs": None, "stop_reason": "length"}],
+                "prompt_logprobs": None,
+                "topk_prompt_logprobs": None,
+            }
+
+        # Merge accumulators into the final response.
+        final["sequences"][0]["tokens"] = accum_tokens
+        final["sequences"][0]["logprobs"] = accum_logprobs if accum_logprobs else None
+        final["sequences"][0]["stop_reason"] = stop_reason
+        return final
 
     async def chat_completion(
         self,
@@ -958,13 +1112,40 @@ class RemoteInferenceClient:
         """Resume generation on all backends."""
         return await self._call_all_servers("/resume")
 
-    async def pause_generation(self, clear_cache: bool = False) -> Dict[str, Any]:
-        """Pause using keep mode - compatibility with InferenceEngineClient interface."""
-        return await self.pause(mode=PauseMode.KEEP, clear_cache=clear_cache)
+    async def pause_generation(
+        self,
+        lora_name: Optional[str] = None,
+        clear_cache: bool = False,
+    ) -> Dict[str, Any]:
+        """Pause generation, optionally targeting a single LoRA adapter.
 
-    async def resume_generation(self) -> Dict[str, Any]:
-        """Resume after pause - compatibility with InferenceEngineClient interface."""
-        return await self.resume()
+        When ``lora_name`` is None, pauses everything via vLLM's keep-mode
+        pause (existing behavior). When ``lora_name`` is provided, only
+        in-flight requests for that LoRA are aborted; other adapters keep
+        running. Client-side, ``sample_with_retry`` callers for that LoRA
+        block on the per-LoRA event until ``resume_generation`` is called.
+
+        TRANSIENT: the ``lora_name`` branch should be deleted when vLLM
+        ships native per-LoRA pause.
+        """
+        if lora_name is None:
+            return await self.pause(mode=PauseMode.KEEP, clear_cache=clear_cache)
+        # Block new/retrying sample_with_retry calls for this LoRA, then give
+        # in-flight client→server requests a moment to enter the scheduler so
+        # the abort fan-out catches them.
+        self._get_lora_pause_event(lora_name).clear()
+        await asyncio.sleep(ABORT_GENERATION_GRACE_PERIOD_SECONDS)
+        return await self._call_all_servers(
+            "/skyrl/v1/abort_lora_requests",
+            json={"lora_name": lora_name},
+        )
+
+    async def resume_generation(self, lora_name: Optional[str] = None) -> Dict[str, Any]:
+        """Resume generation. ``lora_name`` must match the prior pause call."""
+        if lora_name is None:
+            return await self.resume()
+        self._get_lora_pause_event(lora_name).set()
+        return {"status": "ok"}
 
     async def sleep(self, level: int = 2, tags: Optional[List[str]] = None) -> Dict[str, Any]:
         """

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -420,6 +420,28 @@ class VLLMServerActor(ServerActorProtocol):
                 "lora_int_id": lora_int_id,
             }
 
+        # TRANSIENT: Per-LoRA targeted abort for multi-tenant weight sync.
+        # When proper per-LoRA pause lands in vLLM, delete this endpoint and
+        # route pause_generation(lora_name=...) through the native API.
+        @app.post("/skyrl/v1/abort_lora_requests")
+        async def _abort_lora_requests(request: Request):
+            """Abort all in-flight requests targeting a given LoRA adapter.
+
+            Iterates ``engine.output_processor.request_states`` (keyed by internal
+            request IDs) and aborts those whose ``lora_name`` matches. Other
+            adapters' requests are untouched.
+            """
+            body = await request.json()
+            lora_name = body.get("lora_name")
+            if not lora_name:
+                raise HTTPException(status_code=400, detail="'lora_name' required")
+            op = engine.output_processor
+            # request_states is keyed by *internal* IDs; pass internal=True to abort().
+            ids = [rid for rid, st in op.request_states.items() if st.lora_name == lora_name]
+            if ids:
+                await engine.abort(ids, internal=True)
+            return {"status": "ok", "aborted": ids, "count": len(ids)}
+
         # NOTE (sumanthrh): We use a custom generate endpoint /skyrl/v1/generate because the native
         # endpoint /inference/v1/generate does not support returning routed expert IDs.
         # TODO (sumanthrh): Migrate back to /inference/v1/generate once this is fixed on the vllm side

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -515,10 +515,13 @@ class WorkerDispatch:
             await self._inference_engine_client.wake_up(tags=["kv_cache"])
         else:
             # Non-colocated: pause generation to prevent in-flight requests from
-            # reading partially-updated weights during the NCCL broadcast.
-            await self._inference_engine_client.pause_generation()
+            # reading partially-updated weights during the NCCL broadcast. For
+            # multi-LoRA (model_id is set), pause only that LoRA's requests so
+            # the other tenants keep running. For FFT (model_id is None), fall
+            # back to the global keep-mode pause.
+            await self._inference_engine_client.pause_generation(lora_name=model_id)
             try:
                 self._broadcast_to_inference_engines(self._inference_engine_client, model_id=model_id)
                 self._finish_weight_sync()
             finally:
-                await self._inference_engine_client.resume_generation()
+                await self._inference_engine_client.resume_generation(lora_name=model_id)

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -959,6 +959,18 @@ class SkyRLTrainBackend(AbstractBackend):
             for mid in prepared_batch.all_model_ids
         ]
 
+        # Multi-LoRA training shares one inference engine across multiple
+        # tenants. When *one* tenant's weights are being swapped, we abort
+        # only that LoRA's in-flight requests (via pause_generation(lora_name=...))
+        # and rely on sample_with_retry to accumulate partial tokens and
+        # resubmit when resume_generation is called. Other tenants are
+        # unaffected. FFT / single-tenant uses the single-shot path.
+        # TRANSIENT: drop the branch when vLLM ships native per-LoRA pause.
+        is_multi_lora = self._base_lora_signature is not None
+        sample_fn = (
+            self._inference_engine_client.sample_with_retry if is_multi_lora else self._inference_engine_client.sample
+        )
+
         async def sample_all():
             tasks = []
             for i in range(len(prepared_batch.all_model_inputs)):
@@ -973,7 +985,7 @@ class SkyRLTrainBackend(AbstractBackend):
                         "sampling_params": sampling_params.model_dump(),
                     }
                 }
-                tasks.append(self._inference_engine_client.sample(request_payload))
+                tasks.append(sample_fn(request_payload))
 
             try:
                 return await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/backends/skyrl_train/distributed/test_megatron_correctness.py
+++ b/tests/backends/skyrl_train/distributed/test_megatron_correctness.py
@@ -161,8 +161,12 @@ class TestWeightSyncPauseFlush:
         dispatch = WorkerDispatch.__new__(WorkerDispatch)
         dispatch.colocate_all = False
         dispatch._inference_engine_client = AsyncMock()
-        dispatch._inference_engine_client.pause_generation = AsyncMock(side_effect=lambda: call_order.append("pause"))
-        dispatch._inference_engine_client.resume_generation = AsyncMock(side_effect=lambda: call_order.append("resume"))
+        dispatch._inference_engine_client.pause_generation = AsyncMock(
+            side_effect=lambda *a, **kw: call_order.append("pause")
+        )
+        dispatch._inference_engine_client.resume_generation = AsyncMock(
+            side_effect=lambda *a, **kw: call_order.append("resume")
+        )
         dispatch._broadcast_to_inference_engines = MagicMock(
             side_effect=lambda *args, **kwargs: call_order.append("broadcast")
         )

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_pause_lora.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_pause_lora.py
@@ -274,13 +274,21 @@ async def test_sample_with_retry_recovers_from_abort(
          model emitting tokens until ``max_tokens`` (otherwise it stops at
          the natural EOS after a couple of "Meow!"/"Woof!" tokens, the
          pause fires too late, and the retry path is never exercised — the
-         "tasks already completed before pause" warning below catches this).
+         "tasks already completed before pause" assertion below catches this).
       2. After ~1.5s, pause lora-meow → abort fan-out hits all 4 meow
          requests on the server.
-      3. After another ~1.5s (still paused), resume lora-meow.
-      4. Await all tasks. All 8 should complete with non-abort stop_reason
-         and non-empty tokens. Woof tasks should NEVER have observed an
-         abort (they ran straight through).
+      3. After another ~1.5s (still paused), **await the woof tasks BEFORE
+         resuming meow**. This proves cross-LoRA isolation under the
+         strongest condition: woof requests already in-flight when meow's
+         pause fired must still complete while meow's retry loop is gated.
+         Sister test ``test_pause_lora_does_not_affect_other_lora`` covers
+         the "new woof requests after meow is paused" case; this one covers
+         the harder "in-flight woof requests during meow's abort fan-out"
+         case.
+      4. Resume lora-meow and await the meow tasks. All 4 should complete
+         with non-abort stop_reason and "meow" content (proves the abort/
+         retry boundary preserved accumulated state and used the right LoRA
+         weights on resubmit).
     """
     # See ``_sample_no_eos`` — Tinker SamplingParams doesn't expose
     # ignore_eos, so we widen the Tinker→vLLM map for the duration of the
@@ -358,14 +366,31 @@ async def test_sample_with_retry_recovers_from_abort(
                 "the per-LoRA gate did not engage for lora-meow."
             )
 
+            # Await the woof tasks BEFORE resuming meow. This proves cross-LoRA
+            # isolation under the strongest condition: woof requests that were
+            # already in-flight when pause(lora_name="lora-meow") fired must
+            # still finish even though meow's retry loop is gated. If the
+            # server-side /skyrl/v1/abort_lora_requests endpoint accidentally
+            # aborted other LoRAs' requests, or if the client-side gate
+            # spilled across adapters, woof would block here and time out.
+            woof_results = await asyncio.wait_for(
+                asyncio.gather(*woof_tasks, return_exceptions=False),
+                timeout=60.0,
+            )
+            # Meow tasks must STILL be blocked at this point — finishing the
+            # woof tasks should not have side-effected the meow gate.
+            meow_done_after_woof = sum(1 for t in meow_tasks if t.done())
+            assert meow_done_after_woof == 0, (
+                f"{meow_done_after_woof}/4 meow tasks finished while still paused — "
+                "the gate released without resume_generation being called."
+            )
+
             await client.resume_generation(lora_name="lora-meow")
 
-            results = await asyncio.wait_for(
-                asyncio.gather(*meow_tasks, *woof_tasks, return_exceptions=False),
+            meow_results = await asyncio.wait_for(
+                asyncio.gather(*meow_tasks, return_exceptions=False),
                 timeout=120.0,
             )
-            meow_results = results[:4]
-            woof_results = results[4:]
 
             # All meow tasks complete with a non-abort stop_reason and
             # non-empty token output.

--- a/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_pause_lora.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_pause_lora.py
@@ -1,0 +1,576 @@
+"""GPU integration test for targeted per-LoRA pause / resume in RemoteInferenceClient.
+
+Exercises the multi-tenant pause path end-to-end against a real vLLM server
+running two LoRA adapters (Meow + Woof):
+
+1. ``test_pause_lora_does_not_affect_other_lora`` — while LoRA A is paused,
+   LoRA B's sample_with_retry calls still complete normally.
+2. ``test_sample_with_retry_recovers_from_abort`` — A request for LoRA A
+   that is in-flight when pause(lora_name=A) fires comes back with
+   finish_reason="abort", sample_with_retry accumulates partial tokens
+   and resubmits on resume; the merged response is well-formed.
+3. ``test_pause_swap_weights_resume_mid_sample`` — a single sample call
+   spans a real weight sync: Meow tokens pre-pause, Woof tokens
+   post-resume (after load_lora_adapter swaps the adapter's weights
+   in place), proving the abort/retry boundary preserves accumulated
+   state AND that the retried request observes the new weights.
+4. ``test_global_pause_still_works`` — pause_generation() (no lora_name)
+   still drives the global keep-mode pause for FFT / single-tenant flows.
+
+# Run with:
+uv run pytest tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_pause_lora.py -v -s
+
+(The repo convention `uv run --isolated --extra dev --extra fsdp ...` also
+works; either way assumes 1 H100 / A100 free for the single inference
+engine.)
+
+TRANSIENT: delete this file when vLLM ships native per-LoRA pause and
+sample_with_retry is removed from RemoteInferenceClient.
+"""
+
+import asyncio
+import sys
+import time
+from typing import List
+
+import pytest
+import ray
+from huggingface_hub import snapshot_download
+from transformers import AutoTokenizer
+
+from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
+    RemoteInferenceClient,
+)
+from skyrl.train.config import SkyRLLoraConfig, SkyRLTrainConfig
+from tests.backends.skyrl_train.gpu.gpu_ci.conftest import _build_ray_env_vars
+from tests.backends.skyrl_train.gpu.utils import InferenceEngineState
+
+MODEL_QWEN3 = "Qwen/Qwen3-0.6B"
+
+
+@pytest.fixture
+def local_ray_fixture():
+    """Force a fresh local Ray cluster running this test process's Python.
+
+    This file lives under ``gpu_ci/`` whose ``conftest.py`` provides
+    ``ray_init_fixture`` — but that fixture calls ``ray.init()`` without an
+    address, which auto-discovers any pre-existing cluster on the box (often
+    a system anaconda one). When the test process is the uv-managed venv,
+    Ray actors spawned in the foreign cluster try to import SkyRL deps from
+    anaconda's site-packages and crash on the first missing one (e.g.
+    ``omegaconf``).
+
+    We pin ``address="local"`` to start a new cluster and pass
+    ``py_executable=sys.executable`` so Ray workers/actors are launched with
+    the venv's Python and inherit its installed packages.
+    """
+    if ray.is_initialized():
+        ray.shutdown()
+    env_vars = _build_ray_env_vars()
+    ray.init(
+        address="local",
+        runtime_env={"env_vars": env_vars, "py_executable": sys.executable},
+    )
+    try:
+        yield
+    finally:
+        ray.shutdown()
+
+
+# Both LoRA adapters are tuned to override the assistant reply with their
+# animal noise. The simple animal-noise prompt (mirroring
+# ``test_multi_lora_serving.py``) reliably elicits the LoRA-shaped output
+# ("Meow!" / "Woof!"). With a large ``max_tokens`` the LoRA keeps repeating
+# the noise until the length cap — which both (a) gives the pause helper a
+# generous window to abort in-flight requests mid-generation and (b)
+# preserves the LoRA-correctness signal in the final token stream.
+ANIMAL_NOISE_PROMPT = "Make a single short animal noise."
+
+
+@pytest.fixture(scope="module")
+def qwen3_meowing_lora_files():
+    """Download the Qwen3-0.6B Meow LoRA snapshot once per test module."""
+    return snapshot_download(repo_id="Jackmin108/Qwen3-0.6B-Meow-LoRA")
+
+
+@pytest.fixture(scope="module")
+def qwen3_woofing_lora_files():
+    """Download the Qwen3-0.6B Woof LoRA snapshot once per test module."""
+    return snapshot_download(repo_id="Jackmin108/Qwen3-0.6B-Woof-LoRA")
+
+
+def _multi_lora_cfg() -> SkyRLTrainConfig:
+    """Build a minimal Qwen3 LoRA inference-only config sized for two adapters.
+
+    Mirrors the structure used by ``test_multi_lora_serving.py`` — one engine,
+    TP=1, async, non-colocated. We bump ``max_num_seqs`` so all 8 concurrent
+    test requests run simultaneously and the abort fan-out lands on every
+    in-flight request for the targeted LoRA.
+    """
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.policy.model.path = MODEL_QWEN3
+    cfg.trainer.critic.model.path = ""
+    cfg.trainer.strategy = "fsdp"
+    cfg.trainer.placement.colocate_all = False
+    cfg.trainer.placement.policy_num_gpus_per_node = 1
+    cfg.generator.inference_engine.async_engine = True
+    cfg.generator.inference_engine.num_engines = 1
+    cfg.generator.inference_engine.run_engines_locally = True
+    cfg.generator.inference_engine.tensor_parallel_size = 1
+    cfg.generator.inference_engine.max_num_seqs = 16
+    cfg.trainer.policy.model.lora = SkyRLLoraConfig(
+        rank=32,
+        alpha=32,
+        dropout=0.0,
+        target_modules="all-linear",
+        max_loras=2,
+    )
+    return cfg
+
+
+def _build_prompt_token_ids(tokenizer) -> List[int]:
+    messages = [{"role": "user", "content": ANIMAL_NOISE_PROMPT}]
+    return tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_dict=False,
+        enable_thinking=False,
+    )
+
+
+def _make_sample_payload(prompt_token_ids: List[int], model: str, max_tokens: int) -> dict:
+    return {
+        "json": {
+            "model": model,
+            "prompt": {"chunks": [{"tokens": prompt_token_ids}]},
+            "num_samples": 1,
+            "sampling_params": {
+                "temperature": 0.7,
+                "max_tokens": max_tokens,
+                "seed": 1234,
+            },
+        }
+    }
+
+
+async def _sample(client: RemoteInferenceClient, prompt_token_ids: List[int], model: str, max_tokens: int = 384):
+    """Run one ``sample_with_retry`` call and return the single-sequence result."""
+    payload = _make_sample_payload(prompt_token_ids, model, max_tokens)
+    return await client.sample_with_retry(payload)
+
+
+async def _sample_no_eos(
+    client: RemoteInferenceClient,
+    prompt_token_ids: List[int],
+    model: str,
+    max_tokens: int,
+):
+    """Like ``_sample`` but injects ``ignore_eos=True`` into the underlying
+    vLLM sampling params, so the LoRA-tuned model keeps emitting its bias
+    pattern until the length cap rather than stopping on the natural EOS.
+
+    Used by the weight-swap test where we need the request to be reliably
+    mid-generation when the abort fires.
+    """
+    payload = _make_sample_payload(prompt_token_ids, model, max_tokens)
+    payload["json"]["sampling_params"]["ignore_eos"] = True
+    return await client.sample_with_retry(payload)
+
+
+@pytest.mark.asyncio
+async def test_pause_lora_does_not_affect_other_lora(
+    local_ray_fixture, qwen3_meowing_lora_files, qwen3_woofing_lora_files
+):
+    """Pausing one LoRA must not block sample calls for a different LoRA.
+
+    Flow:
+      1. Load adapters ``lora-meow`` and ``lora-woof``.
+      2. Pause ``lora-meow`` (so its event is CLEAR / paused).
+      3. Issue concurrent ``sample_with_retry`` calls for ``lora-woof``.
+      4. Assert woof samples complete promptly (NOT blocked on meow's gate)
+         with sane stop_reasons and non-empty token output.
+      5. Resume meow afterwards so cleanup runs cleanly.
+
+    This is the core selective-pause contract: only the targeted LoRA waits.
+    """
+    cfg = _multi_lora_cfg()
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_QWEN3, trust_remote_code=True)
+    prompt_token_ids = _build_prompt_token_ids(tokenizer)
+
+    async with InferenceEngineState.create(
+        cfg=cfg,
+        model=MODEL_QWEN3,
+        use_local=True,
+        async_engine=True,
+        tp_size=1,
+        colocate_all=False,
+        sleep_level=1,
+        enable_lora=True,
+        lora_max_loras=2,
+    ) as engines:
+        client = engines.client
+        assert isinstance(
+            client, RemoteInferenceClient
+        ), f"This test targets the HTTP path (RemoteInferenceClient), got {type(client).__name__}"
+
+        await client.load_lora_adapter("lora-meow", qwen3_meowing_lora_files)
+        await client.load_lora_adapter("lora-woof", qwen3_woofing_lora_files)
+        try:
+            # 1. Pause meow. The event is now CLEAR — any sample for meow
+            # would block, but woof's gate is untouched (and unborn).
+            await client.pause_generation(lora_name="lora-meow")
+            assert "lora-meow" in client._lora_pause_events
+            assert not client._lora_pause_events["lora-meow"].is_set()
+            assert "lora-woof" not in client._lora_pause_events
+
+            # 2. Launch 4 concurrent woof samples. They must NOT be blocked.
+            start = time.monotonic()
+            woof_tasks = [
+                asyncio.create_task(_sample(client, prompt_token_ids, model="lora-woof", max_tokens=128))
+                for _ in range(4)
+            ]
+            woof_results = await asyncio.wait_for(asyncio.gather(*woof_tasks), timeout=60.0)
+            elapsed = time.monotonic() - start
+            print(f"4 concurrent woof samples completed in {elapsed:.2f}s while meow was paused")
+
+            # 3. Validate woof output:
+            #   (a) completed AT ALL while meow was paused — proves the
+            #       per-LoRA gate doesn't spill across adapters, and
+            #   (b) contains "woof" content — proves the right LoRA weights
+            #       were used (no weight mix-up from the targeted pause).
+            for i, result in enumerate(woof_results):
+                seq = result["sequences"][0]
+                assert seq["stop_reason"] in (
+                    "stop",
+                    "length",
+                ), f"woof[{i}] unexpected stop_reason: {seq['stop_reason']}"
+                assert len(seq["tokens"]) > 0, f"woof[{i}] empty tokens"
+                text = tokenizer.decode(seq["tokens"]).lower()
+                assert "woof" in text, f"woof[{i}] expected lora-woof output, got: {text[:200]!r}"
+
+            # 4. Cleanup: resume meow so the engine doesn't hold stale state.
+            await client.resume_generation(lora_name="lora-meow")
+            assert client._lora_pause_events["lora-meow"].is_set()
+        finally:
+            # Best-effort cleanup; resume is idempotent (event already set is fine).
+            try:
+                await client.resume_generation(lora_name="lora-meow")
+            except Exception:
+                pass
+            await client.unload_lora_adapter("lora-meow")
+            await client.unload_lora_adapter("lora-woof")
+
+
+@pytest.mark.asyncio
+async def test_sample_with_retry_recovers_from_abort(
+    local_ray_fixture, qwen3_meowing_lora_files, qwen3_woofing_lora_files, monkeypatch
+):
+    """In-flight requests for the paused LoRA are aborted, retried after resume.
+
+    Flow:
+      1. Launch 4 long-running sample_with_retry calls on lora-meow + 4 on
+         lora-woof concurrently. ``ignore_eos=True`` keeps the LoRA-tuned
+         model emitting tokens until ``max_tokens`` (otherwise it stops at
+         the natural EOS after a couple of "Meow!"/"Woof!" tokens, the
+         pause fires too late, and the retry path is never exercised — the
+         "tasks already completed before pause" warning below catches this).
+      2. After ~1.5s, pause lora-meow → abort fan-out hits all 4 meow
+         requests on the server.
+      3. After another ~1.5s (still paused), resume lora-meow.
+      4. Await all tasks. All 8 should complete with non-abort stop_reason
+         and non-empty tokens. Woof tasks should NEVER have observed an
+         abort (they ran straight through).
+    """
+    # See ``_sample_no_eos`` — Tinker SamplingParams doesn't expose
+    # ignore_eos, so we widen the Tinker→vLLM map for the duration of the
+    # test. Without this, the LoRAs stop after one noise token and the
+    # abort never has anything to catch.
+    from skyrl.backends.skyrl_train.inference_servers import (
+        remote_inference_client as _ric,
+    )
+
+    monkeypatch.setitem(_ric._TINKER_SAMPLE_TO_VLLM_PARAM_MAP, "ignore_eos", "ignore_eos")
+
+    cfg = _multi_lora_cfg()
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_QWEN3, trust_remote_code=True)
+    prompt_token_ids = _build_prompt_token_ids(tokenizer)
+    max_tokens = 384
+
+    async with InferenceEngineState.create(
+        cfg=cfg,
+        model=MODEL_QWEN3,
+        use_local=True,
+        async_engine=True,
+        tp_size=1,
+        colocate_all=False,
+        sleep_level=1,
+        enable_lora=True,
+        lora_max_loras=2,
+    ) as engines:
+        client = engines.client
+        assert isinstance(client, RemoteInferenceClient)
+
+        await client.load_lora_adapter("lora-meow", qwen3_meowing_lora_files)
+        await client.load_lora_adapter("lora-woof", qwen3_woofing_lora_files)
+        try:
+            meow_tasks = [
+                asyncio.create_task(_sample_no_eos(client, prompt_token_ids, model="lora-meow", max_tokens=max_tokens))
+                for _ in range(4)
+            ]
+            woof_tasks = [
+                asyncio.create_task(_sample_no_eos(client, prompt_token_ids, model="lora-woof", max_tokens=max_tokens))
+                for _ in range(4)
+            ]
+
+            # Give requests time to enter the scheduler.
+            await asyncio.sleep(1.5)
+
+            # No task should have completed yet (max_tokens=384 + ignore_eos
+            # means several seconds of generation on Qwen3-0.6B). If ANY
+            # task finished before we fire the pause, the abort never hits
+            # an in-flight request and the retry path is not exercised —
+            # which would make this test silently vacuous. Hard-fail.
+            done_count_before = sum(1 for t in meow_tasks + woof_tasks if t.done())
+            assert done_count_before == 0, (
+                f"{done_count_before}/8 tasks already completed before pause was fired. "
+                "The abort/retry path will not be exercised. Bump max_tokens or shorten the "
+                "pre-pause sleep so requests are reliably mid-generation when pause fires."
+            )
+
+            pause_t0 = time.monotonic()
+            await client.pause_generation(lora_name="lora-meow")
+            pause_elapsed = time.monotonic() - pause_t0
+            print(f"pause_generation(lora_name='lora-meow') took {pause_elapsed:.2f}s")
+
+            # Hold the pause for a while so the retry loop is genuinely
+            # gated, then resume.
+            await asyncio.sleep(1.5)
+
+            # While paused, the meow tasks should be blocked on the event
+            # (they each saw finish_reason="abort" and are in the retry
+            # loop's await ev.wait()). Hard-fail if any meow task escaped
+            # — that would mean the per-LoRA gate didn't actually engage
+            # for this lora, and the test is again vacuous.
+            meow_done_mid_pause = sum(1 for t in meow_tasks if t.done())
+            assert meow_done_mid_pause == 0, (
+                f"{meow_done_mid_pause}/4 meow tasks finished while pause was active — "
+                "the per-LoRA gate did not engage for lora-meow."
+            )
+
+            await client.resume_generation(lora_name="lora-meow")
+
+            results = await asyncio.wait_for(
+                asyncio.gather(*meow_tasks, *woof_tasks, return_exceptions=False),
+                timeout=120.0,
+            )
+            meow_results = results[:4]
+            woof_results = results[4:]
+
+            # All meow tasks complete with a non-abort stop_reason and
+            # non-empty token output.
+            # All meow tasks complete with non-abort stop_reason, non-empty
+            # tokens, AND "meow" content — the last check verifies the
+            # retried request resumed with the correct LoRA weights
+            # (no adapter mix-up across the abort/retry boundary).
+            for i, result in enumerate(meow_results):
+                seq = result["sequences"][0]
+                assert seq["stop_reason"] in (
+                    "stop",
+                    "length",
+                ), f"meow[{i}] stop_reason should not be 'abort' after retry, got {seq['stop_reason']}"
+                assert len(seq["tokens"]) > 0, f"meow[{i}] empty tokens"
+                text = tokenizer.decode(seq["tokens"]).lower()
+                assert "meow" in text, f"meow[{i}] expected lora-meow output after retry, got: {text[:200]!r}"
+
+            for i, result in enumerate(woof_results):
+                seq = result["sequences"][0]
+                assert seq["stop_reason"] in (
+                    "stop",
+                    "length",
+                ), f"woof[{i}] unexpected stop_reason: {seq['stop_reason']}"
+                assert len(seq["tokens"]) > 0, f"woof[{i}] empty tokens"
+                text = tokenizer.decode(seq["tokens"]).lower()
+                assert "woof" in text, f"woof[{i}] expected lora-woof output, got: {text[:200]!r}"
+        finally:
+            try:
+                await client.resume_generation(lora_name="lora-meow")
+            except Exception:
+                pass
+            await client.unload_lora_adapter("lora-meow")
+            await client.unload_lora_adapter("lora-woof")
+
+
+@pytest.mark.asyncio
+async def test_pause_swap_weights_resume_mid_sample(
+    local_ray_fixture,
+    qwen3_meowing_lora_files,
+    qwen3_woofing_lora_files,
+    monkeypatch,
+):
+    """End-to-end: a single sample call spans a real weight sync.
+
+    Mimics the production multi-tenant weight-sync flow:
+      1. ``lora-target`` is loaded with Meow weights.
+      2. A long sample call against ``lora-target`` starts emitting Meow tokens.
+      3. ``pause_generation(lora_name="lora-target")`` aborts the in-flight
+         request; ``sample_with_retry``'s retry loop accumulates partial Meow
+         tokens and blocks on the per-LoRA event.
+      4. ``load_lora_adapter("lora-target", woof_path)`` swaps the underlying
+         tensors in place (same lora_int_id) — this is exactly what
+         ``worker_dispatch.save_weights_for_sampler(model_id=...)`` triggers
+         via ``update_named_weights(LoraLoadRequest)``.
+      5. ``resume_generation(lora_name="lora-target")`` re-opens the event;
+         the retry loop resubmits with ``prompt + accumulated_meow_tokens``
+         and the remaining ``max_tokens``. The new request runs against the
+         now-Woof weights and emits Woof tokens.
+      6. The merged output for the single logical sample call should contain
+         BOTH "meow" (pre-swap segment, preserved across the abort/retry
+         boundary) AND "woof" (post-swap segment, generated with the freshly
+         loaded weights), with meow ordered before woof.
+
+    Why this matters: it's the smallest test that proves the whole point of
+    the multi-LoRA pause feature — that a tenant's in-flight sample can
+    transparently observe a mid-flight weight update without losing
+    accumulated state.
+
+    We shorten the abort grace period so the abort fires well before the
+    sample would naturally finish at max_tokens (which on Qwen3-0.6B at
+    greedy is around 10 s for 512 tokens).
+    """
+    monkeypatch.setattr(
+        "skyrl.backends.skyrl_train.inference_servers.remote_inference_client.ABORT_GENERATION_GRACE_PERIOD_SECONDS",
+        0.5,
+    )
+    # Tinker SamplingParams doesn't expose ignore_eos, but for this test we
+    # need the LoRA-tuned model to keep generating past its natural EOS so
+    # the abort fan-out catches it mid-flight. Monkey-patch the Tinker→vLLM
+    # forwarding map to recognise ignore_eos for the duration of the test.
+    from skyrl.backends.skyrl_train.inference_servers import (
+        remote_inference_client as _ric,
+    )
+
+    monkeypatch.setitem(_ric._TINKER_SAMPLE_TO_VLLM_PARAM_MAP, "ignore_eos", "ignore_eos")
+
+    cfg = _multi_lora_cfg()
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_QWEN3, trust_remote_code=True)
+    prompt_token_ids = _build_prompt_token_ids(tokenizer)
+
+    async with InferenceEngineState.create(
+        cfg=cfg,
+        model=MODEL_QWEN3,
+        use_local=True,
+        async_engine=True,
+        tp_size=1,
+        colocate_all=False,
+        sleep_level=1,
+        enable_lora=True,
+        lora_max_loras=2,
+    ) as engines:
+        client = engines.client
+        assert isinstance(client, RemoteInferenceClient)
+
+        # Step 1: register the adapter name with Meow weights.
+        await client.load_lora_adapter("lora-target", qwen3_meowing_lora_files)
+        try:
+            # Step 2: launch one long sample. With temperature=0 + LoRA +
+            # ignore_eos, the model will emit "Meow!"-pattern tokens until
+            # max_tokens (instead of stopping after the natural EOS).
+            task = asyncio.create_task(_sample_no_eos(client, prompt_token_ids, model="lora-target", max_tokens=512))
+
+            # Give the request a short head start so SOME Meow tokens land,
+            # but keep the pre-pause segment short. A long Meow prefix in
+            # the retried prompt would otherwise out-bias the Woof LoRA's
+            # signal (in-context attention vs LoRA delta), making the
+            # post-resume segment look meow-shaped too.
+            await asyncio.sleep(0.3)
+            assert not task.done(), "sample completed naturally before pause — bump max_tokens"
+
+            # Step 3: pause. Server-side abort returns finish_reason="abort"
+            # with partial tokens; sample_with_retry accumulates them and
+            # blocks on the per-LoRA event.
+            await client.pause_generation(lora_name="lora-target")
+            assert not task.done(), "sample completed during pause grace period — abort/retry path not exercised"
+
+            # Step 4: swap the adapter's weights in place (Meow → Woof).
+            # vLLM keeps the same lora_int_id; the LoRA tensor cache is
+            # repopulated from the new path.
+            await client.load_lora_adapter("lora-target", qwen3_woofing_lora_files)
+
+            # Step 5: resume. Retry loop resubmits with prompt + meow_tokens
+            # and remaining max_tokens. New request hits the now-Woof weights.
+            await client.resume_generation(lora_name="lora-target")
+
+            result = await asyncio.wait_for(task, timeout=120.0)
+
+            seq = result["sequences"][0]
+            assert seq["stop_reason"] in (
+                "stop",
+                "length",
+            ), f"unexpected stop_reason {seq['stop_reason']}; weight-sync recovery may have failed"
+            text = tokenizer.decode(seq["tokens"]).lower()
+            print(f"[swap-resume] merged output (first 300 chars): {text[:300]!r}")
+
+            # Step 6: the merged output must show both LoRA signatures in order.
+            assert "meow" in text, f"pre-pause Meow tokens were not preserved in the final output: {text[:300]!r}"
+            assert (
+                "woof" in text
+            ), f"post-resume Woof tokens missing — weight sync did not take effect for the retried request: {text[:300]!r}"
+            assert text.index("meow") < text.index(
+                "woof"
+            ), f"meow should appear before woof in the merged output but order was reversed: {text[:300]!r}"
+        finally:
+            try:
+                await client.resume_generation(lora_name="lora-target")
+            except Exception:
+                pass
+            await client.unload_lora_adapter("lora-target")
+
+
+@pytest.mark.asyncio
+async def test_global_pause_still_works(local_ray_fixture, qwen3_meowing_lora_files):
+    """pause_generation() (no lora_name) must still drive the global keep-mode pause.
+
+    Regression for the FFT / single-tenant path — we don't want the new
+    ``lora_name`` kwarg to have side-effected the global path.
+    """
+    cfg = _multi_lora_cfg()
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_QWEN3, trust_remote_code=True)
+    prompt_token_ids = _build_prompt_token_ids(tokenizer)
+
+    async with InferenceEngineState.create(
+        cfg=cfg,
+        model=MODEL_QWEN3,
+        use_local=True,
+        async_engine=True,
+        tp_size=1,
+        colocate_all=False,
+        sleep_level=1,
+        enable_lora=True,
+        lora_max_loras=2,
+    ) as engines:
+        client = engines.client
+        assert isinstance(client, RemoteInferenceClient)
+
+        await client.load_lora_adapter("lora-meow", qwen3_meowing_lora_files)
+        try:
+            # Launch one long sample, give it time to enter the scheduler,
+            # then global-pause-then-resume mid-flight. Keep-mode freezes
+            # rather than aborts, so the request continues to completion
+            # with finish_reason != "abort".
+            task = asyncio.create_task(_sample(client, prompt_token_ids, model="lora-meow", max_tokens=128))
+            await asyncio.sleep(0.8)
+            await client.pause_generation()  # global keep-mode pause
+            # No per-LoRA event should be created by the global path.
+            assert "lora-meow" not in client._lora_pause_events
+            await asyncio.sleep(0.5)
+            await client.resume_generation()
+            result = await asyncio.wait_for(task, timeout=60.0)
+            seq = result["sequences"][0]
+            assert seq["stop_reason"] in (
+                "stop",
+                "length",
+            ), f"global-pause regression: stop_reason should not be 'abort', got {seq['stop_reason']}"
+            assert len(seq["tokens"]) > 0
+        finally:
+            await client.unload_lora_adapter("lora-meow")

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -1558,6 +1558,69 @@ class TestTargetedLoraPause:
             await client.teardown()
 
     @pytest.mark.asyncio
+    async def test_sample_with_retry_truncates_prompt_logprobs(self, mock_servers):
+        """prompt_logprobs from the final retry must be truncated to original prompt length.
+
+        When a retry fires, the resubmitted request has
+        ``token_ids = original_prompt + accumulated_tokens``. The server
+        computes prompt_logprobs over that extended prompt and the final
+        response carries entries for both the original prompt AND the
+        accumulated tokens. The caller asked for prompt_logprobs of their
+        original prompt only — the extra entries must be stripped before
+        return, otherwise the response shape differs between the
+        no-abort and abort-then-retry paths for the same logical request.
+        """
+        # Script one abort with 5 partial tokens. The retry then falls
+        # through to the default mock path which returns prompt_logprobs
+        # whenever sampling_params['prompt_logprobs'] is set.
+        for url in mock_servers["server_urls"]:
+            await _script_generate(
+                url,
+                [
+                    {"token_ids": [100, 101, 102, 103, 104], "finish_reason": "abort"},
+                ],
+            )
+        client = RemoteInferenceClient(
+            proxy_url=mock_servers["proxy_url"],
+            server_urls=mock_servers["server_urls"],
+            model_name="base-model",
+            data_parallel_size=1,
+        )
+        try:
+            request_payload = {
+                "json": {
+                    "model": "base-model",
+                    "prompt": {"chunks": [{"tokens": [10, 20, 30]}]},  # length 3
+                    "num_samples": 1,
+                    "sampling_params": {"max_tokens": 64},
+                    "include_prompt_logprobs": True,
+                }
+            }
+            result = await client.sample_with_retry(request_payload)
+
+            # Final length must be the ORIGINAL prompt length (3), not the
+            # extended prompt length (3 + 5 = 8) that the retry sent.
+            pl = result["prompt_logprobs"]
+            assert pl is not None
+            assert len(pl) == 3, f"expected 3 prompt_logprobs entries, got {len(pl)} (likely missing truncation)"
+            # Values should match a single-shot sample for the same original
+            # prompt (position 0 = no prior context, positions 1-2 follow
+            # the mock's autoregressive logprob formula).
+            assert pl[0] is None
+            assert pl[1] == pytest.approx(-0.5)
+            assert pl[2] == pytest.approx(-1.0)
+
+            # Verify the server actually saw an extended-prompt request on
+            # the retry (otherwise the test isn't proving truncation).
+            all_payloads = []
+            for url in mock_servers["server_urls"]:
+                all_payloads.extend(await _get_generate_payloads(url))
+            assert len(all_payloads) == 2
+            assert len(all_payloads[1]["token_ids"]) == 3 + 5
+        finally:
+            await client.teardown()
+
+    @pytest.mark.asyncio
     async def test_sample_with_retry_no_lora_event_no_blocking(self, mock_servers):
         """When the LoRA has never been paused, sample_with_retry must not block."""
         for url in mock_servers["server_urls"]:

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -32,6 +32,16 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
     app.state.last_render_model = None
     # Per-server LoRA registry: lora_name -> lora_path
     app.state.lora_registry = {}
+    # Scripted-response support for testing sample_with_retry. Tests can
+    # POST to /test/script_generate with a list of partial choice payloads
+    # (each merged into the next /inference/v1/generate response) so the
+    # retry loop can be driven through abort → stop transitions.
+    app.state.generate_script: List[Dict] = []
+    app.state.generate_payloads: List[Dict] = []
+    # Tracks the last per-LoRA abort call made to this server, for
+    # /skyrl/v1/abort_lora_requests.
+    app.state.last_abort_lora_name = None
+    app.state.abort_lora_call_count = 0
 
     @app.get("/health")
     async def health():
@@ -79,6 +89,8 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
         sp = body.get("sampling_params", {})
         input_token_ids = body.get("token_ids", [])
         app.state.last_generate_model = body.get("model")
+        # Record incoming payload for sample_with_retry tests to inspect.
+        app.state.generate_payloads.append(body)
         n = sp.get("n", 1)
         # If logprobs is explicitly set (sample path), use n for num_choices.
         # Otherwise (generate path), use len(token_ids) for per-prompt responses.
@@ -86,6 +98,24 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
             num_choices = n
         else:
             num_choices = 1
+
+        # Scripted response path: tests can pre-load a list of choice
+        # overrides into app.state.generate_script. Each call pops the
+        # front entry and merges it into the default choice. The list is
+        # drained in FIFO order; once empty we fall back to the default
+        # "stop" response below.
+        if app.state.generate_script:
+            override = app.state.generate_script.pop(0)
+            default_choice = {
+                "request_id": "dummy",
+                "token_ids": override.get("token_ids", []),
+                "finish_reason": override.get("finish_reason", "stop"),
+                "logprobs": override.get(
+                    "logprobs",
+                    {"content": [{"logprob": -0.1 * (i + 1)} for i in range(len(override.get("token_ids", [])))]},
+                ),
+            }
+            return {"choices": [default_choice for _ in range(num_choices)]}
 
         response: dict = {
             "choices": [
@@ -210,6 +240,35 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
     @app.post("/resume")
     async def resume():
         return {"status": "resumed", "server_id": server_id}
+
+    @app.post("/skyrl/v1/abort_lora_requests")
+    async def abort_lora_requests(request: Request):
+        body = await request.json()
+        lora_name = body.get("lora_name")
+        if not lora_name:
+            return JSONResponse(status_code=400, content={"error": "'lora_name' required"})
+        app.state.last_abort_lora_name = lora_name
+        app.state.abort_lora_call_count += 1
+        return {"status": "ok", "aborted": [], "count": 0, "server_id": server_id}
+
+    @app.post("/test/script_generate")
+    async def script_generate(request: Request):
+        """Test helper: pre-load scripted responses for /inference/v1/generate."""
+        body = await request.json()
+        app.state.generate_script = list(body.get("script", []))
+        app.state.generate_payloads = []
+        return {"status": "ok"}
+
+    @app.get("/test/abort_lora_state")
+    async def abort_lora_state():
+        return {
+            "last_abort_lora_name": app.state.last_abort_lora_name,
+            "abort_lora_call_count": app.state.abort_lora_call_count,
+        }
+
+    @app.get("/test/generate_payloads")
+    async def get_generate_payloads():
+        return {"payloads": app.state.generate_payloads}
 
     @app.get("/is_paused")
     async def is_paused():
@@ -1243,5 +1302,284 @@ class TestExplicitModelRequired:
             }
             with pytest.raises(ValueError, match="LoRA is enabled"):
                 await client.sample(request_payload)
+        finally:
+            await client.teardown()
+
+
+# ---------------------------------------------------------------------------
+# Targeted (per-LoRA) pause + sample_with_retry tests.
+# TRANSIENT: delete this section when vLLM ships native per-LoRA pause and
+# the sample_with_retry / per-LoRA gate are removed.
+# ---------------------------------------------------------------------------
+
+
+async def _script_generate(server_url: str, script: List[Dict]) -> None:
+    """Helper: pre-load scripted /inference/v1/generate responses on one server."""
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{server_url}/test/script_generate", json={"script": script}) as resp:
+            assert resp.status == 200
+
+
+async def _get_generate_payloads(server_url: str) -> List[Dict]:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{server_url}/test/generate_payloads") as resp:
+            data = await resp.json()
+            return data["payloads"]
+
+
+async def _get_abort_lora_state(server_url: str) -> Dict:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{server_url}/test/abort_lora_state") as resp:
+            return await resp.json()
+
+
+class TestTargetedLoraPause:
+    """Tests for pause_generation(lora_name=...) and sample_with_retry."""
+
+    @pytest.mark.asyncio
+    async def test_pause_generation_with_lora_name_fans_out_abort(self, mock_servers, monkeypatch):
+        """pause_generation(lora_name=X) clears the event and fans out abort to all servers."""
+        # Shorten the grace period so this test runs quickly.
+        monkeypatch.setattr(
+            "skyrl.backends.skyrl_train.inference_servers.remote_inference_client.ABORT_GENERATION_GRACE_PERIOD_SECONDS",
+            0,
+        )
+        client = RemoteInferenceClient(
+            proxy_url=mock_servers["proxy_url"],
+            server_urls=mock_servers["server_urls"],
+            model_name="base-model",
+            data_parallel_size=1,
+        )
+        try:
+            result = await client.pause_generation(lora_name="lora-A")
+            assert len(result) == 2  # fanned out to both servers
+            for url, resp in result.items():
+                assert resp["status"] == 200
+                assert resp["body"]["status"] == "ok"
+                assert resp["body"]["server_id"] in (0, 1)
+            # Both servers should have observed the abort call.
+            for url in mock_servers["server_urls"]:
+                state = await _get_abort_lora_state(url)
+                assert state["last_abort_lora_name"] == "lora-A"
+                assert state["abort_lora_call_count"] >= 1
+            # Event is now CLEAR (paused). resume_generation should re-open it.
+            ev = client._lora_pause_events["lora-A"]
+            assert not ev.is_set()
+            await client.resume_generation(lora_name="lora-A")
+            assert ev.is_set()
+        finally:
+            await client.teardown()
+
+    @pytest.mark.asyncio
+    async def test_pause_generation_without_lora_uses_keep_mode(self, mock_servers):
+        """pause_generation() (no lora_name) preserves the global keep-mode path."""
+        client = RemoteInferenceClient(
+            proxy_url=mock_servers["proxy_url"],
+            server_urls=mock_servers["server_urls"],
+            model_name="base-model",
+            data_parallel_size=1,
+        )
+        try:
+            result = await client.pause_generation()
+            assert len(result) == 2
+            for url, resp in result.items():
+                assert resp["status"] == 200
+                # The mock /pause echoes back the mode query param.
+                assert resp["body"]["mode"] == "keep"
+            # No per-LoRA event should have been created.
+            assert client._lora_pause_events == {}
+        finally:
+            await client.teardown()
+
+    @pytest.mark.asyncio
+    async def test_sample_with_retry_accumulates_on_abort(self, mock_servers):
+        """abort-then-stop: tokens are accumulated, max_tokens decremented, final stop_reason='stop'."""
+        # Script the first response as abort with 5 tokens, second as stop with 4 tokens.
+        # The mock has only one /inference/v1/generate endpoint shared by both servers,
+        # so we script both servers identically — the second call may hit either server
+        # (random load balancing) but both will produce the same scripted "stop" response.
+        for url in mock_servers["server_urls"]:
+            await _script_generate(
+                url,
+                [
+                    {
+                        "token_ids": [100, 101, 102, 103, 104],
+                        "finish_reason": "abort",
+                        "logprobs": {"content": [{"logprob": -0.1 * i} for i in range(1, 6)]},
+                    },
+                    {
+                        "token_ids": [200, 201, 202, 203],
+                        "finish_reason": "stop",
+                        "logprobs": {"content": [{"logprob": -0.2 * i} for i in range(1, 5)]},
+                    },
+                ],
+            )
+
+        client = RemoteInferenceClient(
+            proxy_url=mock_servers["proxy_url"],
+            server_urls=mock_servers["server_urls"],
+            model_name="base-model",
+            data_parallel_size=1,
+        )
+        try:
+            request_payload = {
+                "json": {
+                    "model": "lora-A",
+                    "prompt": {"chunks": [{"tokens": [10, 20, 30]}]},
+                    "num_samples": 1,
+                    "sampling_params": {"max_tokens": 16, "temperature": 0.7},
+                }
+            }
+            result = await client.sample_with_retry(request_payload)
+
+            seq = result["sequences"][0]
+            assert seq["tokens"] == [100, 101, 102, 103, 104, 200, 201, 202, 203]
+            assert seq["stop_reason"] == "stop"
+            assert seq["logprobs"] is not None
+            assert len(seq["logprobs"]) == 9
+
+            # Verify retry math: second call's token_ids = original + accumulated,
+            # max_tokens reduced by len(accumulated). Inspect both servers since
+            # routing is random.
+            all_payloads = []
+            for url in mock_servers["server_urls"]:
+                all_payloads.extend(await _get_generate_payloads(url))
+            assert len(all_payloads) == 2
+            assert all_payloads[0]["token_ids"] == [10, 20, 30]
+            assert all_payloads[0]["sampling_params"]["max_tokens"] == 16
+            assert all_payloads[1]["token_ids"] == [10, 20, 30, 100, 101, 102, 103, 104]
+            assert all_payloads[1]["sampling_params"]["max_tokens"] == 16 - 5
+        finally:
+            await client.teardown()
+
+    @pytest.mark.asyncio
+    async def test_sample_with_retry_no_abort_single_shot(self, mock_servers):
+        """When no abort happens, sample_with_retry behaves like a single sample()."""
+        # Clear any scripts left from prior tests.
+        for url in mock_servers["server_urls"]:
+            await _script_generate(url, [])
+        client = RemoteInferenceClient(
+            proxy_url=mock_servers["proxy_url"],
+            server_urls=mock_servers["server_urls"],
+            model_name="base-model",
+            data_parallel_size=1,
+        )
+        try:
+            request_payload = {
+                "json": {
+                    "model": "lora-A",
+                    "prompt": {"chunks": [{"tokens": [10, 20, 30]}]},
+                    "num_samples": 1,
+                    "sampling_params": {"max_tokens": 16},
+                }
+            }
+            result = await client.sample_with_retry(request_payload)
+            seq = result["sequences"][0]
+            # Default mock returns tokens [0, 1, 2] with stop.
+            assert seq["tokens"] == [0, 1, 2]
+            assert seq["stop_reason"] == "stop"
+        finally:
+            await client.teardown()
+
+    @pytest.mark.asyncio
+    async def test_sample_with_retry_blocks_until_resume(self, mock_servers, monkeypatch):
+        """While pause_generation(lora_name=X) is active, sample_with_retry for X blocks."""
+        # Shorten grace so the test does not stall on the pause helper.
+        monkeypatch.setattr(
+            "skyrl.backends.skyrl_train.inference_servers.remote_inference_client.ABORT_GENERATION_GRACE_PERIOD_SECONDS",
+            0,
+        )
+        # Script every call as abort so the retry loop is bound entirely by the gate.
+        # We only need the gate test, so any abort/stop sequence works once unpaused.
+        for url in mock_servers["server_urls"]:
+            await _script_generate(
+                url,
+                [
+                    {"token_ids": [1, 2, 3], "finish_reason": "abort"},
+                    {"token_ids": [4, 5], "finish_reason": "stop"},
+                ],
+            )
+
+        client = RemoteInferenceClient(
+            proxy_url=mock_servers["proxy_url"],
+            server_urls=mock_servers["server_urls"],
+            model_name="base-model",
+            data_parallel_size=1,
+        )
+        try:
+            # Pause first so the event is created and CLEAR before the sample starts.
+            await client.pause_generation(lora_name="lora-A")
+
+            request_payload = {
+                "json": {
+                    "model": "lora-A",
+                    "prompt": {"chunks": [{"tokens": [10, 20, 30]}]},
+                    "num_samples": 1,
+                    "sampling_params": {"max_tokens": 16},
+                }
+            }
+            sample_task = asyncio.create_task(client.sample_with_retry(request_payload))
+
+            # Give the sample loop time to reach the .wait() on the event.
+            await asyncio.sleep(0.1)
+            assert not sample_task.done(), "sample_with_retry should block while paused"
+
+            # Resume → sample_with_retry continues, completes via scripted stop.
+            await client.resume_generation(lora_name="lora-A")
+            result = await asyncio.wait_for(sample_task, timeout=5.0)
+            seq = result["sequences"][0]
+            # First scripted response is abort with 3 tokens, second is stop with 2.
+            assert seq["tokens"] == [1, 2, 3, 4, 5]
+            assert seq["stop_reason"] == "stop"
+        finally:
+            await client.teardown()
+
+    @pytest.mark.asyncio
+    async def test_sample_with_retry_rejects_n_gt_one(self, mock_servers):
+        """sample_with_retry only supports num_samples=1."""
+        client = RemoteInferenceClient(
+            proxy_url=mock_servers["proxy_url"],
+            server_urls=mock_servers["server_urls"],
+            model_name="base-model",
+            data_parallel_size=1,
+        )
+        try:
+            request_payload = {
+                "json": {
+                    "model": "lora-A",
+                    "prompt": {"chunks": [{"tokens": [1]}]},
+                    "num_samples": 2,
+                    "sampling_params": {"max_tokens": 8},
+                }
+            }
+            with pytest.raises(ValueError, match="num_samples=1"):
+                await client.sample_with_retry(request_payload)
+        finally:
+            await client.teardown()
+
+    @pytest.mark.asyncio
+    async def test_sample_with_retry_no_lora_event_no_blocking(self, mock_servers):
+        """When the LoRA has never been paused, sample_with_retry must not block."""
+        for url in mock_servers["server_urls"]:
+            await _script_generate(url, [])  # default mock returns "stop"
+        client = RemoteInferenceClient(
+            proxy_url=mock_servers["proxy_url"],
+            server_urls=mock_servers["server_urls"],
+            model_name="base-model",
+            data_parallel_size=1,
+        )
+        try:
+            request_payload = {
+                "json": {
+                    "model": "unpaused-lora",
+                    "prompt": {"chunks": [{"tokens": [1]}]},
+                    "num_samples": 1,
+                    "sampling_params": {"max_tokens": 8},
+                }
+            }
+            # Should complete promptly with no event ever created for "unpaused-lora".
+            result = await asyncio.wait_for(client.sample_with_retry(request_payload), timeout=2.0)
+            assert result["sequences"][0]["stop_reason"] == "stop"
+            assert "unpaused-lora" not in client._lora_pause_events
         finally:
             await client.teardown()


### PR DESCRIPTION
Addresses https://github.com/NovaSky-AI/SkyRL/issues/1647

Today's `pause_generation()` is a **global** vLLM keep-mode pause: when one LoRA tenant syncs new weights, every other tenant's in-flight generation freezes for the duration of the swap. This blocks practical multi-tenant LoRA RL training.

This PR adds a per-LoRA `lora_name` arg to pause/resume so a weight sync for adapter A only aborts A's requests; other adapters keep generating. The aborted requests come back with `finish_reason="abort"` and partial tokens, and a new `sample_with_retry()` client method accumulates those partial tokens, awaits resume, and resubmits with `prompt + accumulated` and remaining `max_tokens` until completion.

**This is a transient fix.** Hopefully in the future if we can upstream a lora specific pause, we delete `sample_with_retry`, the per-LoRA gate, and the abort endpoint; the `lora_name` kwarg stays and routes to the new vLLM API.

## What changed

### New: `/skyrl/v1/abort_lora_requests` server endpoint

[vllm_server_actor.py](skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py) gets a small custom endpoint that iterates `engine.output_processor.request_states`, filters by `lora_name`, and calls `engine.abort(ids, internal=True)`. `internal=True` is load-bearing — the states dict is keyed by internal IDs.

### `pause_generation`/`resume_generation` gain `lora_name: Optional[str] = None`

- `lora_name=None` → unchanged: vLLM `/pause?mode=keep` global pause.
- `lora_name="X"` → clears a per-LoRA `asyncio.Event` (gates retries client-side), sleeps a 5 s grace, then fans out to `/skyrl/v1/abort_lora_requests`.

The new inference path (`_SKYRL_USE_NEW_INFERENCE=1`, the default) goes through `RemoteInferenceClient` → `vllm_server_actor`, which is where the new `/skyrl/v1/abort_lora_requests` endpoint lives — so that's the only path that actually supports targeted pause. Legacy-path classes (`InferenceEngineClient`, `RayWrappedInferenceEngine`, `RemoteInferenceEngine`, `AsyncVLLMInferenceEngine`) accept the `lora_name` kwarg as a guardrail but raise `NotImplementedError("targeted pause is HTTP-only")` when it's non-None. The legacy path keeps its existing global-pause behavior unchanged.

### `RemoteInferenceClient`: `sample()` refactor + new `sample_with_retry()`

This is the only data-plane surface that gained retry logic.

**`sample()` is split**:

- `sample()` — renders the prompt and dispatches once. **Public behavior unchanged.**
- `_sample_with_rendered_tokens()` — the post-render half, parameterized on rendered `token_ids`. Pure refactor (regression-checked by the existing `TestSample` tests).

**`sample_with_retry()` is new** — the only retry-bearing method. Renders once, then runs a `while stop_reason == "abort"` loop:

1. `await _lora_pause_events[model].wait()` (no-op if no event exists).
2. Build a body with `token_ids = original_prompt + accum_tokens` and `max_tokens = original_max_tokens - len(accum_tokens)`.
3. Dispatch `_sample_with_rendered_tokens`.
4. Extend `accum_tokens` + `accum_logprobs` with the returned segment.
5. Repeat until non-abort.

Returns the same `SampleResponse` shape as `sample()`. Asserts `num_samples == 1` (current Tinker callers all do this; multi-sample retry is straightforward but deferred).

`generate()`, `chat_completion()`, `completion()` are **untouched** — no retry, no per-LoRA gating. The multi-tenant Tinker path is the only production caller that flips to retry mode.

### `worker_dispatch.save_weights_for_sampler` threads `lora_name`

[worker_dispatch.py](skyrl/backends/skyrl_train/workers/worker_dispatch.py) non-colocate branch forwards `model_id` (set by `SkyRLTrainBackend.save_sampler_checkpoint` to the LoRA name for multi-tenant, `None` for FFT) to the pause/resume calls.

## API impact

| API | Change | Migration |
|---|---|---|
| `InferenceEngineInterface.pause_generation` / `resume_generation` | New optional `lora_name: Optional[str] = None` kwarg. | None — default preserves existing behavior on every subclass. |
| `RemoteInferenceClient.sample()` | **Refactored** into render + dispatch (pure refactor; public behavior unchanged). | None. |
| `RemoteInferenceClient.sample_with_retry()` | **New.** Same signature/return as `sample()`. | Optional; auto-used by the multi-LoRA path in `SkyRLTrainBackend`. |
| `generate()`, `chat_completion()`, `completion()` | **Unchanged.** No retry, no per-LoRA gate. | None. |
| `worker_dispatch.save_weights_for_sampler` | Now forwards `lora_name=model_id` to pause/resume on the non-colocate path. | None — `model_id=None` for FFT preserves the global keep-mode pause. |

## Tests

### Unit (no GPU) — `tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py`

7 new cases in `TestTargetedLoraPause`:

- `pause_generation(lora_name=X)` clears the event and fans out abort.
- `pause_generation()` (no lora_name) still drives keep-mode.
- `sample_with_retry` accumulates partial tokens across an abort, `max_tokens` decrements correctly, logprobs concatenate, final response shape OK.
- `sample_with_retry` no-abort path is a single shot (refactor regression).
- `sample_with_retry` blocks on the per-LoRA event until `resume_generation` is called.
- `sample_with_retry` rejects `num_samples > 1`.
- LoRAs that were never paused never block (no spurious event creation).

### GPU integration — `tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_pause_lora.py`

4 end-to-end cases, run against a real vLLM server with two LoRA adapters (Meow + Woof) loaded:

1. **`test_pause_lora_does_not_affect_other_lora`** — while lora-meow is paused, 4 concurrent `sample_with_retry(model="lora-woof")` calls complete promptly and contain "woof" content (proves the gate doesn't spill across adapters and weights aren't mixed up).
2. **`test_sample_with_retry_recovers_from_abort`** — 4+4 concurrent in-flight samples on meow + woof; pausing lora-meow mid-flight aborts all 4 meow requests, retry resubmits after resume, all 8 complete with non-abort stop reasons and correct content. **Hard-asserts** 0/8 tasks completed pre-pause and 0/4 escaped during the pause window — without these assertions the test would silently no-op if the LoRA emitted EOS too fast.
3. **`test_pause_swap_weights_resume_mid_sample`** — single sample call spans a real weight swap: starts with Meow weights, mid-flight calls `pause → load_lora_adapter("lora-target", woof_path) → resume`, and the merged output literally shows `meow meow meow ... woof woof woof`. Proves the abort/retry boundary preserves accumulated state AND that the retried request observes the newly-loaded weights.
4. **`test_global_pause_still_works`** — `pause_generation()` with no `lora_name` still drives keep-mode pause (FFT regression).