### PR TITLE
[feat] Support tool-calling datasets in SFTTrainer

### DIFF
--- a/examples/train/sft/prepare_apigen_mt.py
+++ b/examples/train/sft/prepare_apigen_mt.py
@@ -42,7 +42,9 @@ def _convert_turn(turn: dict) -> dict:
         return {"role": "assistant", "content": "", "tool_calls": value}
     if role == "observation":
         return {"role": "tool", "content": value}
-    raise ValueError(f"Unknown ShareGPT role {role!r} in APIGen-MT-5k turn; expected one of human/gpt/function_call/observation")
+    raise ValueError(
+        f"Unknown ShareGPT role {role!r} in APIGen-MT-5k turn; expected one of human/gpt/function_call/observation"
+    )
 
 
 def convert_example(example: dict) -> dict:

--- a/examples/train/sft/prepare_apigen_mt.py
+++ b/examples/train/sft/prepare_apigen_mt.py
@@ -1,0 +1,95 @@
+"""Convert Salesforce/APIGen-MT-5k to OpenAI messages format and save locally.
+
+APIGen-MT-5k ships in ShareGPT shape (``conversations`` column with
+``from``/``value`` keys, plus per-row ``tools`` JSON-string and ``system``
+text columns). ``SFTTrainer`` expects an OpenAI-style ``messages`` column
+with ``role``/``content`` keys. This script does the rename + role mapping
+and writes the result as Parquet so ``load_dataset(<dir>)`` picks it up.
+
+Role mapping:
+
+* ``human``         -> ``user``
+* ``gpt``           -> ``assistant`` (text content)
+* ``function_call`` -> ``assistant`` with ``tool_calls`` (content="")
+* ``observation``   -> ``tool``
+
+Usage::
+
+    uv run examples/train/sft/prepare_apigen_mt.py \\
+        --output-dir ~/data/apigen-mt-5k-openai
+"""
+
+import argparse
+import os
+
+from datasets import load_dataset
+
+
+def _convert_turn(turn: dict) -> dict:
+    """Map one ShareGPT turn to an OpenAI-style message dict.
+
+    Raises ``ValueError`` on unknown roles so a dataset-schema change is
+    caught loudly instead of silently dropping turns.
+    """
+    role, value = turn["from"], turn["value"]
+    if role == "human":
+        return {"role": "user", "content": value}
+    if role == "gpt":
+        return {"role": "assistant", "content": value}
+    if role == "function_call":
+        # APIGen ships the call as a JSON-encoded single dict
+        # ({"name": ..., "arguments": ...}).
+        return {"role": "assistant", "content": "", "tool_calls": value}
+    if role == "observation":
+        return {"role": "tool", "content": value}
+    raise ValueError(f"Unknown ShareGPT role {role!r} in APIGen-MT-5k turn; expected one of human/gpt/function_call/observation")
+
+
+def convert_example(example: dict) -> dict:
+    messages = [_convert_turn(turn) for turn in example["conversations"]]
+    return {
+        "messages": messages,
+        # ``tools`` is a JSON-encoded string in the source; ``_coerce_tools``
+        # in sft_trainer.py handles that shape, so leave it untouched.
+        "tools": example["tools"],
+        "system": example["system"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output-dir",
+        default=os.path.expanduser("~/data/apigen-mt-5k-openai"),
+        help="Directory to write the converted parquet shard into.",
+    )
+    parser.add_argument(
+        "--num-rows",
+        type=int,
+        default=None,
+        help="Optional cap on number of rows (for smoke tests). Default: all rows",
+    )
+    args = parser.parse_args()
+
+    output_dir = os.path.abspath(args.output_dir)
+    parquet_path = os.path.join(output_dir, "train.parquet")
+
+    split = "train" if args.num_rows is None else f"train[:{args.num_rows}]"
+    print(f"[prepare_apigen_mt] Loading Salesforce/APIGen-MT-5k split={split} ...")
+    ds = load_dataset("Salesforce/APIGen-MT-5k", split=split)
+
+    print(f"[prepare_apigen_mt] Converting {len(ds)} rows ShareGPT → OpenAI messages ...")
+    ds = ds.map(
+        convert_example,
+        remove_columns=ds.column_names,
+        desc="convert",
+    )
+
+    os.makedirs(output_dir, exist_ok=True)
+    print(f"[prepare_apigen_mt] Writing {parquet_path} ...")
+    ds.to_parquet(parquet_path)
+    print(f"[prepare_apigen_mt] Done. {len(ds)} rows -> {parquet_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/train/sft/run_sft_megatron_apigen_mt.sh
+++ b/examples/train/sft/run_sft_megatron_apigen_mt.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -xeou pipefail
+
+# SFT training with Megatron backend for Qwen2.5-1.5B-Instruct on a
+# tool-calling dataset (Salesforce/APIGen-MT-5k).
+#
+# Usage:
+# 
+# export DATA_DIR=$HOME/data/apigen-mt-5k-openai 
+# uv run examples/train/sft/prepare_apigen_mt.py --output_dir $DATA_DIR
+# export WANDB_API_KEY=<your_key_here>
+# bash examples/train/sft/run_sft_megatron_apigen_mt.sh num_epochs=1 num_steps=<num_steps>
+
+: "${DATA_DIR:="$HOME/data/apigen-mt-5k-openai"}"
+: "${CKPT_PATH:="$HOME/ckpts/skyrl_apigen_mt"}"
+
+uv run --isolated --extra megatron --python 3.12 \
+    python -m skyrl.train.main_sft \
+    strategy=megatron \
+    model.path=Qwen/Qwen2.5-1.5B-Instruct \
+    dataset_name="$DATA_DIR" \
+    dataset_split="train[:4000]" \
+    eval_dataset_name="$DATA_DIR" \
+    eval_dataset_split="train[4000:]" \
+    messages_key=messages \
+    tools_key=tools \
+    system_key=system \
+    max_length=8192 \
+    num_steps=50 \
+    batch_size=8 \
+    micro_train_batch_size_per_gpu=2 \
+    use_sample_packing=true \
+    seed=42 \
+    optimizer_config.lr=1e-6 \
+    optimizer_config.weight_decay=1e-2 \
+    optimizer_config.max_grad_norm=1.0 \
+    optimizer_config.num_warmup_steps=0 \
+    optimizer_config.scheduler=constant_with_warmup \
+    placement.num_nodes=1 \
+    placement.num_gpus_per_node=4 \
+    megatron_config.tensor_model_parallel_size=1 \
+    megatron_config.pipeline_model_parallel_size=1 \
+    megatron_config.context_parallel_size=1 \
+    logger=console \
+    project_name=skyrl_sft \
+    run_name=skyrl_sft_megatron_apigen_mt \
+    ckpt_path="$CKPT_PATH" \
+    ckpt_interval=0 \
+    resume_from="" \
+    train_on_what="all_assistant_messages" \
+    "$@"

--- a/skyrl/train/config/sft_config.py
+++ b/skyrl/train/config/sft_config.py
@@ -128,6 +128,13 @@ class SFTConfig(BaseConfig):
     dataset_name: str = "yahma/alpaca-cleaned"
     dataset_split: str = "train[:100]"
     messages_key: str = "messages"  # column name for chat-format datasets
+    tools_key: str = "tools"
+    """Column name holding per-row tool/function schemas for tool-calling datasets
+    (e.g. APIGen-MT, xLAM, ToolACE). May be a list[dict] or a JSON-encoded string.
+    Ignored if the column is absent from the dataset."""
+    system_key: str = "system"
+    """Column name holding a per-row system prompt to prepend when ``messages``
+    does not already start with a system turn. Ignored if absent."""
 
     # ---- Evaluation dataset ----
     eval_dataset_name: Optional[str] = None

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -602,8 +602,9 @@ def get_response_ids_and_loss_mask_from_messages(
         # 3. Set loss mask and rollout logprobs.
         # Regardless of the message role, each message is responsible for adding its own generation
         # prompt, and we apply the correct masking.
-        if cur_message["role"] == "user":
-            # 3.1. For user messages, it is simply zeros
+        if cur_message["role"] in ("user", "tool"):
+            # 3.1. For user / tool (observation) messages, it is simply zeros.
+            # Tool turns carry environment output, never assistant generation.
             loss_mask.extend([0] * len(cur_token_ids))
             if assistant_logprobs:
                 rollout_logprobs.extend([0.0] * len(cur_token_ids))
@@ -661,7 +662,7 @@ def get_response_ids_and_loss_mask_from_messages(
 
             assistant_msg_idx += 1
         else:
-            raise ValueError(f"Expected message role to be 'user' or 'assistant', got {cur_message['role']}")
+            raise ValueError(f"Expected message role to be 'user', 'assistant', or 'tool', got {cur_message['role']}")
 
         assert len(loss_mask) == len(response_ids)
         assert len(rollout_logprobs) == len(response_ids) if rollout_logprobs is not None else True

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -133,33 +133,49 @@ def _normalize_tool_call_payload(tc: Any) -> Optional[list]:
     return out
 
 
+# Fields we know how to normalize. Anything else on the message is forwarded
+# untouched so model-specific chat templates can read it (e.g. Qwen3 /
+# Nemotron-3 templates emit ``<think>{{ message.reasoning_content }}</think>``
+# blocks; DeepSeek-R1 keys off other fields). Dropping these silently turns
+# thinking-model SFT into vanilla SFT with no warning.
+_NORMALIZED_KEYS = frozenset({"role", "content", "tool_calls"})
+
+
 def _normalize_chat_messages(messages: list[dict]) -> list[dict]:
     """Return messages in a shape that HF chat templates accept.
 
-    Drops dataset-specific extras (e.g. ``thinking``, empty ``tool_calls``) and
-    promotes string-encoded ``tool_calls`` into the OpenAI list-of-dicts form.
-    Tool-result turns (``role == "tool"``) are passed through unchanged so the
-    template can render them as ``<tool_response>``-style observations.
+    Normalizes ``content`` (None -> ""), drops empty/placeholder ``tool_calls``,
+    promotes string-encoded ``tool_calls`` into the OpenAI list-of-dicts form,
+    and preserves any other fields on the message verbatim so chat templates
+    that read e.g. ``reasoning_content``, ``name``, or ``tool_call_id`` see
+    them. Tool-result turns (``role == "tool"``) are passed through unchanged
+    so the template can render them as ``<tool_response>``-style observations.
     """
     out = []
     for msg in messages:
         role = msg["role"]
         content = msg.get("content", "") or ""
+        # Carry forward any extra fields unchanged so model-specific templates
+        # can still read them. Most importantly ``reasoning_content`` for
+        # thinking models (Qwen3, Nemotron-3): dropping it would silently turn
+        # thinking-model SFT into a non-thinking trace.
+        extras = {k: v for k, v in msg.items() if k not in _NORMALIZED_KEYS}
         if role == "assistant":
             tool_calls = _normalize_tool_call_payload(msg.get("tool_calls"))
-            new_msg: dict = {"role": "assistant", "content": content}
+            new_msg: dict = {"role": "assistant", "content": content, **extras}
             if tool_calls:
                 new_msg["tool_calls"] = tool_calls
             out.append(new_msg)
         elif role == "tool":
-            new_msg = {"role": "tool", "content": content}
-            # Some templates key off ``name``/``tool_call_id`` if present.
-            for key in ("name", "tool_call_id"):
-                if msg.get(key):
-                    new_msg[key] = msg[key]
+            # ``tool`` rows shouldn't have ``tool_calls``; strip if present so
+            # we don't accidentally forward a placeholder that fights the
+            # template.
+            extras.pop("tool_calls", None)
+            new_msg = {"role": "tool", "content": content, **extras}
             out.append(new_msg)
         else:
-            out.append({"role": role, "content": content})
+            extras.pop("tool_calls", None)
+            out.append({"role": role, "content": content, **extras})
     return out
 
 

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -20,6 +20,7 @@ Or as a CLI entrypoint::
     python -m skyrl.train.main_sft strategy=megatron model.path=Qwen/Qwen3-0.6B
 """
 
+import functools
 import json
 import os
 import random
@@ -66,21 +67,33 @@ from skyrl.utils.tok import get_tokenizer
 # ---------------------------------------------------------------------------
 
 
+@functools.lru_cache(maxsize=512)
+def _parse_tools_str(tools: str) -> Optional[tuple]:
+    """Parse a JSON-encoded tools string. Cached because tool-calling datasets
+    typically share one schema across thousands of rows (e.g. APIGen's airline
+    domain), and `apply_chat_template` re-tokenizes the schema on every row."""
+    tools = tools.strip()
+    if not tools:
+        return None
+    parsed = json.loads(tools)
+    if not parsed:
+        return None
+    # Return a tuple so the cache stores an immutable value; caller re-lists it.
+    return tuple(parsed)
+
+
 def _coerce_tools(tools: Any) -> Optional[list]:
     """Coerce a dataset's ``tools`` field into a list[dict] for ``apply_chat_template``.
 
-    Tool-calling datasets ship the schema list in different shapes:
-    ``list[dict]`` (parquet-typed), JSON-encoded ``str``, or absent. The HF chat
-    templates (Qwen, Llama 3.1+, Hermes, etc.) all expect ``list[dict]``. Returns
-    ``None`` when there are no tools, so the caller can omit the kwarg entirely.
+    Tool-calling datasets ship the schema list as ``list[dict]`` (parquet-typed),
+    JSON-encoded ``str``, or absent. HF chat templates expect ``list[dict]``;
+    returns ``None`` when there are no tools so the caller can omit the kwarg.
     """
     if tools is None:
         return None
     if isinstance(tools, str):
-        tools = tools.strip()
-        if not tools:
-            return None
-        tools = json.loads(tools)
+        cached = _parse_tools_str(tools)
+        return list(cached) if cached else None
     if isinstance(tools, list):
         return tools or None
     raise TypeError(f"Unsupported `tools` type: {type(tools).__name__}")
@@ -115,67 +128,42 @@ def _normalize_tool_call_payload(tc: Any) -> Optional[list]:
     for call in tc:
         if not isinstance(call, dict):
             raise TypeError(f"tool call entry must be a dict, got {type(call).__name__}")
-        # Already in OpenAI shape.
-        if "function" in call and isinstance(call["function"], dict):
-            fn = call["function"]
-        else:
-            fn = call
-        name = fn.get("name")
+        fn = call["function"] if isinstance(call.get("function"), dict) else call
         arguments = fn.get("arguments", {})
-        # Some datasets store arguments as a JSON string; normalize to a dict so
-        # the chat template can json.dumps it consistently.
         if isinstance(arguments, str):
             try:
                 arguments = json.loads(arguments)
             except json.JSONDecodeError:
-                pass  # keep as string if it isn't JSON
-        out.append({"type": "function", "function": {"name": name, "arguments": arguments}})
+                pass
+        out.append({"type": "function", "function": {"name": fn.get("name"), "arguments": arguments}})
     return out
 
 
-# Fields we know how to normalize. Anything else on the message is forwarded
-# untouched so model-specific chat templates can read it (e.g. Qwen3 /
-# Nemotron-3 templates emit ``<think>{{ message.reasoning_content }}</think>``
-# blocks; DeepSeek-R1 keys off other fields). Dropping these silently turns
-# thinking-model SFT into vanilla SFT with no warning.
+# Fields we explicitly normalize; everything else on the message is forwarded
+# so model-specific templates can read e.g. ``reasoning_content`` (Qwen3,
+# Nemotron-3 thinking models) or ``tool_call_id``.
 _NORMALIZED_KEYS = frozenset({"role", "content", "tool_calls"})
 
 
 def _normalize_chat_messages(messages: list[dict]) -> list[dict]:
     """Return messages in a shape that HF chat templates accept.
 
-    Normalizes ``content`` (None -> ""), drops empty/placeholder ``tool_calls``,
-    promotes string-encoded ``tool_calls`` into the OpenAI list-of-dicts form,
-    and preserves any other fields on the message verbatim so chat templates
-    that read e.g. ``reasoning_content``, ``name``, or ``tool_call_id`` see
-    them. Tool-result turns (``role == "tool"``) are passed through unchanged
-    so the template can render them as ``<tool_response>``-style observations.
+    Normalizes ``content`` (``None`` → ``""``), promotes string-encoded
+    ``tool_calls`` on assistant turns into the OpenAI list-of-dicts form,
+    drops empty/placeholder ``tool_calls`` on every role, and preserves any
+    other fields on the message verbatim.
     """
     out = []
     for msg in messages:
         role = msg["role"]
-        content = msg.get("content", "") or ""
-        # Carry forward any extra fields unchanged so model-specific templates
-        # can still read them. Most importantly ``reasoning_content`` for
-        # thinking models (Qwen3, Nemotron-3): dropping it would silently turn
-        # thinking-model SFT into a non-thinking trace.
-        extras = {k: v for k, v in msg.items() if k not in _NORMALIZED_KEYS}
+        new_msg = {k: v for k, v in msg.items() if k not in _NORMALIZED_KEYS}
+        new_msg["role"] = role
+        new_msg["content"] = msg.get("content", "") or ""
         if role == "assistant":
             tool_calls = _normalize_tool_call_payload(msg.get("tool_calls"))
-            new_msg: dict = {"role": "assistant", "content": content, **extras}
             if tool_calls:
                 new_msg["tool_calls"] = tool_calls
-            out.append(new_msg)
-        elif role == "tool":
-            # ``tool`` rows shouldn't have ``tool_calls``; strip if present so
-            # we don't accidentally forward a placeholder that fights the
-            # template.
-            extras.pop("tool_calls", None)
-            new_msg = {"role": "tool", "content": content, **extras}
-            out.append(new_msg)
-        else:
-            extras.pop("tool_calls", None)
-            out.append({"role": role, "content": content, **extras})
+        out.append(new_msg)
     return out
 
 
@@ -220,8 +208,8 @@ def tokenize_chat_example(
     max_length: Optional[int] = None,
     messages_key: str = "messages",
     train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
-    tools_key: str = "tools",
-    system_key: str = "system",
+    tools_key: Optional[str] = "tools",
+    system_key: Optional[str] = "system",
     **tokenizer_kwargs,
 ) -> dict | None:
     """Tokenize a chat-format example with configurable loss targets.
@@ -241,10 +229,10 @@ def tokenize_chat_example(
         max_length: Maximum sequence length (truncation boundary).
         messages_key: Key in *example* that holds the messages list.
         train_on_what: Which tokens to compute loss on.
-        tools_key: Optional key in *example* whose value is the per-row tool
-            schema list (or JSON-encoded string thereof). Ignored if absent.
-        system_key: Optional key in *example* whose value is a system prompt
-            string. Ignored if absent or empty.
+        tools_key: Key in *example* whose value is the per-row tool schema list
+            (or JSON-encoded string thereof). ``None`` disables the lookup.
+        system_key: Key in *example* whose value is a system prompt string.
+            ``None`` disables the lookup.
         **tokenizer_kwargs: Extra kwargs forwarded to ``apply_chat_template``
             (e.g. ``enable_thinking``).
 
@@ -262,30 +250,23 @@ def tokenize_chat_example(
         )
     messages = list(example[messages_key])
 
-    # Tool-calling datasets sometimes end the row with a trailing ``tool``
-    # observation that has no follow-up assistant response. Trim those so the
-    # conversation ends on an assistant turn (the SFT target). Trailing
-    # ``user`` turns still cause the row to be dropped, matching the existing
-    # contract that an unanswered user prompt is an incomplete example.
+    # Trim trailing tool observations with no follow-up assistant response
+    # (common in APIGen-MT). Trailing user turns still drop the row.
     while messages and messages[-1]["role"] == "tool":
         messages.pop()
 
-    # Validate: last message must be from assistant
     if not messages or messages[-1]["role"] != "assistant":
         return None
 
-    # Normalize tool-calling shapes (string-encoded tool_calls, tool turns).
     messages = _normalize_chat_messages(messages)
 
-    # Prepend system prompt from a separate column if present and not already there.
     system_prompt = example.get(system_key) if system_key else None
     if system_prompt and messages[0].get("role") != "system":
         messages = [{"role": "system", "content": system_prompt}] + messages
 
-    # Forward per-row tool schemas to apply_chat_template via tokenizer_kwargs.
+    # Per-row schemas yield to an explicit caller-provided ``tools`` kwarg.
     tools = _coerce_tools(example.get(tools_key)) if tools_key else None
     if tools is not None:
-        # Don't clobber an explicit caller-provided value.
         tokenizer_kwargs = {"tools": tools, **tokenizer_kwargs}
 
     if train_on_what == TrainOnWhat.LAST_ASSISTANT_MESSAGE:
@@ -592,8 +573,8 @@ class SFTTrainer:
             # Chat format. Tool-calling datasets often ship a per-row ``tools``
             # column (function schemas) and ``system`` column (domain policy)
             # alongside ``messages``; thread those through when present.
-            tools_key = self.sft_cfg.tools_key if self.sft_cfg.tools_key in columns else ""
-            system_key = self.sft_cfg.system_key if self.sft_cfg.system_key in columns else ""
+            tools_key = self.sft_cfg.tools_key if self.sft_cfg.tools_key in columns else None
+            system_key = self.sft_cfg.system_key if self.sft_cfg.system_key in columns else None
             tokenized = [
                 tokenize_chat_example(
                     ex,

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -20,11 +20,12 @@ Or as a CLI entrypoint::
     python -m skyrl.train.main_sft strategy=megatron model.path=Qwen/Qwen3-0.6B
 """
 
+import json
 import os
 import random
 from dataclasses import asdict
 from math import ceil
-from typing import Optional
+from typing import Any, Optional
 
 import ray
 import torch
@@ -63,6 +64,103 @@ from skyrl.utils.tok import get_tokenizer
 # ---------------------------------------------------------------------------
 # Tokenization helpers
 # ---------------------------------------------------------------------------
+
+
+def _coerce_tools(tools: Any) -> Optional[list]:
+    """Coerce a dataset's ``tools`` field into a list[dict] for ``apply_chat_template``.
+
+    Tool-calling datasets ship the schema list in different shapes:
+    ``list[dict]`` (parquet-typed), JSON-encoded ``str``, or absent. The HF chat
+    templates (Qwen, Llama 3.1+, Hermes, etc.) all expect ``list[dict]``. Returns
+    ``None`` when there are no tools, so the caller can omit the kwarg entirely.
+    """
+    if tools is None:
+        return None
+    if isinstance(tools, str):
+        tools = tools.strip()
+        if not tools:
+            return None
+        tools = json.loads(tools)
+    if isinstance(tools, list):
+        return tools or None
+    raise TypeError(f"Unsupported `tools` type: {type(tools).__name__}")
+
+
+def _normalize_tool_call_payload(tc: Any) -> Optional[list]:
+    """Normalize an assistant message's ``tool_calls`` into the OpenAI-style list.
+
+    Datasets in the wild use:
+
+    * ``[]`` / ``""`` / ``None`` — no tool call;
+    * a single JSON-encoded ``{"name": ..., "arguments": ...}`` dict (APIGen-MT);
+    * a JSON-encoded list of such dicts (xLAM, ToolACE);
+    * an already-parsed list of OpenAI-style ``{"type": "function", "function": {...}}``.
+
+    HF chat templates expect ``[{"type": "function", "function": {"name", "arguments"}}]``,
+    so we coerce to that shape. Returns ``None`` when the message has no tool call.
+    """
+    if tc is None:
+        return None
+    if isinstance(tc, str):
+        tc = tc.strip()
+        if not tc or tc == "[]":
+            return None
+        tc = json.loads(tc)
+    if isinstance(tc, dict):
+        tc = [tc]
+    if not isinstance(tc, list) or not tc:
+        return None
+
+    out = []
+    for call in tc:
+        if not isinstance(call, dict):
+            raise TypeError(f"tool call entry must be a dict, got {type(call).__name__}")
+        # Already in OpenAI shape.
+        if "function" in call and isinstance(call["function"], dict):
+            fn = call["function"]
+        else:
+            fn = call
+        name = fn.get("name")
+        arguments = fn.get("arguments", {})
+        # Some datasets store arguments as a JSON string; normalize to a dict so
+        # the chat template can json.dumps it consistently.
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                pass  # keep as string if it isn't JSON
+        out.append({"type": "function", "function": {"name": name, "arguments": arguments}})
+    return out
+
+
+def _normalize_chat_messages(messages: list[dict]) -> list[dict]:
+    """Return messages in a shape that HF chat templates accept.
+
+    Drops dataset-specific extras (e.g. ``thinking``, empty ``tool_calls``) and
+    promotes string-encoded ``tool_calls`` into the OpenAI list-of-dicts form.
+    Tool-result turns (``role == "tool"``) are passed through unchanged so the
+    template can render them as ``<tool_response>``-style observations.
+    """
+    out = []
+    for msg in messages:
+        role = msg["role"]
+        content = msg.get("content", "") or ""
+        if role == "assistant":
+            tool_calls = _normalize_tool_call_payload(msg.get("tool_calls"))
+            new_msg: dict = {"role": "assistant", "content": content}
+            if tool_calls:
+                new_msg["tool_calls"] = tool_calls
+            out.append(new_msg)
+        elif role == "tool":
+            new_msg = {"role": "tool", "content": content}
+            # Some templates key off ``name``/``tool_call_id`` if present.
+            for key in ("name", "tool_call_id"):
+                if msg.get(key):
+                    new_msg[key] = msg[key]
+            out.append(new_msg)
+        else:
+            out.append({"role": role, "content": content})
+    return out
 
 
 def tokenize_sft_example(example: dict, tokenizer, max_length: int = 512, **tokenizer_kwargs) -> dict | None:
@@ -106,6 +204,8 @@ def tokenize_chat_example(
     max_length: Optional[int] = None,
     messages_key: str = "messages",
     train_on_what: TrainOnWhat = TrainOnWhat.LAST_ASSISTANT_MESSAGE,
+    tools_key: str = "tools",
+    system_key: str = "system",
     **tokenizer_kwargs,
 ) -> dict | None:
     """Tokenize a chat-format example with configurable loss targets.
@@ -113,12 +213,22 @@ def tokenize_chat_example(
     Uses ``apply_chat_template`` to tokenize the conversation and determine
     which tokens to train on based on ``train_on_what``.
 
+    For tool-calling datasets (e.g. APIGen-MT, xLAM, ToolACE), if the example
+    has a ``tools_key`` column, its parsed value is forwarded as ``tools=`` to
+    ``apply_chat_template`` so the model sees the function schemas. Likewise,
+    a ``system_key`` column is prepended as a leading system message when no
+    system message is already present.
+
     Args:
         example: Dict containing a ``messages_key`` column with chat messages.
         tokenizer: HuggingFace tokenizer with ``apply_chat_template``.
         max_length: Maximum sequence length (truncation boundary).
         messages_key: Key in *example* that holds the messages list.
         train_on_what: Which tokens to compute loss on.
+        tools_key: Optional key in *example* whose value is the per-row tool
+            schema list (or JSON-encoded string thereof). Ignored if absent.
+        system_key: Optional key in *example* whose value is a system prompt
+            string. Ignored if absent or empty.
         **tokenizer_kwargs: Extra kwargs forwarded to ``apply_chat_template``
             (e.g. ``enable_thinking``).
 
@@ -134,11 +244,33 @@ def tokenize_chat_example(
             f"train_on_what={train_on_what!r} is not yet supported. "
             f"Supported values: {sorted(v.value for v in _SUPPORTED)}"
         )
-    messages = example[messages_key]
+    messages = list(example[messages_key])
+
+    # Tool-calling datasets sometimes end the row with a trailing ``tool``
+    # observation that has no follow-up assistant response. Trim those so the
+    # conversation ends on an assistant turn (the SFT target). Trailing
+    # ``user`` turns still cause the row to be dropped, matching the existing
+    # contract that an unanswered user prompt is an incomplete example.
+    while messages and messages[-1]["role"] == "tool":
+        messages.pop()
 
     # Validate: last message must be from assistant
     if not messages or messages[-1]["role"] != "assistant":
         return None
+
+    # Normalize tool-calling shapes (string-encoded tool_calls, tool turns).
+    messages = _normalize_chat_messages(messages)
+
+    # Prepend system prompt from a separate column if present and not already there.
+    system_prompt = example.get(system_key) if system_key else None
+    if system_prompt and messages[0].get("role") != "system":
+        messages = [{"role": "system", "content": system_prompt}] + messages
+
+    # Forward per-row tool schemas to apply_chat_template via tokenizer_kwargs.
+    tools = _coerce_tools(example.get(tools_key)) if tools_key else None
+    if tools is not None:
+        # Don't clobber an explicit caller-provided value.
+        tokenizer_kwargs = {"tools": tools, **tokenizer_kwargs}
 
     if train_on_what == TrainOnWhat.LAST_ASSISTANT_MESSAGE:
         return _tokenize_chat_last_assistant(messages, tokenizer, max_length, **tokenizer_kwargs)
@@ -441,7 +573,11 @@ class SFTTrainer:
         logger.info("Tokenizing dataset...")
 
         if self.sft_cfg.messages_key in columns:
-            # Chat format
+            # Chat format. Tool-calling datasets often ship a per-row ``tools``
+            # column (function schemas) and ``system`` column (domain policy)
+            # alongside ``messages``; thread those through when present.
+            tools_key = self.sft_cfg.tools_key if self.sft_cfg.tools_key in columns else ""
+            system_key = self.sft_cfg.system_key if self.sft_cfg.system_key in columns else ""
             tokenized = [
                 tokenize_chat_example(
                     ex,
@@ -449,6 +585,8 @@ class SFTTrainer:
                     self.sft_cfg.max_length,
                     self.sft_cfg.messages_key,
                     train_on_what=self.sft_cfg.train_on_what,
+                    tools_key=tools_key,
+                    system_key=system_key,
                 )
                 for ex in dataset
             ]

--- a/tests/train/generators/test_utils.py
+++ b/tests/train/generators/test_utils.py
@@ -575,8 +575,80 @@ class TestGetResponseIdsAndLossMaskFromMessages:
         """Test that invalid message role raises ValueError."""
         messages = [{"role": "system", "content": "You are a helpful assistant."}]
 
-        with pytest.raises(ValueError, match="Expected message role to be 'user' or 'assistant'"):
+        with pytest.raises(ValueError, match="Expected message role to be 'user', 'assistant', or 'tool'"):
             get_response_ids_and_loss_mask_from_messages(messages, qwen_tokenizer)
+
+    # ------------------------------------------------------------------
+    # Tool-calling: tool turns are masked to 0; assistant tool_call turns
+    # are masked the same as regular assistant turns.
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "model_name",
+        ["Qwen/Qwen2.5-0.5B-Instruct", "Qwen/Qwen3-0.6B"],
+        ids=["qwen2_5", "qwen3"],
+    )
+    def test_tool_calling_loss_mask(self, model_name):
+        """Tool observation turns must be fully masked (0); assistant turns
+        with tool_calls must follow the standard assistant masking (gen prompt
+        0, generated tokens including EOS 1, post-EOS 0)."""
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather for a city.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ]
+        messages = [
+            {"role": "user", "content": "What's the weather in Paris?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": {"city": "Paris"}},
+                    }
+                ],
+            },
+            {"role": "tool", "content": '{"temp_c": 21, "conditions": "sunny"}'},
+            {"role": "assistant", "content": "It's 21C and sunny in Paris."},
+        ]
+
+        tokenizer_kwargs = {"tools": tools}
+        response_ids, loss_mask, _ = get_response_ids_and_loss_mask_from_messages(
+            messages, tokenizer, tokenizer_kwargs=tokenizer_kwargs
+        )
+        assert len(response_ids) == len(loss_mask)
+
+        # Check each message individually using the same fixed-base encoding.
+        generation_prompt_ids = get_generation_prompt_ids(tokenizer)
+        cur = 0
+        for msg in messages:
+            msg_ids = encode_messages_subset([msg], tokenizer, tokenizer_kwargs=tokenizer_kwargs)
+            msg_mask = loss_mask[cur : cur + len(msg_ids)]
+
+            if msg["role"] in ("user", "tool"):
+                assert all(m == 0 for m in msg_mask), f"{msg['role']} message must be fully masked"
+            else:
+                # Assistant: header zero, generated (incl. EOS) ones, after-EOS zero.
+                assert msg_mask[: len(generation_prompt_ids)] == [0] * len(generation_prompt_ids)
+                assert tokenizer.eos_token_id in msg_ids
+                last_eos = len(msg_ids) - 1 - msg_ids[::-1].index(tokenizer.eos_token_id)
+                assert all(
+                    m == 1 for m in msg_mask[len(generation_prompt_ids) : last_eos + 1]
+                ), "assistant generated tokens must have mask 1"
+                if last_eos < len(msg_ids) - 1:
+                    assert all(m == 0 for m in msg_mask[last_eos + 1 :])
+            cur += len(msg_ids)
 
     def test_missing_logprobs_raises(self, qwen_tokenizer):
         """Test that missing logprobs for assistant message raises ValueError."""

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -13,6 +13,7 @@ from transformers import AutoTokenizer
 from skyrl.train.config.sft_config import TrainOnWhat
 from skyrl.train.generators.utils import get_generation_prompt_ids
 from skyrl.train.sft_trainer import (
+    _normalize_chat_messages,
     collate_sft_batch,
     tokenize_chat_example,
     tokenize_sft_example,
@@ -715,3 +716,90 @@ def test_chat_tool_calling_tool_turn_masked(tokenizer):
     for k in range(found, close):
         if k >= action_start:
             assert result["loss_mask"][k - action_start] == 0, f"tool-response position {k} must be masked to 0"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_chat_messages preservation
+#
+# Templates for thinking models (Qwen3 / Nemotron-3) emit
+#   <think>{{ message.reasoning_content }}</think>
+# branches that read fields beyond ``role`` / ``content`` / ``tool_calls``.
+# Datasets sometimes attach other extras (``name``, ``tool_call_id``, custom
+# metadata). Silently dropping them turns thinking-model SFT into vanilla SFT
+# with no warning. Pin the preservation behaviour.
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_preserves_reasoning_content_on_assistant():
+    msgs = [
+        {"role": "user", "content": "Q?"},
+        {
+            "role": "assistant",
+            "content": "[ANSWER]A[/ANSWER]",
+            "reasoning_content": "step 1\nstep 2",
+        },
+    ]
+    out = _normalize_chat_messages(msgs)
+    # User message survives unchanged.
+    assert out[0] == {"role": "user", "content": "Q?"}
+    # Assistant keeps reasoning_content alongside role/content.
+    assert out[1]["role"] == "assistant"
+    assert out[1]["content"] == "[ANSWER]A[/ANSWER]"
+    assert out[1]["reasoning_content"] == "step 1\nstep 2"
+
+
+def test_normalize_preserves_unknown_extras_on_all_roles():
+    msgs = [
+        {"role": "system", "content": "sys", "metadata": {"k": 1}},
+        {"role": "user", "content": "u", "name": "alice"},
+        {
+            "role": "assistant",
+            "content": "a",
+            "reasoning_content": "thought",
+            "custom_field": "x",
+        },
+        {
+            "role": "tool",
+            "content": '{"result": 42}',
+            "name": "calculator",
+            "tool_call_id": "call_0",
+        },
+    ]
+    out = _normalize_chat_messages(msgs)
+    assert out[0]["metadata"] == {"k": 1}
+    assert out[1]["name"] == "alice"
+    assert out[2]["reasoning_content"] == "thought"
+    assert out[2]["custom_field"] == "x"
+    assert out[3]["name"] == "calculator"
+    assert out[3]["tool_call_id"] == "call_0"
+
+
+def test_normalize_drops_placeholder_tool_calls_but_keeps_extras():
+    """Placeholder ``tool_calls="[]"`` must still be normalized away (the
+    original bug that crashes Qwen2.5's template), even when other extras
+    are present on the same message."""
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "ok",
+            "reasoning_content": "thinking...",
+            "tool_calls": "[]",
+        },
+    ]
+    out = _normalize_chat_messages(msgs)
+    assert "tool_calls" not in out[0]
+    assert out[0]["reasoning_content"] == "thinking..."
+
+
+def test_normalize_strips_tool_calls_off_non_assistant_roles():
+    """Some datasets sloppily attach ``tool_calls`` to user/system/tool rows.
+    We strip those (they'd fight the template) while keeping other extras."""
+    msgs = [
+        {"role": "user", "content": "u", "tool_calls": "[]", "name": "alice"},
+        {"role": "tool", "content": "t", "tool_calls": "[]", "tool_call_id": "c0"},
+    ]
+    out = _normalize_chat_messages(msgs)
+    assert "tool_calls" not in out[0]
+    assert out[0]["name"] == "alice"
+    assert "tool_calls" not in out[1]
+    assert out[1]["tool_call_id"] == "c0"

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -546,3 +546,172 @@ def test_train_on_what_all_assistants_truncation(tokenizer):
         assert len(result["loss_mask"]) == result["num_actions"]
         # All loss_mask values should be 0 or 1
         assert all(v in (0, 1) for v in result["loss_mask"])
+
+
+# ---------------------------------------------------------------------------
+# Tool-calling datasets (APIGen-MT, xLAM, ToolACE, ...).
+# These ship per-row ``tools`` (function schemas), an optional per-row
+# ``system`` prompt, and ``messages`` containing assistant-with-tool_calls
+# and tool-result turns. ``tokenize_chat_example`` should:
+#   - normalize string-encoded ``tool_calls`` into the OpenAI list shape,
+#   - forward the per-row ``tools`` to ``apply_chat_template``,
+#   - prepend the per-row system message,
+#   - mask tool-result tokens to 0 and assistant-generated tokens to 1.
+# ---------------------------------------------------------------------------
+
+
+_TOOLS_SCHEMA = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+
+def _tool_call_messages():
+    return [
+        {"role": "user", "content": "What's the weather in Paris?", "tool_calls": "[]"},
+        # APIGen-MT shape: tool_calls is a JSON-encoded single dict, content is "".
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": '{"name": "get_weather", "arguments": {"city": "Paris"}}',
+        },
+        {"role": "tool", "content": '{"temp_c": 21, "conditions": "sunny"}'},
+        {"role": "assistant", "content": "It's 21C and sunny in Paris.", "tool_calls": "[]"},
+    ]
+
+
+def test_chat_tool_calling_apigen_shape(tokenizer):
+    """APIGen-MT-style row with stringified tool_calls and a separate `system` /
+    `tools` column tokenizes end-to-end without raising and produces a
+    non-empty loss mask covering the assistant turns."""
+    example = {
+        "messages": _tool_call_messages(),
+        "tools": _TOOLS_SCHEMA,  # already a list; coerce_tools must accept this
+        "system": "You are a weather assistant.",
+    }
+    result = tokenize_chat_example(
+        example,
+        tokenizer,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+    assert result is not None
+    assert result["num_actions"] > 0
+    assert sum(result["loss_mask"]) > 0
+    # The tools schema and system prompt must round-trip into the rendered text.
+    decoded = tokenizer.decode(result["input_ids"])
+    assert "get_weather" in decoded
+    assert "You are a weather assistant." in decoded
+    # The tool-call turn should render as <tool_call>...</tool_call> for Qwen.
+    assert "<tool_call>" in decoded
+    assert "<tool_response>" in decoded
+
+
+def test_chat_tool_calling_tools_as_json_string(tokenizer):
+    """`tools` shipped as a JSON-encoded string (parquet-string column) is
+    accepted and forwarded to ``apply_chat_template``."""
+    import json
+
+    example = {
+        "messages": _tool_call_messages(),
+        "tools": json.dumps(_TOOLS_SCHEMA),
+        "system": "You are a weather assistant.",
+    }
+    result = tokenize_chat_example(
+        example,
+        tokenizer,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+    assert result is not None
+    assert "get_weather" in tokenizer.decode(result["input_ids"])
+
+
+def test_chat_tool_calling_no_tools_column(tokenizer):
+    """A chat dataset without a `tools` column still tokenizes when
+    `tools_key` points at a missing key (caller passes empty string)."""
+    example = {"messages": _tool_call_messages()}
+    result = tokenize_chat_example(
+        example,
+        tokenizer,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+        tools_key="",
+        system_key="",
+    )
+    assert result is not None
+    assert result["num_actions"] > 0
+
+
+def test_chat_tool_calling_trailing_tool_turn_trimmed(tokenizer):
+    """Rows that end with a trailing ``tool`` (or ``user``) turn — common in
+    APIGen-MT — should still tokenize: the trailing non-assistant turns are
+    trimmed so the conversation ends on the last assistant message."""
+    msgs = _tool_call_messages()
+    # Append a trailing tool turn with no follow-up assistant response.
+    msgs.append({"role": "tool", "content": '{"ok": true}'})
+    example = {"messages": msgs, "tools": _TOOLS_SCHEMA, "system": "You are a weather assistant."}
+    result = tokenize_chat_example(
+        example,
+        tokenizer,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+    assert result is not None
+    assert result["num_actions"] > 0
+    # The trailing observation must not appear in the tokenized stream.
+    assert '{"ok": true}' not in tokenizer.decode(result["input_ids"])
+
+
+def test_chat_tool_calling_tool_turn_masked(tokenizer):
+    """Tokens from the ``tool`` observation turn must be fully masked (loss 0).
+
+    We compute the byte range the tool turn would occupy and verify all
+    overlapping loss-mask positions are 0.
+    """
+    example = {
+        "messages": _tool_call_messages(),
+        "tools": _TOOLS_SCHEMA,
+        "system": "You are a weather assistant.",
+    }
+    result = tokenize_chat_example(
+        example,
+        tokenizer,
+        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
+    )
+    assert result is not None
+
+    decoded = tokenizer.decode(result["input_ids"])
+    # The tool result is rendered inside <tool_response>…</tool_response>.
+    assert "21" in decoded
+    # Every tool-response token must be masked to 0. We re-tokenize the
+    # observation segment in isolation and assert that all matching positions
+    # in input_ids share the same mask=0 region.
+    obs_marker_ids = tokenizer.encode("<tool_response>", add_special_tokens=False)
+    input_ids = result["input_ids"]
+    action_start = len(input_ids) - len(result["loss_mask"])
+    # Find the index of the tool_response marker in the input_ids stream.
+    found = -1
+    for i in range(len(input_ids) - len(obs_marker_ids) + 1):
+        if input_ids[i : i + len(obs_marker_ids)] == obs_marker_ids:
+            found = i
+            break
+    assert found >= 0
+    # Every position from the marker through the closing </tool_response>
+    # marker must be masked to 0.
+    close_ids = tokenizer.encode("</tool_response>", add_special_tokens=False)
+    close = -1
+    for i in range(found, len(input_ids) - len(close_ids) + 1):
+        if input_ids[i : i + len(close_ids)] == close_ids:
+            close = i + len(close_ids)
+            break
+    assert close > found
+    for k in range(found, close):
+        if k >= action_start:
+            assert result["loss_mask"][k - action_start] == 0, f"tool-response position {k} must be masked to 0"

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -4,6 +4,7 @@ CPU tests for SFT tokenization and collation helpers.
 uv run --isolated --extra dev --extra fsdp pytest tests/train/test_sft_tokenization.py -v
 """
 
+import json
 from dataclasses import dataclass
 
 import pytest
@@ -591,13 +592,21 @@ def _tool_call_messages():
     ]
 
 
-def test_chat_tool_calling_apigen_shape(tokenizer):
-    """APIGen-MT-style row with stringified tool_calls and a separate `system` /
-    `tools` column tokenizes end-to-end without raising and produces a
-    non-empty loss mask covering the assistant turns."""
+@pytest.mark.parametrize(
+    "tools_value",
+    [
+        _TOOLS_SCHEMA,
+        json.dumps(_TOOLS_SCHEMA),
+    ],
+    ids=["list", "json-string"],
+)
+def test_chat_tool_calling_apigen_shape(tokenizer, tools_value):
+    """APIGen-MT-style row with stringified tool_calls and a separate
+    ``system``/``tools`` column tokenizes end-to-end. ``tools`` is accepted as
+    either a list[dict] (parquet-typed) or a JSON-encoded string."""
     example = {
         "messages": _tool_call_messages(),
-        "tools": _TOOLS_SCHEMA,  # already a list; coerce_tools must accept this
+        "tools": tools_value,
         "system": "You are a weather assistant.",
     }
     result = tokenize_chat_example(
@@ -608,44 +617,23 @@ def test_chat_tool_calling_apigen_shape(tokenizer):
     assert result is not None
     assert result["num_actions"] > 0
     assert sum(result["loss_mask"]) > 0
-    # The tools schema and system prompt must round-trip into the rendered text.
     decoded = tokenizer.decode(result["input_ids"])
     assert "get_weather" in decoded
     assert "You are a weather assistant." in decoded
-    # The tool-call turn should render as <tool_call>...</tool_call> for Qwen.
     assert "<tool_call>" in decoded
     assert "<tool_response>" in decoded
 
 
-def test_chat_tool_calling_tools_as_json_string(tokenizer):
-    """`tools` shipped as a JSON-encoded string (parquet-string column) is
-    accepted and forwarded to ``apply_chat_template``."""
-    import json
-
-    example = {
-        "messages": _tool_call_messages(),
-        "tools": json.dumps(_TOOLS_SCHEMA),
-        "system": "You are a weather assistant.",
-    }
-    result = tokenize_chat_example(
-        example,
-        tokenizer,
-        train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
-    )
-    assert result is not None
-    assert "get_weather" in tokenizer.decode(result["input_ids"])
-
-
 def test_chat_tool_calling_no_tools_column(tokenizer):
-    """A chat dataset without a `tools` column still tokenizes when
-    `tools_key` points at a missing key (caller passes empty string)."""
+    """A chat dataset without a ``tools`` or ``system`` column still tokenizes
+    when ``tools_key``/``system_key`` are explicitly disabled."""
     example = {"messages": _tool_call_messages()}
     result = tokenize_chat_example(
         example,
         tokenizer,
         train_on_what=TrainOnWhat.ALL_ASSISTANT_MESSAGES,
-        tools_key="",
-        system_key="",
+        tools_key=None,
+        system_key=None,
     )
     assert result is not None
     assert result["num_actions"] > 0
@@ -719,33 +707,9 @@ def test_chat_tool_calling_tool_turn_masked(tokenizer):
 
 
 # ---------------------------------------------------------------------------
-# _normalize_chat_messages preservation
-#
-# Templates for thinking models (Qwen3 / Nemotron-3) emit
-#   <think>{{ message.reasoning_content }}</think>
-# branches that read fields beyond ``role`` / ``content`` / ``tool_calls``.
-# Datasets sometimes attach other extras (``name``, ``tool_call_id``, custom
-# metadata). Silently dropping them turns thinking-model SFT into vanilla SFT
-# with no warning. Pin the preservation behaviour.
+# _normalize_chat_messages: preserve fields like ``reasoning_content`` so
+# thinking-model templates (Qwen3, Nemotron-3) keep working.
 # ---------------------------------------------------------------------------
-
-
-def test_normalize_preserves_reasoning_content_on_assistant():
-    msgs = [
-        {"role": "user", "content": "Q?"},
-        {
-            "role": "assistant",
-            "content": "[ANSWER]A[/ANSWER]",
-            "reasoning_content": "step 1\nstep 2",
-        },
-    ]
-    out = _normalize_chat_messages(msgs)
-    # User message survives unchanged.
-    assert out[0] == {"role": "user", "content": "Q?"}
-    # Assistant keeps reasoning_content alongside role/content.
-    assert out[1]["role"] == "assistant"
-    assert out[1]["content"] == "[ANSWER]A[/ANSWER]"
-    assert out[1]["reasoning_content"] == "step 1\nstep 2"
 
 
 def test_normalize_preserves_unknown_extras_on_all_roles():
@@ -775,9 +739,8 @@ def test_normalize_preserves_unknown_extras_on_all_roles():
 
 
 def test_normalize_drops_placeholder_tool_calls_but_keeps_extras():
-    """Placeholder ``tool_calls="[]"`` must still be normalized away (the
-    original bug that crashes Qwen2.5's template), even when other extras
-    are present on the same message."""
+    """Placeholder ``tool_calls="[]"`` is dropped on assistant messages even
+    when other extras are present on the same row."""
     msgs = [
         {
             "role": "assistant",
@@ -792,8 +755,8 @@ def test_normalize_drops_placeholder_tool_calls_but_keeps_extras():
 
 
 def test_normalize_strips_tool_calls_off_non_assistant_roles():
-    """Some datasets sloppily attach ``tool_calls`` to user/system/tool rows.
-    We strip those (they'd fight the template) while keeping other extras."""
+    """``tool_calls`` on user/tool/system rows is stripped (would fight the
+    template) while other extras survive."""
     msgs = [
         {"role": "user", "content": "u", "tool_calls": "[]", "name": "alice"},
         {"role": "tool", "content": "t", "tool_calls": "[]", "tool_call_id": "c0"},


### PR DESCRIPTION
# What does this PR do?

## Summary

Adds end-to-end tool-calling dataset support to `SFTTrainer` so rows with `tool` role messages, `tool_calls` on assistant turns, and per-row `tools` schemas (APIGen-MT, xLAM, ToolACE, etc.) tokenize correctly with assistant-only loss masking.

Today, `get_response_ids_and_loss_mask_from_messages` rejects any role outside `{user, assistant}` (`skyrl/train/generators/utils.py:663`), so a single `tool` turn raises `ValueError` and the trainer drops every tool-calling row. This PR closes that gap generically — APIGen-MT-5k is just the motivating dataset.

## Changes

### `skyrl/train/generators/utils.py`

- `get_response_ids_and_loss_mask_from_messages` accepts `role == "tool"` and masks observation tokens to 0 (same treatment as `user`). Error message updated to mention `tool`.

### `skyrl/train/sft_trainer.py`

- `tokenize_chat_example` gains `tools_key` and `system_key` parameters. When the columns are present:
  - per-row `tools` (list[dict] or JSON-encoded string) is forwarded as `tools=` to **every** `apply_chat_template` call (prompt, full conversation, and per-message in the all-assistants path);
  - per-row `system` prompt is prepended when the conversation does not already start with a system turn.
- New helpers `_coerce_tools`, `_normalize_tool_call_payload`, `_normalize_chat_messages` accept the dataset-in-the-wild shapes (string-encoded single dict, string-encoded list, OpenAI-shaped list, raw dict) and emit the OpenAI list-of-dicts that HF chat templates expect.
- Trailing `tool` turns are trimmed so rows ending in an unanswered tool observation (common in APIGen-MT) still tokenize. Trailing `user` turns continue to drop the row, preserving existing behavior.
- `_load_and_tokenize` only passes `tools_key` / `system_key` when those columns exist on the dataset, so non-tool-calling datasets are unaffected.

### `skyrl/train/config/sft_config.py`

- New fields `tools_key: str = "tools"` and `system_key: str = "system"`.

## Tests

- `tests/train/generators/test_utils.py` — new parametrized `test_tool_calling_loss_mask` (Qwen2.5 + Qwen3) verifies `tool` turns mask to 0 and assistant tool-call turns mask the same as text turns. Updated invalid-role assertion to match the new error message.
- `tests/train/test_sft_tokenization.py` — five new tests:
  - APIGen-shape row (stringified `tool_calls`, list `tools`, separate `system`)
  - `tools` as a JSON-encoded string column
  - missing `tools` column (caller passes `tools_key=\"\"`)
  - trailing-tool-turn trimming
  - tool-response tokens masked to 0

86/86 targeted tests pass:

\`\`\`
uv run --extra dev --extra fsdp pytest tests/train/test_sft_tokenization.py tests/train/generators/test_utils.py
================ 86 passed in 72.34s ================
\`\`\`

Also verified end-to-end against the real `Salesforce/APIGen-MT-5k` dataset (50/50 rows tokenize correctly with `train_on_what=all_assistant_messages`), and confirmed per-message vs full-conversation token equality on Qwen2.5 with `tools=` threaded through.

## Usage

For datasets with `messages` + `tools` + `system` columns:

\`\`\`yaml
dataset_name: Salesforce/APIGen-MT-5k
messages_key: messages
tools_key: tools          # default
system_key: system        # default
train_on_what: all_assistant_messages
\`\`\`