### PR TITLE
[multi-tenant-lora] Expose per-LoRA pause state over HTTP

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -1161,11 +1161,27 @@ class RemoteInferenceClient:
         )
 
     async def resume_generation(self, lora_name: Optional[str] = None) -> Dict[str, Any]:
-        """Resume generation. ``lora_name`` must match the prior pause call."""
+        """Resume generation. ``lora_name`` must match the prior pause call.
+
+        For the per-LoRA branch, releases both the local in-process gate (so
+        in-process ``sample_with_retry`` callers can resubmit immediately) and
+        the server-side gate via ``/skyrl/v1/resume_lora_requests`` (so the
+        submission gate on each worker stops blocking fresh /v1/completions
+        and out-of-process callers polling ``/skyrl/v1/wait_lora_unpaused``
+        unblock). The local set happens first so in-process retries don't
+        wait on the HTTP round-trip; brief inconsistency between the two
+        gates is fine — the retry loop just spins one extra iteration.
+
+        TRANSIENT: the ``lora_name`` branch (and the HTTP call) should be
+        deleted when vLLM ships native per-LoRA pause.
+        """
         if lora_name is None:
             return await self.resume()
         self._get_lora_pause_event(lora_name).set()
-        return {"status": "ok"}
+        return await self._call_all_servers(
+            "/skyrl/v1/resume_lora_requests",
+            json={"lora_name": lora_name},
+        )
 
     async def sleep(self, level: int = 2, tags: Optional[List[str]] = None) -> Dict[str, Any]:
         """

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -3,6 +3,7 @@ vLLM Server Actor - Ray actor running a vLLM OpenAI-compatible API server.
 """
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -369,6 +370,79 @@ class VLLMServerActor(ServerActorProtocol):
         engine = self._engine
         cli_args = self._cli_args
 
+        # TRANSIENT: per-LoRA pause state (``dict[str, asyncio.Event]``) shared
+        # across the abort/resume/wait endpoints below and the /v1/completions
+        # submission gate. Mirrors the in-process ``_lora_pause_events`` dict
+        # on RemoteInferenceClient so out-of-process callers (e.g. the Tinker
+        # SkyRLTrainInferenceForwardingClient) can observe the same pause
+        # window. Delete with ``_abort_lora_requests`` when vLLM ships native
+        # per-LoRA pause.
+        app.state.paused_loras = {}
+
+        def _get_pause_event(lora_name: str) -> asyncio.Event:
+            ev = app.state.paused_loras.get(lora_name)
+            if ev is None:
+                ev = asyncio.Event()
+                ev.set()  # SET = open (not paused)
+                app.state.paused_loras[lora_name] = ev
+            return ev
+
+        # Submission gate: pending /v1/completions and /v1/chat/completions for
+        # a currently-paused LoRA block until resume. Without this, a fresh
+        # request submitted between abort_lora_requests and load_lora_adapter
+        # could observe torn adapter weights.
+        #
+        # Implemented as pure ASGI middleware (not @app.middleware("http"))
+        # because the BaseHTTPMiddleware shim buffers streaming responses,
+        # which would regress vLLM's SSE completions path.
+        _paused_loras = app.state.paused_loras
+        _gated_paths = {"/v1/completions", "/v1/chat/completions"}
+
+        class _LoraPauseSubmissionGate:
+            def __init__(self, inner_app):
+                self.inner_app = inner_app
+
+            async def __call__(self, scope, receive, send):
+                if scope.get("type") != "http" or scope.get("path") not in _gated_paths:
+                    await self.inner_app(scope, receive, send)
+                    return
+
+                # Buffer the request body so we can peek at ``model`` and replay.
+                chunks: list[bytes] = []
+                more_body = True
+                while more_body:
+                    msg = await receive()
+                    chunks.append(msg.get("body", b""))
+                    more_body = msg.get("more_body", False)
+                body = b"".join(chunks)
+
+                model: Optional[str] = None
+                if body:
+                    try:
+                        parsed = json.loads(body)
+                    except json.JSONDecodeError:
+                        parsed = None
+                    if isinstance(parsed, dict):
+                        model = parsed.get("model")
+
+                if model:
+                    ev = _paused_loras.get(model)
+                    if ev is not None and not ev.is_set():
+                        await ev.wait()
+
+                replayed = False
+
+                async def _replay():
+                    nonlocal replayed
+                    if not replayed:
+                        replayed = True
+                        return {"type": "http.request", "body": body, "more_body": False}
+                    return {"type": "http.disconnect"}
+
+                await self.inner_app(scope, _replay, send)
+
+        app.add_middleware(_LoraPauseSubmissionGate)
+
         # Weight sync uses vLLM native endpoints (/init_weight_transfer_engine,
         # /update_weights, /get_world_size) registered by the RLHF router when
         # VLLM_SERVER_DEV_MODE=1.
@@ -430,17 +504,54 @@ class VLLMServerActor(ServerActorProtocol):
             Iterates ``engine.output_processor.request_states`` (keyed by internal
             request IDs) and aborts those whose ``lora_name`` matches. Other
             adapters' requests are untouched.
+
+            Also flips the per-LoRA pause flag (clears the event) so the
+            submission-gate middleware blocks any *fresh* /v1/completions for
+            this LoRA until ``/skyrl/v1/resume_lora_requests`` is called.
             """
             body = await request.json()
             lora_name = body.get("lora_name")
             if not lora_name:
                 raise HTTPException(status_code=400, detail="'lora_name' required")
+            _get_pause_event(lora_name).clear()
             op = engine.output_processor
             # request_states is keyed by *internal* IDs; pass internal=True to abort().
             ids = [rid for rid, st in op.request_states.items() if st.lora_name == lora_name]
             if ids:
                 await engine.abort(ids, internal=True)
             return {"status": "ok", "aborted": ids, "count": len(ids)}
+
+        # TRANSIENT: counterpart to /skyrl/v1/abort_lora_requests. Delete with
+        # that endpoint when vLLM ships native per-LoRA pause.
+        @app.post("/skyrl/v1/resume_lora_requests")
+        async def _resume_lora_requests(request: Request):
+            """Clear a LoRA's pause flag so blocked /v1/completions can proceed."""
+            body = await request.json()
+            lora_name = body.get("lora_name")
+            if not lora_name:
+                raise HTTPException(status_code=400, detail="'lora_name' required")
+            _get_pause_event(lora_name).set()
+            return {"status": "ok"}
+
+        # TRANSIENT: long-poll endpoint that out-of-process clients (e.g. the
+        # Tinker SkyRLTrainInferenceForwardingClient) use to wait for resume
+        # before retrying an aborted sample. Returns ``{"paused": false}`` once
+        # the LoRA is unpaused, or ``{"paused": true}`` after ``timeout_s``
+        # so the caller can loop and re-poll. Delete with the abort/resume
+        # endpoints when vLLM ships native per-LoRA pause.
+        @app.post("/skyrl/v1/wait_lora_unpaused")
+        async def _wait_lora_unpaused(request: Request):
+            body = await request.json()
+            lora_name = body.get("lora_name")
+            if not lora_name:
+                raise HTTPException(status_code=400, detail="'lora_name' required")
+            timeout_s = body.get("timeout_s", 60.0)
+            ev = _get_pause_event(lora_name)
+            try:
+                await asyncio.wait_for(ev.wait(), timeout=float(timeout_s))
+                return {"paused": False}
+            except asyncio.TimeoutError:
+                return {"paused": True}
 
         # NOTE (sumanthrh): We use a custom generate endpoint /skyrl/v1/generate because the native
         # endpoint /inference/v1/generate does not support returning routed expert IDs.

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -251,6 +251,14 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
         app.state.abort_lora_call_count += 1
         return {"status": "ok", "aborted": [], "count": 0, "server_id": server_id}
 
+    @app.post("/skyrl/v1/resume_lora_requests")
+    async def resume_lora_requests(request: Request):
+        body = await request.json()
+        lora_name = body.get("lora_name")
+        if not lora_name:
+            return JSONResponse(status_code=400, content={"error": "'lora_name' required"})
+        return {"status": "ok", "server_id": server_id}
+
     @app.post("/test/script_generate")
     async def script_generate(request: Request):
         """Test helper: pre-load scripted responses for /inference/v1/generate."""


### PR DESCRIPTION
## Summary

Exposes the per-LoRA pause state from `RemoteInferenceClient.sample_with_retry` over HTTP so out-of-process callers (the Tinker `SkyRLTrainInferenceForwardingClient` from #1638) can participate in the same pause/resume cycle as in-process callers.

This is the first of two PRs that finish the fully-async multi-tenant Tinker path. Follow-up PR will use these endpoints to add `sample_with_retry`-equivalent abort recovery to the Tinker forwarding client and add Tinker-side tests that mirror `test_pause_lora.py`.

## Background

Today `RemoteInferenceClient.sample_with_retry` (added in #1657) uses an in-process `_lora_pause_events: dict[str, asyncio.Event]` to gate retries during a per-LoRA pause window. The Tinker API process runs in a separate Python process and cannot observe that dict, so an in-flight Tinker asample for a paused LoRA today:

1. Sees `finish_reason="abort"` in the vLLM response but maps it to `stop_reason="length"` (silent corruption — fix lands in the follow-up PR), and
2. A fresh Tinker asample for the same LoRA submitted during the pause window races with `load_lora_adapter` and can observe torn adapter weights.

## Changes

`skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py`:
- `app.state.paused_loras: dict[str, asyncio.Event]` initialised in `_add_custom_endpoints`. Mirrors the in-process gate.
- Existing `POST /skyrl/v1/abort_lora_requests` (#1657) now also clears the per-LoRA event before the `engine.abort()` fan-out.
- New `POST /skyrl/v1/resume_lora_requests {lora_name}`: sets the event.
- New `POST /skyrl/v1/wait_lora_unpaused {lora_name, timeout_s?}`: long-polls; returns `{paused: false}` once the event is set or `{paused: true}` after timeout so the caller can loop.
- New pure-ASGI submission-gate middleware: pending `/v1/completions` and `/v1/chat/completions` for a currently-paused LoRA block until resume. Closes the race in (2) above. Pure ASGI (not `@app.middleware("http")`) because `BaseHTTPMiddleware` buffers streaming responses and would regress vLLM's SSE completions path.

`skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py`:
- `resume_generation(lora_name=X)` now also POSTs `/skyrl/v1/resume_lora_requests` to all `server_urls` so the server-side flag matches the in-process gate. The local set still happens first, so in-process retries don't wait on the HTTP round-trip; brief inconsistency between the two gates just causes one extra retry-loop iteration.

All new endpoints carry the same TRANSIENT marker as the existing abort endpoint: delete the stack when vLLM ships native per-LoRA pause.

## Test plan

- [x] `ruff` + `black` clean
- [ ] `tests/backends/skyrl_train/gpu/gpu_ci/inference_servers/test_pause_lora.py` (existing pause/resume suite) passes — every test exercises `pause_generation` and `resume_generation`, so my changes are validated indirectly. New endpoints (`/skyrl/v1/wait_lora_unpaused`, submission gate) are exercised by the follow-up PR's Tinker-side test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)