### PR TITLE
[tinker] [WIP] Fix new inference code path for Tinker API with Ray CPU only head node

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/utils.py
+++ b/skyrl/backends/skyrl_train/inference_servers/utils.py
@@ -56,8 +56,51 @@ def resolve_policy_model_name(cfg: SkyRLTrainConfig) -> str:
 
 
 # TODO: Add a test for validation
+_VLLM_DEVICE_CONFIG_PATCHED = False
+
+
+def _ensure_vllm_cuda_platform_stub() -> None:
+    """Force ``DeviceConfig`` to behave as if running on CUDA in the driver.
+
+    Building vLLM's CLI args runs ``_compute_kwargs(VllmConfig)``, which
+    materializes the default for the ``device_config`` field by calling
+    ``DeviceConfig()``. With ``device="auto"``, ``DeviceConfig.__post_init__``
+    reads ``current_platform.device_type``; on a no-GPU driver (e.g. the Ray
+    head node hosting the Tinker engine subprocess), NVML detection fails and
+    the platform resolves to ``UnspecifiedPlatform``, causing
+    ``RuntimeError("Failed to infer device type")``. The actor process imports
+    vLLM fresh on a GPU node and detects CUDA normally, so this only needs to
+    satisfy CLI-args building in the driver.
+
+    Monkey-patching ``DeviceConfig.__post_init__`` is the most reliable
+    intervention: it doesn't depend on whether module-level ``__setattr__``
+    hooks are honored by the running Python or how vLLM's lazy
+    ``current_platform`` accessor is cached across submodules.
+    """
+    global _VLLM_DEVICE_CONFIG_PATCHED
+    if _VLLM_DEVICE_CONFIG_PATCHED:
+        return
+
+    import torch
+    from vllm.config.device import DeviceConfig
+
+    original_post_init = DeviceConfig.__post_init__
+
+    def _patched_post_init(self) -> None:
+        if self.device == "auto":
+            self.device_type = "cuda"
+            self.device = torch.device("cuda")
+            return
+        original_post_init(self)
+
+    DeviceConfig.__post_init__ = _patched_post_init
+    _VLLM_DEVICE_CONFIG_PATCHED = True
+
+
 def build_vllm_cli_args(cfg: SkyRLTrainConfig) -> Namespace:
     """Build CLI args for vLLM server from config."""
+    _ensure_vllm_cuda_platform_stub()
+
     from vllm import AsyncEngineArgs
     from vllm.config import WeightTransferConfig
     from vllm.entrypoints.openai.cli_args import FrontendArgs


### PR DESCRIPTION
This is currently not the right fix, but it does fix the problem -- what happens here is vLLM tries to detect the accelerator type on the head node and errors with
```
2026-05-28 19:33:46,334 - ERROR - skyrl: Error processing batch: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on      
verbose logging to help debug the issue.                                                                                                                                      
╭──────────────────────────────────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────────────────────────────────╮
│ /home/ray/default/SkyRL/skyrl/tinker/engine.py:741 in process_batch_requests                                                                                               │
│                                                                                                                                                                            │
│   738 │   │   │   try:                                                                                                                                                     │
│   739 │   │   │   │   error_results, valid_requests = self._filter_valid_requests(requests)                                                                                │
│   740 │   │   │   │   if valid_requests:                                                                                                                                   │
│ ❱ 741 │   │   │   │   │   results = processor(valid_requests)                                                                                                              │
│   742 │   │   │   │   │   results.update(error_results)                                                                                                                    │
│   743 │   │   │   │   else:                                                                                                                                                │
│   744 │   │   │   │   │   results = error_results                                                                                                                          │
│                                                                                                                                                                            │
│ /home/ray/default/SkyRL/skyrl/tinker/engine.py:582 in process_forward_backward                                                                                             │
│                                                                                                                                                                            │
│   579 │   def process_forward_backward(self, requests: dict[str, tuple[str,                                                                                                │
│       types.ForwardBackwardInput]]) -> dict:                                                                                                                               │
│   580 │   │   """Run forward and backward pass on a batch of requests."""                                                                                                  │
│   581 │   │   prepared = prepare_model_pass_batch(requests)                                                                                                                │
│ ❱ 582 │   │   return self.backend.forward_backward(prepared)                                                                                                               │
│   583 │                                                                                                                                                                    │
│   584 │   def process_forward(self, requests: dict[str, tuple[str,                                                                                                         │
│       types.ForwardBackwardInput]]) -> dict:                                                                                                                               │
│   585 │   │   """Run forward-only pass on a batch of requests."""                                                                                                          │
│                                                                                                                                                                            │
│ /home/ray/default/SkyRL/skyrl/backends/skyrl_train_backend.py:751 in forward_backward                                                                                      │
│                                                                                                                                                                            │
│    748 │   │   self._sleep_inference_engines()                                                                                                                             │
│    749 │   │   results = {}                                                                                                                                                │
│    750 │   │   for sub_batch in self._split_model_pass_batch_by_model_id(prepared_batch):                                                                                  │
│ ❱  751 │   │   │   results.update(self._forward_backward_single_model_batch(sub_batch))                                                                                    │
│    752 │   │   return results                                                                                                                                              │
│    753 │                                                                                                                                                                   │
│    754 │   def _forward_backward_single_model_batch(                                                                                                                       │
│                                                                                                                                                                            │
│ /home/ray/default/SkyRL/skyrl/backends/skyrl_train_backend.py:768 in _forward_backward_single_model_batch                                                                  │
│                                                                                                                                                                            │
│    765 │   │   │   )                                                                                                                                                       │
│    766 │   │   ):                                                                                                                                                          │
│    767 │   │   │   raise ValueError("Critic forward_backward requires values and returns for                                                                               │
│        every response token")                                                                                                                                              │
│ ❱  768 │   │   batch = self._to_training_batch(prepared_batch, role)                                                                                                       │
│    769 │   │   micro_bs = (                                                                                                                                                │
│    770 │   │   │   self._cfg.trainer.micro_train_batch_size_per_gpu if                                                                                                     │
│        self._cfg.trainer.strategy == "megatron" else None                                                                                                                  │
│    771 │   │   )                                                                                                                                                           │
│                                                                                                                                                                            │
│ /home/ray/default/SkyRL/skyrl/backends/skyrl_train_backend.py:547 in _to_training_batch                                                                                    │
│                                                                                                                                                                            │
│    544 │   │                                                                                                                                                               │
│    545 │   │   if _SKYRL_USE_NEW_INFERENCE:                                                                                                                                │
│    546 │   │   │   if self._renderer is None:                                                                                                                              │
│ ❱  547 │   │   │   │   self._ensure_inference_engines()                                                                                                                    │
│    548 │   │   │   │   self._renderer = VLLMRenderer(self._inference_engine_client,                                                                                        │
│        self._cfg.trainer.policy.model.path)                                                                                                                                │
│    549 │   │   │   rendered_inputs =                                                                                                                                       │
│        asyncio.run(self._renderer(prepared_batch.all_model_inputs))                                                                                                        │
│    550 │   │   else:                                                                                                                                                       │
│                                                                                                                                                                            │
│ /home/ray/default/SkyRL/skyrl/backends/skyrl_train_backend.py:385 in _ensure_inference_engines                                                                             │
│                                                                                                                                                                            │
│    382 │   │   │   return                                                                                                                                                  │
│    383 │   │                                                                                                                                                               │
│    384 │   │   if _SKYRL_USE_NEW_INFERENCE:                                                                                                                                │
│ ❱  385 │   │   │   self._create_new_inference_client()                                                                                                                     │
│    386 │   │   else:                                                                                                                                                       │
│    387 │   │   │   self._create_legacy_inference_client()                                                                                                                  │
│    388                                                                                                                                                                     │
│                                                                                                                                                                            │
│ /home/ray/default/SkyRL/skyrl/backends/skyrl_train_backend.py:366 in _create_new_inference_client                                                                          │
│                                                                                                                                                                            │
│    363 │   │   )                                                                                                                                                           │
│    364 │   │                                                                                                                                                               │
│    365 │   │   is_colocated = self._cfg.trainer.placement.colocate_all                                                                                                     │
│ ❱  366 │   │   client, server_setup = build_new_inference_client(                                                                                                          │
│    367 │   │   │   self._cfg,                                                                                                                                              │
│    368 │   │   │   self._tokenizer,                                                                                                                                        │
│    369 │   │   │   placement_group=self._colocate_pg if is_colocated else None,                                                                                            │
│                                                                                                                                                                            │
│ /home/ray/default/SkyRL/skyrl/backends/skyrl_train/inference_servers/setup.py:275 in build_new_inference_client                                                            │
│                                                                                                                                                                            │
│   272 │   │   )                                                                                                                                                            │
│   273 │   │   server_setup = InferenceServerSetup(proxy_url=proxy_url,                                                                                                     │
│       server_urls=server_urls, router=router)                                                                                                                              │
│   274 │   else:                                                                                                                                                            │
│ ❱ 275 │   │   cli_args = build_vllm_cli_args(cfg)                                                                                                                          │
│   276 │   │   server_setup = create_inference_servers(                                                                                                                     │
│   277 │   │   │   ie_cfg,                                                                                                                                                  │
│   278 │   │   │   cli_args,                                                                                                                                                │
│                                                                                                                                                                            │
│ /home/ray/default/SkyRL/skyrl/backends/skyrl_train/inference_servers/utils.py:69 in build_vllm_cli_args                                                                    │
│                                                                                                                                                                            │
│    66 │   # Create common CLI args namespace                                                                                                                               │
│    67 │   parser = FlexibleArgumentParser()                                                                                                                                │
│    68 │   parser = FrontendArgs.add_cli_args(parser)                                                                                                                       │
│ ❱  69 │   parser = AsyncEngineArgs.add_cli_args(parser)                                                                                                                    │
│    70 │   # parse args without any command line arguments                                                                                                                  │
│    71 │   args: Namespace = parser.parse_args(args=[])                                                                                                                     │
│    72                                                                                                                                                                      │
│                                                                                                                                                                            │
│ /home/ray/.cache/uv/builds-v0/.tmpbskITE/lib/python3.12/site-packages/vllm/engine/arg_utils.py:2429 in add_cli_args                                                        │
│                                                                                                                                                                            │
│   2426 │   │   # a new device to --device argument.                                                                                                                        │
│   2427 │   │   load_general_plugins()                                                                                                                                      │
│   2428 │   │   if not async_args_only:                                                                                                                                     │
│ ❱ 2429 │   │   │   parser = EngineArgs.add_cli_args(parser)                                                                                                                │
│   2430 │   │   parser.add_argument(                                                                                                                                        │
│   2431 │   │   │   "--enable-log-requests",                                                                                                                                │
│   2432 │   │   │   action=argparse.BooleanOptionalAction,                                                                                                                  │
│                                                                                                                                                                            │
│ /home/ray/.cache/uv/builds-v0/.tmpbskITE/lib/python3.12/site-packages/vllm/engine/arg_utils.py:1371 in add_cli_args                                                        │
│                                                                                                                                                                            │
│   1368 │   │   kernel_group.add_argument("--moe-backend", **moe_backend_kwargs)                                                                                            │
│   1369 │   │                                                                                                                                                               │
│   1370 │   │   # vLLM arguments                                                                                                                                            │
│ ❱ 1371 │   │   vllm_kwargs = get_kwargs(VllmConfig)                                                                                                                        │
│   1372 │   │   vllm_group = parser.add_argument_group(                                                                                                                     │
│   1373 │   │   │   title="VllmConfig",                                                                                                                                     │
│   1374 │   │   │   description=VllmConfig.__doc__,                                                                                                                         │
│                                                                                                                                                                            │
│ /home/ray/.cache/uv/builds-v0/.tmpbskITE/lib/python3.12/site-packages/vllm/engine/arg_utils.py:399 in get_kwargs                                                           │
│                                                                                                                                                                            │
│    396 │   is returned so callers can mutate the dictionary without affecting the                                                                                          │
│    397 │   cached version.                                                                                                                                                 │
│    398 │   """                                                                                                                                                             │
│ ❱  399 │   return copy.deepcopy(_compute_kwargs(cls))                                                                                                                      │
│    400                                                                                                                                                                     │
│    401                                                                                                                                                                     │
│    402 @dataclass                                                                                                                                                          │
│                                                                                                                                                                            │
│ /home/ray/.cache/uv/builds-v0/.tmpbskITE/lib/python3.12/site-packages/vllm/engine/arg_utils.py:309 in _compute_kwargs                                                      │
│                                                                                                                                                                            │
│    306 │   │   │   │   │   # VllmConfig's Fields have default_factory set to config classes.                                                                               │
│    307 │   │   │   │   │   # These could emit logs on init, which would be confusing.                                                                                      │
│    308 │   │   │   │   │   with suppress_logging():                                                                                                                        │
│ ❱  309 │   │   │   │   │   │   default = default.default_factory()  # type: ignore[call-arg]                                                                               │
│    310 │   │   elif field.default_factory is not MISSING:                                                                                                                  │
│    311 │   │   │   default = field.default_factory()                                                                                                                       │
│    312                                                                                                                                                                     │
│                                                                                                                                                                            │
│ /home/ray/.cache/uv/builds-v0/.tmpbskITE/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py:121 in __init__                                                   │
│                                                                                                                                                                            │
│   118 │   def __init__(__dataclass_self__: PydanticDataclass, *args: Any, **kwargs: Any) ->                                                                                │
│       None:                                                                                                                                                                │
│   119 │   │   __tracebackhide__ = True                                                                                                                                     │
│   120 │   │   s = __dataclass_self__                                                                                                                                       │
│ ❱ 121 │   │   s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs),                                                                                           │
│       self_instance=s)                                                                                                                                                     │
│   122 │                                                                                                                                                                    │
│   123 │   __init__.__qualname__ = f'{cls.__qualname__}.__init__'                                                                                                           │
│   124                                                                                                                                                                      │
│                                                                                                                                                                            │
│ /home/ray/.cache/uv/builds-v0/.tmpbskITE/lib/python3.12/site-packages/vllm/config/device.py:56 in __post_init__                                                            │
│                                                                                                                                                                            │
│   53 │   │   │                                                                                                                                                             │
│   54 │   │   │   self.device_type = current_platform.device_type                                                                                                           │
│   55 │   │   │   if not self.device_type:                                                                                                                                  │
│ ❱ 56 │   │   │   │   raise RuntimeError(                                                                                                                                   │
│   57 │   │   │   │   │   "Failed to infer device type, please set "                                                                                                        │
│   58 │   │   │   │   │   "the environment variable `VLLM_LOGGING_LEVEL=DEBUG` "                                                                                            │
│   59 │   │   │   │   │   "to turn on verbose logging to help debug the issue."                                                                                             │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
RuntimeError: Failed to infer device type, please set the environment variable `VLLM_LOGGING_LEVEL=DEBUG` to turn on verbose logging to help debug the issue.
```