### PR TITLE
Removed dead `timeout` parameter from `DistributedStrategy` subclasses

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -4,7 +4,6 @@ import json
 import os
 import random
 from collections import defaultdict
-from datetime import timedelta
 from typing import List, Optional, Union
 
 import numpy as np
@@ -98,7 +97,7 @@ class FSDPStrategy(DistributedStrategy):
         torch.manual_seed(seed)
         torch.cuda.manual_seed_all(seed)
 
-    def setup_distributed(self, timeout=timedelta(minutes=30)) -> None:
+    def setup_distributed(self) -> None:
         self.set_seed(self.seed)
 
         local_rank = int(os.environ.get("LOCAL_RANK", "-1"))

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -4,7 +4,6 @@ import random
 import re
 import shutil
 import tempfile
-from datetime import timedelta
 from typing import List, Optional, Union
 
 import megatron.core.parallel_state as mpu
@@ -160,7 +159,7 @@ class MegatronStrategy(DistributedStrategy):
 
             tensor_parallel.model_parallel_cuda_manual_seed(seed)
 
-    def setup_distributed(self, timeout=timedelta(minutes=30)) -> None:
+    def setup_distributed(self) -> None:
         local_rank = int(os.environ.get("LOCAL_RANK", "-1"))
         if local_rank != -1:
             torch.cuda.set_device(local_rank)


### PR DESCRIPTION
It seems:

1. https://github.com/NovaSky-AI/SkyRL/pull/27 added `FSDPStrategy.setup_distributed` with a dead `timeout` parameter
2. https://github.com/NovaSky-AI/SkyRL/pull/223 propagated the dead `timeout` parameter to `MegatronStrategy.setup_distributed`

This PR just removes this dead parameter, which confused coding agents today. The base class `DistributedStrategy.setup_distributed` does not have this `timeout` parameter.