### PR TITLE
[feat] Add a Tinker-compatible `forward(loss_fn=...)` API to SkyRL's FSDP and Megatron policy workers and refactor worker outputs

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/dispatch.py
+++ b/skyrl/backends/skyrl_train/distributed/dispatch.py
@@ -272,3 +272,35 @@ def concatenate_outputs_after_mesh_dispatch(
     for i in range(actor_infos[0].rank.dp_size):
         shards.append(dp_rank_to_shard[i])
     return TrainingOutputBatch.cat(shards)
+
+
+def concatenate_dict_outputs_after_mesh_dispatch(
+    actor_infos: List[ActorInfo], data_batches: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Concatenate dict-of-tensor outputs from different ranks after mesh dispatch.
+
+    Plain-dict counterpart of :func:`concatenate_outputs_after_mesh_dispatch`,
+    used now that worker ``forward`` methods return ``Dict[str, Any]`` instead
+    of ``TrainingOutputBatch``. Tensors under the same key are concatenated
+    along dim 0 across DP ranks; non-tensor values are taken from the first
+    DP shard.
+    """
+    import torch
+
+    assert len(actor_infos) == len(data_batches), "`actor_infos` and `data_batches` must have the same length"
+    dp_rank_to_shard: Dict[int, Dict[str, Any]] = {}
+    for actor_info, data_batch in zip(actor_infos, data_batches):
+        if actor_info.rank.is_collection_dp_rank():
+            dp_rank_to_shard[actor_info.rank.dp] = data_batch
+    shards = [dp_rank_to_shard[i] for i in range(actor_infos[0].rank.dp_size)]
+    if not shards:
+        return {}
+
+    out: Dict[str, Any] = {}
+    for key, value in shards[0].items():
+        if isinstance(value, torch.Tensor):
+            out[key] = torch.cat([shard[key] for shard in shards], dim=0)
+        else:
+            # Non-tensor (e.g. scalar metric) — keep the first shard's value.
+            out[key] = value
+    return out

--- a/skyrl/backends/skyrl_train/distributed/dispatch.py
+++ b/skyrl/backends/skyrl_train/distributed/dispatch.py
@@ -275,7 +275,7 @@ def concatenate_outputs_after_mesh_dispatch(
     return TrainingOutputBatch.cat(shards)
 
 
-@dataclass
+@dataclass(frozen=True)
 class WorkerOutput:
     """Unified worker output for ``forward`` and ``forward_backward``.
 

--- a/skyrl/backends/skyrl_train/distributed/dispatch.py
+++ b/skyrl/backends/skyrl_train/distributed/dispatch.py
@@ -1,10 +1,11 @@
 """Defines dispatch and collect logic for distributed training"""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Tuple, Type
 
 import ray
+import torch
 from ray import ObjectRef
 from ray.actor import ActorHandle
 
@@ -274,33 +275,72 @@ def concatenate_outputs_after_mesh_dispatch(
     return TrainingOutputBatch.cat(shards)
 
 
-def concatenate_dict_outputs_after_mesh_dispatch(
-    actor_infos: List[ActorInfo], data_batches: List[Dict[str, Any]]
-) -> Dict[str, Any]:
-    """Concatenate dict-of-tensor outputs from different ranks after mesh dispatch.
+@dataclass
+class WorkerOutput:
+    """Unified worker output for ``forward`` and ``forward_backward``.
 
-    Plain-dict counterpart of :func:`concatenate_outputs_after_mesh_dispatch`,
-    used now that worker ``forward`` methods return ``Dict[str, Any]`` instead
-    of ``TrainingOutputBatch``. Tensors under the same key are concatenated
-    along dim 0 across DP ranks; non-tensor values are taken from the first
-    DP shard.
+    All worker-side outputs (RL / SFT, inference / loss-with-backward) flow
+    through this dataclass at the dispatch boundary so callers can program
+    against a uniform API.
+
+    Attributes:
+        loss_fn_output_type: Tag describing the schema of each entry in
+            ``loss_fn_outputs`` (e.g. ``"scalar"`` for per-token scalar arrays).
+        loss_fn_outputs: Per-sample list of dicts. Each entry contains keys
+            specific to the worker role (e.g. ``logprobs`` for policy/ref,
+            ``values`` for critic, plus optional ``elementwise_loss`` on the
+            SFT path).
+        metrics: Scalar metrics (loss, lr, response_length, ...). Already
+            all-reduced across DP ranks by the worker.
     """
-    import torch
 
-    assert len(actor_infos) == len(data_batches), "`actor_infos` and `data_batches` must have the same length"
-    dp_rank_to_shard: Dict[int, Dict[str, Any]] = {}
-    for actor_info, data_batch in zip(actor_infos, data_batches):
-        if actor_info.rank.is_collection_dp_rank():
-            dp_rank_to_shard[actor_info.rank.dp] = data_batch
-    shards = [dp_rank_to_shard[i] for i in range(actor_infos[0].rank.dp_size)]
-    if not shards:
-        return {}
+    loss_fn_output_type: str = "scalar"
+    loss_fn_outputs: List[Dict[str, Any]] = field(default_factory=list)
+    metrics: Dict[str, Any] = field(default_factory=dict)
 
-    out: Dict[str, Any] = {}
-    for key, value in shards[0].items():
-        if isinstance(value, torch.Tensor):
-            out[key] = torch.cat([shard[key] for shard in shards], dim=0)
-        else:
-            # Non-tensor (e.g. scalar metric) — keep the first shard's value.
-            out[key] = value
-    return out
+    @classmethod
+    def cat(cls, actor_infos: List[ActorInfo], shards: List["WorkerOutput"]) -> "WorkerOutput":
+        """Concatenate per-DP-rank shards in DP-rank order.
+
+        Only collects from collection DP ranks (matches
+        :meth:`MeshRank.is_collection_dp_rank`). ``loss_fn_outputs`` are
+        concatenated; ``metrics`` are taken from the first DP shard (they are
+        already all-reduced across DP within the worker).
+        """
+        assert len(actor_infos) == len(shards), "`actor_infos` and `shards` must have the same length"
+        dp_rank_to_shard: Dict[int, "WorkerOutput"] = {}
+        for ai, s in zip(actor_infos, shards):
+            if ai.rank.is_collection_dp_rank():
+                dp_rank_to_shard[ai.rank.dp] = s
+        if not dp_rank_to_shard:
+            return cls()
+        ordered = [dp_rank_to_shard[i] for i in range(actor_infos[0].rank.dp_size)]
+        return cls(
+            loss_fn_output_type=ordered[0].loss_fn_output_type,
+            loss_fn_outputs=[x for s in ordered for x in s.loss_fn_outputs],
+            metrics=dict(ordered[0].metrics),
+        )
+
+
+def loss_fn_outputs_to_tensor(
+    outputs: List[Dict[str, Any]],
+    key: str = "logprobs",
+    pad_value: float = 0.0,
+    dtype=torch.float32,
+    device=None,
+) -> torch.Tensor:
+    """Re-stack per-sample loss_fn_outputs into a right-padded ``[B, T_max]`` tensor.
+
+    Args:
+        outputs: Per-sample list of dicts (as in :attr:`WorkerOutput.loss_fn_outputs`).
+        key: Field to extract from each dict (e.g. ``"logprobs"`` for policy/ref,
+            ``"values"`` for critic).
+        pad_value: Padding value for right-padding shorter sequences.
+        dtype: Target dtype for the output tensor.
+        device: Optional target device.
+
+    Returns:
+        ``torch.Tensor[B, T_max]`` right-padded with ``pad_value``.
+    """
+    seqs = [torch.tensor(o[key], dtype=dtype, device=device) for o in outputs]
+    return torch.nn.utils.rnn.pad_sequence(seqs, batch_first=True, padding_value=pad_value)

--- a/skyrl/backends/skyrl_train/distributed/dispatch.py
+++ b/skyrl/backends/skyrl_train/distributed/dispatch.py
@@ -313,11 +313,15 @@ class WorkerOutput:
             if ai.rank.is_collection_dp_rank():
                 dp_rank_to_shard[ai.rank.dp] = s
         if not dp_rank_to_shard:
+            # Unreachable in practice: any actor group has at least one collection
+            # DP rank. Default ``loss_fn_output_type="scalar"`` is fine here.
             return cls()
         ordered = [dp_rank_to_shard[i] for i in range(actor_infos[0].rank.dp_size)]
         return cls(
             loss_fn_output_type=ordered[0].loss_fn_output_type,
             loss_fn_outputs=[x for s in ordered for x in s.loss_fn_outputs],
+            # metrics are already all-reduced across DP within each worker, so
+            # taking rank 0's dict (rather than re-aggregating) is correct.
             metrics=dict(ordered[0].metrics),
         )
 

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -331,12 +331,14 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
     def forward(
         self,
         data: TrainingInputBatch,
-    ) -> TrainingOutputBatch:
+        loss_fn=None,
+        loss_fn_config=None,
+    ):
         """Run forward pass on data in inference mode.
 
         Reshard the model after forward pass to redistribute memory and allow for offloading to cpu.
         """
-        output = super().forward(data)
+        output = super().forward(data, loss_fn=loss_fn, loss_fn_config=loss_fn_config)
         # unshard the root FSDP module (https://pytorch.org/docs/stable/notes/fsdp.html#fsdp-notes)
         if self._world_size > 1 and fsdp_version(self.model.model) == 1:
             self.model.model._handle.reshard(True)

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -1,6 +1,6 @@
 import io
 import os
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Optional
 
 import ray
 import torch
@@ -22,6 +22,7 @@ try:
 except ImportError:
     from torch.distributed._tensor import DTensor
 
+from skyrl.backends.skyrl_train.distributed.dispatch import WorkerOutput
 from skyrl.backends.skyrl_train.distributed.fsdp_strategy import FSDPStrategy
 from skyrl.backends.skyrl_train.distributed.fsdp_utils import (
     fsdp_version,
@@ -332,7 +333,7 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
         data: TrainingInputBatch,
         loss_fn=None,
         loss_fn_config=None,
-    ) -> Dict[str, Any]:
+    ) -> WorkerOutput:
         """Run forward pass on data in inference mode.
 
         Reshard the model after forward pass to redistribute memory and allow for offloading to cpu.
@@ -399,7 +400,7 @@ class FSDPCriticWorkerBase(CriticWorkerBase):
     def forward(
         self,
         data: TrainingInputBatch,
-    ) -> Dict[str, Any]:
+    ) -> WorkerOutput:
         """Run forward pass on data in inference mode.
 
         Reshard the model after forward pass to redistribute memory and allow for offloading to cpu.
@@ -449,7 +450,7 @@ class FSDPRefWorkerBase(RefWorkerBase):
     def forward(
         self,
         data: TrainingInputBatch,
-    ) -> Dict[str, Any]:
+    ) -> WorkerOutput:
         """Run forward pass on data in inference mode.
 
         Reshard the model after forward pass to redistribute memory and allow for offloading to cpu.

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -1,6 +1,6 @@
 import io
 import os
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import ray
 import torch
@@ -32,7 +32,6 @@ from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import
 )
 from skyrl.backends.skyrl_train.training_batch import (
     TrainingInputBatch,
-    TrainingOutputBatch,
 )
 from skyrl.backends.skyrl_train.weight_sync import (
     LoraLoadRequest,
@@ -333,7 +332,7 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
         data: TrainingInputBatch,
         loss_fn=None,
         loss_fn_config=None,
-    ):
+    ) -> Dict[str, Any]:
         """Run forward pass on data in inference mode.
 
         Reshard the model after forward pass to redistribute memory and allow for offloading to cpu.
@@ -400,7 +399,7 @@ class FSDPCriticWorkerBase(CriticWorkerBase):
     def forward(
         self,
         data: TrainingInputBatch,
-    ) -> TrainingOutputBatch:
+    ) -> Dict[str, Any]:
         """Run forward pass on data in inference mode.
 
         Reshard the model after forward pass to redistribute memory and allow for offloading to cpu.
@@ -450,7 +449,7 @@ class FSDPRefWorkerBase(RefWorkerBase):
     def forward(
         self,
         data: TrainingInputBatch,
-    ) -> TrainingOutputBatch:
+    ) -> Dict[str, Any]:
         """Run forward pass on data in inference mode.
 
         Reshard the model after forward pass to redistribute memory and allow for offloading to cpu.

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -293,24 +293,32 @@ class MegatronModelWrapper:
                     if loss_mask is not None:
                         elementwise_loss = elementwise_loss * loss_mask
 
-                # Build per-sequence loss_fn_outputs
+                # Build per-sequence loss_fn_outputs.
+                # Compute valid_lens vectorized on GPU, then move tensors to CPU
+                # exactly once before iterating in Python — avoids ~3N GPU->CPU
+                # syncs per micro-batch (item()/cpu()/tolist() inside the loop).
                 batch_size = action_log_probs.shape[0]
+                seq_len = action_log_probs.shape[1]
+                if action_mask is not None:
+                    valid_lens_t = action_mask.sum(dim=-1).long()
+                elif loss_mask is not None:
+                    valid_lens_t = loss_mask.sum(dim=-1).long()
+                else:
+                    valid_lens_t = torch.full((batch_size,), seq_len, device=action_log_probs.device, dtype=torch.long)
+
+                # Bulk GPU->CPU sync: one transfer for logprobs, elementwise_loss, and valid_lens.
+                action_log_probs_cpu = action_log_probs.detach().cpu()
+                elementwise_loss_cpu = elementwise_loss.detach().cpu()
+                valid_lens = valid_lens_t.cpu().tolist()
+
                 loss_fn_outputs = []
                 for i in range(batch_size):
-                    if action_mask is not None:
-                        valid_len = int(action_mask[i].sum().item())
-                    elif loss_mask is not None:
-                        valid_len = int(loss_mask[i].sum().item())
-                    else:
-                        valid_len = action_log_probs.shape[1]
-
+                    valid_len = valid_lens[i]
                     loss_fn_outputs.append(
                         {
-                            "logprobs": (
-                                action_log_probs[i, -valid_len:].detach().cpu().tolist() if valid_len > 0 else []
-                            ),
+                            "logprobs": (action_log_probs_cpu[i, -valid_len:].tolist() if valid_len > 0 else []),
                             "elementwise_loss": (
-                                elementwise_loss[i, -valid_len:].detach().cpu().tolist() if valid_len > 0 else []
+                                elementwise_loss_cpu[i, -valid_len:].tolist() if valid_len > 0 else []
                             ),
                         }
                     )

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -201,6 +201,7 @@ class MegatronModelWrapper:
         temperature: float = 1.0,
         loss_fn: Optional[str] = None,
         loss_fn_config: Optional[Dict[str, Any]] = None,
+        forward_only: bool = False,
     ) -> List[dict]:
         """
         Run forward-backward over a full mini-batch consisting of multiple micro-batches.
@@ -216,6 +217,9 @@ class MegatronModelWrapper:
             loss_fn: Optional loss function name (e.g., "cross_entropy", "ppo").
                      If provided, overrides the config's policy_loss_type.
             loss_fn_config: Optional config overrides for the loss function.
+            forward_only: If True, run the forward pass without backward (no gradients).
+                          Useful for evaluation / loss-only inference paths (e.g., SFT
+                          ``forward(loss_fn=...)`` codepath).
 
         Returns:
             List[dict]: one metrics dict per micro-batch in order.
@@ -468,7 +472,7 @@ class MegatronModelWrapper:
             num_microbatches=len(micro_batches),
             seq_length=seq_len,
             micro_batch_size=micro_batch_size,
-            forward_only=False,
+            forward_only=forward_only,
         )
 
         # broadcast metrics to all pp ranks

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -478,59 +478,6 @@ class MegatronWorker:
         )
         return model
 
-    def _megatron_inference_forward(self, data: TrainingInputBatch, *, output_key: str = "logprobs") -> WorkerOutput:
-        """Megatron-specific inference forward: pass the full mini batch through
-        ``MegatronModelWrapper.forward``.
-
-        Returns a :class:`WorkerOutput` whose ``loss_fn_outputs`` is a per-sample
-        list of dicts (each entry holds the full ``T_response`` row under
-        ``output_key``).  Concatenation across DP ranks happens in the dispatcher.
-        """
-        from skyrl.backends.skyrl_train.utils.replay_utils import clear_router_replay
-
-        # Run in micro batches grouped into a single mini-batch
-        micro_bsz = self.cfg.micro_forward_batch_size_per_gpu
-        micro_batches = data.chunk(micro_bsz)
-
-        # Build micro-batch dicts expected by policy.forward_mini_batch
-        micro_dicts = []
-        device = torch.cuda.current_device()
-        for micro in micro_batches:
-            micro.to(device)
-            sequences = micro["sequences"]
-            attention_mask = micro["attention_mask"]
-            num_actions = micro.metadata["response_length"]
-            position_ids = attention_mask.long().cumsum(-1) - 1
-            position_ids.masked_fill_(attention_mask == 0, 0)
-            rollout_expert_indices = micro.get("rollout_expert_indices")
-            if rollout_expert_indices is not None:
-                rollout_expert_indices = rollout_expert_indices.to(torch.int32)
-            micro_dicts.append(
-                {
-                    "sequences": sequences,
-                    "attention_mask": attention_mask,
-                    "position_ids": position_ids,
-                    "num_actions": num_actions,
-                    "rollout_expert_indices": (rollout_expert_indices if self.enable_router_replay else None),
-                }
-            )
-
-        self.model.eval()
-        seq_len = micro_dicts[0]["sequences"].shape[1]
-        mbs = micro_dicts[0]["sequences"].shape[0]
-        with torch.no_grad():
-            log_probs = self.model.forward(
-                micro_batches=micro_dicts,
-                seq_len=seq_len,
-                micro_batch_size=mbs,
-                temperature=self.cfg.algorithm.temperature,
-            )
-
-        log_probs = log_probs.to("cpu")
-        clear_router_replay()
-        loss_fn_outputs = [{output_key: log_probs[i].tolist()} for i in range(log_probs.shape[0])]
-        return WorkerOutput(loss_fn_outputs=loss_fn_outputs, metrics={})
-
     def save_hf_model(self, export_dir: str, tokenizer):
         # Save model in HuggingFace safetensors format
         self.strategy.save_hf_model(
@@ -695,10 +642,52 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
           :class:`WorkerOutput` with per-sample ``loss_fn_outputs`` plus scalar
           ``metrics`` (including ``"loss"``).
         """
-        if loss_fn is None:
-            return self._megatron_inference_forward(data, output_key="logprobs")
-
         from skyrl.backends.skyrl_train.utils.replay_utils import clear_router_replay
+
+        if loss_fn is None:
+            # Megatron inference forward path: pass the full mini batch through
+            # MegatronModelWrapper.forward and emit per-sample logprobs.
+            micro_bsz = self.cfg.micro_forward_batch_size_per_gpu
+            micro_batches = data.chunk(micro_bsz)
+
+            # Build micro-batch dicts expected by policy.forward_mini_batch
+            micro_dicts = []
+            device = torch.cuda.current_device()
+            for micro in micro_batches:
+                micro.to(device)
+                sequences = micro["sequences"]
+                attention_mask = micro["attention_mask"]
+                num_actions = micro.metadata["response_length"]
+                position_ids = attention_mask.long().cumsum(-1) - 1
+                position_ids.masked_fill_(attention_mask == 0, 0)
+                rollout_expert_indices = micro.get("rollout_expert_indices")
+                if rollout_expert_indices is not None:
+                    rollout_expert_indices = rollout_expert_indices.to(torch.int32)
+                micro_dicts.append(
+                    {
+                        "sequences": sequences,
+                        "attention_mask": attention_mask,
+                        "position_ids": position_ids,
+                        "num_actions": num_actions,
+                        "rollout_expert_indices": (rollout_expert_indices if self.enable_router_replay else None),
+                    }
+                )
+
+            self.model.eval()
+            seq_len = micro_dicts[0]["sequences"].shape[1]
+            mbs = micro_dicts[0]["sequences"].shape[0]
+            with torch.no_grad():
+                log_probs = self.model.forward(
+                    micro_batches=micro_dicts,
+                    seq_len=seq_len,
+                    micro_batch_size=mbs,
+                    temperature=self.cfg.algorithm.temperature,
+                )
+
+            log_probs = log_probs.to("cpu")
+            clear_router_replay()
+            loss_fn_outputs = [{"logprobs": log_probs[i].tolist()} for i in range(log_probs.shape[0])]
+            return WorkerOutput(loss_fn_outputs=loss_fn_outputs, metrics={})
 
         self.model.eval()
 
@@ -1149,7 +1138,50 @@ class MegatronRefWorkerBase(MegatronWorker, RefWorkerBase):
         Returns a :class:`WorkerOutput` whose ``loss_fn_outputs`` carries one
         per-sample dict with key ``"logprobs"``.
         """
-        return self._megatron_inference_forward(data, output_key="logprobs")
+        from skyrl.backends.skyrl_train.utils.replay_utils import clear_router_replay
+
+        # Run in micro batches grouped into a single mini-batch
+        micro_bsz = self.cfg.micro_forward_batch_size_per_gpu
+        micro_batches = data.chunk(micro_bsz)
+
+        # Build micro-batch dicts expected by policy.forward_mini_batch
+        micro_dicts = []
+        device = torch.cuda.current_device()
+        for micro in micro_batches:
+            micro.to(device)
+            sequences = micro["sequences"]
+            attention_mask = micro["attention_mask"]
+            num_actions = micro.metadata["response_length"]
+            position_ids = attention_mask.long().cumsum(-1) - 1
+            position_ids.masked_fill_(attention_mask == 0, 0)
+            rollout_expert_indices = micro.get("rollout_expert_indices")
+            if rollout_expert_indices is not None:
+                rollout_expert_indices = rollout_expert_indices.to(torch.int32)
+            micro_dicts.append(
+                {
+                    "sequences": sequences,
+                    "attention_mask": attention_mask,
+                    "position_ids": position_ids,
+                    "num_actions": num_actions,
+                    "rollout_expert_indices": (rollout_expert_indices if self.enable_router_replay else None),
+                }
+            )
+
+        self.model.eval()
+        seq_len = micro_dicts[0]["sequences"].shape[1]
+        mbs = micro_dicts[0]["sequences"].shape[0]
+        with torch.no_grad():
+            log_probs = self.model.forward(
+                micro_batches=micro_dicts,
+                seq_len=seq_len,
+                micro_batch_size=mbs,
+                temperature=self.cfg.algorithm.temperature,
+            )
+
+        log_probs = log_probs.to("cpu")
+        clear_router_replay()
+        loss_fn_outputs = [{"logprobs": log_probs[i].tolist()} for i in range(log_probs.shape[0])]
+        return WorkerOutput(loss_fn_outputs=loss_fn_outputs, metrics={})
 
     def init_worker_process_group(self):
         """

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -691,7 +691,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
 
         self.model.eval()
 
-        micro_batch_size = self.cfg.micro_train_batch_size_per_gpu
+        micro_batch_size = self.cfg.micro_forward_batch_size_per_gpu
         all_metrics = defaultdict(list)
         all_loss_fn_outputs: List[Dict[str, Any]] = []
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -19,7 +19,7 @@ from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 from omegaconf import OmegaConf
 from transformers import AutoConfig
 
-from skyrl.backends.skyrl_train.distributed.dispatch import MeshRank
+from skyrl.backends.skyrl_train.distributed.dispatch import MeshRank, WorkerOutput
 from skyrl.backends.skyrl_train.distributed.megatron.megatron_strategy import (
     MegatronStrategy,
 )
@@ -478,10 +478,13 @@ class MegatronWorker:
         )
         return model
 
-    def _megatron_inference_forward(self, data: TrainingInputBatch) -> Dict[str, Any]:
+    def _megatron_inference_forward(self, data: TrainingInputBatch, *, output_key: str = "logprobs") -> WorkerOutput:
         """Megatron-specific inference forward: pass the full mini batch through
-        ``MegatronModelWrapper.forward``. Returns a plain dict (``{"output": tensor}``)
-        so concatenation across DP ranks happens uniformly in the dispatcher.
+        ``MegatronModelWrapper.forward``.
+
+        Returns a :class:`WorkerOutput` whose ``loss_fn_outputs`` is a per-sample
+        list of dicts (each entry holds the full ``T_response`` row under
+        ``output_key``).  Concatenation across DP ranks happens in the dispatcher.
         """
         from skyrl.backends.skyrl_train.utils.replay_utils import clear_router_replay
 
@@ -525,7 +528,8 @@ class MegatronWorker:
 
         log_probs = log_probs.to("cpu")
         clear_router_replay()
-        return {"output": log_probs}
+        loss_fn_outputs = [{output_key: log_probs[i].tolist()} for i in range(log_probs.shape[0])]
+        return WorkerOutput(loss_fn_outputs=loss_fn_outputs, metrics={})
 
     def save_hf_model(self, export_dir: str, tokenizer):
         # Save model in HuggingFace safetensors format
@@ -680,17 +684,19 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         data: TrainingInputBatch,
         loss_fn: Optional[str] = None,
         loss_fn_config: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ) -> WorkerOutput:
         """Forward pass.
 
-        - Without ``loss_fn``: runs Megatron's pipeline inference and returns a plain
-          dict (``{"output": logprobs}``).
+        - Without ``loss_fn``: runs Megatron's pipeline inference and returns a
+          :class:`WorkerOutput` with per-sample ``loss_fn_outputs`` (``logprobs``
+          key) and empty ``metrics``.
         - With ``loss_fn`` (e.g., ``"cross_entropy"``): runs the SFT loss through Megatron's
-          pipeline schedule with ``forward_only=True`` (no backward) and returns a metrics
-          dict containing ``"loss"`` and per-sample ``"loss_fn_outputs"``.
+          pipeline schedule with ``forward_only=True`` (no backward) and returns a
+          :class:`WorkerOutput` with per-sample ``loss_fn_outputs`` plus scalar
+          ``metrics`` (including ``"loss"``).
         """
         if loss_fn is None:
-            return self._megatron_inference_forward(data)
+            return self._megatron_inference_forward(data, output_key="logprobs")
 
         from skyrl.backends.skyrl_train.utils.replay_utils import clear_router_replay
 
@@ -734,7 +740,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             m_batch["num_microbatches"] = len(micro_buffer)
 
         if not micro_buffer:
-            return {}
+            return WorkerOutput()
 
         seq_len = micro_buffer[0]["sequences"].shape[1]
         micro_bsz = micro_buffer[0]["sequences"].shape[0]
@@ -769,18 +775,15 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         group = mpu.get_data_parallel_group(with_context_parallel=False)
         status = all_reduce_metrics(status, self.strategy, group=group, sum_loss_metrics=sum_loss_metrics)
 
-        if all_loss_fn_outputs:
-            status["loss_fn_outputs"] = all_loss_fn_outputs
-
         clear_router_replay()
-        return status
+        return WorkerOutput(loss_fn_outputs=all_loss_fn_outputs, metrics=status)
 
     def forward_backward(
         self,
         data: TrainingInputBatch,
         loss_fn: Optional[str] = None,
         loss_fn_config: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, float]:
+    ) -> WorkerOutput:
         """
         Perform forward and backward passes for a batch, handling micro-batching internally.
 
@@ -794,7 +797,8 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             loss_fn_config: Optional config overrides for the loss function.
 
         Returns:
-            Aggregated metrics dict across all micro batches
+            :class:`WorkerOutput` with per-sample ``loss_fn_outputs`` and scalar
+            ``metrics`` (all-reduced across DP).
         """
         from skyrl.backends.skyrl_train.utils.replay_utils import clear_router_replay
 
@@ -840,7 +844,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             m_batch["num_microbatches"] = len(micro_buffer)
 
         if not micro_buffer:
-            return {}
+            return WorkerOutput()
 
         seq_len = micro_buffer[0]["sequences"].shape[1]
         micro_bsz = micro_buffer[0]["sequences"].shape[0]
@@ -879,13 +883,9 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         group = mpu.get_data_parallel_group(with_context_parallel=False)
         status = all_reduce_metrics(status, self.strategy, group=group, sum_loss_metrics=sum_loss_metrics)
 
-        # Add loss_fn_outputs back (not reduced, kept as list)
-        if all_loss_fn_outputs:
-            status["loss_fn_outputs"] = all_loss_fn_outputs
-
         clear_router_replay()
 
-        return status
+        return WorkerOutput(loss_fn_outputs=all_loss_fn_outputs, metrics=status)
 
     def optim_step(self) -> Optional[float]:
         """
@@ -1143,9 +1143,13 @@ class MegatronRefWorkerBase(MegatronWorker, RefWorkerBase):
         self.model: MegatronModelWrapper = None
         self.actor_module: List[nn.Module] = None
 
-    def forward(self, data: TrainingInputBatch) -> Dict[str, Any]:
-        """Run inference forward pass. Returns ``{"output": log_probs}`` as a plain dict."""
-        return self._megatron_inference_forward(data)
+    def forward(self, data: TrainingInputBatch) -> WorkerOutput:
+        """Run inference forward pass.
+
+        Returns a :class:`WorkerOutput` whose ``loss_fn_outputs`` carries one
+        per-sample dict with key ``"logprobs"``.
+        """
+        return self._megatron_inference_forward(data, output_key="logprobs")
 
     def init_worker_process_group(self):
         """

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -677,6 +677,106 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
 
         self.empty_cuda_cache = self.cfg.policy.megatron_config.empty_cuda_cache
 
+    def forward(
+        self,
+        data: TrainingInputBatch,
+        loss_fn: Optional[str] = None,
+        loss_fn_config: Optional[Dict[str, Any]] = None,
+    ):
+        """Forward pass.
+
+        - Without ``loss_fn``: delegates to :meth:`MegatronWorker.forward`, returning a
+          ``TrainingOutputBatch`` with ``"output"`` containing logprobs.
+        - With ``loss_fn`` (e.g., ``"cross_entropy"``): runs the SFT loss through Megatron's
+          pipeline schedule with ``forward_only=True`` (no backward) and returns a metrics
+          dict containing ``"loss"`` and per-sample ``"loss_fn_outputs"``.
+        """
+        if loss_fn is None:
+            return MegatronWorker.forward(self, data)
+
+        from skyrl.backends.skyrl_train.utils.replay_utils import clear_router_replay
+
+        self.model.eval()
+
+        micro_batch_size = self.cfg.micro_train_batch_size_per_gpu
+        all_metrics = defaultdict(list)
+        all_loss_fn_outputs: List[Dict[str, Any]] = []
+
+        # Move data to GPU
+        data.to(torch.cuda.current_device())
+
+        # Build micro-batch dicts expected by forward_backward_mini_batch
+        micro_buffer = []
+        for experience in BatchIterator(data, micro_batch_size, drop_last=False):
+            sequences = experience.sequences
+            attention_mask = experience.attention_mask
+            position_ids = attention_mask.long().cumsum(-1) - 1
+            position_ids.masked_fill_(attention_mask == 0, 0)
+            rollout_expert_indices = experience.rollout_expert_indices
+            if rollout_expert_indices is not None:
+                rollout_expert_indices = rollout_expert_indices.to(torch.int32)
+
+            micro_buffer.append(
+                {
+                    "sequences": sequences,
+                    "attention_mask": attention_mask,
+                    "position_ids": position_ids,
+                    "num_actions": experience.num_actions,
+                    "old_action_log_probs": experience.action_log_probs,
+                    "base_action_log_probs": experience.base_action_log_probs,
+                    "advantages": experience.advantages,
+                    "loss_mask": experience.loss_mask,
+                    "rollout_action_logprobs": experience.rollout_logprobs,
+                    "action_mask": experience.action_mask,
+                    "rollout_expert_indices": rollout_expert_indices if self.enable_router_replay else None,
+                }
+            )
+
+        for m_batch in micro_buffer:
+            m_batch["num_microbatches"] = len(micro_buffer)
+
+        if not micro_buffer:
+            return {}
+
+        seq_len = micro_buffer[0]["sequences"].shape[1]
+        micro_bsz = micro_buffer[0]["sequences"].shape[0]
+
+        with torch.no_grad():
+            metrics_list = self.model.forward_backward_mini_batch(
+                micro_batches=micro_buffer,
+                seq_len=seq_len,
+                micro_batch_size=micro_bsz,
+                temperature=self.cfg.algorithm.temperature,
+                loss_fn=loss_fn,
+                loss_fn_config=loss_fn_config,
+                forward_only=True,
+            )
+
+        if self.empty_cuda_cache:
+            torch.cuda.empty_cache()
+
+        # Aggregate metrics across micro-batches
+        for metrics in metrics_list:
+            if metrics is None:
+                continue
+            if "loss_fn_outputs" in metrics:
+                all_loss_fn_outputs.extend(metrics.pop("loss_fn_outputs"))
+            for k, v in metrics.items():
+                all_metrics[k].append(v)
+
+        resolved_loss_name = loss_fn or self.cfg.algorithm.policy_loss_type
+        sum_loss_metrics = resolved_loss_name != "cross_entropy"
+
+        status = reduce_metrics(all_metrics, sum_loss_metrics=sum_loss_metrics)
+        group = mpu.get_data_parallel_group(with_context_parallel=False)
+        status = all_reduce_metrics(status, self.strategy, group=group, sum_loss_metrics=sum_loss_metrics)
+
+        if all_loss_fn_outputs:
+            status["loss_fn_outputs"] = all_loss_fn_outputs
+
+        clear_router_replay()
+        return status
+
     def forward_backward(
         self,
         data: TrainingInputBatch,

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -38,7 +38,6 @@ from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import
 )
 from skyrl.backends.skyrl_train.training_batch import (
     TrainingInputBatch,
-    TrainingOutputBatch,
 )
 from skyrl.backends.skyrl_train.utils.profiler import Profiler
 from skyrl.backends.skyrl_train.weight_sync import (
@@ -479,9 +478,10 @@ class MegatronWorker:
         )
         return model
 
-    def forward(self, data: TrainingInputBatch):
-        """
-        Override `Worker.forward` to support passing the full mini batch to the MegatronModelWrapper.forward method.
+    def _megatron_inference_forward(self, data: TrainingInputBatch) -> Dict[str, Any]:
+        """Megatron-specific inference forward: pass the full mini batch through
+        ``MegatronModelWrapper.forward``. Returns a plain dict (``{"output": tensor}``)
+        so concatenation across DP ranks happens uniformly in the dispatcher.
         """
         from skyrl.backends.skyrl_train.utils.replay_utils import clear_router_replay
 
@@ -524,10 +524,8 @@ class MegatronWorker:
             )
 
         log_probs = log_probs.to("cpu")
-        output = TrainingOutputBatch({"output": log_probs})
-        output.metadata = data.metadata
         clear_router_replay()
-        return output
+        return {"output": log_probs}
 
     def save_hf_model(self, export_dir: str, tokenizer):
         # Save model in HuggingFace safetensors format
@@ -682,17 +680,17 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         data: TrainingInputBatch,
         loss_fn: Optional[str] = None,
         loss_fn_config: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> Dict[str, Any]:
         """Forward pass.
 
-        - Without ``loss_fn``: delegates to :meth:`MegatronWorker.forward`, returning a
-          ``TrainingOutputBatch`` with ``"output"`` containing logprobs.
+        - Without ``loss_fn``: runs Megatron's pipeline inference and returns a plain
+          dict (``{"output": logprobs}``).
         - With ``loss_fn`` (e.g., ``"cross_entropy"``): runs the SFT loss through Megatron's
           pipeline schedule with ``forward_only=True`` (no backward) and returns a metrics
           dict containing ``"loss"`` and per-sample ``"loss_fn_outputs"``.
         """
         if loss_fn is None:
-            return MegatronWorker.forward(self, data)
+            return self._megatron_inference_forward(data)
 
         from skyrl.backends.skyrl_train.utils.replay_utils import clear_router_replay
 
@@ -1144,6 +1142,10 @@ class MegatronRefWorkerBase(MegatronWorker, RefWorkerBase):
         super().__init__(**kwargs)
         self.model: MegatronModelWrapper = None
         self.actor_module: List[nn.Module] = None
+
+    def forward(self, data: TrainingInputBatch) -> Dict[str, Any]:
+        """Run inference forward pass. Returns ``{"output": log_probs}`` as a plain dict."""
+        return self._megatron_inference_forward(data)
 
     def init_worker_process_group(self):
         """

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -390,10 +390,24 @@ class Worker(DistributedTorchRayActor):
 
         torch.distributed.barrier()
 
-    def forward(self, data: TrainingInputBatch) -> TrainingOutputBatch:
-        """Run forward pass on the input batch in inference mode.
+    def forward(self, *args, **kwargs) -> Dict[str, Any]:
+        """Run forward pass on the input batch.
 
-        This is a wrapper around `_forward_micro_batch` that runs in micro batches of `cfg.micro_forward_batch_size_per_gpu`.
+        Each worker subclass declares its own concrete signature and return
+        contract; the base class only fixes the convention that the result is a
+        plain ``Dict[str, Any]`` so callers can program against a uniform API.
+        """
+        raise NotImplementedError()
+
+    def _inference_forward(self, data: TrainingInputBatch) -> Dict[str, Any]:
+        """Legacy forward path: run inference in micro batches and return ``{"output": tensor}``.
+
+        Shared implementation used by RefWorker, CriticWorker, and the
+        ``loss_fn is None`` branch of PolicyWorker. Subclasses provide
+        ``_forward_micro_batch`` for the per-micro-batch model call.
+
+        Returns a plain dict (``{"output": tensor}``) — concatenation across DP
+        ranks happens in the dispatcher, not here.
         """
         # run in micro batches of cfg.micro_forward_batch_size_per_gpu
         # TODO (sumanthrh): this can be in the policy/critic impl if the micro batch size can be specific to policy, critic, etc.
@@ -405,7 +419,8 @@ class Worker(DistributedTorchRayActor):
         output = TrainingOutputBatch.cat(outputs)
         if output.device is not None and output.device != torch.device("cpu"):
             output = output.to("cpu")
-        return output
+        # Return as a plain dict; the dispatcher concatenates dict shards across DP ranks.
+        return dict(output.items())
 
     def _forward_micro_batch(self, micro_batch: TrainingInputBatch) -> TrainingOutputBatch:
         raise NotImplementedError()
@@ -963,18 +978,19 @@ class PolicyWorkerBase(Worker):
         data: TrainingInputBatch,
         loss_fn: Optional[str] = None,
         loss_fn_config: Optional[Dict[str, Any]] = None,
-    ) -> Union[TrainingOutputBatch, Dict[str, Any]]:
+    ) -> Dict[str, Any]:
         """Run forward pass.
 
-        - When ``loss_fn`` is None: behaves like :meth:`Worker.forward` and returns a
-          ``TrainingOutputBatch`` with ``"output"`` containing the logprobs.
+        - When ``loss_fn`` is None: runs inference in micro batches via
+          :meth:`Worker._inference_forward` and returns a plain dict
+          (``{"output": tensor}``).
         - When ``loss_fn`` is set (e.g., ``"cross_entropy"``): runs the loss in ``no_grad`` mode
           (no backward), iterating over micro-batches of ``micro_forward_batch_size_per_gpu``,
           and returns a metrics dict including ``"loss"`` and per-sample ``"loss_fn_outputs"``.
           Metrics are all-reduced across the DP group to mirror :meth:`forward_backward`.
         """
         if loss_fn is None:
-            return super().forward(data)
+            return self._inference_forward(data)
 
         micro_batch_size = self.cfg.micro_forward_batch_size_per_gpu
         all_metrics = defaultdict(list)
@@ -1254,6 +1270,10 @@ class CriticWorkerBase(Worker):
         output.metadata = micro_batch.metadata
         return output
 
+    def forward(self, data: TrainingInputBatch) -> Dict[str, Any]:
+        """Run inference forward pass. Returns ``{"output": values}`` as a plain dict."""
+        return self._inference_forward(data)
+
 
 class RefWorkerBase(Worker):
     def __init__(self, **kwargs):
@@ -1262,6 +1282,10 @@ class RefWorkerBase(Worker):
         # Ref does not train. Expose ``None`` defaults so inherited methods (e.g. offload_to_cpu) work.
         self.optimizer = None
         self.scheduler = None
+
+    def forward(self, data: TrainingInputBatch) -> Dict[str, Any]:
+        """Run inference forward pass. Returns ``{"output": log_probs}`` as a plain dict."""
+        return self._inference_forward(data)
 
     def _forward_micro_batch(self, micro_batch: TrainingInputBatch) -> TrainingOutputBatch:
         device = torch.cuda.current_device()

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -399,41 +399,6 @@ class Worker(DistributedTorchRayActor):
         """
         raise NotImplementedError()
 
-    def _inference_forward(self, data: TrainingInputBatch, *, output_key: str = "logprobs") -> WorkerOutput:
-        """Legacy forward path: run inference in micro batches and emit per-sample outputs.
-
-        Shared implementation used by RefWorker, CriticWorker, and the
-        ``loss_fn is None`` branch of PolicyWorker. Subclasses provide
-        ``_forward_micro_batch`` for the per-micro-batch model call (returns a
-        ``TrainingOutputBatch`` with ``"output"`` of shape ``[B, T_response]``).
-
-        Args:
-            data: Mini-batch input.
-            output_key: Per-sample dict key under which the row tensor is stored
-                in ``loss_fn_outputs`` (``"logprobs"`` for policy/ref,
-                ``"values"`` for critic).
-
-        Returns:
-            :class:`WorkerOutput` with a per-sample ``loss_fn_outputs`` list.
-            Each entry holds one row of the worker's output tensor; downstream
-            (trainer / backend) reassembles into a ``[B, T]`` tensor via
-            :func:`loss_fn_outputs_to_tensor` when a tensor view is needed.
-            Concatenation across DP ranks happens in the dispatcher.
-        """
-        # run in micro batches of cfg.micro_forward_batch_size_per_gpu
-        # TODO (sumanthrh): this can be in the policy/critic impl if the micro batch size can be specific to policy, critic, etc.
-        micro_batches = data.chunk(self.cfg.micro_forward_batch_size_per_gpu)
-
-        outputs = []
-        for micro_batch in micro_batches:
-            outputs.append(self._forward_micro_batch(micro_batch))
-        output = TrainingOutputBatch.cat(outputs)
-        if output.device is not None and output.device != torch.device("cpu"):
-            output = output.to("cpu")
-        row_tensor = output["output"]
-        loss_fn_outputs = [{output_key: row_tensor[i].tolist()} for i in range(row_tensor.shape[0])]
-        return WorkerOutput(loss_fn_outputs=loss_fn_outputs, metrics={})
-
     def _forward_micro_batch(self, micro_batch: TrainingInputBatch) -> TrainingOutputBatch:
         raise NotImplementedError()
 
@@ -990,8 +955,8 @@ class PolicyWorkerBase(Worker):
     ) -> WorkerOutput:
         """Run forward pass.
 
-        - When ``loss_fn`` is None: runs inference in micro batches via
-          :meth:`Worker._inference_forward` and returns a :class:`WorkerOutput`
+        - When ``loss_fn`` is None: runs inference in micro batches of
+          ``micro_forward_batch_size_per_gpu`` and returns a :class:`WorkerOutput`
           with per-sample ``loss_fn_outputs`` (``logprobs`` key) and empty
           ``metrics``.
         - When ``loss_fn`` is set (e.g., ``"cross_entropy"``): runs the loss in ``no_grad`` mode
@@ -1001,7 +966,17 @@ class PolicyWorkerBase(Worker):
           to mirror :meth:`forward_backward`.
         """
         if loss_fn is None:
-            return self._inference_forward(data, output_key="logprobs")
+            # Inference forward path: run in micro batches and emit per-sample logprobs.
+            micro_batches = data.chunk(self.cfg.micro_forward_batch_size_per_gpu)
+            outputs = []
+            for micro_batch in micro_batches:
+                outputs.append(self._forward_micro_batch(micro_batch))
+            output = TrainingOutputBatch.cat(outputs)
+            if output.device is not None and output.device != torch.device("cpu"):
+                output = output.to("cpu")
+            row_tensor = output["output"]
+            loss_fn_outputs = [{"logprobs": row_tensor[i].tolist()} for i in range(row_tensor.shape[0])]
+            return WorkerOutput(loss_fn_outputs=loss_fn_outputs, metrics={})
 
         micro_batch_size = self.cfg.micro_forward_batch_size_per_gpu
         all_metrics = defaultdict(list)
@@ -1285,7 +1260,17 @@ class CriticWorkerBase(Worker):
         Returns a :class:`WorkerOutput` whose ``loss_fn_outputs`` carries one
         per-sample dict with key ``"values"``.
         """
-        return self._inference_forward(data, output_key="values")
+        # Run in micro batches and emit per-sample values.
+        micro_batches = data.chunk(self.cfg.micro_forward_batch_size_per_gpu)
+        outputs = []
+        for micro_batch in micro_batches:
+            outputs.append(self._forward_micro_batch(micro_batch))
+        output = TrainingOutputBatch.cat(outputs)
+        if output.device is not None and output.device != torch.device("cpu"):
+            output = output.to("cpu")
+        row_tensor = output["output"]
+        loss_fn_outputs = [{"values": row_tensor[i].tolist()} for i in range(row_tensor.shape[0])]
+        return WorkerOutput(loss_fn_outputs=loss_fn_outputs, metrics={})
 
 
 class RefWorkerBase(Worker):
@@ -1302,7 +1287,17 @@ class RefWorkerBase(Worker):
         Returns a :class:`WorkerOutput` whose ``loss_fn_outputs`` carries one
         per-sample dict with key ``"logprobs"``.
         """
-        return self._inference_forward(data, output_key="logprobs")
+        # Run in micro batches and emit per-sample logprobs.
+        micro_batches = data.chunk(self.cfg.micro_forward_batch_size_per_gpu)
+        outputs = []
+        for micro_batch in micro_batches:
+            outputs.append(self._forward_micro_batch(micro_batch))
+        output = TrainingOutputBatch.cat(outputs)
+        if output.device is not None and output.device != torch.device("cpu"):
+            output = output.to("cpu")
+        row_tensor = output["output"]
+        loss_fn_outputs = [{"logprobs": row_tensor[i].tolist()} for i in range(row_tensor.shape[0])]
+        return WorkerOutput(loss_fn_outputs=loss_fn_outputs, metrics={})
 
     def _forward_micro_batch(self, micro_batch: TrainingInputBatch) -> TrainingOutputBatch:
         device = torch.cuda.current_device()

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -833,24 +833,30 @@ class PolicyWorkerBase(Worker):
 
             # Build per-sequence loss_fn_outputs (matches Tinker's ForwardBackwardOutput structure)
             # Trim to actual response length per sample (Tinker expects variable-length arrays
-            # that align with the input weights, not padded to batch max)
+            # that align with the input weights, not padded to batch max).
+            # Compute valid_lens vectorized on GPU, then move tensors to CPU exactly
+            # once before iterating in Python — avoids ~3N GPU->CPU syncs per micro-batch.
             batch_size = action_log_probs.shape[0]
+            seq_len = action_log_probs.shape[1]
+            if action_mask is not None:
+                valid_lens_t = action_mask.sum(dim=-1).long()
+            elif loss_mask is not None:
+                valid_lens_t = loss_mask.sum(dim=-1).long()
+            else:
+                valid_lens_t = torch.full((batch_size,), seq_len, device=action_log_probs.device, dtype=torch.long)
+
+            # Bulk GPU->CPU sync: one transfer for logprobs, elementwise_loss, and valid_lens.
+            action_log_probs_cpu = action_log_probs.detach().cpu()
+            elementwise_loss_cpu = elementwise_loss.detach().cpu()
+            valid_lens = valid_lens_t.cpu().tolist()
+
             loss_fn_outputs = []
             for i in range(batch_size):
-                # Prefer a binary action mask for length; fall back to loss_mask.
-                if action_mask is not None:
-                    valid_len = int(action_mask[i].sum().item())
-                elif loss_mask is not None:
-                    valid_len = int(loss_mask[i].sum().item())
-                else:
-                    valid_len = action_log_probs.shape[1]
-
+                valid_len = valid_lens[i]
                 loss_fn_outputs.append(
                     {
-                        "logprobs": action_log_probs[i, -valid_len:].detach().cpu().tolist() if valid_len > 0 else [],
-                        "elementwise_loss": (
-                            elementwise_loss[i, -valid_len:].detach().cpu().tolist() if valid_len > 0 else []
-                        ),
+                        "logprobs": action_log_probs_cpu[i, -valid_len:].tolist() if valid_len > 0 else [],
+                        "elementwise_loss": (elementwise_loss_cpu[i, -valid_len:].tolist() if valid_len > 0 else []),
                     }
                 )
 
@@ -1058,22 +1064,30 @@ class PolicyWorkerBase(Worker):
             if loss_mask is not None:
                 elementwise_loss = elementwise_loss * loss_mask
 
+            # Compute valid_lens vectorized on GPU, then move tensors to CPU
+            # exactly once before iterating in Python. Avoids ~3N GPU->CPU syncs
+            # per micro-batch (item()/cpu()/tolist() inside the per-sample loop).
             batch_size = action_log_probs.shape[0]
+            seq_len = action_log_probs.shape[1]
+            if action_mask is not None:
+                valid_lens_t = action_mask.sum(dim=-1).long()
+            elif loss_mask is not None:
+                valid_lens_t = loss_mask.sum(dim=-1).long()
+            else:
+                valid_lens_t = torch.full((batch_size,), seq_len, device=action_log_probs.device, dtype=torch.long)
+
+            # Bulk GPU->CPU sync: one transfer for logprobs, elementwise_loss, and valid_lens.
+            action_log_probs_cpu = action_log_probs.detach().cpu()
+            elementwise_loss_cpu = elementwise_loss.detach().cpu()
+            valid_lens = valid_lens_t.cpu().tolist()
+
             loss_fn_outputs = []
             for i in range(batch_size):
-                if action_mask is not None:
-                    valid_len = int(action_mask[i].sum().item())
-                elif loss_mask is not None:
-                    valid_len = int(loss_mask[i].sum().item())
-                else:
-                    valid_len = action_log_probs.shape[1]
-
+                valid_len = valid_lens[i]
                 loss_fn_outputs.append(
                     {
-                        "logprobs": action_log_probs[i, -valid_len:].detach().cpu().tolist() if valid_len > 0 else [],
-                        "elementwise_loss": (
-                            elementwise_loss[i, -valid_len:].detach().cpu().tolist() if valid_len > 0 else []
-                        ),
+                        "logprobs": action_log_probs_cpu[i, -valid_len:].tolist() if valid_len > 0 else [],
+                        "elementwise_loss": (elementwise_loss_cpu[i, -valid_len:].tolist() if valid_len > 0 else []),
                     }
                 )
 

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -958,6 +958,132 @@ class PolicyWorkerBase(Worker):
             grad_norm = grad_norm.detach().cpu().item()
         return grad_norm
 
+    def forward(
+        self,
+        data: TrainingInputBatch,
+        loss_fn: Optional[str] = None,
+        loss_fn_config: Optional[Dict[str, Any]] = None,
+    ) -> Union[TrainingOutputBatch, Dict[str, Any]]:
+        """Run forward pass.
+
+        - When ``loss_fn`` is None: behaves like :meth:`Worker.forward` and returns a
+          ``TrainingOutputBatch`` with ``"output"`` containing the logprobs.
+        - When ``loss_fn`` is set (e.g., ``"cross_entropy"``): runs the loss in ``no_grad`` mode
+          (no backward), iterating over micro-batches of ``micro_forward_batch_size_per_gpu``,
+          and returns a metrics dict including ``"loss"`` and per-sample ``"loss_fn_outputs"``.
+          Metrics are all-reduced across the DP group to mirror :meth:`forward_backward`.
+        """
+        if loss_fn is None:
+            return super().forward(data)
+
+        micro_batch_size = self.cfg.micro_forward_batch_size_per_gpu
+        all_metrics = defaultdict(list)
+        all_loss_fn_outputs: List[Dict[str, Any]] = []
+
+        for micro_batch in BatchIterator(data, micro_batch_size, drop_last=False):
+            metrics = self._forward_micro_with_loss(micro_batch, loss_fn=loss_fn, loss_fn_config=loss_fn_config)
+            if "loss_fn_outputs" in metrics:
+                all_loss_fn_outputs.extend(metrics.pop("loss_fn_outputs"))
+            for k, v in metrics.items():
+                all_metrics[k].append(v)
+
+        # SFT path averages metrics across microbatches and DP ranks (mirror forward_backward).
+        resolved_loss_name = loss_fn or self.cfg.algorithm.policy_loss_type
+        sum_loss_metrics = resolved_loss_name != "cross_entropy"
+
+        result = reduce_metrics(all_metrics, sum_loss_metrics=sum_loss_metrics)
+        dp_group = self.device_mesh.get_group("dp")
+        result = all_reduce_metrics(result, self.strategy, group=dp_group, sum_loss_metrics=sum_loss_metrics)
+
+        if all_loss_fn_outputs:
+            result["loss_fn_outputs"] = all_loss_fn_outputs
+
+        return result
+
+    def _forward_micro_with_loss(
+        self,
+        experience: Experience,
+        loss_fn: str,
+        loss_fn_config: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Forward-only counterpart of :meth:`_forward_backward_micro`'s SFT branch.
+
+        Runs the model + loss under ``torch.no_grad()`` (no backward, no KL/entropy terms),
+        and returns the same metrics shape as the SFT branch of ``_forward_backward_micro``,
+        minus ``lr`` (no optimizer state involved).
+        """
+        self.model.eval()
+        experience.to_device(torch.cuda.current_device())
+
+        sequences = experience.sequences
+        old_action_log_probs = experience.action_log_probs
+        advantages = experience.advantages
+        num_actions = experience.num_actions
+        attention_mask = experience.attention_mask
+        loss_mask = experience.loss_mask
+        action_mask = experience.action_mask
+        rollout_action_logprobs = experience.rollout_logprobs
+
+        current_loss_fn = PolicyLossRegistry.get(loss_fn)
+
+        # Build config for loss function, applying any overrides
+        loss_config = self.cfg.algorithm
+        if loss_fn_config is not None:
+            from dataclasses import asdict
+
+            new_loss_config = OmegaConf.merge(OmegaConf.create(asdict(loss_config)), OmegaConf.create(loss_fn_config))
+            loss_config = type(loss_config).from_dict_config(new_loss_config)
+
+        with torch.no_grad(), torch.autocast(dtype=torch.bfloat16, device_type="cuda"):
+            action_log_probs, _ = self.model(
+                sequences,
+                num_actions,
+                attention_mask=attention_mask,
+                temperature=self.cfg.algorithm.temperature,
+                return_output=True,
+                compute_entropy=False,
+                entropy_requires_grad=False,
+                pixel_values=experience.pixel_values,
+                image_grid_thw=experience.image_grid_thw,
+            )
+            policy_loss, _ = current_loss_fn(
+                action_log_probs,
+                old_action_log_probs,
+                advantages,
+                config=loss_config,
+                loss_mask=loss_mask,
+                rollout_logprobs=rollout_action_logprobs,
+            )
+
+            elementwise_loss = -action_log_probs
+            if loss_mask is not None:
+                elementwise_loss = elementwise_loss * loss_mask
+
+            batch_size = action_log_probs.shape[0]
+            loss_fn_outputs = []
+            for i in range(batch_size):
+                if action_mask is not None:
+                    valid_len = int(action_mask[i].sum().item())
+                elif loss_mask is not None:
+                    valid_len = int(loss_mask[i].sum().item())
+                else:
+                    valid_len = action_log_probs.shape[1]
+
+                loss_fn_outputs.append(
+                    {
+                        "logprobs": action_log_probs[i, -valid_len:].detach().cpu().tolist() if valid_len > 0 else [],
+                        "elementwise_loss": (
+                            elementwise_loss[i, -valid_len:].detach().cpu().tolist() if valid_len > 0 else []
+                        ),
+                    }
+                )
+
+        return {
+            "loss": policy_loss.item(),
+            "response_length": num_actions,
+            "loss_fn_outputs": loss_fn_outputs,
+        }
+
     def _forward_micro_batch(self, micro_batch: TrainingInputBatch) -> TrainingOutputBatch:
         device = torch.cuda.current_device()
         micro_batch.to(device)

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -28,6 +28,7 @@ from skyrl.backends.skyrl_train.distributed.dispatch import (
     Dispatch,
     DispatchRegistry,
     MeshRank,
+    WorkerOutput,
 )
 from skyrl.backends.skyrl_train.distributed.strategy import DistributedStrategy
 from skyrl.backends.skyrl_train.distributed.ulysses import (
@@ -390,24 +391,34 @@ class Worker(DistributedTorchRayActor):
 
         torch.distributed.barrier()
 
-    def forward(self, *args, **kwargs) -> Dict[str, Any]:
+    def forward(self, *args, **kwargs) -> WorkerOutput:
         """Run forward pass on the input batch.
 
-        Each worker subclass declares its own concrete signature and return
-        contract; the base class only fixes the convention that the result is a
-        plain ``Dict[str, Any]`` so callers can program against a uniform API.
+        Each worker subclass declares its own concrete signature and returns a
+        :class:`WorkerOutput` so callers can program against a uniform API.
         """
         raise NotImplementedError()
 
-    def _inference_forward(self, data: TrainingInputBatch) -> Dict[str, Any]:
-        """Legacy forward path: run inference in micro batches and return ``{"output": tensor}``.
+    def _inference_forward(self, data: TrainingInputBatch, *, output_key: str = "logprobs") -> WorkerOutput:
+        """Legacy forward path: run inference in micro batches and emit per-sample outputs.
 
         Shared implementation used by RefWorker, CriticWorker, and the
         ``loss_fn is None`` branch of PolicyWorker. Subclasses provide
-        ``_forward_micro_batch`` for the per-micro-batch model call.
+        ``_forward_micro_batch`` for the per-micro-batch model call (returns a
+        ``TrainingOutputBatch`` with ``"output"`` of shape ``[B, T_response]``).
 
-        Returns a plain dict (``{"output": tensor}``) — concatenation across DP
-        ranks happens in the dispatcher, not here.
+        Args:
+            data: Mini-batch input.
+            output_key: Per-sample dict key under which the row tensor is stored
+                in ``loss_fn_outputs`` (``"logprobs"`` for policy/ref,
+                ``"values"`` for critic).
+
+        Returns:
+            :class:`WorkerOutput` with a per-sample ``loss_fn_outputs`` list.
+            Each entry holds one row of the worker's output tensor; downstream
+            (trainer / backend) reassembles into a ``[B, T]`` tensor via
+            :func:`loss_fn_outputs_to_tensor` when a tensor view is needed.
+            Concatenation across DP ranks happens in the dispatcher.
         """
         # run in micro batches of cfg.micro_forward_batch_size_per_gpu
         # TODO (sumanthrh): this can be in the policy/critic impl if the micro batch size can be specific to policy, critic, etc.
@@ -419,8 +430,9 @@ class Worker(DistributedTorchRayActor):
         output = TrainingOutputBatch.cat(outputs)
         if output.device is not None and output.device != torch.device("cpu"):
             output = output.to("cpu")
-        # Return as a plain dict; the dispatcher concatenates dict shards across DP ranks.
-        return dict(output.items())
+        row_tensor = output["output"]
+        loss_fn_outputs = [{output_key: row_tensor[i].tolist()} for i in range(row_tensor.shape[0])]
+        return WorkerOutput(loss_fn_outputs=loss_fn_outputs, metrics={})
 
     def _forward_micro_batch(self, micro_batch: TrainingInputBatch) -> TrainingOutputBatch:
         raise NotImplementedError()
@@ -712,7 +724,7 @@ class PolicyWorkerBase(Worker):
         data: TrainingInputBatch,
         loss_fn: Optional[str] = None,
         loss_fn_config: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, float]:
+    ) -> WorkerOutput:
         """
         Perform forward and backward passes for a batch, handling micro-batching internally.
 
@@ -727,7 +739,8 @@ class PolicyWorkerBase(Worker):
                            (e.g., {"clip_low_threshold": 0.9} for PPO)
 
         Returns:
-            Aggregated metrics dict across all micro batches
+            :class:`WorkerOutput` with per-sample ``loss_fn_outputs`` and scalar
+            ``metrics`` (all-reduced across DP).
         """
         micro_batch_size = self.cfg.micro_train_batch_size_per_gpu
         all_metrics = defaultdict(list)
@@ -757,11 +770,7 @@ class PolicyWorkerBase(Worker):
         dp_group = self.device_mesh.get_group("dp")
         result = all_reduce_metrics(result, self.strategy, group=dp_group, sum_loss_metrics=sum_loss_metrics)
 
-        # Add back loss_fn_outputs (concatenated across micro-batches)
-        if all_loss_fn_outputs:
-            result["loss_fn_outputs"] = all_loss_fn_outputs
-
-        return result
+        return WorkerOutput(loss_fn_outputs=all_loss_fn_outputs, metrics=result)
 
     def _forward_backward_micro(
         self,
@@ -978,19 +987,21 @@ class PolicyWorkerBase(Worker):
         data: TrainingInputBatch,
         loss_fn: Optional[str] = None,
         loss_fn_config: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ) -> WorkerOutput:
         """Run forward pass.
 
         - When ``loss_fn`` is None: runs inference in micro batches via
-          :meth:`Worker._inference_forward` and returns a plain dict
-          (``{"output": tensor}``).
+          :meth:`Worker._inference_forward` and returns a :class:`WorkerOutput`
+          with per-sample ``loss_fn_outputs`` (``logprobs`` key) and empty
+          ``metrics``.
         - When ``loss_fn`` is set (e.g., ``"cross_entropy"``): runs the loss in ``no_grad`` mode
           (no backward), iterating over micro-batches of ``micro_forward_batch_size_per_gpu``,
-          and returns a metrics dict including ``"loss"`` and per-sample ``"loss_fn_outputs"``.
-          Metrics are all-reduced across the DP group to mirror :meth:`forward_backward`.
+          and returns a :class:`WorkerOutput` with per-sample ``loss_fn_outputs`` plus
+          ``metrics`` (e.g. ``"loss"``).  Metrics are all-reduced across the DP group
+          to mirror :meth:`forward_backward`.
         """
         if loss_fn is None:
-            return self._inference_forward(data)
+            return self._inference_forward(data, output_key="logprobs")
 
         micro_batch_size = self.cfg.micro_forward_batch_size_per_gpu
         all_metrics = defaultdict(list)
@@ -1011,10 +1022,7 @@ class PolicyWorkerBase(Worker):
         dp_group = self.device_mesh.get_group("dp")
         result = all_reduce_metrics(result, self.strategy, group=dp_group, sum_loss_metrics=sum_loss_metrics)
 
-        if all_loss_fn_outputs:
-            result["loss_fn_outputs"] = all_loss_fn_outputs
-
-        return result
+        return WorkerOutput(loss_fn_outputs=all_loss_fn_outputs, metrics=result)
 
     def _forward_micro_with_loss(
         self,
@@ -1140,7 +1148,7 @@ class CriticWorkerBase(Worker):
         self.critic_loss_fn: Callable = ppo_critic_loss
         self._micro_batches_accumulated = 0
 
-    def forward_backward(self, data: TrainingInputBatch) -> Dict[str, float]:
+    def forward_backward(self, data: TrainingInputBatch) -> WorkerOutput:
         """
         Perform forward and backward passes for a batch, handling micro-batching internally.
 
@@ -1151,7 +1159,8 @@ class CriticWorkerBase(Worker):
             data: TrainingInputBatch (already DP-sharded by WorkerDispatch/MeshDispatch)
 
         Returns:
-            Aggregated metrics dict across all micro batches
+            :class:`WorkerOutput` with empty ``loss_fn_outputs`` and scalar
+            ``metrics`` (all-reduced across DP).
         """
         micro_batch_size = self.cfg.micro_train_batch_size_per_gpu
         all_metrics = defaultdict(list)
@@ -1168,7 +1177,7 @@ class CriticWorkerBase(Worker):
         # all reduce metrics across DP workers
         result = all_reduce_metrics(result, self.strategy)
 
-        return result
+        return WorkerOutput(metrics=result)
 
     def _forward_backward_micro(self, experience: Experience) -> Dict[str, float]:
         """
@@ -1270,9 +1279,13 @@ class CriticWorkerBase(Worker):
         output.metadata = micro_batch.metadata
         return output
 
-    def forward(self, data: TrainingInputBatch) -> Dict[str, Any]:
-        """Run inference forward pass. Returns ``{"output": values}`` as a plain dict."""
-        return self._inference_forward(data)
+    def forward(self, data: TrainingInputBatch) -> WorkerOutput:
+        """Run inference forward pass.
+
+        Returns a :class:`WorkerOutput` whose ``loss_fn_outputs`` carries one
+        per-sample dict with key ``"values"``.
+        """
+        return self._inference_forward(data, output_key="values")
 
 
 class RefWorkerBase(Worker):
@@ -1283,9 +1296,13 @@ class RefWorkerBase(Worker):
         self.optimizer = None
         self.scheduler = None
 
-    def forward(self, data: TrainingInputBatch) -> Dict[str, Any]:
-        """Run inference forward pass. Returns ``{"output": log_probs}`` as a plain dict."""
-        return self._inference_forward(data)
+    def forward(self, data: TrainingInputBatch) -> WorkerOutput:
+        """Run inference forward pass.
+
+        Returns a :class:`WorkerOutput` whose ``loss_fn_outputs`` carries one
+        per-sample dict with key ``"logprobs"``.
+        """
+        return self._inference_forward(data, output_key="logprobs")
 
     def _forward_micro_batch(self, micro_batch: TrainingInputBatch) -> TrainingOutputBatch:
         device = torch.cuda.current_device()

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -16,7 +16,7 @@ from ray import ObjectRef
 
 from skyrl.backends.skyrl_train.distributed.dispatch import (
     MeshDispatch,
-    concatenate_dict_outputs_after_mesh_dispatch,
+    WorkerOutput,
 )
 from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import (
     InferenceEngineClient,
@@ -198,15 +198,17 @@ class WorkerDispatch:
         loss_fn: Optional[str] = None,
         loss_fn_config: Optional[Dict[str, Any]] = None,
         model_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """Run inference forward pass. Only loads model (not optimizer).
+    ) -> WorkerOutput:
+        """Run forward pass. Only loads model (not optimizer).
 
-        Always returns a ``dict``:
-        - When ``loss_fn`` is None (RL/inference path): returns ``{"output": Tensor[batch, max_response_len]}``
-          where ``Tensor`` is the concatenated output across DP ranks (e.g., logprobs for policy/ref,
-          values for critic).
-        - When ``loss_fn`` is set (e.g., ``"cross_entropy"``): returns a metrics dict containing at
-          minimum ``"loss"`` and ``"loss_fn_outputs"`` (per-sample list aggregated across DP ranks).
+        Returns a :class:`WorkerOutput` aggregated across DP ranks:
+
+        - When ``loss_fn`` is None (RL/inference path): ``loss_fn_outputs`` is a
+          per-sample list of dicts (one entry per batch item) keyed by
+          ``logprobs`` (policy/ref) or ``values`` (critic); ``metrics`` is empty.
+        - When ``loss_fn`` is set (e.g., ``"cross_entropy"``): ``loss_fn_outputs``
+          carries per-sample arrays (e.g. ``logprobs`` / ``elementwise_loss``)
+          and ``metrics`` contains scalar metrics like ``"loss"``.
 
         Args:
             model: Model identifier ("policy", "critic", or "ref")
@@ -229,21 +231,7 @@ class WorkerDispatch:
         refs = self._actor_groups[model].async_run_ray_method("mesh", "forward", data=data, **kwargs)
         results = ray.get(refs)
 
-        if loss_fn is not None:
-            # Forward-with-loss path: each DP rank returns a dict of metrics + per-sample loss_fn_outputs.
-            # Concatenate loss_fn_outputs across DP ranks (rank order); scalar metrics are already all-reduced.
-            all_loss_fn_outputs = []
-            for status in results:
-                if status and "loss_fn_outputs" in status:
-                    all_loss_fn_outputs.extend(status.pop("loss_fn_outputs", []))
-            result = results[0] if results else {}
-            if all_loss_fn_outputs:
-                result["loss_fn_outputs"] = all_loss_fn_outputs
-            return result
-
-        # Inference path (no loss_fn): worker returns a plain dict (``{"output": tensor}``) per DP
-        # rank; concatenate the tensors across DP to reconstruct the full batch.
-        return concatenate_dict_outputs_after_mesh_dispatch(self._actor_groups[model].actor_infos, results)
+        return WorkerOutput.cat(self._actor_groups[model].actor_infos, results)
 
     def stage_data(
         self,
@@ -275,7 +263,7 @@ class WorkerDispatch:
         loss_fn: Optional[str] = None,
         loss_fn_config: Optional[Dict[str, Any]] = None,
         model_id: Optional[str] = None,
-    ) -> Dict[str, float]:
+    ) -> WorkerOutput:
         """Run forward/backward pass. Needs model + optimizer.
 
         Args:
@@ -290,7 +278,8 @@ class WorkerDispatch:
                      LoRA adapter is swapped in before the forward/backward.
 
         Returns:
-            Dictionary of training metrics
+            :class:`WorkerOutput` with per-sample ``loss_fn_outputs`` aggregated
+            across DP ranks plus scalar ``metrics`` (already all-reduced).
         """
         self._ensure_on_gpu(model, need_optimizer=True, need_model=True)
         self.ensure_active_adapter(model, model_id)
@@ -307,18 +296,7 @@ class WorkerDispatch:
 
         self._save_memory_snapshot(model, "forward_backward")
 
-        # With DP>1, each rank returns loss_fn_outputs for its data chunk.
-        # Concatenate them in rank order to get the full batch's outputs.
-        # Scalar metrics (loss, lr) are already all-reduced, so use statuses[0] for those.
-        if len(statuses) > 1 and statuses[0] and "loss_fn_outputs" in statuses[0]:
-            all_loss_fn_outputs = []
-            for status in statuses:
-                all_loss_fn_outputs.extend(status.pop("loss_fn_outputs", []))
-            result = statuses[0]
-            result["loss_fn_outputs"] = all_loss_fn_outputs
-            return result
-
-        return statuses[0]
+        return WorkerOutput.cat(self._actor_groups[model].actor_infos, statuses)
 
     def forward_backward_from_staged(
         self,
@@ -327,7 +305,7 @@ class WorkerDispatch:
         loss_fn: Optional[str] = None,
         loss_fn_config: Optional[Dict[str, Any]] = None,
         model_id: Optional[str] = None,
-    ) -> Dict[str, float]:
+    ) -> WorkerOutput:
         """
         Run forward/backward pass using pre-staged per-DP chunks.
 
@@ -339,7 +317,8 @@ class WorkerDispatch:
             chunk_refs: Pre-staged ObjectRefs, one per DP rank (from ``stage_data``)
 
         Returns:
-            Aggregated metrics dict from training
+            :class:`WorkerOutput` with per-sample ``loss_fn_outputs`` aggregated
+            across DP ranks plus scalar ``metrics`` (already all-reduced).
         """
         self._ensure_on_gpu(model, need_optimizer=True, need_model=True)
         self.ensure_active_adapter(model, model_id)
@@ -360,7 +339,7 @@ class WorkerDispatch:
         statuses = ray.get(refs)
 
         self._save_memory_snapshot(model, "forward_backward")
-        return statuses[0]
+        return WorkerOutput.cat(self._actor_groups[model].actor_infos, statuses)
 
     def optim_step(self, model: str, model_id: Optional[str] = None) -> Optional[float]:
         """Run optimizer step. For single-tenant training, the model should already be on GPU from forward_backward.

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -16,7 +16,7 @@ from ray import ObjectRef
 
 from skyrl.backends.skyrl_train.distributed.dispatch import (
     MeshDispatch,
-    concatenate_outputs_after_mesh_dispatch,
+    concatenate_dict_outputs_after_mesh_dispatch,
 )
 from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import (
     InferenceEngineClient,
@@ -241,10 +241,9 @@ class WorkerDispatch:
                 result["loss_fn_outputs"] = all_loss_fn_outputs
             return result
 
-        # Inference path (no loss_fn): worker returns TrainingOutputBatch per DP rank; concatenate
-        # across DP and unwrap into a plain dict so the API is uniformly ``dict``.
-        output = concatenate_outputs_after_mesh_dispatch(self._actor_groups[model].actor_infos, results)
-        return dict(output.items())
+        # Inference path (no loss_fn): worker returns a plain dict (``{"output": tensor}``) per DP
+        # rank; concatenate the tensors across DP to reconstruct the full batch.
+        return concatenate_dict_outputs_after_mesh_dispatch(self._actor_groups[model].actor_infos, results)
 
     def stage_data(
         self,

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -23,7 +23,6 @@ from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import
 )
 from skyrl.backends.skyrl_train.training_batch import (
     TrainingInputBatch,
-    TrainingOutputBatch,
 )
 from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
 from skyrl.train.config import SkyRLTrainConfig
@@ -192,16 +191,60 @@ class WorkerDispatch:
             return
         self._gpu_state[model] = GPUState()
 
-    def forward(self, model: str, data: TrainingInputBatch, model_id: Optional[str] = None) -> TrainingOutputBatch:
-        """Run inference forward pass. Only loads model (not optimizer)."""
+    def forward(
+        self,
+        model: str,
+        data: TrainingInputBatch,
+        loss_fn: Optional[str] = None,
+        loss_fn_config: Optional[Dict[str, Any]] = None,
+        model_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Run inference forward pass. Only loads model (not optimizer).
+
+        Always returns a ``dict``:
+        - When ``loss_fn`` is None (RL/inference path): returns ``{"output": Tensor[batch, max_response_len]}``
+          where ``Tensor`` is the concatenated output across DP ranks (e.g., logprobs for policy/ref,
+          values for critic).
+        - When ``loss_fn`` is set (e.g., ``"cross_entropy"``): returns a metrics dict containing at
+          minimum ``"loss"`` and ``"loss_fn_outputs"`` (per-sample list aggregated across DP ranks).
+
+        Args:
+            model: Model identifier ("policy", "critic", or "ref")
+            data: Training batch data
+            loss_fn: Optional resolved loss function name (e.g., "cross_entropy"). When set,
+                     the worker computes loss + per-sample outputs without backward (no_grad).
+            loss_fn_config: Optional config overrides for the loss function.
+            model_id: Optional Tinker model_id; when set, the corresponding LoRA adapter
+                     is swapped in before the forward.
+        """
         self._ensure_on_gpu(model, need_optimizer=False, need_model=True)
         self.ensure_active_adapter(model, model_id)
 
-        refs = self._actor_groups[model].async_run_ray_method("mesh", "forward", data=data)
+        kwargs = {}
+        if loss_fn is not None:
+            kwargs["loss_fn"] = loss_fn
+        if loss_fn_config is not None:
+            kwargs["loss_fn_config"] = loss_fn_config
+
+        refs = self._actor_groups[model].async_run_ray_method("mesh", "forward", data=data, **kwargs)
         results = ray.get(refs)
 
+        if loss_fn is not None:
+            # Forward-with-loss path: each DP rank returns a dict of metrics + per-sample loss_fn_outputs.
+            # Concatenate loss_fn_outputs across DP ranks (rank order); scalar metrics are already all-reduced.
+            all_loss_fn_outputs = []
+            for status in results:
+                if status and "loss_fn_outputs" in status:
+                    all_loss_fn_outputs.extend(status.pop("loss_fn_outputs", []))
+            result = results[0] if results else {}
+            if all_loss_fn_outputs:
+                result["loss_fn_outputs"] = all_loss_fn_outputs
+            return result
+
+        # Inference path (no loss_fn): worker returns TrainingOutputBatch per DP rank; concatenate
+        # across DP and unwrap into a plain dict so the API is uniformly ``dict``.
         output = concatenate_outputs_after_mesh_dispatch(self._actor_groups[model].actor_infos, results)
-        return output
+        return dict(output.items())
 
     def stage_data(
         self,

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -760,17 +760,18 @@ class SkyRLTrainBackend(AbstractBackend):
             )
 
         # Trim padding entries from loss_fn_outputs
-        if pad_size > 0 and "loss_fn_outputs" in data:
-            data["loss_fn_outputs"] = data["loss_fn_outputs"][:-pad_size]
+        per_sample_outputs = data.loss_fn_outputs
+        if pad_size > 0 and per_sample_outputs:
+            per_sample_outputs = per_sample_outputs[:-pad_size]
 
-        metrics = self._extract_metrics(data)
+        metrics = self._extract_metrics(data.metrics)
 
         results = {}
         for request_id, _, start_idx, end_idx in prepared_batch.request_batch_slices:
-            if "loss_fn_outputs" in data:
+            if per_sample_outputs:
                 loss_fn_outputs = []
                 for i in range(start_idx, end_idx):
-                    raw_output = data["loss_fn_outputs"][i]
+                    raw_output = per_sample_outputs[i]
                     formatted_output = {}
                     for key in ("elementwise_loss", "logprobs", "values"):
                         values = list(raw_output.get(key, []))
@@ -784,7 +785,7 @@ class SkyRLTrainBackend(AbstractBackend):
             else:
                 loss_fn_outputs = [{} for _ in range(end_idx - start_idx)]
             results[request_id] = types.ForwardBackwardOutput(
-                loss_fn_output_type="scalar",
+                loss_fn_output_type=data.loss_fn_output_type,
                 loss_fn_outputs=loss_fn_outputs,
                 metrics=metrics,
             )
@@ -816,11 +817,10 @@ class SkyRLTrainBackend(AbstractBackend):
         model_id = prepared_batch.all_model_ids[0] if prepared_batch.all_model_ids else None
         data = self._dispatch.forward(role, batch, model_id=model_id)
 
-        # dispatch.forward() returns a plain dict {"output": tensor[batch, max_response_len]}.
-        # Trim padding entries from output
-        output_tensor = data["output"]
-        if pad_size > 0:
-            output_tensor = output_tensor[:-pad_size]
+        # Workers emit per-sample loss_fn_outputs directly. Trim padding entries.
+        per_sample_outputs = data.loss_fn_outputs
+        if pad_size > 0 and per_sample_outputs:
+            per_sample_outputs = per_sample_outputs[:-pad_size]
 
         results = {}
         for request_id, _, start_idx, end_idx in prepared_batch.request_batch_slices:
@@ -828,9 +828,14 @@ class SkyRLTrainBackend(AbstractBackend):
             for i in range(start_idx, end_idx):
                 # Use token weights length to determine each example's actual response length
                 valid_len = len(prepared_batch.all_token_weights[i])
-                start = max(output_tensor.shape[1] - valid_len, 0)
-                outputs = output_tensor[i, start:].tolist()
                 output_key = "values" if role == "critic" else "logprobs"
+                raw_values = per_sample_outputs[i].get(output_key, []) if per_sample_outputs else []
+                # Each per-sample list has length ``max_response_len`` (the batch's
+                # response length), left-padded with zeros so the real per-token
+                # values land in the rightmost ``valid_len`` positions. Slice the
+                # tail to recover this sample's actual response tokens.
+                start = max(len(raw_values) - valid_len, 0)
+                outputs = list(raw_values[start:])
                 loss_fn_outputs.append(
                     {
                         output_key: {
@@ -841,7 +846,7 @@ class SkyRLTrainBackend(AbstractBackend):
                     }
                 )
             results[request_id] = types.ForwardBackwardOutput(
-                loss_fn_output_type="scalar",
+                loss_fn_output_type=data.loss_fn_output_type,
                 loss_fn_outputs=loss_fn_outputs,
                 metrics={},
             )

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -816,7 +816,7 @@ class SkyRLTrainBackend(AbstractBackend):
         model_id = prepared_batch.all_model_ids[0] if prepared_batch.all_model_ids else None
         data = self._dispatch.forward(role, batch, model_id=model_id)
 
-        # dispatch.forward() returns TrainingOutputBatch({"output": tensor[batch, max_response_len]})
+        # dispatch.forward() returns a plain dict {"output": tensor[batch, max_response_len]}.
         # Trim padding entries from output
         output_tensor = data["output"]
         if pad_size > 0:

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -615,10 +615,11 @@ class SFTTrainer:
         """
         timings: dict[str, float] = {}
         with Timer("forward_backward", timings):
-            metrics = self.dispatch.forward_backward("policy", batch, loss_fn="cross_entropy")
+            output = self.dispatch.forward_backward("policy", batch, loss_fn="cross_entropy")
         with Timer("optim_step", timings):
             grad_norm = self.dispatch.optim_step("policy")
 
+        metrics = output.metrics
         loss_val = metrics.get("final_loss", metrics.get("loss", float("nan")))
         return {
             "loss": loss_val,

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -18,6 +18,7 @@ from transformers import AutoTokenizer
 from skyrl.backends.skyrl_train.distributed.dispatch import (
     ActorInfo,
     MeshRank,
+    loss_fn_outputs_to_tensor,
 )
 from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import (
     InferenceEngineClient,
@@ -995,17 +996,17 @@ class RayPPOTrainer:
         # Critic forward (dispatch handles offload/backload automatically)
         if self.has_critic:
             critic_output = self.dispatch.forward("critic", data_fwd_pass)
-            values = critic_output["output"]
+            values = loss_fn_outputs_to_tensor(critic_output.loss_fn_outputs, key="values")
 
         # Ref forward
         if self.ref_model is not None:
             ref_output = self.dispatch.forward("ref", data_fwd_pass)
-            base_log_probs = ref_output["output"]
+            base_log_probs = loss_fn_outputs_to_tensor(ref_output.loss_fn_outputs, key="logprobs")
             self.dispatch.empty_cache("ref")
 
         # Policy forward
         policy_output = self.dispatch.forward("policy", data_fwd_pass)
-        action_log_probs = policy_output["output"]
+        action_log_probs = loss_fn_outputs_to_tensor(policy_output.loss_fn_outputs, key="logprobs")
 
         # Empty cache after all forward passes
         self.dispatch.empty_cache()
@@ -1160,7 +1161,7 @@ class RayPPOTrainer:
         for _epoch in range(self.cfg.trainer.update_epochs_per_batch):
             for chunk_refs in all_chunk_refs:
                 status = self.dispatch.forward_backward_from_staged(model, chunk_refs)
-                for k, v in status.items():
+                for k, v in status.metrics.items():
                     all_metrics[k].append(v)
 
                 # Optimizer step after each mini batch
@@ -1169,8 +1170,6 @@ class RayPPOTrainer:
                     all_metrics["grad_norm"].append(grad_norm)
 
         # Reduce metrics across all mini-batches and epochs
-        # pop out loss_fn_outputs since it's not a scalar metric and to avoid logging it
-        all_metrics.pop("loss_fn_outputs", None)
         reduced_metrics = reduce_metrics(all_metrics, sum_loss_metrics=False)
         return reduced_metrics
 

--- a/tests/backends/skyrl_train/distributed/test_dispatch.py
+++ b/tests/backends/skyrl_train/distributed/test_dispatch.py
@@ -4,6 +4,7 @@ uv run --isolated --extra dev pytest tests/backends/skyrl_train/distributed/test
 
 from typing import List
 
+import pytest
 import ray
 import torch
 from ray import ObjectRef
@@ -16,6 +17,7 @@ from skyrl.backends.skyrl_train.distributed.dispatch import (
     MeshRank,
     PassThroughDispatch,
     concatenate_outputs_after_mesh_dispatch,
+    loss_fn_outputs_to_tensor,
 )
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.train.dataset.preprocess import compute_prompt_mini_batch_boundaries
@@ -119,6 +121,53 @@ def test_pass_through_dispatch():
     actor_group = RayActorGroup(num_actors)
     ret = actor_group.pass_through_dispatch(1, 2)
     assert ret == [None] * num_actors
+
+
+def test_loss_fn_outputs_to_tensor_basic():
+    """Default key="logprobs", default pad_value=0.0: pads to [B, T_max]."""
+    outputs = [
+        {"logprobs": [1.0, 2.0]},
+        {"logprobs": [3.0, 4.0, 5.0]},
+        {"logprobs": [6.0]},
+    ]
+    tensor = loss_fn_outputs_to_tensor(outputs)
+    expected = torch.tensor(
+        [
+            [1.0, 2.0, 0.0],
+            [3.0, 4.0, 5.0],
+            [6.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    assert tensor.shape == (3, 3)
+    assert tensor.dtype == torch.float32
+    assert torch.equal(tensor, expected)
+
+
+def test_loss_fn_outputs_to_tensor_custom_key_and_pad():
+    """Custom key="values" and pad_value=-1.0 propagate correctly."""
+    outputs = [
+        {"values": [0.5]},
+        {"values": [0.1, 0.2, 0.3, 0.4]},
+        {"values": [0.7, 0.8]},
+    ]
+    tensor = loss_fn_outputs_to_tensor(outputs, key="values", pad_value=-1.0)
+    expected = torch.tensor(
+        [
+            [0.5, -1.0, -1.0, -1.0],
+            [0.1, 0.2, 0.3, 0.4],
+            [0.7, 0.8, -1.0, -1.0],
+        ],
+        dtype=torch.float32,
+    )
+    assert tensor.shape == (3, 4)
+    assert torch.equal(tensor, expected)
+
+
+def test_loss_fn_outputs_to_tensor_empty():
+    """Empty input list raises RuntimeError from torch.nn.utils.rnn.pad_sequence."""
+    with pytest.raises(RuntimeError, match="empty list of sequences"):
+        loss_fn_outputs_to_tensor([])
 
 
 def test_dispatch_registry():

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_models.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_models.py
@@ -9,7 +9,8 @@ import torch
 from transformers import AutoTokenizer
 
 from skyrl.backends.skyrl_train.distributed.dispatch import (
-    concatenate_dict_outputs_after_mesh_dispatch,
+    WorkerOutput,
+    loss_fn_outputs_to_tensor,
 )
 from skyrl.backends.skyrl_train.inference_engines.utils import (
     get_sampling_params_for_backend,
@@ -266,7 +267,8 @@ async def test_logprobs_matching_roundtrip(
 
             refs = policy.async_run_ray_method("mesh", "forward", data=training_input)
             results = ray.get(refs)
-            logprobs_megatron = concatenate_dict_outputs_after_mesh_dispatch(policy.actor_infos, results)["output"]
+            policy_output = WorkerOutput.cat(policy.actor_infos, results)
+            logprobs_megatron = loss_fn_outputs_to_tensor(policy_output.loss_fn_outputs, key="logprobs")
 
             mask = response_mask.bool()
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_models.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_models.py
@@ -9,7 +9,7 @@ import torch
 from transformers import AutoTokenizer
 
 from skyrl.backends.skyrl_train.distributed.dispatch import (
-    concatenate_outputs_after_mesh_dispatch,
+    concatenate_dict_outputs_after_mesh_dispatch,
 )
 from skyrl.backends.skyrl_train.inference_engines.utils import (
     get_sampling_params_for_backend,
@@ -266,7 +266,7 @@ async def test_logprobs_matching_roundtrip(
 
             refs = policy.async_run_ray_method("mesh", "forward", data=training_input)
             results = ray.get(refs)
-            logprobs_megatron = concatenate_outputs_after_mesh_dispatch(policy.actor_infos, results)["output"]
+            logprobs_megatron = concatenate_dict_outputs_after_mesh_dispatch(policy.actor_infos, results)["output"]
 
             mask = response_mask.bool()
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
@@ -513,22 +513,21 @@ async def test_megatron_train(
         ray.get(actor_group.async_run_ray_method("pass_through", "optim_step"))
         # Get learning rate from worker
         lr_results = ray.get(actor_group.async_run_ray_method("pass_through", "get_lr"))
+        # `forward_backward` returns WorkerOutput (frozen); mutate the `metrics` dict in place.
         for i, result in enumerate(results_megatron):
-            result["policy_lr"] = lr_results[i]
+            result.metrics["policy_lr"] = lr_results[i]
 
     memory = ray.get(actor_group.async_run_ray_method("pass_through", "get_cuda_memory"))
     memory = memory[0]
     print_mem("memory after training step", memory)
 
     for result in results_megatron:
-        assert isinstance(result, dict), "Result should be a dictionary of training stats"
-        assert "policy_loss" in result
-        assert "policy_lr" in result
-        assert "loss_metrics/clip_ratio" in result
-        assert "policy_entropy" in result
-        for k, v in result.items():
-            if k == "loss_fn_outputs":
-                continue
+        assert isinstance(result, WorkerOutput), "Result should be a WorkerOutput of training stats"
+        assert "policy_loss" in result.metrics
+        assert "policy_lr" in result.metrics
+        assert "loss_metrics/clip_ratio" in result.metrics
+        assert "policy_entropy" in result.metrics
+        for k, v in result.metrics.items():
             assert isinstance(v, (int, float)), f"{k} should be an int or float"
 
     ray.shutdown()
@@ -559,8 +558,9 @@ async def test_megatron_train(
     ray.get(actor_group.async_run_ray_method("pass_through", "optim_step"))
     # Get learning rate from worker
     lr_results = ray.get(actor_group.async_run_ray_method("pass_through", "get_lr"))
+    # `forward_backward` returns WorkerOutput (frozen); mutate the `metrics` dict in place.
     for i, result in enumerate(results_fsdp):
-        result["policy_lr"] = lr_results[i]
+        result.metrics["policy_lr"] = lr_results[i]
 
     print("megatron results: ", results_megatron[0])
     print("\n\n")
@@ -587,8 +587,8 @@ async def test_megatron_train(
                 # because the logits for padding tokens are all 0 for the non-sample packing case in megatron
                 # the entropy calculation is different (fsdp has random logits for padding tokens)
                 continue
-            assert isinstance(result[k], (int, float)), f"{k} should be an int or float"
-            assert abs(result[k] - results_megatron[i][k]) < 4e-1, f"diff in {k} is too large!"
+            assert isinstance(result.metrics[k], (int, float)), f"{k} should be an int or float"
+            assert abs(result.metrics[k] - results_megatron[i].metrics[k]) < 4e-1, f"diff in {k} is too large!"
 
 
 @pytest.mark.asyncio
@@ -637,22 +637,21 @@ async def test_megatron_dp(ray_init_fixture, worker_type, tp, pp, gpus_per_node)
     results_megatron = ray.get(actor_group.async_run_ray_method("mesh", "forward_backward", batch))
     ray.get(actor_group.async_run_ray_method("pass_through", "optim_step"))
     lr_results = ray.get(actor_group.async_run_ray_method("pass_through", "get_lr"))
+    # `forward_backward` returns WorkerOutput (frozen); mutate the `metrics` dict in place.
     for i, result in enumerate(results_megatron):
-        result["policy_lr"] = lr_results[i]
+        result.metrics["policy_lr"] = lr_results[i]
 
     memory = ray.get(actor_group.async_run_ray_method("pass_through", "get_cuda_memory"))
     memory = memory[0]
     print_mem("memory after training step", memory)
 
     for result in results_megatron:
-        assert isinstance(result, dict), "Result should be a dictionary of training stats"
-        assert "policy_loss" in result
-        assert "policy_lr" in result
-        assert "loss_metrics/clip_ratio" in result
-        assert "policy_entropy" in result
-        for k, v in result.items():
-            if k == "loss_fn_outputs":
-                continue
+        assert isinstance(result, WorkerOutput), "Result should be a WorkerOutput of training stats"
+        assert "policy_loss" in result.metrics
+        assert "policy_lr" in result.metrics
+        assert "loss_metrics/clip_ratio" in result.metrics
+        assert "policy_entropy" in result.metrics
+        for k, v in result.metrics.items():
             assert isinstance(v, (int, float)), f"{k} should be an int or float"
 
     ray.shutdown()
@@ -684,8 +683,9 @@ async def test_megatron_dp(ray_init_fixture, worker_type, tp, pp, gpus_per_node)
     results_megatron_dp = ray.get(actor_group.async_run_ray_method("mesh", "forward_backward", batch))
     ray.get(actor_group.async_run_ray_method("pass_through", "optim_step"))
     lr_results_dp = ray.get(actor_group.async_run_ray_method("pass_through", "get_lr"))
+    # `forward_backward` returns WorkerOutput (frozen); mutate the `metrics` dict in place.
     for i, result in enumerate(results_megatron_dp):
-        result["policy_lr"] = lr_results_dp[i]
+        result.metrics["policy_lr"] = lr_results_dp[i]
 
     print("megatron results: ", results_megatron)
     print("\n\n")
@@ -700,8 +700,8 @@ async def test_megatron_dp(ray_init_fixture, worker_type, tp, pp, gpus_per_node)
     ]
     for i, result in enumerate(results_megatron_dp):
         for k in keys_to_compare:
-            assert isinstance(result[k], (int, float)), f"{k} should be an int or float"
-            assert abs(result[k] - results_megatron[i][k]) < 1.5e-1, f"diff in {k} is too large!"
+            assert isinstance(result.metrics[k], (int, float)), f"{k} should be an int or float"
+            assert abs(result.metrics[k] - results_megatron[i].metrics[k]) < 1.5e-1, f"diff in {k} is too large!"
 
 
 @pytest.mark.asyncio
@@ -810,8 +810,11 @@ async def test_megatron_offload_memory_and_correctness(ray_init_fixture, worker_
     results_backload = ray.get(actor_group.async_run_ray_method("mesh", "forward_backward", batch))
     ray.get(actor_group.async_run_ray_method("pass_through", "optim_step"))
 
+    # `forward_backward` returns a WorkerOutput per actor (frozen dataclass);
+    # compare scalar `metrics` and per-sample `loss_fn_outputs` directly.
     for i, result in enumerate(results):
         result_backload = results_backload[i]
-        for k, v in result.items():
-            assert k in result_backload
-            assert v == result_backload[k], f"Results mismatch for {k}: {v} != {result_backload[k]}"
+        for k, v in result.metrics.items():
+            assert k in result_backload.metrics
+            assert v == result_backload.metrics[k], f"Metrics mismatch for {k}: {v} != {result_backload.metrics[k]}"
+        assert result.loss_fn_outputs == result_backload.loss_fn_outputs, "loss_fn_outputs mismatch after backload"

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
@@ -9,7 +9,8 @@ import torch
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 from skyrl.backends.skyrl_train.distributed.dispatch import (
-    concatenate_dict_outputs_after_mesh_dispatch,
+    WorkerOutput,
+    loss_fn_outputs_to_tensor,
 )
 from skyrl.backends.skyrl_train.inference_engines.utils import (
     get_sampling_params_for_backend,
@@ -260,9 +261,8 @@ async def test_megatron_forward(
 
     action_log_probs_refs = actor_group.async_run_ray_method("mesh", "forward", data=batch)
     all_rank_action_log_probs = ray.get(action_log_probs_refs)
-    action_log_probs_megatron = concatenate_dict_outputs_after_mesh_dispatch(
-        actor_group.actor_infos, all_rank_action_log_probs
-    )["output"]
+    megatron_output = WorkerOutput.cat(actor_group.actor_infos, all_rank_action_log_probs)
+    action_log_probs_megatron = loss_fn_outputs_to_tensor(megatron_output.loss_fn_outputs, key="logprobs")
 
     ray.shutdown()
     ray_init_for_tests()
@@ -382,9 +382,8 @@ async def test_megatron_lora_forward(ray_init_fixture, tp, pp, cp, ep, etp, gpus
 
     action_log_probs_refs = actor_group.async_run_ray_method("mesh", "forward", data=batch)
     all_rank_action_log_probs = ray.get(action_log_probs_refs)
-    action_log_probs_full = concatenate_dict_outputs_after_mesh_dispatch(
-        actor_group.actor_infos, all_rank_action_log_probs
-    )["output"]
+    full_output = WorkerOutput.cat(actor_group.actor_infos, all_rank_action_log_probs)
+    action_log_probs_full = loss_fn_outputs_to_tensor(full_output.loss_fn_outputs, key="logprobs")
 
     ray.shutdown()
     ray_init_for_tests()
@@ -418,9 +417,8 @@ async def test_megatron_lora_forward(ray_init_fixture, tp, pp, cp, ep, etp, gpus
 
     action_log_probs_refs = actor_group.async_run_ray_method("mesh", "forward", data=batch)
     all_rank_action_log_probs = ray.get(action_log_probs_refs)
-    action_log_probs_lora = concatenate_dict_outputs_after_mesh_dispatch(
-        actor_group.actor_infos, all_rank_action_log_probs
-    )["output"]
+    lora_output = WorkerOutput.cat(actor_group.actor_infos, all_rank_action_log_probs)
+    action_log_probs_lora = loss_fn_outputs_to_tensor(lora_output.loss_fn_outputs, key="logprobs")
 
     #### Compare results ####
     # compare just non-padding tokens

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
@@ -9,7 +9,7 @@ import torch
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 from skyrl.backends.skyrl_train.distributed.dispatch import (
-    concatenate_outputs_after_mesh_dispatch,
+    concatenate_dict_outputs_after_mesh_dispatch,
 )
 from skyrl.backends.skyrl_train.inference_engines.utils import (
     get_sampling_params_for_backend,
@@ -260,7 +260,7 @@ async def test_megatron_forward(
 
     action_log_probs_refs = actor_group.async_run_ray_method("mesh", "forward", data=batch)
     all_rank_action_log_probs = ray.get(action_log_probs_refs)
-    action_log_probs_megatron = concatenate_outputs_after_mesh_dispatch(
+    action_log_probs_megatron = concatenate_dict_outputs_after_mesh_dispatch(
         actor_group.actor_infos, all_rank_action_log_probs
     )["output"]
 
@@ -382,9 +382,9 @@ async def test_megatron_lora_forward(ray_init_fixture, tp, pp, cp, ep, etp, gpus
 
     action_log_probs_refs = actor_group.async_run_ray_method("mesh", "forward", data=batch)
     all_rank_action_log_probs = ray.get(action_log_probs_refs)
-    action_log_probs_full = concatenate_outputs_after_mesh_dispatch(actor_group.actor_infos, all_rank_action_log_probs)[
-        "output"
-    ]
+    action_log_probs_full = concatenate_dict_outputs_after_mesh_dispatch(
+        actor_group.actor_infos, all_rank_action_log_probs
+    )["output"]
 
     ray.shutdown()
     ray_init_for_tests()
@@ -418,9 +418,9 @@ async def test_megatron_lora_forward(ray_init_fixture, tp, pp, cp, ep, etp, gpus
 
     action_log_probs_refs = actor_group.async_run_ray_method("mesh", "forward", data=batch)
     all_rank_action_log_probs = ray.get(action_log_probs_refs)
-    action_log_probs_lora = concatenate_outputs_after_mesh_dispatch(actor_group.actor_infos, all_rank_action_log_probs)[
-        "output"
-    ]
+    action_log_probs_lora = concatenate_dict_outputs_after_mesh_dispatch(
+        actor_group.actor_infos, all_rank_action_log_probs
+    )["output"]
 
     #### Compare results ####
     # compare just non-padding tokens

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_router_replay.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_router_replay.py
@@ -9,7 +9,8 @@ import torch
 from transformers import AutoTokenizer
 
 from skyrl.backends.skyrl_train.distributed.dispatch import (
-    concatenate_dict_outputs_after_mesh_dispatch,
+    WorkerOutput,
+    loss_fn_outputs_to_tensor,
 )
 from skyrl.backends.skyrl_train.inference_engines.utils import (
     get_sampling_params_for_backend,
@@ -246,7 +247,8 @@ async def test_logprobs(ray_init_fixture, tp, pp, cp, ep, etp, extra_tf_kwargs):
 
             refs = actor_group.async_run_ray_method("mesh", "forward", data=training_input)
             results = ray.get(refs)
-            outputs = concatenate_dict_outputs_after_mesh_dispatch(actor_group.actor_infos, results)["output"]
+            output = WorkerOutput.cat(actor_group.actor_infos, results)
+            outputs = loss_fn_outputs_to_tensor(output.loss_fn_outputs, key="logprobs")
 
             for actor in actor_group._actor_handlers:
                 ray.kill(actor)

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_router_replay.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_router_replay.py
@@ -9,7 +9,7 @@ import torch
 from transformers import AutoTokenizer
 
 from skyrl.backends.skyrl_train.distributed.dispatch import (
-    concatenate_outputs_after_mesh_dispatch,
+    concatenate_dict_outputs_after_mesh_dispatch,
 )
 from skyrl.backends.skyrl_train.inference_engines.utils import (
     get_sampling_params_for_backend,
@@ -246,7 +246,7 @@ async def test_logprobs(ray_init_fixture, tp, pp, cp, ep, etp, extra_tf_kwargs):
 
             refs = actor_group.async_run_ray_method("mesh", "forward", data=training_input)
             results = ray.get(refs)
-            outputs = concatenate_outputs_after_mesh_dispatch(actor_group.actor_infos, results)["output"]
+            outputs = concatenate_dict_outputs_after_mesh_dispatch(actor_group.actor_infos, results)["output"]
 
             for actor in actor_group._actor_handlers:
                 ray.kill(actor)

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py
@@ -325,6 +325,12 @@ async def test_sft_forward_with_cross_entropy(ray_init_fixture, cfg, strategy):
         loss_fn_config=None,
     )
 
+    # NOTE: The loss-fn forward path is no-grad: ``_forward_micro_with_loss``
+    # wraps the model call in ``torch.no_grad()`` (worker.py), so policy
+    # parameters accrue no ``.grad`` from this call. We don't assert that
+    # directly here because parameters live inside the Ray actors and reaching
+    # in adds a remote round-trip with no extra signal — the contract is
+    # enforced at the implementation site.
     assert "loss" in result.metrics
     assert math.isfinite(result.metrics["loss"]) and result.metrics["loss"] > 1e-3
     assert len(result.loss_fn_outputs) == batch_size

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py
@@ -79,17 +79,14 @@ async def test_policy_forward_backward_and_optim_step(ray_init_fixture, cfg, pac
         print_mem("memory after forward_backward + optim_step", memory)
 
         for result in results:
-            assert isinstance(result, dict), "Result should be a dictionary of training stats"
-            assert "policy_loss" in result
-            assert "loss_metrics/clip_ratio" in result
-            assert "policy_entropy" in result
-            assert "loss_fn_outputs" in result, "RL path should return loss_fn_outputs"
-            loss_fn_outputs = result.pop("loss_fn_outputs")
-            assert isinstance(loss_fn_outputs, list)
-            for output in loss_fn_outputs:
+            assert "policy_loss" in result.metrics
+            assert "loss_metrics/clip_ratio" in result.metrics
+            assert "policy_entropy" in result.metrics
+            assert result.loss_fn_outputs, "RL path should return loss_fn_outputs"
+            for output in result.loss_fn_outputs:
                 assert "logprobs" in output, "Each output should have logprobs"
                 assert isinstance(output["logprobs"], list)
-            for k, v in result.items():
+            for k, v in result.metrics.items():
                 assert isinstance(v, (int, float)), f"{k} should be an int or float"
 
     finally:
@@ -133,8 +130,8 @@ async def test_policy_loss_fn_outputs_variable_lengths(ray_init_fixture, cfg):
         # Collect all loss_fn_outputs across DP ranks (returned in rank order)
         all_outputs = []
         for result in results:
-            assert "loss_fn_outputs" in result
-            all_outputs.extend(result["loss_fn_outputs"])
+            assert result.loss_fn_outputs
+            all_outputs.extend(result.loss_fn_outputs)
 
         assert len(all_outputs) == batch_size
         for i, output in enumerate(all_outputs):
@@ -181,10 +178,9 @@ async def test_critic_forward_backward_and_optim_step(ray_init_fixture, cfg, pac
         ray.get(actor_group.async_run_ray_method("pass_through", "optim_step"))
 
         for result in results:
-            assert isinstance(result, dict), "Result should be a dictionary of training stats"
-            assert "critic_loss" in result
-            assert "values_mean" in result
-            for k, v in result.items():
+            assert "critic_loss" in result.metrics
+            assert "values_mean" in result.metrics
+            for k, v in result.metrics.items():
                 assert isinstance(v, float), f"{k} should be a float"
 
     finally:
@@ -270,12 +266,10 @@ async def test_sft_forward_backward_with_cross_entropy(ray_init_fixture, cfg, st
         # Each DP rank returns its chunk's results
         all_loss_fn_outputs = []
         for result in results:
-            assert isinstance(result, dict)
-            assert "loss" in result
-            assert "loss_fn_outputs" in result, "SFT path should return loss_fn_outputs"
+            assert "loss" in result.metrics
+            assert result.loss_fn_outputs, "SFT path should return loss_fn_outputs"
 
-            loss_fn_outputs = result["loss_fn_outputs"]
-            assert isinstance(loss_fn_outputs, list)
+            loss_fn_outputs = result.loss_fn_outputs
             assert len(loss_fn_outputs) == samples_per_rank, f"Expected {samples_per_rank} outputs per rank"
             all_loss_fn_outputs.extend(loss_fn_outputs)
 
@@ -332,12 +326,10 @@ async def test_sft_forward_with_cross_entropy(ray_init_fixture, cfg, strategy):
             loss_fn_config=None,
         )
 
-        assert isinstance(result, dict)
-        assert "loss" in result
-        assert math.isfinite(result["loss"]) and result["loss"] > 1e-3
-        assert "loss_fn_outputs" in result
-        assert len(result["loss_fn_outputs"]) == batch_size
-        for out in result["loss_fn_outputs"]:
+        assert "loss" in result.metrics
+        assert math.isfinite(result.metrics["loss"]) and result.metrics["loss"] > 1e-3
+        assert len(result.loss_fn_outputs) == batch_size
+        for out in result.loss_fn_outputs:
             assert "logprobs" in out and len(out["logprobs"]) == num_actions
             assert "elementwise_loss" in out and len(out["elementwise_loss"]) == num_actions
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py
@@ -3,9 +3,12 @@ Run with:
 uv run --isolated --extra dev --extra fsdp -- pytest tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py
 """
 
+import math
+
 import pytest
 import ray
 
+from skyrl.backends.skyrl_train.workers.worker_dispatch import WorkerDispatch
 from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.utils.utils import print_mem, validate_cfg
 from tests.backends.skyrl_train.gpu.utils import (
@@ -285,6 +288,58 @@ async def test_sft_forward_backward_with_cross_entropy(ray_init_fixture, cfg, st
             assert "elementwise_loss" in output, f"Output {i} missing elementwise_loss"
             # Verify trimmed to valid length (loss_mask is all 1s, so should equal num_actions)
             assert len(output["logprobs"]) == num_actions
+
+    finally:
+        ray.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "strategy",
+    ["fsdp2", pytest.param("megatron", marks=pytest.mark.megatron)],
+    ids=["fsdp2", "megatron"],
+)
+async def test_sft_forward_with_cross_entropy(ray_init_fixture, cfg, strategy):
+    """forward(loss_fn='cross_entropy') returns a non-zero loss + per-sample loss_fn_outputs (no grads)."""
+    cfg.trainer.use_sample_packing = False
+    cfg.trainer.strategy = strategy
+    if strategy == "megatron":
+        cfg.trainer.policy.megatron_config.tensor_model_parallel_size = 1
+        cfg.trainer.policy.megatron_config.pipeline_model_parallel_size = 1
+        cfg.trainer.placement.policy_num_gpus_per_node = 2
+    validate_cfg(cfg)
+
+    try:
+        actor_group = init_worker_with_type(
+            "policy",
+            shared_pg=None,
+            colocate_all=False,
+            num_gpus_per_node=cfg.trainer.placement.policy_num_gpus_per_node,
+            cfg=cfg,
+        )
+
+        dp_size = actor_group.actor_infos[0].rank.dp_size
+        batch_size = dp_size * 2  # Ensure multiple samples per DP rank
+        num_actions = 4
+        dummy_batch = make_dummy_training_batch(batch_size=batch_size, num_actions=num_actions)
+
+        dispatch = WorkerDispatch(cfg, policy_actor_group=actor_group)
+
+        result = dispatch.forward(
+            "policy",
+            dummy_batch,
+            loss_fn="cross_entropy",
+            loss_fn_config=None,
+        )
+
+        assert isinstance(result, dict)
+        assert "loss" in result
+        assert math.isfinite(result["loss"]) and result["loss"] > 1e-3
+        assert "loss_fn_outputs" in result
+        assert len(result["loss_fn_outputs"]) == batch_size
+        for out in result["loss_fn_outputs"]:
+            assert "logprobs" in out and len(out["logprobs"]) == num_actions
+            assert "elementwise_loss" in out and len(out["elementwise_loss"]) == num_actions
 
     finally:
         ray.shutdown()

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py
@@ -303,35 +303,31 @@ async def test_sft_forward_with_cross_entropy(ray_init_fixture, cfg, strategy):
         cfg.trainer.placement.policy_num_gpus_per_node = 2
     validate_cfg(cfg)
 
-    try:
-        actor_group = init_worker_with_type(
-            "policy",
-            shared_pg=None,
-            colocate_all=False,
-            num_gpus_per_node=cfg.trainer.placement.policy_num_gpus_per_node,
-            cfg=cfg,
-        )
+    actor_group = init_worker_with_type(
+        "policy",
+        shared_pg=None,
+        colocate_all=False,
+        num_gpus_per_node=cfg.trainer.placement.policy_num_gpus_per_node,
+        cfg=cfg,
+    )
 
-        dp_size = actor_group.actor_infos[0].rank.dp_size
-        batch_size = dp_size * 2  # Ensure multiple samples per DP rank
-        num_actions = 4
-        dummy_batch = make_dummy_training_batch(batch_size=batch_size, num_actions=num_actions)
+    dp_size = actor_group.actor_infos[0].rank.dp_size
+    batch_size = dp_size * 2  # Ensure multiple samples per DP rank
+    num_actions = 4
+    dummy_batch = make_dummy_training_batch(batch_size=batch_size, num_actions=num_actions)
 
-        dispatch = WorkerDispatch(cfg, policy_actor_group=actor_group)
+    dispatch = WorkerDispatch(cfg, policy_actor_group=actor_group)
 
-        result = dispatch.forward(
-            "policy",
-            dummy_batch,
-            loss_fn="cross_entropy",
-            loss_fn_config=None,
-        )
+    result = dispatch.forward(
+        "policy",
+        dummy_batch,
+        loss_fn="cross_entropy",
+        loss_fn_config=None,
+    )
 
-        assert "loss" in result.metrics
-        assert math.isfinite(result.metrics["loss"]) and result.metrics["loss"] > 1e-3
-        assert len(result.loss_fn_outputs) == batch_size
-        for out in result.loss_fn_outputs:
-            assert "logprobs" in out and len(out["logprobs"]) == num_actions
-            assert "elementwise_loss" in out and len(out["elementwise_loss"]) == num_actions
-
-    finally:
-        ray.shutdown()
+    assert "loss" in result.metrics
+    assert math.isfinite(result.metrics["loss"]) and result.metrics["loss"] > 1e-3
+    assert len(result.loss_fn_outputs) == batch_size
+    for out in result.loss_fn_outputs:
+        assert "logprobs" in out and len(out["logprobs"]) == num_actions
+        assert "elementwise_loss" in out and len(out["elementwise_loss"]) == num_actions

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_worker_offload.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_worker_offload.py
@@ -145,11 +145,14 @@ async def test_critic_policy_offload_memory_and_correctness(ray_init_fixture, cf
         results_backload = ray.get(actor_group.async_run_ray_method("mesh", "forward_backward", data=dummy_batch))
         ray.get(actor_group.async_run_ray_method("pass_through", "optim_step"))
 
+        # `forward_backward` returns a WorkerOutput per actor (frozen dataclass);
+        # compare scalar `metrics` and per-sample `loss_fn_outputs` directly.
         for i, result in enumerate(results):
             result_backload = results_backload[i]
-            for k, v in result.items():
-                assert k in result_backload
-                assert v == result_backload[k], f"Results mismatch for {k}: {v} != {result_backload[k]}"
+            for k, v in result.metrics.items():
+                assert k in result_backload.metrics
+                assert v == result_backload.metrics[k], f"Metrics mismatch for {k}: {v} != {result_backload.metrics[k]}"
+            assert result.loss_fn_outputs == result_backload.loss_fn_outputs, "loss_fn_outputs mismatch after backload"
 
     finally:
         ray.shutdown()  # Clean up Ray resources after the test

--- a/tests/backends/skyrl_train/gpu/utils.py
+++ b/tests/backends/skyrl_train/gpu/utils.py
@@ -16,7 +16,7 @@ from ray.util.placement_group import placement_group
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from skyrl.backends.skyrl_train.distributed.dispatch import (
-    concatenate_outputs_after_mesh_dispatch,
+    concatenate_dict_outputs_after_mesh_dispatch,
 )
 from skyrl.backends.skyrl_train.inference_engines.base import InferenceEngineInput
 from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import (
@@ -41,7 +41,6 @@ from skyrl.backends.skyrl_train.inference_servers.vllm_router import VLLMRouter
 from skyrl.backends.skyrl_train.training_batch import (
     TensorBatch,
     TrainingInputBatch,
-    TrainingOutputBatch,
 )
 from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
 from skyrl.env_vars import _SKYRL_USE_NEW_INFERENCE, SKYRL_PYTHONPATH_EXPORT
@@ -370,8 +369,8 @@ def get_model_logits_from_actor(actor_group: PPORayActorGroup, input_sequences, 
 
     results_refs = actor_group.async_run_ray_method("mesh", "forward", data)
     results = ray.get(results_refs)
-    ret_databatch: TrainingOutputBatch = concatenate_outputs_after_mesh_dispatch(actor_group.actor_infos, results)
-    logits = ret_databatch["output"]
+    ret_dict = concatenate_dict_outputs_after_mesh_dispatch(actor_group.actor_infos, results)
+    logits = ret_dict["output"]
 
     return logits
 

--- a/tests/backends/skyrl_train/gpu/utils.py
+++ b/tests/backends/skyrl_train/gpu/utils.py
@@ -16,7 +16,8 @@ from ray.util.placement_group import placement_group
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from skyrl.backends.skyrl_train.distributed.dispatch import (
-    concatenate_dict_outputs_after_mesh_dispatch,
+    WorkerOutput,
+    loss_fn_outputs_to_tensor,
 )
 from skyrl.backends.skyrl_train.inference_engines.base import InferenceEngineInput
 from skyrl.backends.skyrl_train.inference_engines.inference_engine_client import (
@@ -369,8 +370,8 @@ def get_model_logits_from_actor(actor_group: PPORayActorGroup, input_sequences, 
 
     results_refs = actor_group.async_run_ray_method("mesh", "forward", data)
     results = ray.get(results_refs)
-    ret_dict = concatenate_dict_outputs_after_mesh_dispatch(actor_group.actor_infos, results)
-    logits = ret_dict["output"]
+    output = WorkerOutput.cat(actor_group.actor_infos, results)
+    logits = loss_fn_outputs_to_tensor(output.loss_fn_outputs, key="logprobs")
 
     return logits
 

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -545,8 +545,7 @@ def test_forward_backward_batch_calculations():
     ), f"PolicyWorker: Expected {expected_micro_batches} _forward_backward_micro calls, got {len(policy_forward_backward_micro_calls)}"
 
     # Verify result structure
-    assert isinstance(result, dict)
-    assert "policy_loss" in result
+    assert "policy_loss" in result.metrics
 
     # Test CriticWorkerBase with same pattern
     critic_worker = create_test_worker(CriticWorkerBase)
@@ -576,8 +575,7 @@ def test_forward_backward_batch_calculations():
     assert critic_worker._micro_batches_accumulated == expected_micro_batches
 
     # Verify result structure for critic
-    assert isinstance(result, dict)
-    assert "critic_loss" in result
+    assert "critic_loss" in result.metrics
 
 
 def test_validate_batch_sizes_lcm_dp_requirement():


### PR DESCRIPTION
# What does this PR do?

## Summary

Adds a Tinker-compatible `forward(loss_fn=...)` API to SkyRL's FSDP and Megatron policy workers, and refactors the worker output contract to a single `WorkerOutput` dataclass mirroring Tinker's `ForwardBackwardOutput`.

## Changes

### `forward(loss_fn=...)` on policy workers

`WorkerDispatch.forward` now accepts `loss_fn` and `loss_fn_config` kwargs. When set, the worker runs the model under `torch.no_grad()` (no backward), computes the requested loss, and returns per-sample `loss_fn_outputs` alongside scalar metrics. When unset, the existing logprobs-only path is preserved.

- `PolicyWorkerBase.forward` dispatches on `loss_fn`; new `_forward_micro_with_loss` mirrors the SFT branch of `_forward_backward_micro` but skips `strategy.backward` and KL/entropy.
- `MegatronModelWrapper.forward_backward_mini_batch` gains a `forward_only` flag so Megatron's pipeline schedule machinery is reused for the no-grad path.
- DP all-reduce on metrics matches the existing training-path semantics.

### `WorkerOutput` dataclass

`forward` and `forward_backward` now both return a `WorkerOutput` dataclass mirroring Tinker's `ForwardBackwardOutput`:

```python
@dataclass
class WorkerOutput:
    loss_fn_output_type: str = "scalar"
    loss_fn_outputs: List[Dict[str, Any]] = field(default_factory=list)
    metrics: Dict[str, Any] = field(default_factory=dict)
```

- Single `WorkerOutput.cat(actor_infos, shards)` classmethod replaces the previous dual concat code paths. List-extend for `loss_fn_outputs`, take-rank-0 for already-DP-reduced `metrics`.
- Freestanding `loss_fn_outputs_to_tensor(outputs, key, ...)` helper for callers that need a padded batch-dim tensor.
- `skyrl_train_backend.py`'s HTTP serving path simplifies: workers now emit per-sample lists directly, so the manual per-row tensor slicing is removed.

### Worker signature cleanup

- `Worker.forward` is abstract (`*args, **kwargs`, raises `NotImplementedError`). Each subclass (`PolicyWorkerBase`, `RefWorkerBase`, `CriticWorkerBase`) declares its own concrete signature
- All worker `forward` methods return `WorkerOutput` (FSDP override annotations updated to match).

## Test plan

- [x] `tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py::test_sft_forward_with_cross_entropy[fsdp2|megatron]` — both PASS (81s + 126s)
- [x] `tests/backends/skyrl_train/gpu/gpu_ci/test_training_step.py::test_sft_forward_backward_with_cross_entropy[fsdp2|megatron]` — both PASS (75s + 119s)
- [x] `tests/train/test_sft_tokenization.py` — 23 passed
- [x] ruff clean on `skyrl/train/` + `skyrl/backends/skyrl_train/workers/`