### PR TITLE
[fix] Explicitly set vLLM `device_type` to cuda

### DIFF
--- a/.github/workflows/cpu_skyrl_train.yaml
+++ b/.github/workflows/cpu_skyrl_train.yaml
@@ -69,8 +69,10 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           activate-environment: true
-      - name: Run cpu tests
-        run:  uv run --isolated --extra skyrl-train --extra dev pytest tests/train/ tests/backends/skyrl_train/ --ignore=tests/backends/skyrl_train/gpu
+      - name: Run cpu tests (without vllm)
+        run:  uv run --isolated --extra skyrl-train --extra dev pytest tests/train/ tests/backends/skyrl_train/ --ignore=tests/backends/skyrl_train/gpu -m "not vllm"
+      - name: Run cpu tests (with vllm)
+        run: uv run --isolated --extra fsdp --extra dev pytest tests/train/ tests/backends/skyrl_train/ --ignore=tests/backends/skyrl_train/gpu -m "vllm"
   
   skyrl_gym_tests:
     needs: check_code_quality

--- a/skyrl/backends/skyrl_train/inference_servers/utils.py
+++ b/skyrl/backends/skyrl_train/inference_servers/utils.py
@@ -61,7 +61,20 @@ def build_vllm_cli_args(cfg: SkyRLTrainConfig) -> Namespace:
     from vllm import AsyncEngineArgs
     from vllm.config import WeightTransferConfig
     from vllm.entrypoints.openai.cli_args import FrontendArgs
+    from vllm.platforms import current_platform
     from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    # This function may run a GPU-less Ray head
+    # node, where ``current_platform`` resolves to ``UnspecifiedPlatform`` with
+    # ``device_type == ""``. vLLM's ``add_cli_args`` walks ``VllmConfig`` defaults
+    # and instantiates ``DeviceConfig()`` (device="auto"), which in turn runs
+    # ``DeviceConfig.__post_init__`` and raises ``Failed to infer device type``.
+    # Explicitly pin the platform's device type to ``cuda`` so the autodetection
+    # path in ``DeviceConfig.__post_init__`` succeeds during arg parsing.
+    # NOTE: mutating current_platform.device_type relies on vLLM 0.20.2's singleton
+    # initialization where instance attrs shadow class attrs. This should be re-verified on vLLM bumps.
+    if not current_platform.device_type:
+        current_platform.device_type = "cuda"
 
     # Create common CLI args namespace
     parser = FlexibleArgumentParser()

--- a/tests/backends/skyrl_train/inference_servers/test_build_vllm_cli_args.py
+++ b/tests/backends/skyrl_train/inference_servers/test_build_vllm_cli_args.py
@@ -1,13 +1,16 @@
 """Tests for build_vllm_cli_args on GPU-less hosts."""
 
-import vllm.platforms
-from vllm.platforms.interface import UnspecifiedPlatform
+import pytest
 
 from skyrl.backends.skyrl_train.inference_servers.utils import build_vllm_cli_args
 from skyrl.train.config import SkyRLTrainConfig
 
 
+@pytest.mark.vllm
 def test_build_vllm_cli_args_succeeds_on_gpu_less_host(monkeypatch):
+    import vllm.platforms
+    from vllm.platforms.interface import UnspecifiedPlatform
+
     # Simulate the GPU-less Ray head-node case: vLLM resolves current_platform
     # to UnspecifiedPlatform (device_type == ""), so AsyncEngineArgs.add_cli_args
     # walks VllmConfig defaults, instantiates DeviceConfig() and its

--- a/tests/backends/skyrl_train/inference_servers/test_build_vllm_cli_args.py
+++ b/tests/backends/skyrl_train/inference_servers/test_build_vllm_cli_args.py
@@ -1,0 +1,25 @@
+"""Tests for build_vllm_cli_args on GPU-less hosts."""
+
+import vllm.platforms
+from vllm.platforms.interface import UnspecifiedPlatform
+
+from skyrl.backends.skyrl_train.inference_servers.utils import build_vllm_cli_args
+from skyrl.train.config import SkyRLTrainConfig
+
+
+def test_build_vllm_cli_args_succeeds_on_gpu_less_host(monkeypatch):
+    # Simulate the GPU-less Ray head-node case: vLLM resolves current_platform
+    # to UnspecifiedPlatform (device_type == ""), so AsyncEngineArgs.add_cli_args
+    # walks VllmConfig defaults, instantiates DeviceConfig() and its
+    # __post_init__ raises "Failed to infer device type" during arg parsing.
+    # With the fix in build_vllm_cli_args, current_platform.device_type is
+    # pinned to "cuda" before add_cli_args runs.
+    monkeypatch.setattr(vllm.platforms, "_current_platform", UnspecifiedPlatform())
+
+    cfg = SkyRLTrainConfig()
+    args = build_vllm_cli_args(cfg)
+
+    assert args is not None
+    assert args.model == cfg.trainer.policy.model.path
+    assert args.tensor_parallel_size == cfg.generator.inference_engine.tensor_parallel_size
+    assert vllm.platforms.current_platform.device_type == "cuda"


### PR DESCRIPTION
# What does this PR do?

vLLM 0.20.2's `DeviceConfig.__post_init__` raises "Failed to infer device type" when `build_vllm_cli_args` runs on a GPU-less host (the Ray head-node entrypoint actor with no GPU constraint). 

This PR pins the device type to `cuda` to avoid the issue.  Also adds a test to CPU CI to make sure that `build_vllm_cli_args` can run successfully without GPUs