### PR TITLE
[logging] Wrap `run` in try/except + surface exceptions to wandb if supported

### DIFF
--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -387,15 +387,30 @@ class BasePPOExp:
             generator=generator,
             colocate_pg=self.colocate_pg,
         )
+        # Expose the trainer on self so callers can log exceptions raised
+        # during `build_models` (which happens before _setup_trainer returns).
+        self.trainer = trainer
 
         # Build the models
         trainer.build_models(PolicyWorker, CriticWorker, RefWorker)
         return trainer
 
     def run(self):
-        trainer = self._setup_trainer()
-        # Start the training loop
-        asyncio.run(trainer.train())
+        self.trainer = None
+        try:
+            trainer = self._setup_trainer()
+            # Start the training loop
+            asyncio.run(trainer.train())
+        except Exception as e:
+            # OOMs raised inside actor init (e.g. FSDPPolicyWorkerBase.init_model)
+            # surface here as RayTaskError. Without this they only land in Ray
+            # worker logs; route them through the tracker so wandb users see
+            # them as an `error/tracebacks` table row.
+            if self.trainer is not None and self.trainer.tracker is not None:
+                self.trainer.tracker.log_exception(e, step=self.trainer.global_step)
+            else:
+                logger.error(f"Setup failed before tracker was initialized:\n{e}")
+            raise
 
 
 @ray.remote(num_cpus=1)

--- a/skyrl/train/main_sft.py
+++ b/skyrl/train/main_sft.py
@@ -12,6 +12,7 @@ Usage::
 import sys
 
 import ray
+from loguru import logger
 
 from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.config.sft_config import (
@@ -35,9 +36,19 @@ def sft_entrypoint(cfg: SFTConfig, skyrl_cfg: SkyRLTrainConfig):
     need to rebuild the bridge config.
     """
     trainer = SFTTrainer(cfg, skyrl_cfg=skyrl_cfg)
-    trainer.setup()
-    trainer.train()
-    trainer.shutdown()
+    try:
+        trainer.setup()
+        trainer.train()
+        trainer.shutdown()
+    except Exception as e:
+        # OOMs (and other crashes) raised inside actor init / training surface
+        # here. Route them through the tracker so wandb users see them as an
+        # `error/tracebacks` table row rather than only in Ray worker logs.
+        if trainer.tracker is not None:
+            trainer.tracker.log_exception(e, step=trainer.global_step)
+        else:
+            logger.error(f"SFT setup failed before tracker was initialized:\n{e}")
+        raise
 
 
 def main():

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -708,8 +708,8 @@ class SFTTrainer:
             use_fast=not self.cfg.trainer.disable_fast_tokenizer,
             padding_side="left",
         )
-        self._init_workers()
         self._init_tracker()
+        self._init_workers()
 
     def _init_workers(self):
         """Create PPORayActorGroup and WorkerDispatch.

--- a/skyrl/train/utils/tracking.py
+++ b/skyrl/train/utils/tracking.py
@@ -17,6 +17,7 @@
 
 import dataclasses
 import pprint
+import traceback
 from enum import Enum
 from functools import partial
 from pathlib import Path
@@ -81,6 +82,8 @@ class Tracking:
             self.console_logger = ConsoleLogger()
             self.logger["console"] = self.console_logger
 
+        self._exception_logged = False
+
     def log(self, data, step, commit=False):
         for logger_name, logger_instance in self.logger.items():
             if logger_name == "wandb":
@@ -100,6 +103,44 @@ class Tracking:
                     logger_instance.finish()
             except Exception as e:
                 logger.warning(f"Attempted to finish tracking with logger {logger_name} but got error {e}")
+
+    def log_exception(self, e: BaseException, step: int = 0) -> None:
+        """Log the active exception's traceback to all configured backends.
+
+        Always prints the traceback on the driver via loguru (so it lands in
+        Ray driver logs instead of being swallowed). If wandb is configured,
+        also logs a row to an `error/tracebacks` wandb.Table and calls
+        `finish()` to flush the async upload before the process re-raises.
+
+        Ray-wrapped worker errors (e.g. OOMs raised inside actors) include
+        both local and remote frames in `traceback.format_exc()`.
+
+        Idempotent: a second call is a no-op so an outer except handler can
+        safely call this even if an inner handler already did.
+        """
+        if self._exception_logged:
+            return
+        self._exception_logged = True
+        tb_str = traceback.format_exc()[-10000:]
+        logger.error(f"Training failed at step {step} with {type(e).__name__}:\n{tb_str}")
+        if "wandb" in self.logger:
+            try:
+                import wandb
+
+                error_table = wandb.Table(columns=["step", "type", "traceback"])
+                error_table.add_data(step, type(e).__name__, tb_str)
+                # Note: omit `step=` here. Per-step logs use commit=True, so
+                # re-logging at the same step would be dropped. The step value
+                # is also embedded in the table row itself.
+                self.logger["wandb"].log({"error/tracebacks": error_table})
+                # Tables upload asynchronously. Finish the run so the upload
+                # completes before the caller re-raises and the process dies.
+                try:
+                    self.finish()
+                except Exception as finish_exc:
+                    logger.warning(f"tracker.finish() raised after logging exception: {finish_exc}")
+            except Exception as log_exc:
+                logger.warning(f"Failed to log exception traceback to wandb: {log_exc}")
 
     def __del__(self):
         try:


### PR DESCRIPTION
## Summary
- Add `Tracking.log_exception`: prints the traceback via loguru and, when wandb is configured, logs an `error/tracebacks` `wandb.Table` row then finishes the run to flush the async upload. Idempotent.
- Wrap `BasePPOExp.run` and the SFT entrypoint in try/except so OOMs and other crashes raised inside actor init / training are routed through the tracker instead of only landing in Ray worker logs.

## Test plan
- [ ] Trigger an OOM / actor-init failure and confirm an `error/tracebacks` row appears in wandb
