### PR TITLE
GPU utilization from Ray for both RL + SFT

### DIFF
--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -644,6 +644,8 @@ class TrainerConfig(BaseConfig):
     project_name: str = "skyrl"
     run_name: str = "test_run"
     logger: str = "wandb"
+    enable_ray_gpu_monitor: bool = True
+    """Enable background Ray GPU/RAM metrics collection and logging to wandb."""
     dump_data_batch: bool = False
     dump_eval_results: bool = True
     rope_scaling: Optional[Dict[str, Any]] = None

--- a/skyrl/train/config/sft_config.py
+++ b/skyrl/train/config/sft_config.py
@@ -159,6 +159,8 @@ class SFTConfig(BaseConfig):
     logger: str = "console"  # "console" or "wandb"
     project_name: str = "skyrl_sft"
     run_name: str = "skyrl_sft_run"
+    enable_ray_gpu_monitor: bool = True
+    """Enable background Ray GPU/RAM metrics collection and logging to wandb."""
     ckpt_path: str = ""  # empty string = no checkpointing
     ckpt_interval: int = 0
     max_ckpts_to_keep: int = -1

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -55,6 +55,7 @@ from skyrl.train.generators.utils import (
     get_response_ids_and_loss_mask_from_messages,
 )
 from skyrl.train.utils import get_ray_pg_ready_with_timeout
+from skyrl.train.utils.ray_gpu_monitor import RayGpuMonitor
 from skyrl.train.utils.tracking import Tracking
 from skyrl.train.utils.trainer_utils import (
     GLOBAL_STEP_PREFIX,
@@ -691,6 +692,8 @@ class SFTTrainer:
         self.global_step = 0
         # running count of total non-padding tokens trained on
         self._total_tokens_processed = 0
+        self._num_training_gpus: int = cfg.placement.num_nodes * cfg.placement.num_gpus_per_node
+        self._ray_gpu_monitor = RayGpuMonitor() if cfg.enable_ray_gpu_monitor else None
 
     # ------------------------------------------------------------------ #
     # Setup
@@ -1283,6 +1286,8 @@ class SFTTrainer:
             f"(batch_size={self.sft_cfg.batch_size}, max_length={self.sft_cfg.max_length})..."
         )
 
+        if self._ray_gpu_monitor is not None:
+            self._ray_gpu_monitor.start()
         for step in range(num_steps):
             all_timings: dict[str, float] = {}
 
@@ -1298,10 +1303,13 @@ class SFTTrainer:
                 "train/loss": step_result["loss"],
                 "train/grad_norm": step_result["grad_norm"],
                 "train/tokens_per_second": tokens_per_second,
+                "train/tokens_per_second_per_gpu": tokens_per_second / self._num_training_gpus,
                 "train/actual_num_tokens": actual_num_tokens,
                 "train/total_tokens_processed": self._total_tokens_processed,
             }
             log_dict.update({f"timing/{k}": v for k, v in all_timings.items()})
+            if self._ray_gpu_monitor is not None:
+                log_dict.update(self._ray_gpu_monitor.flush())
 
             self.tracker.log(log_dict, step=step, commit=True)
             logger.info(
@@ -1387,6 +1395,8 @@ class SFTTrainer:
         logger.info(f"Starting SFT training for {num_steps} steps (batch_size={batch_size})...")
         if start_step > 0:
             logger.info(f"Resuming from step {start_step}")
+        if self._ray_gpu_monitor is not None:
+            self._ray_gpu_monitor.start()
         while self.global_step <= num_steps:
             all_timings: dict[str, float] = {}
 
@@ -1417,11 +1427,14 @@ class SFTTrainer:
                 "train/loss": step_result["loss"],
                 "train/grad_norm": step_result["grad_norm"],
                 "train/tokens_per_second": tokens_per_second,
+                "train/tokens_per_second_per_gpu": tokens_per_second / self._num_training_gpus,
                 "train/actual_num_tokens": actual_num_tokens,
                 "train/batch_padded_seq_len": batch_padded_seq_len,
                 "train/total_tokens_processed": self._total_tokens_processed,
             }
             log_dict.update({f"timing/{k}": v for k, v in all_timings.items()})
+            if self._ray_gpu_monitor is not None:
+                log_dict.update(self._ray_gpu_monitor.flush())
 
             # Checkpoint at regular intervals
             if (
@@ -1587,5 +1600,7 @@ class SFTTrainer:
         within the task would be incorrect.  The head-node process owns
         the Ray lifecycle.
         """
+        if self._ray_gpu_monitor is not None:
+            self._ray_gpu_monitor.stop()
         if self.tracker is not None:
             self.tracker.finish()

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -68,6 +68,7 @@ from skyrl.train.utils import (
     trainer_utils,
 )
 from skyrl.train.utils.logging_utils import log_example
+from skyrl.train.utils.ray_gpu_monitor import RayGpuMonitor
 from skyrl.train.utils.tracking import Tracking
 from skyrl.train.utils.trainer_utils import (
     GLOBAL_STEP_PREFIX,
@@ -123,6 +124,8 @@ class RayPPOTrainer:
         self._vllm_metrics_scraper: Optional[VLLMMetricsScraper] = (
             VLLMMetricsScraper() if cfg.generator.inference_engine.enable_ray_prometheus_stats else None
         )
+
+        self._ray_gpu_monitor = RayGpuMonitor() if cfg.trainer.enable_ray_gpu_monitor else None
 
         # initialized in `build_models`
         self.policy_model: PPORayActorGroup = None
@@ -188,6 +191,9 @@ class RayPPOTrainer:
         """
         Main training loop for PPO
         """
+        if self._ray_gpu_monitor is not None:
+            self._ray_gpu_monitor.start()
+
         # Initialize weight sync state between policy model and inference engines.
         with Timer("init_weight_sync_state"):
             self.init_weight_sync_state()
@@ -344,6 +350,8 @@ class RayPPOTrainer:
                 }
                 if self._vllm_metrics_scraper is not None:
                     log_payload.update(await self._vllm_metrics_scraper.sample())
+                if self._ray_gpu_monitor is not None:
+                    log_payload.update(self._ray_gpu_monitor.flush())
                 self.tracker.log(log_payload, step=self.global_step, commit=True)
                 self.all_metrics = {}
                 self.all_timings = {}
@@ -370,6 +378,8 @@ class RayPPOTrainer:
                 logger.info("Saved final model.")
         if self._vllm_metrics_scraper is not None:
             await self._vllm_metrics_scraper.aclose()
+        if self._ray_gpu_monitor is not None:
+            self._ray_gpu_monitor.stop()
         self.tracker.finish()
         logger.info("Training done!")
 

--- a/skyrl/train/utils/ray_gpu_monitor.py
+++ b/skyrl/train/utils/ray_gpu_monitor.py
@@ -1,0 +1,181 @@
+"""Background GPU/RAM monitor that scrapes Ray node Prometheus endpoints.
+
+Collects per-node, per-GPU utilization and memory metrics in a daemon thread and
+exposes them via ``flush()``, which returns averaged readings since the last call.
+The returned dict uses ``ray/`` prefixed keys and is ready to be merged into
+``self.all_metrics`` before the wandb log step.
+
+Per-GPU / per-node metrics (multiple lines on the same wandb chart)
+-------------------------------------------------------------------
+ray/node.<idx>.gpu.<gpu_idx>.util        GPU utilization (%) — tagged by node+GPU ID
+ray/node.<idx>.gpu.<gpu_idx>.mem_used_gb GPU memory used (GB) — tagged by node+GPU ID
+ray/node.<idx>.cpu_ram_used_gb           Host CPU RAM used (GB) — tagged by node ID
+
+Cluster-wide averages (single line per metric)
+----------------------------------------------
+ray/gpu.util.avg                         Average GPU utilization across all GPUs
+ray/gpu.mem_used_gb.avg                  Average GPU memory used across all GPUs
+ray/cpu_ram_used_gb.avg                  Average CPU RAM used across all nodes
+"""
+
+import threading
+import time
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+import httpx
+import ray
+from loguru import logger
+
+from skyrl.train.utils.vllm_metrics_scraper import (
+    discover_ray_metrics_urls,
+    parse_metrics_text,
+)
+
+# Ray Prometheus metric names published by Ray's node metrics agent.
+_GPU_UTIL = "ray_node_gpus_utilization"
+_GPU_MEM = "ray_node_gram_used"
+_RAM_USED = "ray_node_mem_used"
+
+
+class RayGpuMonitor:
+    """Scrape Ray node GPU/RAM metrics in a background thread.
+
+    Args:
+        collection_interval: Seconds between Prometheus scrapes.
+        request_timeout_s: Per-request HTTP timeout.
+    """
+
+    def __init__(
+        self,
+        collection_interval: float = 5.0,
+        request_timeout_s: float = 3.0,
+    ):
+        self.collection_interval = collection_interval
+        self._timeout = request_timeout_s
+
+        self._buffer: List[Dict[str, float]] = []
+        self._lock = threading.Lock()
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+        self._urls: List[str] = []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Discover Ray node endpoints and start the collection thread."""
+        if self._running:
+            return
+
+        if not ray.is_initialized():
+            logger.warning("RayGpuMonitor: Ray is not initialized — GPU monitoring disabled.")
+            return
+
+        self._urls = discover_ray_metrics_urls()
+        if not self._urls:
+            logger.warning("RayGpuMonitor: no Ray metrics endpoints found — GPU monitoring disabled.")
+            return
+
+        self._running = True
+        self._thread = threading.Thread(target=self._loop, daemon=True, name="ray-gpu-monitor")
+        self._thread.start()
+        logger.info(
+            f"RayGpuMonitor started: {len(self._urls)} node(s), " f"collection_interval={self.collection_interval}s"
+        )
+
+    def stop(self) -> None:
+        """Stop the collection thread."""
+        self._running = False
+        if self._thread is not None:
+            self._thread.join(timeout=self.collection_interval * 2)
+        logger.info("RayGpuMonitor stopped.")
+
+    # ------------------------------------------------------------------
+    # Data access
+    # ------------------------------------------------------------------
+
+    def flush(self) -> Dict[str, float]:
+        """Return averaged metrics collected since the last flush and clear the buffer.
+
+        Returns an empty dict if nothing was collected yet or monitoring is disabled.
+        The keys are prefixed with ``ray/``.
+
+        Per-GPU/per-node keys are included as-is so wandb renders them as
+        multiple lines on the same chart (grouped by metric name, split by tag).
+        Cluster-wide averages are appended as separate scalar keys.
+        """
+        with self._lock:
+            if not self._buffer:
+                return {}
+            snapshots = self._buffer.copy()
+            self._buffer.clear()
+
+        # Average each metric across all collected time-snapshots.
+        totals: Dict[str, float] = defaultdict(float)
+        counts: Dict[str, int] = defaultdict(int)
+        for snap in snapshots:
+            for k, v in snap.items():
+                totals[k] += v
+                counts[k] += 1
+
+        averaged = {k: totals[k] / counts[k] for k in totals}
+
+        # Build output: individual tagged metrics + cluster-wide averages.
+        out: Dict[str, float] = {f"ray/{k}": v for k, v in averaged.items()}
+
+        gpu_util_vals = [v for k, v in averaged.items() if k.endswith(".util")]
+        gpu_mem_vals = [v for k, v in averaged.items() if ".gpu." in k and k.endswith(".mem_used_gb")]
+        cpu_mem_vals = [v for k, v in averaged.items() if k.endswith(".cpu_ram_used_gb")]
+
+        if gpu_util_vals:
+            out["ray/gpu.util.avg"] = sum(gpu_util_vals) / len(gpu_util_vals)
+        if gpu_mem_vals:
+            out["ray/gpu.mem_used_gb.avg"] = sum(gpu_mem_vals) / len(gpu_mem_vals)
+        if cpu_mem_vals:
+            out["ray/cpu_ram_used_gb.avg"] = sum(cpu_mem_vals) / len(cpu_mem_vals)
+
+        return out
+
+    # ------------------------------------------------------------------
+    # Internal collection loop
+    # ------------------------------------------------------------------
+
+    def _loop(self) -> None:
+        with httpx.Client(timeout=self._timeout) as client:
+            while self._running:
+                try:
+                    snapshot = self._collect(client)
+                    if snapshot:
+                        with self._lock:
+                            self._buffer.append(snapshot)
+                except Exception as exc:
+                    logger.debug(f"RayGpuMonitor: collection error: {exc}")
+                time.sleep(self.collection_interval)
+
+    def _collect(self, client: httpx.Client) -> Dict[str, float]:
+        """Fetch and parse GPU/RAM metrics from every Ray node."""
+        result: Dict[str, float] = {}
+        for node_idx, url in enumerate(self._urls):
+            try:
+                resp = client.get(url)
+                resp.raise_for_status()
+            except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+                logger.debug(f"RayGpuMonitor: failed to scrape {url}: {exc}")
+                continue
+
+            parsed = parse_metrics_text(resp.text)
+            for (name, labels), value in parsed.items():
+                labels_dict = dict(labels)
+                if name == _GPU_UTIL:
+                    gpu_idx = labels_dict.get("GpuIndex", "0")
+                    result[f"node.{node_idx}.gpu.{gpu_idx}.util"] = value
+                elif name == _GPU_MEM:
+                    gpu_idx = labels_dict.get("GpuIndex", "0")
+                    # Ray reports gram_used in MB; convert to GB.
+                    result[f"node.{node_idx}.gpu.{gpu_idx}.mem_used_gb"] = value / 1024.0
+                elif name == _RAM_USED:
+                    # Ray reports mem_used in bytes; convert to GB (host CPU RAM utilized).
+                    result[f"node.{node_idx}.cpu_ram_used_gb"] = value / (1024**3)
+        return result

--- a/skyrl/train/utils/ray_gpu_monitor.py
+++ b/skyrl/train/utils/ray_gpu_monitor.py
@@ -16,6 +16,8 @@ Cluster-wide averages (single line per metric)
 ray/gpu.util.avg                         Average GPU utilization across all GPUs
 ray/gpu.mem_used_gb.avg                  Average GPU memory used across all GPUs
 ray/cpu_ram_used_gb.avg                  Average CPU RAM used across all nodes
+
+Inspired by: https://github.com/NVIDIA-NeMo/RL/blob/65683e0f071031a3b64b1dd44a6f2a5c97452597/nemo_rl/utils/logger.py#L478
 """
 
 import threading
@@ -164,18 +166,20 @@ class RayGpuMonitor:
             except (httpx.RequestError, httpx.HTTPStatusError) as exc:
                 logger.debug(f"RayGpuMonitor: failed to scrape {url}: {exc}")
                 continue
-
-            parsed = parse_metrics_text(resp.text)
-            for (name, labels), value in parsed.items():
-                labels_dict = dict(labels)
-                if name == _GPU_UTIL:
-                    gpu_idx = labels_dict.get("GpuIndex", "0")
-                    result[f"node.{node_idx}.gpu.{gpu_idx}.util"] = value
-                elif name == _GPU_MEM:
-                    gpu_idx = labels_dict.get("GpuIndex", "0")
-                    # Ray reports gram_used in MB; convert to GB.
-                    result[f"node.{node_idx}.gpu.{gpu_idx}.mem_used_gb"] = value / 1024.0
-                elif name == _RAM_USED:
-                    # Ray reports mem_used in bytes; convert to GB (host CPU RAM utilized).
-                    result[f"node.{node_idx}.cpu_ram_used_gb"] = value / (1024**3)
+            try:
+                parsed = parse_metrics_text(resp.text)
+                for (name, labels), value in parsed.items():
+                    labels_dict = dict(labels)
+                    if name == _GPU_UTIL:
+                        gpu_idx = labels_dict.get("GpuIndex", "0")
+                        result[f"node.{node_idx}.gpu.{gpu_idx}.util"] = value
+                    elif name == _GPU_MEM:
+                        gpu_idx = labels_dict.get("GpuIndex", "0")
+                        # Ray reports gram_used in MB; convert to GB.
+                        result[f"node.{node_idx}.gpu.{gpu_idx}.mem_used_gb"] = value / 1024.0
+                    elif name == _RAM_USED:
+                        # Ray reports mem_used in bytes; convert to GB (host CPU RAM utilized).
+                        result[f"node.{node_idx}.cpu_ram_used_gb"] = value / (1024**3)
+            except Exception as exc:
+                logger.debug(f"RayGpuMonitor: failed to scrape or parse {url}: {exc}")
         return result

--- a/tests/train/utils/test_ray_gpu_monitor.py
+++ b/tests/train/utils/test_ray_gpu_monitor.py
@@ -1,0 +1,290 @@
+"""
+uv run --isolated --extra dev --extra skyrl-train  pytest tests/train/utils/test_ray_gpu_monitor.py
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from skyrl.train.utils.ray_gpu_monitor import RayGpuMonitor
+
+# ---------------------------------------------------------------------------
+# Minimal Prometheus text payload used across multiple tests
+# ---------------------------------------------------------------------------
+_PROMETHEUS_TEXT = """\
+# HELP ray_node_gpus_utilization GPU utilization
+# TYPE ray_node_gpus_utilization gauge
+ray_node_gpus_utilization{GpuIndex="0",GpuDeviceName="NVIDIA H100"} 75.5
+ray_node_gpus_utilization{GpuIndex="1",GpuDeviceName="NVIDIA H100"} 50.0
+# HELP ray_node_gram_used GPU memory used (MB)
+# TYPE ray_node_gram_used gauge
+ray_node_gram_used{GpuIndex="0",GpuDeviceName="NVIDIA H100"} 81920.0
+ray_node_gram_used{GpuIndex="1",GpuDeviceName="NVIDIA H100"} 40960.0
+# HELP ray_node_mem_used Host RAM used (bytes)
+# TYPE ray_node_mem_used gauge
+ray_node_mem_used{InstanceId="n/a"} 107374182400.0
+"""
+
+# 81920 MB / 1024 = 80.0 GB, 40960 / 1024 = 40.0 GB
+# 107374182400 bytes / 1024^3 = 100.0 GB
+
+
+class TestRayGpuMonitorInit:
+    def test_default_params(self):
+        monitor = RayGpuMonitor()
+        assert monitor.collection_interval == 5.0
+        assert monitor._timeout == 3.0
+        assert monitor._buffer == []
+        assert monitor._running is False
+        assert monitor._thread is None
+        assert monitor._urls == []
+
+    def test_custom_params(self):
+        monitor = RayGpuMonitor(collection_interval=10.0, request_timeout_s=1.0)
+        assert monitor.collection_interval == 10.0
+        assert monitor._timeout == 1.0
+
+
+class TestRayGpuMonitorStart:
+    @patch("skyrl.train.utils.ray_gpu_monitor.ray")
+    @patch("skyrl.train.utils.ray_gpu_monitor.threading.Thread")
+    @patch("skyrl.train.utils.ray_gpu_monitor.discover_ray_metrics_urls")
+    def test_start_launches_thread(self, mock_discover, mock_thread, mock_ray):
+        mock_ray.is_initialized.return_value = True
+        mock_discover.return_value = ["http://10.0.0.1:8080/metrics"]
+
+        monitor = RayGpuMonitor()
+        monitor.start()
+
+        mock_thread.assert_called_once()
+        mock_thread.return_value.start.assert_called_once()
+        assert monitor._running is True
+        assert monitor._thread is mock_thread.return_value
+
+    @patch("skyrl.train.utils.ray_gpu_monitor.ray")
+    def test_start_noop_when_ray_not_initialized(self, mock_ray):
+        mock_ray.is_initialized.return_value = False
+
+        monitor = RayGpuMonitor()
+        monitor.start()  # should warn, not raise
+
+        assert monitor._running is False
+        assert monitor._thread is None
+
+    @patch("skyrl.train.utils.ray_gpu_monitor.ray")
+    @patch("skyrl.train.utils.ray_gpu_monitor.discover_ray_metrics_urls")
+    def test_start_noop_when_no_urls(self, mock_discover, mock_ray):
+        mock_ray.is_initialized.return_value = True
+        mock_discover.return_value = []
+
+        monitor = RayGpuMonitor()
+        monitor.start()
+
+        assert monitor._running is False
+        assert monitor._thread is None
+
+    @patch("skyrl.train.utils.ray_gpu_monitor.ray")
+    @patch("skyrl.train.utils.ray_gpu_monitor.threading.Thread")
+    @patch("skyrl.train.utils.ray_gpu_monitor.discover_ray_metrics_urls")
+    def test_start_idempotent(self, mock_discover, mock_thread, mock_ray):
+        mock_ray.is_initialized.return_value = True
+        mock_discover.return_value = ["http://10.0.0.1:8080/metrics"]
+
+        monitor = RayGpuMonitor()
+        monitor.start()
+        monitor.start()  # second call should be a no-op
+
+        assert mock_thread.call_count == 1
+
+
+class TestRayGpuMonitorStop:
+    @patch("skyrl.train.utils.ray_gpu_monitor.ray")
+    @patch("skyrl.train.utils.ray_gpu_monitor.threading.Thread")
+    @patch("skyrl.train.utils.ray_gpu_monitor.discover_ray_metrics_urls")
+    def test_stop_clears_running_flag(self, mock_discover, mock_thread, mock_ray):
+        mock_ray.is_initialized.return_value = True
+        mock_discover.return_value = ["http://10.0.0.1:8080/metrics"]
+
+        monitor = RayGpuMonitor()
+        monitor.start()
+        monitor.stop()
+
+        assert monitor._running is False
+        mock_thread.return_value.join.assert_called_once()
+
+
+class TestRayGpuMonitorCollect:
+    def test_collect_parses_gpu_and_ram_metrics(self):
+        monitor = RayGpuMonitor()
+        monitor._urls = ["http://10.0.0.1:8080/metrics"]
+
+        mock_resp = MagicMock()
+        mock_resp.text = _PROMETHEUS_TEXT
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_resp
+
+        result = monitor._collect(mock_client)
+
+        assert result["node.0.gpu.0.util"] == pytest.approx(75.5)
+        assert result["node.0.gpu.1.util"] == pytest.approx(50.0)
+        assert result["node.0.gpu.0.mem_used_gb"] == pytest.approx(80.0)
+        assert result["node.0.gpu.1.mem_used_gb"] == pytest.approx(40.0)
+        assert result["node.0.cpu_ram_used_gb"] == pytest.approx(100.0)
+
+    def test_collect_multi_node(self):
+        monitor = RayGpuMonitor()
+        monitor._urls = [
+            "http://10.0.0.1:8080/metrics",
+            "http://10.0.0.2:8080/metrics",
+        ]
+
+        mock_resp = MagicMock()
+        mock_resp.text = _PROMETHEUS_TEXT
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_resp
+
+        result = monitor._collect(mock_client)
+
+        # node 0 and node 1 keys should both be present
+        assert "node.0.gpu.0.util" in result
+        assert "node.1.gpu.0.util" in result
+
+    def test_collect_tolerates_http_error(self):
+        import httpx
+
+        monitor = RayGpuMonitor()
+        monitor._urls = ["http://10.0.0.1:8080/metrics"]
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = httpx.RequestError("connection refused")
+
+        result = monitor._collect(mock_client)
+        assert result == {}
+
+
+class TestRayGpuMonitorFlush:
+    def test_flush_empty_buffer_returns_empty_dict(self):
+        monitor = RayGpuMonitor()
+        assert monitor.flush() == {}
+
+    def test_flush_returns_ray_prefixed_keys(self):
+        monitor = RayGpuMonitor()
+        monitor._buffer = [{"node.0.gpu.0.util": 80.0}]
+
+        result = monitor.flush()
+        assert "ray/node.0.gpu.0.util" in result
+
+    def test_flush_clears_buffer(self):
+        monitor = RayGpuMonitor()
+        monitor._buffer = [{"node.0.gpu.0.util": 80.0}]
+
+        monitor.flush()
+        assert monitor._buffer == []
+
+    def test_flush_time_averages_across_snapshots(self):
+        monitor = RayGpuMonitor()
+        monitor._buffer = [
+            {"node.0.gpu.0.util": 60.0},
+            {"node.0.gpu.0.util": 80.0},
+            {"node.0.gpu.0.util": 100.0},
+        ]
+
+        result = monitor.flush()
+        assert result["ray/node.0.gpu.0.util"] == pytest.approx(80.0)
+
+    def test_flush_handles_missing_keys_across_snapshots(self):
+        # GPU 1 only appears in 2 of 3 snapshots — should still average correctly
+        monitor = RayGpuMonitor()
+        monitor._buffer = [
+            {"node.0.gpu.0.util": 60.0, "node.0.gpu.1.util": 40.0},
+            {"node.0.gpu.0.util": 80.0},
+            {"node.0.gpu.0.util": 100.0, "node.0.gpu.1.util": 60.0},
+        ]
+
+        result = monitor.flush()
+        assert result["ray/node.0.gpu.0.util"] == pytest.approx(80.0)
+        assert result["ray/node.0.gpu.1.util"] == pytest.approx(50.0)  # (40+60)/2
+
+    def test_flush_computes_gpu_util_average(self):
+        monitor = RayGpuMonitor()
+        monitor._buffer = [
+            {
+                "node.0.gpu.0.util": 60.0,
+                "node.0.gpu.1.util": 80.0,
+                "node.1.gpu.0.util": 70.0,
+            }
+        ]
+
+        result = monitor.flush()
+        assert result["ray/gpu.util.avg"] == pytest.approx((60.0 + 80.0 + 70.0) / 3)
+
+    def test_flush_computes_gpu_mem_average(self):
+        monitor = RayGpuMonitor()
+        monitor._buffer = [
+            {
+                "node.0.gpu.0.mem_used_gb": 40.0,
+                "node.0.gpu.1.mem_used_gb": 80.0,
+            }
+        ]
+
+        result = monitor.flush()
+        assert result["ray/gpu.mem_used_gb.avg"] == pytest.approx(60.0)
+
+    def test_flush_computes_cpu_ram_average(self):
+        monitor = RayGpuMonitor()
+        monitor._buffer = [
+            {
+                "node.0.cpu_ram_used_gb": 100.0,
+                "node.1.cpu_ram_used_gb": 200.0,
+            }
+        ]
+
+        result = monitor.flush()
+        assert result["ray/cpu_ram_used_gb.avg"] == pytest.approx(150.0)
+
+    def test_flush_cpu_mem_average_excludes_gpu_mem(self):
+        # GPU mem keys contain ".gpu." — they must not be counted in CPU RAM avg
+        monitor = RayGpuMonitor()
+        monitor._buffer = [
+            {
+                "node.0.gpu.0.mem_used_gb": 80.0,
+                "node.0.cpu_ram_used_gb": 120.0,
+            }
+        ]
+
+        result = monitor.flush()
+        assert result["ray/cpu_ram_used_gb.avg"] == pytest.approx(120.0)
+        assert result["ray/gpu.mem_used_gb.avg"] == pytest.approx(80.0)
+
+    def test_flush_no_avg_keys_when_no_data(self):
+        # If only CPU RAM is present, gpu averages must not appear
+        monitor = RayGpuMonitor()
+        monitor._buffer = [{"node.0.cpu_ram_used_gb": 50.0}]
+
+        result = monitor.flush()
+        assert "ray/gpu.util.avg" not in result
+        assert "ray/gpu.mem_used_gb.avg" not in result
+        assert "ray/cpu_ram_used_gb.avg" in result
+
+    def test_flush_thread_safe(self):
+        """flush() must drain the buffer under the lock."""
+        import threading
+
+        monitor = RayGpuMonitor()
+        monitor._buffer = [{"node.0.gpu.0.util": 90.0}]
+
+        results = []
+
+        def do_flush():
+            results.append(monitor.flush())
+
+        threads = [threading.Thread(target=do_flush) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Exactly one flush should have seen data; the rest return empty dicts
+        non_empty = [r for r in results if r]
+        assert len(non_empty) == 1
+        assert non_empty[0]["ray/node.0.gpu.0.util"] == pytest.approx(90.0)


### PR DESCRIPTION
## Summary
- Add `RayGpuMonitor` (`skyrl/train/utils/ray_gpu_monitor.py`): a background daemon thread that scrapes Ray node Prometheus endpoints each training step and logs per-GPU utilization, GPU memory, and CPU RAM — plus cluster-wide averages — to wandb under `ray/` keys.
- Wire it into both the RL trainer and SFT trainer behind a new `enable_ray_gpu_monitor` config flag (default `True`).
- Add `train/tokens_per_second_per_gpu` to SFT (parallel to the RL metric).

## Test plan
- [ ] `uv run --isolated --extra dev pytest tests/train/utils/test_ray_gpu_monitor.py` (collection, averaging, thread-safety — no live Ray cluster or GPUs required)
