### PR TITLE
[logging] Add MoE auxiliary loss

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -21,7 +21,7 @@
 # limitations under the License.
 
 import gc
-from typing import List, Union
+from typing import Any, List, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -31,6 +31,11 @@ from megatron.core.distributed import DistributedDataParallel as DDP
 from megatron.core.optimizer import ChainedOptimizer
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.transformer.module import Float16Module
+from megatron.core.transformer.moe.moe_utils import (
+    clear_aux_losses_tracker,
+    get_moe_layer_wise_logging_tracker,
+    reduce_aux_losses_tracker_across_ranks,
+)
 from megatron.core.utils import get_attr_wrapped_model
 
 ALL_MODULE_WRAPPER_CLASSNAMES = (DDP, Float16Module)
@@ -93,6 +98,52 @@ def get_model_size(model: nn.Module, scale="auto"):
         raise NotImplementedError(f"Unknown scale {scale}")
 
     return n_params, scale
+
+
+def get_moe_metrics(
+    loss_scale: float,
+    total_loss_dict: Optional[dict] = None,
+    per_layer_logging: bool = False,
+) -> dict[str, Any]:
+    """Returns Mixture of Experts (MoE) auxiliary-loss metrics.
+
+    This function reduces MoE auxiliary losses across ranks, aggregates them, and
+    returns a dictionary of metrics.
+
+    Args:
+        loss_scale: Scale factor to apply to each auxiliary loss (e.g., 1/num_microbatches).
+        total_loss_dict: If provided, accumulate means into this dict (by name).
+        per_layer_logging: If True, include per-layer values in the returned dict.
+
+    Returns:
+        dict[str, Any]: A flat dict of aggregated metrics. For each aux loss name,
+        the mean value is returned under the same key (e.g., "load_balancing_loss").
+        If per_layer_logging is True, per-layer values are returned under keys of the
+        form "moe/{name}_layer_{i}".
+    """
+    reduce_aux_losses_tracker_across_ranks()
+    tracker = get_moe_layer_wise_logging_tracker()
+
+    metrics: dict[str, Any] = {}
+    if len(tracker) > 0:
+        aux_losses = {k: v["values"].float() * loss_scale for k, v in tracker.items()}
+        for name, loss_list in aux_losses.items():
+            # Megatron-Core aggregates aux losses across layers and normalizes by number of MoE layers
+            num_layers = int(loss_list.numel()) if loss_list.numel() > 0 else 1
+            aggregated_value = loss_list.sum() / num_layers
+            metrics[name] = float(aggregated_value.item())
+            if total_loss_dict is not None:
+                if name not in total_loss_dict:
+                    total_loss_dict[name] = aggregated_value
+                else:
+                    total_loss_dict[name] += aggregated_value
+
+            if per_layer_logging:
+                for i, loss in enumerate(loss_list.tolist()):
+                    metrics[f"moe/{name}_layer_{i}"] = float(loss)
+
+    clear_aux_losses_tracker()
+    return metrics
 
 
 def freeze_moe_router(model_or_models: Union[nn.Module, List[nn.Module]]):

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -26,6 +26,8 @@ from skyrl.backends.skyrl_train.distributed.megatron.megatron_strategy import (
 from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
     broadcast_object_across_pp_ranks,
     freeze_moe_router,
+    get_model_config,
+    get_moe_metrics,
     print_model_size,
 )
 from skyrl.backends.skyrl_train.distributed.megatron.optimizer import (
@@ -383,6 +385,7 @@ class MegatronWorker:
         # overridden by transformer_config_kwargs if needed.
         provider.moe_token_dispatcher_type = megatron_config.moe_token_dispatcher_type
         provider.moe_router_load_balancing_type = megatron_config.moe_router_load_balancing_type
+        provider.moe_router_dtype = megatron_config.moe_router_dtype
         provider.moe_grouped_gemm = megatron_config.moe_grouped_gemm
         if megatron_config.moe_router_score_function is not None:
             provider.moe_router_score_function = megatron_config.moe_router_score_function
@@ -871,6 +874,23 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         status["policy_lr"] = self.optimizer.param_groups[0]["lr"]
         group = mpu.get_data_parallel_group(with_context_parallel=False)
         status = all_reduce_metrics(status, self.strategy, group=group, sum_loss_metrics=sum_loss_metrics)
+
+        # Collect MoE aux metrics averaged across microbatches (all-reduced across ranks
+        # inside get_moe_metrics) aggregating after per-microbatch scalar metrics.
+        total_num_microbatches = len(micro_buffer)
+        model_config = get_model_config(self.actor_module[0])
+        num_moe_experts = getattr(model_config, "num_moe_experts", None)
+        moe_metrics: Dict[str, Any] = {}
+        if num_moe_experts is not None and num_moe_experts > 1:
+            moe_loss_scale = 1.0 / max(1, total_num_microbatches)
+            moe_metrics = get_moe_metrics(
+                loss_scale=moe_loss_scale,
+                per_layer_logging=self.cfg.policy.megatron_config.moe_per_layer_logging,
+            )
+            # moe_metrics will only be non-empty if "moe_router_load_balancing_type" is set to "aux_loss", "seq_aux_loss", or "global_aux_loss"
+            if moe_metrics:
+                for k, v in moe_metrics.items():
+                    status[k] = v
 
         clear_router_replay()
 

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -168,10 +168,15 @@ class MegatronConfig(BaseConfig):
     # MoE runtime configuration flags
     moe_token_dispatcher_type: str = "alltoall"
     moe_router_load_balancing_type: str = "none"
+    """Set to "aux_loss", "seq_aux_loss", or "global_aux_loss" to enable aux loss-based load balancing and logging."""
     moe_grouped_gemm: bool = True
     moe_router_score_function: Optional[str] = None
     moe_router_enable_expert_bias: Optional[bool] = None
     moe_enable_routing_replay: bool = False
+    moe_per_layer_logging: bool = False
+    """Enable per-layer logging of MoE metrics (i.e. per layer aux losses)."""
+    moe_router_dtype: str = "fp32"
+    """Pass through to Megatron-Bridge - can be set to 'fp64' for additional numerical stability."""
     ddp_config: MegatronDDPConfig = field(default_factory=MegatronDDPConfig)
     torch_profiler_config: MegatronTorchProfilerConfig = field(default_factory=MegatronTorchProfilerConfig)
     lora_config: MegatronLoraConfig = field(default_factory=MegatronLoraConfig)

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py
@@ -491,6 +491,9 @@ async def test_megatron_train(
         cfg.trainer.algorithm.off_policy_correction.geo_mask_high = 1.02
         cfg.trainer.algorithm.off_policy_correction.geo_mask_low = 0.98
 
+        cfg.trainer.policy.megatron_config.moe_router_load_balancing_type = "seq_aux_loss"
+        cfg.trainer.policy.megatron_config.moe_per_layer_logging = True
+
     # set batch sizes correctly
     cfg.trainer.train_batch_size = batch_size
     cfg.trainer.policy_mini_batch_size = gpus_per_node
@@ -529,7 +532,14 @@ async def test_megatron_train(
         assert "policy_entropy" in result.metrics
         for k, v in result.metrics.items():
             assert isinstance(v, (int, float)), f"{k} should be an int or float"
-
+        if ep > 1:
+            assert "seq_load_balancing_loss" in result.metrics, "Load balancing loss should be present"
+            assert (
+                "moe/seq_load_balancing_loss_layer_0" in result.metrics
+            ), "Load balancing loss layer 0 should be present"
+            assert (
+                "moe/seq_load_balancing_loss_layer_1" in result.metrics
+            ), "Load balancing loss layer 1 should be present"
     ray.shutdown()
     ray_init_for_tests()
 


### PR DESCRIPTION
## Summary
- Add `get_moe_metrics` to `megatron_utils.py` that reduces MoE auxiliary losses across ranks and returns aggregated (optionally per-layer) values.
- Wire it into `MegatronPolicyWorker.forward_backward` so MoE aux losses are scaled by `1/num_microbatches` and surfaced in worker metrics when `num_moe_experts > 1`.
- Add `MegatronConfig.moe_per_layer_logging` to gate per-layer reporting, plus `moe_router_dtype` (pass-through to Megatron).

## Test plan
- [ ] `tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_worker.py` (asserts `seq_load_balancing_loss` and per-layer metrics are present)
