### PR TITLE
Add Trackio rollout trace logging

### DIFF
--- a/docs/content/docs/configuration/config.mdx
+++ b/docs/content/docs/configuration/config.mdx
@@ -116,16 +116,21 @@ logger: "wandb"
 project_name: "skyrl"
 run_name: "test_run"
 log_path: "/tmp/skyrl-logs"
+trackio_trace:
+  max_traces_per_step: 16
+  trace_key: "rollout/traces"
 dump_data_batch: false
 dump_eval_results: true
 log_example_interval: 1
 
 ```
 
-- `logger`: Logger to use. Currently, we support `wandb`, `mlflow`, and `console`. `console` will simply log metrics to the console.
-- `project_name`: Name of the project in WandB and MLFlow.
-- `run_name`: Name of the run in WandB and MLFlow.
+- `logger`: Logger to use. Currently, we support `wandb`, `mlflow`, `swanlab`, `tensorboard`, `trackio`, and `console`. `console` will simply log metrics to the console.
+- `project_name`: Name of the project in WandB, MLFlow, SwanLab, and Trackio.
+- `run_name`: Name of the run in WandB, MLFlow, SwanLab, and Trackio.
 - `log_path`: Path for infrastructure log files. Infrastructure logs (vLLM engine startup, model loading, worker initialization) are written to `{log_path}/infra-YYMMDD_HHMMSS.log`. For multi-node training, use a shared filesystem path to consolidate logs into a single file. See the [logging guide](../checkpointing-logging/logging) for details.
+- `trackio_trace.max_traces_per_step`: Maximum number of rollout samples to log as Trackio traces per generation call when `trackio` is enabled. Set to `0` to disable trace logging.
+- `trackio_trace.trace_key`: Metric key used for logged `trackio.Trace` records.
 - `dump_data_batch`: Whether to dump the data batch to a file. This is useful for debugging. When `true`, the data batch will be dumped to a file in the `export_path` directory. The training batch at global step `N` is saved to `self.cfg.trainer.export_path / "dumped_data" / global_step_N_training_input`
 - `dump_eval_results`: Whether to dump the evaluation results to a file. When `true`, the full evaluation results will be dumped to a file in the `export_path` directory. The evaluation results at global step `N` is saved to `self.cfg.trainer.export_path / "dumped_eval" / global_step_N_eval_results`
 - `log_example_interval`: Log an example prompt every N training steps, `0`/`-1` to disable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ skyrl-train = [
     "debugpy==1.8.0",
     "hf_transfer",
     "wandb",
+    "trackio",
     "datasets>=4.0.0",
     "tensordict",
     "jaxtyping",
@@ -357,4 +358,3 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["skyrl", "skyrl_gym"]
-

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -416,6 +416,16 @@ class FullyAsyncConfig(BaseConfig):
     <= ``policy_mini_batch_size * (max_staleness_steps + 1)``."""
 
 
+@dataclass
+class TrackioTraceConfig(BaseConfig):
+    """Configuration for logging rollout samples as Trackio traces."""
+
+    max_traces_per_step: int = 16
+    """Maximum number of rollout traces to log per generation call. Set to ``0`` to disable."""
+    trace_key: str = "rollout/traces"
+    """Metric key used when logging ``trackio.Trace`` records."""
+
+
 # ---------------------------------------------------------------------------
 # Sampling / Chat Template
 # ---------------------------------------------------------------------------
@@ -644,6 +654,7 @@ class TrainerConfig(BaseConfig):
     project_name: str = "skyrl"
     run_name: str = "test_run"
     logger: str = "wandb"
+    trackio_trace: TrackioTraceConfig = field(default_factory=TrackioTraceConfig)
     dump_data_batch: bool = False
     dump_eval_results: bool = True
     rope_scaling: Optional[Dict[str, Any]] = None

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -29,7 +29,7 @@ from skyrl.backends.skyrl_train.inference_engines.utils import (
 )
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.backends.skyrl_train.utils.io import io
-from skyrl.train.generators.base import GeneratorOutput
+from skyrl.train.generators.base import GeneratorInput, GeneratorOutput
 from skyrl.train.generators.utils import (
     concatenate_generator_outputs,
     prepare_generator_input,
@@ -55,6 +55,7 @@ class GeneratedOutputGroup:
     """
 
     generator_output: GeneratorOutput
+    generator_input: GeneratorInput
     uid: str
     global_step_when_scheduled: int
 
@@ -589,6 +590,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                     generation_output_group_buffer.put_nowait(
                         GeneratedOutputGroup(
                             generator_output=cur_generator_output,
+                            generator_input=generator_input,
                             uid=uids[0],
                             global_step_when_scheduled=global_step_at_start,
                         )
@@ -615,6 +617,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
     ) -> TrainingInputBatch:
         """Given a mini-batch of generated groups, concatenate them into a single GeneratorOutput, then convert to a TrainingInputBatch."""
         generator_outputs = []
+        generator_inputs = []
         uids = []
         stalenesses = []
         staleness_violation_count = 0
@@ -622,6 +625,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             cur_staleness = self.global_step - cur_generated_output_group.global_step_when_scheduled
             stalenesses.append(cur_staleness)
             generator_outputs.append(cur_generated_output_group.generator_output)
+            generator_inputs.append(cur_generated_output_group.generator_input)
             # NOTE(Charlie): for step-wise training each group can contain a variable number of entries
             # (n_samples_per_prompt * variable turns_per_trajectory), so the uid fanout is per-group.
             group_size = len(cur_generated_output_group.generator_output["response_ids"])
@@ -644,6 +648,10 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         )
         assert generator_output["rollout_metrics"] is not None, "Rollout metrics should be non-null."
         self.all_metrics.update(generator_output["rollout_metrics"])
+        self._log_trackio_rollout_traces(
+            self._merge_generator_inputs_for_trace_logging(generator_inputs),
+            generator_output,
+        )
         generator_output.pop("rollout_metrics", None)
 
         # Log staleness statistics for this step
@@ -665,6 +673,27 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         logger.info(f"Example generated: {vis}")
 
         return self.convert_to_training_input(generator_output, uids)
+
+    @staticmethod
+    def _merge_generator_inputs_for_trace_logging(generator_inputs: List[GeneratorInput]) -> GeneratorInput:
+        assert generator_inputs, "Expected at least one generator input."
+        first = generator_inputs[0]
+        return {
+            "prompts": sum((generator_input["prompts"] for generator_input in generator_inputs), []),
+            "env_classes": sum((generator_input["env_classes"] for generator_input in generator_inputs), []),
+            "env_extras": (
+                sum((generator_input["env_extras"] for generator_input in generator_inputs), [])
+                if first.get("env_extras") is not None
+                else None
+            ),
+            "sampling_params": first.get("sampling_params"),
+            "trajectory_ids": (
+                sum((generator_input["trajectory_ids"] for generator_input in generator_inputs), [])
+                if first.get("trajectory_ids") is not None
+                else None
+            ),
+            "batch_metadata": first.get("batch_metadata"),
+        }
 
     def save_checkpoints(self):
         """

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -739,15 +739,101 @@ class RayPPOTrainer:
         # add rollout metrics to self.all_metrics
         if generator_output["rollout_metrics"] is not None:
             self.all_metrics.update(generator_output["rollout_metrics"])
-        generator_output.pop("rollout_metrics", None)
 
         validate_generator_output(
             len(input_batch["prompts"]),
             generator_output,
             step_wise=self.cfg.generator.step_wise_trajectories,
         )
+        self._log_trackio_rollout_traces(input_batch, generator_output)
+        generator_output.pop("rollout_metrics", None)
 
         return generator_output
+
+    def _log_trackio_rollout_traces(self, input_batch: GeneratorInput, generator_output: GeneratorOutput):
+        trace_cfg = self.cfg.trainer.trackio_trace
+        if trace_cfg.max_traces_per_step <= 0 or "trackio" not in self.tracker.logger:
+            return
+
+        step = input_batch["batch_metadata"].global_step if input_batch.get("batch_metadata") is not None else None
+        records = self._build_trackio_rollout_trace_records(
+            input_batch,
+            generator_output,
+            max_traces=trace_cfg.max_traces_per_step,
+        )
+        self.tracker.log_traces(trace_cfg.trace_key, records, step=step)
+
+    def _build_trackio_rollout_trace_records(
+        self,
+        input_batch: GeneratorInput,
+        generator_output: GeneratorOutput,
+        max_traces: int,
+    ) -> List[Dict[str, Any]]:
+        records: List[Dict[str, Any]] = []
+        prompts = input_batch["prompts"]
+        if not prompts:
+            return records
+        input_trajectory_ids = input_batch.get("trajectory_ids") or []
+        output_trajectory_ids = generator_output.get("trajectory_ids") or []
+        trajectory_id_to_input_idx = {
+            trajectory_id.to_string(): idx for idx, trajectory_id in enumerate(input_trajectory_ids)
+        }
+        rewards = generator_output.get("rewards") or []
+        stop_reasons = generator_output.get("stop_reasons")
+        batch_metadata = input_batch.get("batch_metadata")
+
+        num_traces = min(max_traces, len(generator_output["response_ids"]))
+        samples_per_prompt = max(1, len(generator_output["response_ids"]) // len(prompts))
+        for sample_index in range(num_traces):
+            input_idx = min(sample_index // samples_per_prompt, len(prompts) - 1)
+            output_trajectory_id = None
+            if sample_index < len(output_trajectory_ids):
+                output_trajectory_id = output_trajectory_ids[sample_index]
+                input_idx = trajectory_id_to_input_idx.get(output_trajectory_id.to_string(), input_idx)
+
+            response = self.tokenizer.decode(generator_output["response_ids"][sample_index], skip_special_tokens=False)
+            messages = self._messages_for_trackio_trace(prompts[input_idx], response)
+            metadata: Dict[str, Any] = {
+                "sample_index": sample_index,
+                "input_index": input_idx,
+            }
+            if batch_metadata is not None:
+                metadata["step"] = batch_metadata.global_step
+                metadata["split"] = batch_metadata.training_phase
+            if sample_index < len(rewards):
+                metadata["reward"] = self._trackio_metadata_value(rewards[sample_index])
+            if stop_reasons is not None and sample_index < len(stop_reasons):
+                metadata["stop_reason"] = stop_reasons[sample_index]
+            if output_trajectory_id is not None:
+                metadata["trajectory_id"] = output_trajectory_id.to_string()
+                metadata["instance_id"] = output_trajectory_id.instance_id
+                metadata["repetition_id"] = output_trajectory_id.repetition_id
+
+            records.append({"messages": messages, "metadata": metadata})
+        return records
+
+    @staticmethod
+    def _messages_for_trackio_trace(prompt: Any, response: str) -> List[Dict[str, Any]]:
+        if isinstance(prompt, list):
+            messages = [dict(message) for message in prompt if isinstance(message, dict)]
+        elif isinstance(prompt, dict):
+            messages = [dict(prompt)]
+        else:
+            messages = [{"role": "user", "content": str(prompt)}]
+        messages.append({"role": "assistant", "content": response})
+        return messages
+
+    @staticmethod
+    def _trackio_metadata_value(value: Any) -> Any:
+        if isinstance(value, torch.Tensor):
+            return RayPPOTrainer._trackio_metadata_value(value.detach().cpu().tolist())
+        if isinstance(value, np.generic):
+            return value.item()
+        if isinstance(value, dict):
+            return {str(k): RayPPOTrainer._trackio_metadata_value(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [RayPPOTrainer._trackio_metadata_value(v) for v in value]
+        return value
 
     @torch.no_grad()
     def postprocess_generator_output(

--- a/skyrl/train/utils/tracking.py
+++ b/skyrl/train/utils/tracking.py
@@ -30,7 +30,7 @@ from skyrl.train.config import SkyRLTrainConfig, get_config_as_dict
 
 # TODO(tgriggs): Test all backends.
 class Tracking:
-    supported_backends = ["wandb", "mlflow", "swanlab", "tensorboard", "console"]
+    supported_backends = ["wandb", "mlflow", "swanlab", "tensorboard", "console", "trackio"]
 
     def __init__(
         self,
@@ -81,12 +81,23 @@ class Tracking:
             self.console_logger = ConsoleLogger()
             self.logger["console"] = self.console_logger
 
+        if "trackio" in backends:
+            self.logger["trackio"] = _TrackioLoggingAdapter(project_name, experiment_name, config)
+
     def log(self, data, step, commit=False):
         for logger_name, logger_instance in self.logger.items():
             if logger_name == "wandb":
                 logger_instance.log(data=data, step=step, commit=commit)
             else:
                 logger_instance.log(data=data, step=step)
+
+    def log_traces(self, trace_key: str, records: List[Dict[str, Any]], step: Optional[int] = None):
+        if not records:
+            return
+        for logger_instance in self.logger.values():
+            log_traces = getattr(logger_instance, "log_traces", None)
+            if log_traces is not None:
+                log_traces(trace_key, records, step=step)
 
     def finish(self):
         for logger_name, logger_instance in self.logger.items():
@@ -150,6 +161,27 @@ class _TensorboardAdapter:
 
     def finish(self):
         self.writer.close()
+
+
+class _TrackioLoggingAdapter:
+    def __init__(self, project_name, experiment_name, config: Optional[Union[SkyRLTrainConfig, DictConfig]] = None):
+        import trackio
+
+        self.trackio = trackio
+        self.run = trackio.init(project=project_name, name=experiment_name, config=get_config_as_dict(config))
+
+    def log(self, data, step):
+        self.run.log(data, step=step)
+
+    def log_traces(self, trace_key: str, records: List[Dict[str, Any]], step: Optional[int] = None):
+        traces = [
+            self.trackio.Trace(messages=record["messages"], metadata=record.get("metadata")) for record in records
+        ]
+        if traces:
+            self.run.log({trace_key: traces}, step=step)
+
+    def finish(self):
+        self.run.finish()
 
 
 class _MlflowLoggingAdapter:

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -14,6 +14,8 @@ from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.backends.skyrl_train.workers.worker import CriticWorkerBase, PolicyWorkerBase
 from skyrl.backends.skyrl_train.workers.worker_utils import BatchIterator
 from skyrl.train.config import SkyRLTrainConfig
+from skyrl.train.fully_async_trainer import FullyAsyncRayPPOTrainer
+from skyrl.train.generators.base import BatchMetadata, TrajectoryID
 from skyrl.train.trainer import RayPPOTrainer
 from skyrl.train.utils.utils import validate_batch_sizes
 from tests.train.util import example_dummy_config
@@ -130,6 +132,143 @@ def test_calculate_kl_create_experience_batched(dummy_config):
     assert metrics["avg_kl_max"] == approx(0.3143, abs=1e-4)
     # Note; the raw KL mean is 0.054, but then the masked mean is different.
     assert metrics["avg_kl"] == approx(0.1249, abs=1e-4)
+
+
+def test_log_trackio_rollout_traces(dummy_config):
+    dummy_config.trainer.trackio_trace.max_traces_per_step = 1
+    dummy_config.trainer.trackio_trace.trace_key = "rollout/traces"
+    tracker = MagicMock()
+    tracker.logger = {"trackio": MagicMock()}
+    tokenizer = MagicMock()
+    tokenizer.decode.return_value = "4"
+    trainer = RayPPOTrainer(
+        cfg=dummy_config,
+        tracker=tracker,
+        tokenizer=tokenizer,
+        train_dataset=None,
+        inference_engine_client=MagicMock(),
+        generator=MagicMock(),
+    )
+    generator_input = {
+        "prompts": [[{"role": "user", "content": "What is 2 + 2?"}]],
+        "env_classes": ["gsm8k"],
+        "env_extras": [{}],
+        "sampling_params": {"temperature": 0.0},
+        "trajectory_ids": [TrajectoryID(instance_id="uid-1", repetition_id=0)],
+        "batch_metadata": BatchMetadata(global_step=7, training_phase="train"),
+    }
+    generator_output = {
+        "prompt_token_ids": [[1, 2]],
+        "response_ids": [[3, 4]],
+        "rewards": [1.0],
+        "loss_masks": [[1, 1]],
+        "stop_reasons": ["stop"],
+        "rollout_metrics": {},
+        "rollout_logprobs": None,
+        "trajectory_ids": [TrajectoryID(instance_id="uid-1", repetition_id=0)],
+        "rollout_expert_indices": None,
+        "is_last_step": None,
+        "env_metrics": None,
+        "pixel_values": None,
+        "image_grid_thw": None,
+    }
+
+    trainer._log_trackio_rollout_traces(generator_input, generator_output)
+
+    tracker.log_traces.assert_called_once()
+    trace_key, records = tracker.log_traces.call_args.args
+    assert trace_key == "rollout/traces"
+    assert tracker.log_traces.call_args.kwargs["step"] == 7
+    assert records == [
+        {
+            "messages": [
+                {"role": "user", "content": "What is 2 + 2?"},
+                {"role": "assistant", "content": "4"},
+            ],
+            "metadata": {
+                "sample_index": 0,
+                "input_index": 0,
+                "step": 7,
+                "split": "train",
+                "reward": 1.0,
+                "stop_reason": "stop",
+                "trajectory_id": "uid-1_0",
+                "instance_id": "uid-1",
+                "repetition_id": 0,
+            },
+        }
+    ]
+
+
+def test_build_trackio_rollout_trace_records_uses_blocked_prompt_fallback(dummy_config):
+    tracker = MagicMock()
+    tracker.logger = {"trackio": MagicMock()}
+    tokenizer = MagicMock()
+    tokenizer.decode.side_effect = lambda ids, skip_special_tokens=False: f"response-{ids[0]}"
+    trainer = RayPPOTrainer(
+        cfg=dummy_config,
+        tracker=tracker,
+        tokenizer=tokenizer,
+        train_dataset=None,
+        inference_engine_client=MagicMock(),
+        generator=MagicMock(),
+    )
+    generator_input = {
+        "prompts": [
+            [{"role": "user", "content": "prompt-0"}],
+            [{"role": "user", "content": "prompt-1"}],
+        ],
+        "env_classes": ["gsm8k", "gsm8k"],
+        "env_extras": [{}, {}],
+        "sampling_params": {"temperature": 0.0},
+        "trajectory_ids": None,
+        "batch_metadata": BatchMetadata(global_step=7, training_phase="train"),
+    }
+    generator_output = {
+        "prompt_token_ids": [[1], [2], [3], [4]],
+        "response_ids": [[1], [2], [3], [4]],
+        "rewards": [1.0, 0.9, 0.8, 0.7],
+        "loss_masks": [[1], [1], [1], [1]],
+        "stop_reasons": ["stop"] * 4,
+        "rollout_metrics": {},
+        "rollout_logprobs": None,
+        "trajectory_ids": None,
+        "rollout_expert_indices": None,
+        "is_last_step": None,
+        "env_metrics": None,
+        "pixel_values": None,
+        "image_grid_thw": None,
+    }
+
+    records = trainer._build_trackio_rollout_trace_records(generator_input, generator_output, max_traces=4)
+
+    assert [record["messages"][0]["content"] for record in records] == ["prompt-0", "prompt-0", "prompt-1", "prompt-1"]
+
+
+def test_merge_generator_inputs_for_trace_logging():
+    first = {
+        "prompts": [[{"role": "user", "content": "prompt-0"}]],
+        "env_classes": ["gsm8k"],
+        "env_extras": [{"source": "a"}],
+        "sampling_params": {"temperature": 0.0},
+        "trajectory_ids": [TrajectoryID(instance_id="uid-0", repetition_id=0)],
+        "batch_metadata": BatchMetadata(global_step=3, training_phase="train"),
+    }
+    second = {
+        "prompts": [[{"role": "user", "content": "prompt-1"}]],
+        "env_classes": ["gsm8k"],
+        "env_extras": [{"source": "b"}],
+        "sampling_params": {"temperature": 0.0},
+        "trajectory_ids": [TrajectoryID(instance_id="uid-1", repetition_id=0)],
+        "batch_metadata": BatchMetadata(global_step=3, training_phase="train"),
+    }
+
+    merged = FullyAsyncRayPPOTrainer._merge_generator_inputs_for_trace_logging([first, second])
+
+    assert [prompt[0]["content"] for prompt in merged["prompts"]] == ["prompt-0", "prompt-1"]
+    assert merged["env_extras"] == [{"source": "a"}, {"source": "b"}]
+    assert [trajectory_id.to_string() for trajectory_id in merged["trajectory_ids"]] == ["uid-0_0", "uid-1_0"]
+    assert merged["batch_metadata"].global_step == 3
 
 
 @patch("skyrl.backends.skyrl_train.utils.ppo_utils.compute_advantages_and_returns", new_callable=MagicMock)

--- a/uv.lock
+++ b/uv.lock
@@ -2737,6 +2737,22 @@ wheels = [
 ]
 
 [[package]]
+name = "gradio-client"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/e6/6b6029f5fe2ad7f1211105d530e34d991014c2cae463f9223033031cfc4f/gradio_client-2.5.0.tar.gz", hash = "sha256:4cde99bad62149595c30c90876ca2e405e3a13687ecf895474f3412cb476673d", size = 59013, upload-time = "2026-04-20T23:16:21.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/81/0a861b8e1ff42960139c6cd4c7dd591292fa09ea1ae2d87677441cba4c00/gradio_client-2.5.0-py3-none-any.whl", hash = "sha256:d43e2179c29076292a76485ad7ed2e6eaa19d14ac58283bd7f5beabfe4ca958c", size = 59952, upload-time = "2026-04-20T23:16:20.186Z" },
+]
+
+[[package]]
 name = "graphene"
 version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3143,7 +3159,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.9.1"
+version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -3156,9 +3172,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/40/68d9b286b125d9318ae95c8f8b206e8672e7244b0eea61ebb4a88037638c/huggingface_hub-1.9.1.tar.gz", hash = "sha256:442af372207cc24dcb089caf507fcd7dbc1217c11d6059a06f6b90afe64e8bd2", size = 750355, upload-time = "2026-04-07T13:47:59.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/af/10a89c54937dccf6c10792770f362d96dd67aedfde108e6e1fd7a0836789/huggingface_hub-1.9.1-py3-none-any.whl", hash = "sha256:8dae771b969b318203727a6c6c5209d25e661f6f0dd010fc09cc4a12cf81c657", size = 637356, upload-time = "2026-04-07T13:47:57.239Z" },
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -9725,6 +9741,7 @@ flashrl = [
     { name = "torchvision", version = "0.22.0", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'extra-5-skyrl-flashrl') or (python_full_version >= '3.14' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp') or (python_full_version >= '3.14' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu') or (python_full_version >= '3.14' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-jax') or (python_full_version >= '3.14' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron') or (python_full_version >= '3.14' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-miniswe') or (python_full_version >= '3.14' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-tpu') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-jax') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-miniswe') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-tpu') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-jax') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-megatron') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-megatron') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-jax' and extra == 'extra-5-skyrl-megatron') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-miniswe') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-tpu') or (platform_machine != 'aarch64' and extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-jax') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-miniswe') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-tpu') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-jax') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-megatron') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-megatron') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-jax' and extra == 'extra-5-skyrl-megatron') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-miniswe') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-tpu') or (platform_python_implementation != 'CPython' and extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-jax') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-miniswe') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-tpu') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-jax') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-megatron') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-megatron') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-jax' and extra == 'extra-5-skyrl-megatron') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-miniswe') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-tpu') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-jax') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-megatron') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-megatron') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-jax' and extra == 'extra-5-skyrl-megatron') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-miniswe') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-tpu') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu')" },
     { name = "torchvision", version = "0.22.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp') or (python_full_version < '3.14' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu') or (python_full_version < '3.14' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-jax') or (python_full_version < '3.14' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron') or (python_full_version < '3.14' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-miniswe') or (python_full_version < '3.14' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-tpu') or (python_full_version >= '3.14' and sys_platform == 'linux' and extra == 'extra-5-skyrl-flashrl') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-5-skyrl-flashrl') or (platform_python_implementation != 'CPython' and sys_platform == 'linux' and extra == 'extra-5-skyrl-flashrl') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-jax') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-miniswe') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-tpu') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-jax') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-megatron') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-megatron') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-jax' and extra == 'extra-5-skyrl-megatron') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-miniswe') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-tpu') or (sys_platform != 'linux' and extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-jax') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-megatron') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-megatron') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-jax' and extra == 'extra-5-skyrl-megatron') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-miniswe') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-tpu') or (extra != 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu')" },
     { name = "tqdm" },
+    { name = "trackio" },
     { name = "uvicorn" },
     { name = "vllm-router", marker = "sys_platform == 'linux'" },
     { name = "wandb" },
@@ -9763,6 +9780,7 @@ fsdp = [
     { name = "torchdata" },
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu')" },
     { name = "tqdm" },
+    { name = "trackio" },
     { name = "uvicorn" },
     { name = "vllm", marker = "sys_platform == 'linux' or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu')" },
     { name = "vllm-router", marker = "sys_platform == 'linux' or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu')" },
@@ -9821,6 +9839,7 @@ megatron = [
     { name = "torchdata" },
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
     { name = "tqdm" },
+    { name = "trackio" },
     { name = "transformer-engine", extra = ["pytorch"], marker = "(sys_platform == 'linux' and extra == 'extra-5-skyrl-megatron') or (extra == 'extra-5-skyrl-jax' and extra == 'extra-5-skyrl-megatron') or (extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-miniswe') or (extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-tpu') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-jax') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-miniswe') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-tpu') or (extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-jax') or (extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-megatron') or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-megatron') or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu')" },
     { name = "uvicorn" },
     { name = "vllm", marker = "sys_platform == 'linux'" },
@@ -9855,6 +9874,7 @@ miniswe = [
     { name = "tensordict" },
     { name = "torchdata" },
     { name = "tqdm" },
+    { name = "trackio" },
     { name = "uvicorn" },
     { name = "vllm-router", marker = "sys_platform == 'linux' or (extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-jax')" },
     { name = "wandb" },
@@ -9888,6 +9908,7 @@ skyrl-train = [
     { name = "tensordict" },
     { name = "torchdata" },
     { name = "tqdm" },
+    { name = "trackio" },
     { name = "uvicorn" },
     { name = "vllm-router", marker = "sys_platform == 'linux' or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-fsdp') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-gpu') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-jax') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-megatron') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-miniswe') or (extra == 'extra-5-skyrl-flashrl' and extra == 'extra-5-skyrl-tpu') or (extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-jax') or (extra == 'extra-5-skyrl-fsdp' and extra == 'extra-5-skyrl-megatron') or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-megatron') or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-miniswe') or (extra == 'extra-5-skyrl-gpu' and extra == 'extra-5-skyrl-tpu') or (extra == 'extra-5-skyrl-jax' and extra == 'extra-5-skyrl-megatron') or (extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-miniswe') or (extra == 'extra-5-skyrl-megatron' and extra == 'extra-5-skyrl-tpu') or (extra == 'extra-5-skyrl-miniswe' and extra == 'extra-5-skyrl-tpu')" },
     { name = "wandb" },
@@ -10010,6 +10031,7 @@ requires-dist = [
     { name = "torchvision", marker = "sys_platform == 'linux' and extra == 'fsdp'", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchvision", marker = "sys_platform == 'linux' and extra == 'megatron'", index = "https://download.pytorch.org/whl/cu128" },
     { name = "tqdm", marker = "extra == 'skyrl-train'" },
+    { name = "trackio", marker = "extra == 'skyrl-train'" },
     { name = "transformer-engine", extras = ["pytorch"], marker = "sys_platform == 'linux' and extra == 'megatron'", specifier = "==2.11.0" },
     { name = "transformers", specifier = ">=5.6.1,<=5.8.0" },
     { name = "ty", marker = "extra == 'dev'" },
@@ -11076,6 +11098,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "trackio"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gradio-client" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "orjson" },
+    { name = "pillow" },
+    { name = "python-multipart" },
+    { name = "starlette" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9a/80caa250ef9e0e465db883958764c9b27a413c8b246349f60c237b820201/trackio-0.25.1-py3-none-any.whl", hash = "sha256:d019b79a8dfb14264db1055b7e9b2681984138b827dabd5ec01585c0bd24116d", size = 1653922, upload-time = "2026-04-26T02:13:41.814Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hi folks! This PR adds trace logging via Trackio, the free, local-first experiment tracking library from Hugging Face 🤗

This PR follows SkyRL's existing metric logging and rollout generation patterns. Specifically, I did this:

- added `trackio` as a supported training logger backend
- added configurable rollout trace logging with `trainer.trackio_trace.max_traces_per_step` and `trainer.trackio_trace.trace_key`
- logged rollout prompt/response conversations as `trackio.Trace` records with step, split, reward, stop reason, and trajectory metadata
- covered both synchronous and fully async rollout generation paths
- documented the Trackio logger and trace settings
- added a mocked Trackio rollout trace test

Here's what it looks like:

<img width="1512" height="755" alt="image" src="https://github.com/user-attachments/assets/b80d1d69-9dfc-4f48-a4bb-dc7fbc3cb970" />


AI assistance was used to prepare this PR.