### PR TITLE
[megatron] add aux loss coeff explicitly and add post init to keep config default kwargs even when overriden

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -385,6 +385,7 @@ class MegatronWorker:
         # overridden by transformer_config_kwargs if needed.
         provider.moe_token_dispatcher_type = megatron_config.moe_token_dispatcher_type
         provider.moe_router_load_balancing_type = megatron_config.moe_router_load_balancing_type
+        provider.moe_aux_loss_coeff = megatron_config.moe_aux_loss_coeff
         provider.moe_router_dtype = megatron_config.moe_router_dtype
         provider.moe_grouped_gemm = megatron_config.moe_grouped_gemm
         if megatron_config.moe_router_score_function is not None:

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -169,6 +169,8 @@ class MegatronConfig(BaseConfig):
     moe_token_dispatcher_type: str = "alltoall"
     moe_router_load_balancing_type: str = "none"
     """Set to "aux_loss", "seq_aux_loss", or "global_aux_loss" to enable aux loss-based load balancing and logging."""
+    moe_aux_loss_coeff: int = 0
+    """Scaling coefficient for the moe load balancing loss if moe_router_load_balancing_type is not 'none'. Will disable aux loss in megatron-core if set to 0."""
     moe_grouped_gemm: bool = True
     moe_router_score_function: Optional[str] = None
     moe_router_enable_expert_bias: Optional[bool] = None
@@ -192,6 +194,14 @@ class MegatronConfig(BaseConfig):
     freeze_moe_router: bool = False
     """If True, freeze MoE router parameters so they are not updated during training. No-op on
     non-MoE models."""
+
+    def __post_init__(self):
+        # Backfill defaults for any keys the user didn't override so an override dict
+        # doesn't have to repeat every default just to set one value.
+        for k, v in DEFAULT_TRANSFORMER_CONFIG_KWARGS.items():
+            self.transformer_config_kwargs.setdefault(k, copy.deepcopy(v))
+        for k, v in DEFAULT_MEGATRON_OPTIMIZER_KWARGS.items():
+            self.optimizer_config_kwargs.setdefault(k, copy.deepcopy(v))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> **Stacked on #1701** — this PR targets the `moe_aux_loss` branch, not `main`. After #1701 merges, rebase this branch onto `main` and retarget the PR base to `main`.

## Summary
- Add `MegatronConfig.moe_aux_loss_coeff` and pass it through to the model provider (set to `0` to disable aux loss in megatron-core).
- Add a `__post_init__` to `MegatronConfig` that backfills `DEFAULT_TRANSFORMER_CONFIG_KWARGS` / `DEFAULT_MEGATRON_OPTIMIZER_KWARGS` so an override dict need not repeat every default just to set one value.
