### PR TITLE
[fix] handle "uni" processor case on new inference code path

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/server_group.py
+++ b/skyrl/backends/skyrl_train/inference_servers/server_group.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 # about the GPU ID to pack actors appropriately on different nodes.
 # Thus we use a fractional CPU allocation for colocated actors.
 COLOCATED_ACTOR_CPU_FRACTION = 0.2
+# For the "uni" backend (single-GPU engines), the actor itself is the vLLM worker
+# and holds the GPU. Colocated engines share each GPU bundle with a training worker
+# (fractional); non-colocated engines own the whole GPU.
+COLOCATED_ACTOR_GPU_FRACTION = 0.2
 
 
 class ServerGroup:
@@ -105,6 +109,16 @@ class ServerGroup:
         # Query the actor class for GPU requirements
         self._num_gpus_per_server = self._server_actor_cls.compute_num_gpus_per_server(cli_args)
 
+        # Single-GPU engines run vLLM in-process ("uni") so the actor is scheduled
+        # directly onto its bundle's GPU. This is robust to NOSET_VISIBLE_DEVICES and
+        # to multiple placement groups sharing a node, unlike the ray/mp backends
+        # which spawn a separate worker. Matches the legacy inference path
+        # (ray_wrapped_inference_engine.py).
+        configured_backend = self._server_actor_kwargs.get("distributed_executor_backend", "ray")
+        self._executor_backend = "uni" if self._num_gpus_per_server == 1 else configured_backend
+        # Propagate the resolved backend to the actor (and prepare_server_kwargs).
+        self._server_actor_kwargs["distributed_executor_backend"] = self._executor_backend
+
         logger.info(
             f"ServerGroup: actor_cls={self._server_actor_cls.__name__}, "
             f"num_servers={num_servers}, "
@@ -133,10 +147,24 @@ class ServerGroup:
             self._internal_pg = self._create_placement_group()
         return self._internal_pg
 
+    def _actor_num_gpus(self) -> float:
+        """GPUs the server actor itself should request.
+
+        For the "uni" backend the actor IS the vLLM worker and must hold the GPU.
+        For ray/mp, vLLM spawns workers that hold the GPUs, so the actor needs none
+        (GPU allocation is managed by the placement group / per-worker request).
+        """
+        if self._executor_backend != "uni":
+            return 0.0
+        # Mirrors the VLLM_RAY_PER_WORKER_GPUS fraction set in VLLMServerActor:
+        # colocated engines share a bundle's GPU with a training worker, while
+        # non-colocated engines own the whole GPU.
+        return COLOCATED_ACTOR_GPU_FRACTION if self._external_pg is not None else 1.0
+
     def _create_actor_class(self, pg: PlacementGroup, start_bundle_idx: int) -> Any:
         """Create actor class with scheduling constraints for a specific bundle."""
         return ray.remote(self._server_actor_cls).options(
-            num_gpus=0,  # GPU allocation managed by placement group
+            num_gpus=self._actor_num_gpus(),
             num_cpus=COLOCATED_ACTOR_CPU_FRACTION,
             scheduling_strategy=PlacementGroupSchedulingStrategy(
                 placement_group=pg,

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -10,6 +10,7 @@ from argparse import Namespace
 from typing import List, Optional, Tuple
 
 import httpx
+import ray
 import uvicorn
 import vllm.envs as envs
 from fastapi import HTTPException, Request
@@ -120,6 +121,10 @@ class VLLMServerActor(ServerActorProtocol):
                 ``"ray"`` spawns TP/PP workers as Ray tasks (default).
                 ``"mp"`` spawns workers as local processes using
                 CUDA_VISIBLE_DEVICES.
+                ``"uni"`` runs the engine in-process in this actor (no separate
+                workers). ServerGroup auto-selects ``"uni"`` for single-GPU
+                engines (TP*PP == 1); the actor itself holds the GPU via its
+                placement-group bundle.
             mp_cuda_visible_devices: Comma-separated physical GPU IDs for the
                 ``"mp"`` backend. Pre-computed by ServerGroup from the
                 per-server placement group. Only used when
@@ -139,6 +144,7 @@ class VLLMServerActor(ServerActorProtocol):
         self._server_idx = server_idx
         self._num_gpus_per_server = self.compute_num_gpus_per_server(vllm_cli_args)
         self._use_mp_backend = distributed_executor_backend == "mp"
+        self._use_uni_backend = distributed_executor_backend == "uni"
         self._enable_ray_prometheus_stats = enable_ray_prometheus_stats
 
         # Ensure vLLM sleep endpoints are enabled by using dev mode
@@ -189,6 +195,8 @@ class VLLMServerActor(ServerActorProtocol):
         # Configure GPU visibility for this server's TP/PP workers
         if self._use_mp_backend:
             self._setup_mp_gpu_visibility(mp_cuda_visible_devices)
+        elif self._use_uni_backend:
+            self._setup_uni_gpu_visibility()
         else:
             os.environ["VLLM_RAY_PER_WORKER_GPUS"] = str(0.2 if colocated_training else 1.0)
             # Set bundle indices for this server's TP/PP workers in the placement group.
@@ -224,6 +232,25 @@ class VLLMServerActor(ServerActorProtocol):
             logger.info(
                 f"Server {self._server_idx}: mp backend, " f"cleared CUDA_VISIBLE_DEVICES (single-GPU or auto-detect)"
             )
+
+    def _setup_uni_gpu_visibility(self) -> None:
+        """Pin GPU visibility for the uni (in-process) executor backend.
+
+        With the uni backend vLLM runs inside this actor process, so it uses the
+        GPU Ray assigned to the actor via its placement-group bundle. Normally Ray
+        masks CUDA_VISIBLE_DEVICES to that GPU; but when
+        RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is set (SkyRL's default so training
+        workers manage their own devices) Ray leaves all GPUs visible, so we pin
+        CUDA_VISIBLE_DEVICES to the assigned GPU ourselves. Mirrors the legacy
+        inference path (vllm_engine.setup_envvars_for_vllm).
+        """
+        from skyrl.train.utils.utils import ray_noset_visible_devices
+
+        if ray_noset_visible_devices():
+            gpu_ids = ray.get_gpu_ids()
+            if gpu_ids:
+                os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_ids[0])
+                logger.info(f"Server {self._server_idx}: uni backend, " f"CUDA_VISIBLE_DEVICES={gpu_ids[0]}")
 
     def _setup_nixl_side_channel(self, side_channel_port: int) -> None:
         """


### PR DESCRIPTION
## Fix TP=1 inference engines scheduling on the wrong GPU (use `uni` executor backend)

  ### Problem

  Running two colocated TP=1 jobs on the same node (e.g. two instances of
  `run_dapo_qwen3_1.7b_aime.sh`) caused the second run's vLLM to start on `cuda:0` —
  already occupied by the first run's training process — instead of its own
  placement-group GPU:

```
  ValueError: Free memory on device cuda:0 (17.41/178.35 GiB) on startup is less
  than desired GPU memory utilization (0.8, 142.68 GiB).
```
  The new inference server path only supported the `ray`/`mp` executor backends. For
  single-GPU engines it used `ray`, scheduling the actor with `num_gpus=0` and relying
  on vLLM's Ray worker placement + `VLLM_RAY_BUNDLE_INDICES`. With
  `RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES` set (SkyRL's default) and multiple
  placement groups on one node, that single-GPU worker placement does not reliably land
  on the bundle's physical GPU.

  ### Fix

  Port the proven `uni` (in-process) backend from the legacy path
  (`ray_wrapped_inference_engine.py`) into the new server path. For `TP × PP == 1`,
  vLLM now runs in-process inside the actor, which is scheduled directly onto its
  placement-group bundle and holds the GPU — so it always lands on the correct physical
  GPU regardless of how many jobs share the node.

  - **`server_group.py`**: resolve the backend to `uni` when `num_gpus_per_server == 1`;
    the actor itself requests the GPU (`0.2` colocated / `1.0` non-colocated) via the new
    `_actor_num_gpus()`.
  - **`vllm_server_actor.py`**: add the `uni` branch — when NOSET is set, pin
    `CUDA_VISIBLE_DEVICES = ray.get_gpu_ids()[0]` and skip the Ray-only env vars.

  The change is **resource-neutral** (same GPU fraction as today's
  `VLLM_RAY_PER_WORKER_GPUS`, just requested on the actor instead of a spawned worker)
  and leaves the TP>1 `ray`/`mp` path untouched.

  ### Testing

  - [x] `ruff` / `black` clean; both modules import.
  - [x] Logic test confirms backend resolution and GPU-fraction selection across
    TP=1/TP=2 × colocated/non-colocated.
  - [ ] TP=2 GPU CI regression (`test_inference_server_group.py`)
  - [ ] Two-concurrent-jobs repro on a node with ≥8 GPUs

  That's the raw GitHub-flavored markdown — copy the block above into the PR description. Want me to open the PR with gh using this?