### PR TITLE
[fix] Preserve original AutoConfig in MegatronWorker.init_configs

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -331,7 +331,7 @@ class MegatronWorker:
         Initialize the Megatron-Bridge bridge and provider objects + hf_config and tokenizer
         """
         tokenizer = get_tokenizer(model_path, trust_remote_code=True)
-        hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        hf_config_original = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
 
         override_config_kwargs = {
             "bos_token_id": tokenizer.bos_token_id,
@@ -339,7 +339,7 @@ class MegatronWorker:
             "pad_token_id": tokenizer.pad_token_id,
         }
         override_config_kwargs.update(model_config_kwargs.get("model_config", {}))
-        update_model_config(hf_config, override_config_kwargs=override_config_kwargs)
+        hf_config = update_model_config(hf_config_original, override_config_kwargs=override_config_kwargs)
 
         transformer_config_kwargs = (
             transformer_config_kwargs
@@ -402,7 +402,10 @@ class MegatronWorker:
         self.provider = provider
         self.bridge = bridge
 
-        self.strategy.hf_config = hf_config
+        # strategy.hf_config is the on-disk source-of-truth used by
+        # save_hf_configs and must NOT carry runtime overrides like
+        # mtp_num_layers=0; assign the un-mutated AutoConfig here.
+        self.strategy.hf_config = hf_config_original
         self.tokenizer = tokenizer
         self.enable_router_replay = megatron_config.moe_enable_routing_replay
 

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -6,6 +6,7 @@ import os
 import socket
 import sys
 import time
+from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 
@@ -976,15 +977,30 @@ def peer_access_supported(max_num_gpus_per_node: int):
 
 
 def update_model_config(module_config, override_config_kwargs):
-    """Update the module config with the override_config_kwargs.
+    """Return a copy of ``module_config`` with ``override_config_kwargs`` applied.
+
+    The returned config is a deep copy, so the caller's input is left
+    unmodified. Nested dict values in ``override_config_kwargs`` recurse into
+    the corresponding sub-config attribute (which is already part of the deep
+    copy, so the recursion mutates the copy in place).
 
     Args:
         module_config: The module config from Huggingface Transformers.
         override_config_kwargs: The kwargs to override the module config.
+
+    Returns:
+        A new module config with the overrides applied.
     """
+    new_config = deepcopy(module_config)
+    _apply_overrides_in_place(new_config, override_config_kwargs)
+    return new_config
+
+
+def _apply_overrides_in_place(module_config, override_config_kwargs):
+    """Apply override kwargs to ``module_config`` in place (used for sub-configs)."""
     for key, val in override_config_kwargs.items():
         if isinstance(val, dict):
-            update_model_config(getattr(module_config, key), val)
+            _apply_overrides_in_place(getattr(module_config, key), val)
         else:
             setattr(module_config, key, val)
 

--- a/tests/train/utils/test_update_model_config.py
+++ b/tests/train/utils/test_update_model_config.py
@@ -1,5 +1,5 @@
 """
-uv run --isolated --extra dev pytest tests/train/utils/test_utils.py
+uv run --isolated --extra dev pytest tests/train/utils/test_update_model_config.py
 """
 
 from copy import deepcopy

--- a/tests/train/utils/test_utils.py
+++ b/tests/train/utils/test_utils.py
@@ -1,0 +1,38 @@
+"""
+uv run --isolated --extra dev pytest tests/train/utils/test_utils.py
+"""
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+from skyrl.train.utils.utils import update_model_config
+
+
+def _make_config():
+    """Build a config-like object with a nested sub-config attribute."""
+    sub = SimpleNamespace(mtp_num_layers=4, hidden_size=128)
+    return SimpleNamespace(num_nextn_predict_layers=4, sub_config=sub)
+
+
+class TestUpdateModelConfigNonMutating:
+    """Lock in the non-mutating contract of ``update_model_config``."""
+
+    def test_input_is_not_mutated_at_top_level(self):
+        cfg = _make_config()
+        before = deepcopy(cfg)
+        update_model_config(cfg, {"num_nextn_predict_layers": 0})
+        assert cfg.num_nextn_predict_layers == before.num_nextn_predict_layers
+        assert cfg.sub_config.mtp_num_layers == before.sub_config.mtp_num_layers
+
+    def test_returned_copy_carries_top_level_overrides(self):
+        cfg = _make_config()
+        new_cfg = update_model_config(cfg, {"num_nextn_predict_layers": 0})
+        assert new_cfg.num_nextn_predict_layers == 0
+        assert new_cfg is not cfg
+
+    def test_nested_overrides_do_not_leak_back_into_input(self):
+        cfg = _make_config()
+        new_cfg = update_model_config(cfg, {"sub_config": {"mtp_num_layers": 0}})
+        assert new_cfg.sub_config.mtp_num_layers == 0
+        assert cfg.sub_config.mtp_num_layers == 4
+        assert new_cfg.sub_config is not cfg.sub_config


### PR DESCRIPTION
## Summary

A Megatron-Bridge SFT run launched with overrides like `++transformer_config_kwargs.mtp_num_layers=0` produced an exported HF checkpoint whose `config.json` carried the runtime override (`num_nextn_predict_layers=0`) instead of the on-disk source-of-truth value (e.g. 4 for Nemotron-H 120B). The saved directory was silently inconsistent with the reference repo. This PR makes `update_model_config` non-mutating and ensures `MegatronStrategy.save_hf_configs` publishes the un-mutated, on-disk `AutoConfig`.

## Root cause

`update_model_config` in `skyrl/train/utils/utils.py` mutated the input `AutoConfig` in place via `setattr` (recursing into sub-configs the same way). `MegatronWorker.init_configs` in `skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py` then assigned the already-mutated object to `self.strategy.hf_config`, and `MegatronStrategy.save_hf_configs` (in `skyrl/backends/skyrl_train/distributed/strategy.py`) published it via `model_config.save_pretrained(work_dir)`.

## Fix

- `skyrl/train/utils/utils.py`: `update_model_config` now returns a `deepcopy` of the input with overrides applied. The recursive setattr logic is preserved unchanged in a private `_apply_overrides_in_place` helper used internally on the copy.
- `skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py`: `init_configs` keeps the un-mutated `AutoConfig.from_pretrained(...)` result as `hf_config_original` and assigns it to `self.strategy.hf_config`, while the Megatron provider/runtime path continues to use the override-applied copy returned by `update_model_config`.

## Trade-off on tokenizer-id overrides

The override dict in `MegatronWorker.init_configs` mixes two categories: tokenizer-id overrides (`bos_token_id`, `eos_token_id`, `pad_token_id`) and runtime overrides (`mtp_num_layers=0`, etc). Pre-PR, both leaked into the saved `config.json`; post-PR, neither does. We accept this as the right behavior because (i) the on-disk `config.json` should match the source repo exactly, (ii) tokenizer ids are duplicated in `tokenizer_config.json` / `special_tokens_map.json` which are written separately via `tokenizer.save_pretrained`, and (iii) the on-disk-source-of-truth contract is cleaner. If a future use case needs tokenizer-id overrides persisted to the saved config, splitting the override dict into `tokenizer_overrides` (applied to the saved copy) and `model_overrides` (runtime-only) is a localized follow-up.

## Verification

- [x] CPU unit tests added at `tests/train/utils/test_utils.py` covering the non-mutating contract: input config is unchanged at top level, returned copy carries top-level overrides, nested-dict overrides do not leak back into the input. Includes the Bug B repro (`update_model_config(cfg, {"num_nextn_predict_layers": 0})` leaves the input's `num_nextn_predict_layers` at its original value). Runs in `cpu_skyrl_train.yaml`.
- [x] Lint/format clean: `pre-commit run --files skyrl/train/utils/utils.py skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py tests/train/utils/test_utils.py` (ruff, black, gitleaks) all pass.
- [x] Manual repro target: after this fix, `config.json` written by `MegatronStrategy.save_hf_configs` for a Nemotron-H 120B SFT run launched with `++transformer_config_kwargs.mtp_num_layers=0` matches the on-disk reference (no `num_nextn_predict_layers=0` leak).

## Risk

Low. The only call site of `update_model_config` is updated in this commit to consume the returned value. The recursion-via-setattr semantics are identical to before; only the target object changed (a deep-copied config instead of the caller's input).

## Notes

The `_apply_overrides_in_place` helper is the original recursive body and remains internally callable, so future call sites that explicitly want in-place behavior can opt in.