### PR TITLE
feat(tracking): plumb wandb tags through Tracking init

### DIFF
--- a/docs/content/docs/configuration/config.mdx
+++ b/docs/content/docs/configuration/config.mdx
@@ -119,6 +119,7 @@ log_path: "/tmp/skyrl-logs"
 dump_data_batch: false
 dump_eval_results: true
 log_example_interval: 1
+tags: null
 
 ```
 
@@ -129,6 +130,7 @@ log_example_interval: 1
 - `dump_data_batch`: Whether to dump the data batch to a file. This is useful for debugging. When `true`, the data batch will be dumped to a file in the `export_path` directory. The training batch at global step `N` is saved to `self.cfg.trainer.export_path / "dumped_data" / global_step_N_training_input`
 - `dump_eval_results`: Whether to dump the evaluation results to a file. When `true`, the full evaluation results will be dumped to a file in the `export_path` directory. The evaluation results at global step `N` is saved to `self.cfg.trainer.export_path / "dumped_eval" / global_step_N_eval_results`
 - `log_example_interval`: Log an example prompt every N training steps, `0`/`-1` to disable.
+- `tags`: Optional list of tags to apply to the W&B run (e.g. `["sft", "experiment-1"]`). Has no effect on other backends.
 
 ## Training Backends
 

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -675,6 +675,8 @@ class TrainerConfig(BaseConfig):
     logger: str = "wandb"
     enable_ray_gpu_monitor: bool = True
     """Enable background Ray GPU/RAM metrics collection and logging to wandb."""
+    tags: Optional[List[str]] = None
+    """Optional list of tags to apply to the W&B run. Has no effect on other backends."""
     dump_data_batch: bool = False
     dump_eval_results: bool = True
     rope_scaling: Optional[Dict[str, Any]] = None

--- a/skyrl/train/config/sft_config.py
+++ b/skyrl/train/config/sft_config.py
@@ -177,6 +177,8 @@ class SFTConfig(BaseConfig):
     logger: str = "console"  # "console" or "wandb"
     project_name: str = "skyrl_sft"
     run_name: str = "skyrl_sft_run"
+    tags: Optional[List[str]] = None
+    """Optional list of tags to apply to the W&B run. Has no effect on other backends."""
     ckpt_path: str = ""
     ckpt_interval: int = 0  # <= 0 -> no checkpointing
     enable_ray_gpu_monitor: bool = True
@@ -338,6 +340,7 @@ def build_skyrl_config_for_sft(sft_cfg: SFTConfig) -> SkyRLTrainConfig:
     cfg.trainer.logger = sft_cfg.logger
     cfg.trainer.project_name = sft_cfg.project_name
     cfg.trainer.run_name = sft_cfg.run_name
+    cfg.trainer.tags = sft_cfg.tags
     if sft_cfg.ckpt_path:
         cfg.trainer.ckpt_path = sft_cfg.ckpt_path
         cfg.trainer.ckpt_interval = sft_cfg.ckpt_interval

--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -280,6 +280,7 @@ class BasePPOExp:
             experiment_name=self.cfg.trainer.run_name,
             backends=self.cfg.trainer.logger,
             config=self.cfg,
+            tags=self.cfg.trainer.tags,
         )
 
     def get_inference_client(self) -> InferenceEngineInterface:

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -784,6 +784,7 @@ class SFTTrainer:
             experiment_name=self.cfg.trainer.run_name,
             backends=self.cfg.trainer.logger,
             config=self.sft_cfg,
+            tags=self.cfg.trainer.tags,
         )
 
     def add_callback(self, callback: TrainingCallback) -> None:

--- a/skyrl/train/utils/tracking.py
+++ b/skyrl/train/utils/tracking.py
@@ -39,6 +39,7 @@ class Tracking:
         experiment_name,
         backends: Union[str, List[str]] = "console",
         config: Optional[Union[SkyRLTrainConfig, DictConfig]] = None,
+        tags: Optional[List[str]] = None,
     ):
         if isinstance(backends, str):
             backends = [backends]
@@ -50,7 +51,12 @@ class Tracking:
         if "wandb" in backends:
             import wandb
 
-            wandb.init(project=project_name, name=experiment_name, config=get_config_as_dict(config))
+            wandb.init(
+                project=project_name,
+                name=experiment_name,
+                config=get_config_as_dict(config),
+                tags=tags,
+            )
             self.logger["wandb"] = wandb
 
         if "mlflow" in backends:

--- a/tests/train/test_tracking.py
+++ b/tests/train/test_tracking.py
@@ -1,0 +1,41 @@
+"""
+uv run --isolated --extra dev --extra skyrl-train pytest -s tests/train/test_tracking.py
+"""
+
+from unittest.mock import MagicMock, patch
+
+from skyrl.train.utils.tracking import Tracking
+
+
+def test_wandb_init_receives_tags():
+    """Tags passed to Tracking are forwarded to wandb.init."""
+    with patch.dict("sys.modules", {"wandb": MagicMock()}) as mocked:
+        wandb_mock = mocked["wandb"]
+        Tracking(
+            project_name="proj",
+            experiment_name="exp",
+            backends=["wandb"],
+            config={},
+            tags=["foo", "bar"],
+        )
+
+        wandb_mock.init.assert_called_once()
+        kwargs = wandb_mock.init.call_args.kwargs
+        assert kwargs["tags"] == ["foo", "bar"]
+        assert kwargs["project"] == "proj"
+        assert kwargs["name"] == "exp"
+
+
+def test_wandb_init_tags_default_none():
+    """When tags are not provided, wandb.init receives tags=None."""
+    with patch.dict("sys.modules", {"wandb": MagicMock()}) as mocked:
+        wandb_mock = mocked["wandb"]
+        Tracking(
+            project_name="proj",
+            experiment_name="exp",
+            backends=["wandb"],
+            config={},
+        )
+
+        wandb_mock.init.assert_called_once()
+        assert wandb_mock.init.call_args.kwargs["tags"] is None


### PR DESCRIPTION
## Why

`Tracking` doesn't currently pass `tags` to `wandb.init`, so SkyRL-driven runs are always untagged. Tags are W&B's primary primitive for filtering, grouping, and organizing runs in the UI; not having them means callers can't distinguish, e.g., "baseline vs. ablation," "SFT vs. RL," or sibling runs in a sweep.

This also closes a small surprise gap: the lower-level `WandbTracker` in `skyrl/utils/log.py` already plumbs arbitrary kwargs to `wandb.init`, so power users discovered they could set tags through that path but not through the supported `Tracking` adapter.

## What

- `Tracking.__init__` accepts a new explicit `tags: Optional[List[str]] = None` parameter.
- The wandb branch forwards it to `wandb.init(tags=tags)`.
- New `trainer.tags` config field (default `None`).
- `get_tracker` in `main_base.py` forwards `cfg.trainer.tags`.
- The SFT path mirrors this: `SFTConfig.tags` bridges to `cfg.trainer.tags`, and `SFTTrainer._init_tracker` forwards it.
- Tags are wandb-specific; other backends are unchanged.

## Why an explicit param

`Tracking` is an adapter over five backends (wandb, mlflow, swanlab, tensorboard, console). A `**kwargs` passthrough would couple the adapter to wandb's API surface. An explicit, typed parameter keeps the contract clear and leaves a clean place to add matching primitives (mlflow tags, etc.) without breaking changes.

## Test plan

- [x] Unit test: `Tracking(..., tags=["a","b"])` results in `wandb.init(..., tags=["a","b"])`.
- [x] Unit test: default `tags=None` is forwarded when not passed.
- [x] Format/lint clean.
- [x] No behavior change when `tags` is not passed.

## Compatibility

Strictly additive. `wandb.init(tags=None)` is a no-op; the SDK still honors `WANDB_TAGS` env var.