### PR TITLE
[feat] Add prompt_mean loss reduction

### DIFF
--- a/docs/content/docs/configuration/config.mdx
+++ b/docs/content/docs/configuration/config.mdx
@@ -374,7 +374,7 @@ algorithm:
   advantage_batch_normalize: false
   value_head_prefix: "value_head"
   policy_loss_type: "regular" # "regular", "dual_clip", "gspo", "clip_cov", "kl_cov" or customizable with PolicyLossRegistry
-  loss_reduction: "token_mean" # "token_mean", "sequence_mean", "seq_mean_token_sum_norm"
+  loss_reduction: "token_mean" # "token_mean", "sequence_mean", "seq_mean_token_sum_norm", "prompt_mean"
   grpo_norm_by_std: true # set to false to disable normalization by std in GRPO (used in Dr. GRPO)
   zero_variance_filter: false # set to true to loss mask out prompts with zero variance rewards. only applicable when rewards are response-level.
 
@@ -495,6 +495,7 @@ algorithm:
   - `token_mean`: computes average loss over all valid tokens in the batch. Used in [DAPO](https://dapo-sia.github.io/).
   - `sequence_mean`: computes per-sequence avg token loss, then averages over the batch.
   - `seq_mean_token_sum_norm`: computes the sum of token losses for each sequence, normalizes by `max_seq_len`, and then averages over the batch. This is used in [Dr. GRPO](https://arxiv.org/abs/2503.20783). `algorithm.max_seq_len` must be set explicitly for this mode because multi-turn/token budgets are workload-dependent.
+  - `prompt_mean`: computes the average token loss within each prompt group (all `generator.n_samples_per_prompt` responses sampled for a prompt), then averages over prompts. Unlike `token_mean`, every prompt contributes equally regardless of how many tokens its responses contain.
 
 - `algorithm.grpo_norm_by_std`: Whether to normalize advantages by the standard deviation in GRPO. This is set to `false` in [Dr. GRPO](https://arxiv.org/abs/2503.20783).
 - `algorithm.zero_variance_filter`: Whether to loss mask out prompts with zero variance rewards. This is only applicable when rewards are response-level.

--- a/skyrl/backends/skyrl_train/utils/ppo_utils.py
+++ b/skyrl/backends/skyrl_train/utils/ppo_utils.py
@@ -1004,6 +1004,7 @@ def apply_loss_reduction_to_advantages_minibatch(
     loss_reduction: str,
     micro_batch_size: int,
     max_seq_len: int,
+    prompt_boundaries: Optional[List[Tuple[int, int]]] = None,
 ) -> torch.Tensor:
     """Scale advantages so that summing produces the desired loss reduction.
 
@@ -1011,9 +1012,12 @@ def apply_loss_reduction_to_advantages_minibatch(
         advantages: Advantage tensor of shape (minibatch_size, seq_len).
             For step-wise training, minibatch_size can be variable.
         loss_mask: Mask of shape (minibatch_size, seq_len) indicating valid loss tokens.
-        loss_reduction: One of "token_mean", "token_mean_legacy", "sequence_mean", "seq_mean_token_sum_norm".
+        loss_reduction: One of "token_mean", "token_mean_legacy", "sequence_mean",
+            "seq_mean_token_sum_norm", "prompt_mean".
         micro_batch_size: Number of sequences per micro-batch
         max_seq_len: Maximum sequence length.
+        prompt_boundaries: Mini-batch-relative (start, end) slices grouping the sequences of
+            each prompt. Required for "prompt_mean"; ignored otherwise.
 
     Returns:
         Scaled advantages tensor.
@@ -1046,6 +1050,18 @@ def apply_loss_reduction_to_advantages_minibatch(
     # Option 3: Dr. GRPO style loss reduction to avoid length bias by normalizing by a constant
     elif loss_reduction == "seq_mean_token_sum_norm":
         normalized_advantages = advantages / (batch_size * max_seq_len)
+
+    # Option 4: Prompt level mean - token mean within each prompt, then average over all prompts.
+    # A "prompt" is a group of sequences sharing the same prompt (e.g. the n_samples_per_prompt
+    # GRPO responses). Scale token [i, t] in prompt p by 1 / (num_prompts * tokens_in_prompt_p)
+    # so that summing the per-token policy loss yields mean_p(token_mean within prompt p).
+    elif loss_reduction == "prompt_mean":
+        if prompt_boundaries is None:
+            raise ValueError("`prompt_mean` loss reduction requires `prompt_boundaries`")
+        num_prompts = len(prompt_boundaries)
+        for p_start, p_end in prompt_boundaries:
+            prompt_tokens = loss_mask[p_start:p_end].sum().clamp(min=1)
+            normalized_advantages[p_start:p_end] = advantages[p_start:p_end] / (num_prompts * prompt_tokens)
 
     else:
         raise ValueError(f"Invalid loss reduction type: {loss_reduction}")

--- a/skyrl/train/dataset/preprocess.py
+++ b/skyrl/train/dataset/preprocess.py
@@ -190,6 +190,36 @@ def convert_prompts_responses_to_batch_tensors(
     )
 
 
+def compute_prompt_boundaries(uids: List[str]) -> List[Tuple[int, int]]:
+    """Compute per-prompt ``(start, end)`` slices from a flat ``uids`` list.
+
+    Args:
+        uids: List of uids, representing which prompt each sequence belongs to. Consecutive
+            equal entries belong to the same prompt (same assumption as
+            ``compute_prompt_mini_batch_boundaries``).
+
+    Returns:
+        List of (start, end) indices, one per prompt, in order. Works for both step-wise
+        (variable sequences per prompt) and non-step-wise training.
+
+    Example: uids = ["p0", "p0", "p1", "p1", "p1"] -> [(0, 2), (2, 5)]
+    """
+    boundaries: List[Tuple[int, int]] = []
+    seen_uids: set[str] = set()
+    start = 0
+    for i in range(1, len(uids)):
+        if uids[i] != uids[i - 1]:
+            assert (
+                uids[i] not in seen_uids
+            ), f"uid {uids[i]!r} appears in non-contiguous positions at index {i}. Full uids: {uids}"
+            seen_uids.add(uids[i - 1])
+            boundaries.append((start, i))
+            start = i
+    if uids:
+        boundaries.append((start, len(uids)))
+    return boundaries
+
+
 def compute_prompt_mini_batch_boundaries(
     uids: List[str],
     mini_batch_size: int,

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -48,6 +48,7 @@ from skyrl.env_vars import SKYRL_RAY_PG_TIMEOUT_IN_S
 from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.dataset import PromptDataset
 from skyrl.train.dataset.preprocess import (
+    compute_prompt_boundaries,
     compute_prompt_mini_batch_boundaries,
     convert_prompts_responses_to_batch_tensors,
 )
@@ -805,6 +806,9 @@ class RayPPOTrainer:
         training_input.metadata["policy_mini_batch_boundaries"] = compute_prompt_mini_batch_boundaries(
             uids, self.cfg.trainer.policy_mini_batch_size, train_batch_size, is_stepwise, n_samples_per_prompt
         )
+        # Per-prompt boundaries (used by the `prompt_mean` loss reduction). Policy-only,
+        # since advantage normalization only applies to the policy.
+        training_input.metadata["policy_prompt_boundaries"] = compute_prompt_boundaries(uids)
         if self.cfg.trainer.critic.model.path is not None:
             training_input.metadata["critic_mini_batch_boundaries"] = compute_prompt_mini_batch_boundaries(
                 uids, self.cfg.trainer.critic_mini_batch_size, train_batch_size, is_stepwise, n_samples_per_prompt
@@ -1218,6 +1222,7 @@ class RayPPOTrainer:
         self,
         data: TrainingInputBatch,
         mini_batch_boundaries: List[Tuple[int, int]],
+        prompt_boundaries: Optional[List[Tuple[int, int]]] = None,
     ) -> TrainingInputBatch:
         advantages = data["advantages"]
         response_mask = data["response_mask"]
@@ -1234,12 +1239,22 @@ class RayPPOTrainer:
         normalized_advantages = torch.zeros_like(advantages)
         for start_idx, end_idx in mini_batch_boundaries:
             mini_batch = data[start_idx:end_idx]
+            # For prompt_mean, select the prompt boundaries falling within this mini-batch
+            # and rebase them to mini-batch-relative indices.
+            mb_prompt_boundaries = None
+            if prompt_boundaries is not None:
+                mb_prompt_boundaries = [
+                    (p_start - start_idx, p_end - start_idx)
+                    for p_start, p_end in prompt_boundaries
+                    if start_idx <= p_start < end_idx
+                ]
             normalized_advantages[start_idx:end_idx] = apply_loss_reduction_to_advantages_minibatch(
                 advantages=mini_batch["advantages"],
                 loss_mask=mini_batch["loss_mask"],
                 loss_reduction=self.cfg.trainer.algorithm.loss_reduction,
                 micro_batch_size=self.cfg.trainer.micro_train_batch_size_per_gpu,
                 max_seq_len=self.cfg.trainer.algorithm.max_seq_len,
+                prompt_boundaries=mb_prompt_boundaries,
             )
 
         data["advantages"] = normalized_advantages
@@ -1266,7 +1281,8 @@ class RayPPOTrainer:
 
         if model == "policy":
             # Normalize advantages for policy training; critic training does not need this
-            data = self._normalize_advantages(data, boundaries)
+            prompt_boundaries = data.metadata.get("policy_prompt_boundaries")
+            data = self._normalize_advantages(data, boundaries, prompt_boundaries)
 
         all_metrics: Dict[str, List[float]] = defaultdict(list)
 

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -310,9 +310,11 @@ def validate_cfg(cfg: SkyRLTrainConfig):
         "token_mean_legacy",
         "sequence_mean",
         "seq_mean_token_sum_norm",
+        "prompt_mean",
     ), (
         f"invalid loss_reduction: {cfg.trainer.algorithm.loss_reduction}. "
-        f"Must be one of `['token_mean', 'sequence_mean', 'seq_mean_token_sum_norm']`"
+        f"Must be one of `['token_mean', 'token_mean_legacy', 'sequence_mean', "
+        f"'seq_mean_token_sum_norm', 'prompt_mean']`"
     )
     if cfg.trainer.algorithm.loss_reduction == "seq_mean_token_sum_norm":
         if cfg.trainer.algorithm.max_seq_len is None:

--- a/tests/backends/skyrl_train/utils/test_ppo_utils.py
+++ b/tests/backends/skyrl_train/utils/test_ppo_utils.py
@@ -684,6 +684,39 @@ class TestApplyLossReductionToAdvantagesMinibatch:
         loss = reduce_loss(scaled, loss_mask)
         assert torch.allclose(loss, torch.tensor(8.5))
 
+    def test_prompt_mean(self):
+        """Prompt mean: token mean within each prompt group, then average over prompts."""
+        # 4 sequences forming 2 prompts (2 samples each): rows [0,1] -> p0, rows [2,3] -> p1.
+        advantages = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+        loss_mask = torch.tensor([[1.0, 1.0], [1.0, 0.0], [1.0, 1.0], [1.0, 1.0]])
+        prompt_boundaries = [(0, 2), (2, 4)]
+        # prompt 0: token mean = (1+2+3)/3 = 2.0
+        # prompt 1: token mean = (5+6+7+8)/4 = 6.5
+        # mean over prompts = (2.0 + 6.5) / 2 = 4.25
+        scaled = apply_loss_reduction_to_advantages_minibatch(
+            advantages=advantages,
+            loss_mask=loss_mask,
+            loss_reduction="prompt_mean",
+            micro_batch_size=1,
+            max_seq_len=2,
+            prompt_boundaries=prompt_boundaries,
+        )
+        loss = reduce_loss(scaled, loss_mask)
+        assert torch.allclose(loss, torch.tensor(4.25))
+
+    def test_prompt_mean_requires_boundaries(self):
+        """prompt_mean without prompt_boundaries should raise ValueError."""
+        advantages = torch.tensor([[1.0, 2.0]])
+        loss_mask = torch.tensor([[1.0, 1.0]])
+        with pytest.raises(ValueError, match="prompt_mean"):
+            apply_loss_reduction_to_advantages_minibatch(
+                advantages=advantages,
+                loss_mask=loss_mask,
+                loss_reduction="prompt_mean",
+                micro_batch_size=1,
+                max_seq_len=2,
+            )
+
     def test_invalid_loss_reduction_raises(self):
         """Invalid loss_reduction should raise ValueError."""
         advantages = torch.tensor([[1.0]])

--- a/tests/train/test_prompt_mini_batch.py
+++ b/tests/train/test_prompt_mini_batch.py
@@ -12,7 +12,10 @@ import torch
 
 from skyrl.backends.skyrl_train.distributed.dispatch import MeshDispatch
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
-from skyrl.train.dataset.preprocess import compute_prompt_mini_batch_boundaries
+from skyrl.train.dataset.preprocess import (
+    compute_prompt_boundaries,
+    compute_prompt_mini_batch_boundaries,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -72,6 +75,24 @@ def _make_batch(num_sequences: int, seq_len: int = 8) -> TrainingInputBatch:
 # ---------------------------------------------------------------------------
 # Tests for compute_prompt_mini_batch_boundaries
 # ---------------------------------------------------------------------------
+
+
+class TestComputePromptBoundaries:
+    def test_nonstepwise(self):
+        uids = ["p0", "p0", "p1", "p1", "p2", "p2"]
+        assert compute_prompt_boundaries(uids) == [(0, 2), (2, 4), (4, 6)]
+
+    def test_variable_group_sizes(self):
+        uids = ["p0", "p0", "p0", "p1", "p2", "p2"]
+        assert compute_prompt_boundaries(uids) == [(0, 3), (3, 4), (4, 6)]
+
+    def test_empty(self):
+        assert compute_prompt_boundaries([]) == []
+
+    def test_noncontiguous_uids_raise(self):
+        uids = ["p0", "p0", "p1", "p0"]
+        with pytest.raises(AssertionError, match="uid 'p0' appears in non-contiguous positions at index 3."):
+            compute_prompt_boundaries(uids)
 
 
 class TestComputePromptMiniBatchBoundaries:


### PR DESCRIPTION
Add a `prompt_mean` option to `algorithm.loss_reduction`: compute the token-mean within each prompt group (the `n_samples_per_prompt` responses sampled for a prompt), then average over prompts. Each token [i, t] in prompt p is scaled by 1 / (num_prompts * tokens_in_prompt_p) so that summing the per-token policy loss yields mean_p(token_mean within prompt p). Unlike `token_mean`, every prompt contributes equally regardless of total token count.

- preprocess: add `compute_prompt_boundaries(uids)` for per-prompt slices (works for step-wise and non-step-wise training).
- trainer: thread per-prompt boundaries through metadata into `_normalize_advantages`, rebased to mini-batch-relative indices.
- ppo_utils: implement the `prompt_mean` branch in `apply_loss_reduction_to_advantages_minibatch`.
- config validation + docs updated for the new option.
- unit tests for `compute_prompt_boundaries` and `prompt_mean`.


## Validation Experiments

### DAPO on Qwen3-1.7B-Base
`prompt_mean` grows training and eval reward more quickly than `token_mean`, and roughly matches `token_mean_legacy` performance. It does increase average generation length more, but this may be related to the overlong penalty used in DAPO (longer average length groups have larger negative advantage, which get upweighted and punished more for `token_mean` than for `prompt_mean`).

<img width="977" height="239" alt="image" src="https://github.com/user-attachments/assets/504d0054-8ac3-48b3-93d3-04989634a839" />
<img width="492" height="592" alt="image" src="https://github.com/user-attachments/assets/72a4ec09-1132-4609-928b-f6c0674e62b1" />


### DAPO on Qwen3-30B-A3B-Base

We see roughly the same trends on Qwen3-30B as Qwen3-1.7B.
<img width="970" height="239" alt="image" src="https://github.com/user-attachments/assets/229f8e54-e2dd-4963-b52f-cb23570bb148" />
<img width="488" height="594" alt="image" src="https://github.com/user-attachments/assets/955896fd-6924-4002-9666-ddd10b634011" />

