### PR TITLE
[tinker] bump async db pool default 5+10→20+40 for concurrent multi-LoRA

### DIFF
--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -108,7 +108,19 @@ async def lifespan(app: FastAPI):
     """Lifespan event handler for startup and shutdown."""
 
     db_url = get_async_database_url(app.state.engine_config.database_url)
-    app.state.db_engine = create_async_engine(db_url, echo=False)
+    # Bump pool above SQLAlchemy defaults (5 + 10 = 15) so concurrent multi-LoRA
+    # async clients (each holding several in-flight requests during rollouts +
+    # forward_backward) don't saturate the connection pool. Observed at 4
+    # concurrent async clients × mbs=32: pool exhausts → HTTP 500s →
+    # client-side "Sampling session not found" cascading failures. With
+    # pool_size=20, max_overflow=40 (60 total) we measured 4 concurrent async
+    # clients running cleanly with 0 QueuePool errors.
+    app.state.db_engine = create_async_engine(
+        db_url,
+        echo=False,
+        pool_size=int(os.environ.get("SKYRL_DB_POOL_SIZE", "20")),
+        max_overflow=int(os.environ.get("SKYRL_DB_MAX_OVERFLOW", "40")),
+    )
     enable_sqlite_wal(app.state.db_engine.sync_engine)
 
     async with app.state.db_engine.begin() as conn:


### PR DESCRIPTION
Title: [tinker] bump async db pool default 5+10→20+40 + env-var tunable

Body: Concurrent multi-LoRA async clients (each holding multiple in-flight requests during rollouts + forward_backward) saturate the SQLAlchemy connection pool at the default pool_size=5, max_overflow=10 (15 total). Observed with 3+ concurrent async clients × mbs=32: pool exhausts → HTTP 500s → client-side "Sampling session not found" cascading failures.

This change raises defaults to pool_size=20, max_overflow=40 (60 total) and makes them env-var-tunable via SKYRL_DB_POOL_SIZE / SKYRL_DB_MAX_OVERFLOW.

Empirically with these defaults, 3 concurrent async clients at mbs=32 run with zero QueuePool errors (vs 100% failure at the old default).

Note: 4+ concurrent async clients are still bottlenecked even with pool_size=500, max_overflow=1000 — uvicorn single-worker + SQLite write contention saturates before pool is even used. That's a separate architectural follow-up (multi-worker uvicorn, or non-SQLite DB).