### PR TITLE
[bug] Fix documentation build issue after  #1682

### DIFF
--- a/.claude/docs/contributing.md
+++ b/.claude/docs/contributing.md
@@ -24,6 +24,7 @@ Start off any modification or debugging with SkyRL using this file as the primar
 - Ensure you've updated relevant example scripts and documentation for any changes
 - Ensure you've updated `.claude/` files and `CLAUDE.md` for any changes in paths, naming, etc.
 - When bumping the `megatron-bridge` version, refresh the parallelism strategies skill which is based on content in `megatron-bridge`: `.claude/skills/parallelism-strategies/SKILL.md`
+- If making documentation changes, ensure that docs build can succeed: `cd docs/; npm run build`
 
 ## New Model Support (Megatron)
 

--- a/.claude/docs/contributing.md
+++ b/.claude/docs/contributing.md
@@ -24,7 +24,7 @@ Start off any modification or debugging with SkyRL using this file as the primar
 - Ensure you've updated relevant example scripts and documentation for any changes
 - Ensure you've updated `.claude/` files and `CLAUDE.md` for any changes in paths, naming, etc.
 - When bumping the `megatron-bridge` version, refresh the parallelism strategies skill which is based on content in `megatron-bridge`: `.claude/skills/parallelism-strategies/SKILL.md`
-- If making documentation changes, ensure that docs build can succeed: `cd docs/; npm run build`
+- If making documentation changes, ensure that docs build can succeed: `cd docs/; npm install; npm run build`
 
 ## New Model Support (Megatron)
 

--- a/docs/content/docs/troubleshooting/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting/troubleshooting.mdx
@@ -36,7 +36,7 @@ In Ray, all tasks and actors are run in a "worker process". Each worker process 
 
 The error message is referring to worker process not starting up within timeout. This can be due to
 
-1. Incorrect startup command : maybe the path to an env file passed to uv run --env-file <env_file> .. is incorrect, or not available on the worker node, etc
+1. Incorrect startup command : maybe the path to an env file passed to `uv run --env-file <env_file> ..` is incorrect, or not available on the worker node, etc
    - Fix: Correct the startup command so that it is valid when run inside the working directory on the head as well as worker nodes.
 2. Slow startup : Your run can hang even if you simply exceed Ray's timeout limit for worker startup. This can happen with a cold-start run - the first SkyRL run in your cluster when `uv` has to download all the dependencies and populate its cache.
    - Fix: Increase the registration timeout for Ray workers with `RAY_worker_register_timeout_seconds` (say 600). This should be set before the ray cluster is launched with ray start. The ideal fix is to bake this large value in the container. 


### PR DESCRIPTION
Minor PR to fix documentation build issue after https://github.com/NovaSky-AI/SkyRL/pull/1682 . There was a bare `<env_file>` which was being interpreted by mdx as an  unclosed JSX tag