### PR TITLE
[tinker] Add session-based routing example + docs

### DIFF
--- a/docs/content/docs/tinker/meta.json
+++ b/docs/content/docs/tinker/meta.json
@@ -5,6 +5,7 @@
     "quickstart",
     "architecture",
     "multi_tenancy",
+    "session_based_routing",
     "cookbook",
     "configuration",
     "limitations"

--- a/docs/content/docs/tinker/session_based_routing.mdx
+++ b/docs/content/docs/tinker/session_based_routing.mdx
@@ -1,0 +1,70 @@
+---
+title: "Session-based Routing"
+---
+
+SkyRL's Tinker server forwards a stable routing key with every sample request so `vllm-router` can pin a logical request — including all of its `num_samples` expansions and any retries — to a single inference backend. This keeps the prefix cache warm across the turns of one rollout and across retries of one request, while still spreading distinct requests across backends.
+
+## Routing key
+
+For each `/api/v1/asample` call, the server computes:
+
+```
+X-Session-ID = "<sampling_session_id>:<seq_id>"
+```
+
+- `sampling_session_id` is per-client, assigned by `service_client.create_sampling_client()` (or `training_client.save_weights_and_get_sampling_client()`).
+- `seq_id` is per-request within the session. The Tinker SDK auto-bumps it on every `SamplingClient.sample(...)` call.
+
+The key is emitted on both sample dispatch paths:
+
+- `SkyRLTrainBackend._sample_with_remote_client` sets `session_id` on the engine-client payload (the engine subprocess path used in colocated mode).
+- `SkyRLTrainInferenceForwardingClient._forward` sets `X-Session-ID` directly on the `POST /v1/completions` request to vllm-router (the async-forwarding path used in non-colocated mode).
+
+If either `sampling_session_id` or `seq_id` is absent (e.g. direct base-model sampling without an SDK session), the header is omitted and vllm-router falls back to plain load-balancing.
+
+## When you'd care
+
+- **Multi-turn rollouts.** Reuse the same `seq_id` across all turns of one trajectory so they land on the same backend and the second turn hits the prefix cache from the first.
+- **Retries.** A retried sample request inherits the original `seq_id` and therefore the original routing key, so it returns to the same backend.
+- **`num_samples > 1`.** All N samples of one request already share a routing key (same `seq_id` on the server) — they co-locate on one backend automatically.
+
+## Driving it explicitly from a client
+
+The standard `SamplingClient.sample(...)` API auto-bumps `seq_id` on each call and doesn't expose it to the user. To pin a trajectory's turns to one backend you need caller-controlled `seq_id`, which means bypassing `SamplingClient.sample` and dispatching a raw `SampleRequest` via the low-level `client.sampling.asample` (where `client` is obtained from `holder.aclient(...)`).
+
+A runnable demo lives at [`examples/tinker/session_based_routing/`](https://github.com/NovaSky-AI/SkyRL/tree/main/examples/tinker/session_based_routing). It starts a SkyRL Tinker server, runs N parallel trajectories each over T turns where every turn reuses `seq_id=trajectory_idx`, and prints the routing key on dispatch:
+
+```bash
+# Terminal 1
+bash examples/tinker/session_based_routing/run_tinker_server.sh
+
+# Terminal 2
+TINKER_API_KEY=tml-dummy uv run --extra tinker --with torch --with transformers \
+    python examples/tinker/session_based_routing/sample_session_routing_demo.py \
+    --num-trajectories 4 --turns 3
+```
+
+You should see the client and server agree 1:1 on the routing key for every dispatch:
+
+```
+client: dispatch routing-key=sampling_<id>:<seq_id>
+server: [sticky-routing] dispatch idx=<i> model=<...> session_id=sampling_<id>:<seq_id>
+```
+
+
+The `vllm-router` logs can also be inspected to confirm that requests with the same session ID land on the same worker (`sampling_33680dc2:1` consistently maps to `:8001`, `sampling_33680dc2:0` to `:8300`):
+
+```text
+# /tmp/skyrl-logs/router-xxx.log
+INFO consistent_hash: Hash key 'header:x-session-id:sampling_33680dc2:1' mapped to worker: http://10.206.0.28:8001
+INFO consistent_hash: Consistent hash routing: key='header:x-session-id:sampling_33680dc2:1' -> worker='http://10.206.0.28:8001' (index=2)
+INFO consistent_hash: Found session key in header 'x-session-id': sampling_33680dc2:0
+INFO consistent_hash: Extracted hash key: header:x-session-id:sampling_33680dc2:0
+INFO consistent_hash: Hash key 'header:x-session-id:sampling_33680dc2:0' mapped to worker: http://10.206.0.28:8300
+INFO consistent_hash: Consistent hash routing: key='header:x-session-id:sampling_33680dc2:0' -> worker='http://10.206.0.28:8300' (index=3)
+INFO consistent_hash: Found session key in header 'x-session-id': sampling_33680dc2:1
+INFO consistent_hash: Extracted hash key: header:x-session-id:sampling_33680dc2:1
+INFO consistent_hash: Hash key 'header:x-session-id:sampling_33680dc2:1' mapped to worker: http://10.206.0.28:8001
+```
+
+See the example's [`sample_session_routing_demo.py`](https://github.com/NovaSky-AI/SkyRL/tree/main/examples/tinker/session_based_routing/sample_session_routing_demo.py) for more details.

--- a/docs/content/docs/tinker/session_based_routing.mdx
+++ b/docs/content/docs/tinker/session_based_routing.mdx
@@ -15,11 +15,6 @@ X-Session-ID = "<sampling_session_id>:<seq_id>"
 - `sampling_session_id` is per-client, assigned by `service_client.create_sampling_client()` (or `training_client.save_weights_and_get_sampling_client()`).
 - `seq_id` is per-request within the session. The Tinker SDK auto-bumps it on every `SamplingClient.sample(...)` call.
 
-The key is emitted on both sample dispatch paths:
-
-- `SkyRLTrainBackend._sample_with_remote_client` sets `session_id` on the engine-client payload (the engine subprocess path used in colocated mode).
-- `SkyRLTrainInferenceForwardingClient._forward` sets `X-Session-ID` directly on the `POST /v1/completions` request to vllm-router (the async-forwarding path used in non-colocated mode).
-
 If either `sampling_session_id` or `seq_id` is absent (e.g. direct base-model sampling without an SDK session), the header is omitted and vllm-router falls back to plain load-balancing.
 
 ## When you'd care
@@ -30,9 +25,9 @@ If either `sampling_session_id` or `seq_id` is absent (e.g. direct base-model sa
 
 ## Driving it explicitly from a client
 
-The standard `SamplingClient.sample(...)` API auto-bumps `seq_id` on each call and doesn't expose it to the user. To pin a trajectory's turns to one backend you need caller-controlled `seq_id`, which means bypassing `SamplingClient.sample` and dispatching a raw `SampleRequest` via the low-level `client.sampling.asample` (where `client` is obtained from `holder.aclient(...)`).
+The standard `SamplingClient.sample(...)` API auto-bumps `seq_id` on each call and doesn't expose it to the user. To pin a trajectory's turns to one backend you need caller-controlled `seq_id`. This means bypassing `SamplingClient.sample` and dispatching a raw `SampleRequest` via the low-level `client.sampling.asample` API.
 
-A runnable demo lives at [`examples/tinker/session_based_routing/`](https://github.com/NovaSky-AI/SkyRL/tree/main/examples/tinker/session_based_routing). It starts a SkyRL Tinker server, runs N parallel trajectories each over T turns where every turn reuses `seq_id=trajectory_idx`, and prints the routing key on dispatch:
+An example for configuring this is at [`examples/tinker/session_based_routing/`](https://github.com/NovaSky-AI/SkyRL/tree/main/examples/tinker/session_based_routing). It starts a SkyRL Tinker server, runs N parallel trajectories each over T turns where every turn reuses `seq_id=trajectory_idx`, and prints the routing key on dispatch:
 
 ```bash
 # Terminal 1

--- a/examples/tinker/session_based_routing/README.md
+++ b/examples/tinker/session_based_routing/README.md
@@ -1,0 +1,46 @@
+# Tinker Session-based Routing Example
+
+This example shows how to exercise SkyRL's deterministic sampling-session routing — pinning a multi-turn trajectory to one inference engine by reusing a fixed `seq_id` across its sample calls.
+
+Setup:
+- base model: `Qwen/Qwen2.5-1.5B-Instruct`
+- backend: `--backend fsdp` (full fine-tune via `rank=0`)
+- N parallel trajectories × T turns, each trajectory's turns share `seq_id=trajectory_idx`
+
+
+## 1. Start the Tinker API server
+
+```bash
+bash examples/tinker/session_based_routing/run_tinker_server.sh
+```
+
+The launcher already includes server-side defaults for colocated placement, four inference engines, and micro-batching. To override them, pass your own `BACKEND_CONFIG=...`:
+
+```bash
+BACKEND_CONFIG='{
+  "trainer.placement.policy_num_gpus_per_node": 2,
+  "generator.inference_engine.num_engines": 2
+}' bash examples/tinker/session_based_routing/run_tinker_server.sh
+```
+
+## 2. Run the routing demo client
+
+```bash
+TINKER_API_KEY=tml-dummy uv run --extra tinker --with torch --with transformers \
+    python examples/tinker/session_based_routing/sample_session_routing_demo.py \
+    --num-trajectories 4 --turns 3
+```
+
+Each `/api/v1/asample` dispatch is logged on both sides with the same routing key:
+
+```
+client: dispatch routing-key=sampling_<id>:<seq_id>
+server: [sticky-routing] dispatch idx=<i> model=<...> session_id=sampling_<id>:<seq_id>
+```
+
+All turns of trajectory `i` share `session_id=sampling_<id>:i` and therefore land on the same backend; distinct trajectories spread across backends.
+
+## Notes
+
+- The demo uses `service_client.create_lora_training_client(..., rank=0)` to bootstrap the policy via the SkyRL-Train backend, then `save_weights_and_get_sampling_client(...)` to obtain a sampling session. Everything after that bypasses `SamplingClient.sample` and calls `client.sampling.asample` directly so the caller controls `seq_id`.
+- See [docs/content/docs/tinker/session_based_routing.mdx](../../../docs/content/docs/tinker/session_based_routing.mdx) for the feature design and routing-key contract.

--- a/examples/tinker/session_based_routing/run_tinker_server.sh
+++ b/examples/tinker/session_based_routing/run_tinker_server.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEFAULT_BACKEND_CONFIG='{"trainer.placement.colocate_all": true, "trainer.placement.policy_num_gpus_per_node": 4, "trainer.micro_forward_batch_size_per_gpu": 64, "trainer.micro_train_batch_size_per_gpu": 64, "generator.inference_engine.num_engines": 4, "generator.inference_engine.tensor_parallel_size": 1, "generator.inference_engine.backend": "vllm", "generator.inference_engine.run_engines_locally": true, "generator.inference_engine.weight_sync_backend": "nccl", "generator.inference_engine.async_engine": true, "generator.inference_engine.gpu_memory_utilization": 0.8, "generator.batched": true}'
+BACKEND_CONFIG="${BACKEND_CONFIG:-$DEFAULT_BACKEND_CONFIG}"
+
+uv run --extra tinker --extra fsdp -m skyrl.tinker.api \
+  --base-model "Qwen/Qwen2.5-1.5B-Instruct" \
+  --backend fsdp \
+  --port 8000 \
+  --backend-config "$BACKEND_CONFIG" \
+  "$@"

--- a/examples/tinker/session_based_routing/sample_session_routing_demo.py
+++ b/examples/tinker/session_based_routing/sample_session_routing_demo.py
@@ -1,0 +1,161 @@
+"""Demo of explicit ``seq_id`` for trajectory-pinned routing on SkyRL's Tinker API.
+
+Usage:
+    # Terminal 1: start a SkyRL Tinker API server with the SkyRL-Train backend
+    bash examples/tinker/session_based_routing/run_tinker_server.sh
+
+    # Terminal 2
+    TINKER_API_KEY=tml-dummy uv run --extra tinker --with torch --with transformers \\
+        python examples/tinker/session_based_routing/sample_session_routing_demo.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import time
+
+import tinker
+from tinker import types
+from tinker.lib.api_future_impl import _APIFuture
+from tinker.lib.client_connection_pool_type import ClientConnectionPoolType
+from transformers import AutoTokenizer
+
+
+DEFAULT_BASE_URL = "http://localhost:8000"
+DEFAULT_MODEL = "Qwen/Qwen2.5-1.5B-Instruct"
+MAX_TOKENS_PER_TURN = 32
+logger = logging.getLogger("sample_session_routing_demo")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    p.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    p.add_argument("--api-key", default=os.environ.get("TINKER_API_KEY", "tml-dummy"))
+    p.add_argument("--model", default=DEFAULT_MODEL)
+    p.add_argument("--num-trajectories", type=int, default=4)
+    p.add_argument("--turns", type=int, default=3)
+    p.add_argument("--seed", type=int, default=0)
+    return p.parse_args()
+
+
+async def asample_explicit(
+    holder,
+    *,
+    sampling_session_id: str,
+    seq_id: int,
+    prompt: types.ModelInput,
+    sampling_params: types.SamplingParams,
+) -> types.SampleResponse:
+    """Submit one /api/v1/asample with caller-controlled ``sampling_session_id`` + ``seq_id``.
+
+    ``SamplingClient.sample`` does not expose ``seq_id``, so the demo builds the
+    raw ``SampleRequest`` and dispatches via ``client.sampling.asample`` directly.
+    """
+    request = types.SampleRequest(
+        sampling_session_id=sampling_session_id,
+        seq_id=seq_id,
+        num_samples=1,
+        prompt=prompt,
+        sampling_params=sampling_params,
+        prompt_logprobs=False,
+        topk_prompt_logprobs=0,
+    )
+    logger.info("dispatch routing-key=%s:%d", sampling_session_id, seq_id)
+
+    start = time.time()
+    with holder.aclient(ClientConnectionPoolType.SAMPLE) as client:
+        untyped_future = await client.sampling.asample(request=request, max_retries=0)
+    return await _APIFuture(
+        types.SampleResponse,
+        holder,
+        untyped_future,
+        request_start_time=start,
+        request_type="Sample",
+    )
+
+
+async def run_trajectory(
+    holder,
+    tokenizer,
+    *,
+    sampling_session_id: str,
+    trajectory_idx: int,
+    num_turns: int,
+    seed: int,
+) -> list[str]:
+    """Multi-turn rollout where every turn reuses ``seq_id=trajectory_idx`` so the
+    whole trajectory lands on the same backend (warm prefix cache)."""
+    chat = [{"role": "user", "content": f"Tell me a one-sentence story about trajectory #{trajectory_idx}."}]
+    outputs: list[str] = []
+    for turn in range(num_turns):
+        prompt_tokens = tokenizer.apply_chat_template(
+            chat, add_generation_prompt=True, tokenize=True, return_dict=False
+        )
+        result = await asample_explicit(
+            holder,
+            sampling_session_id=sampling_session_id,
+            seq_id=trajectory_idx,
+            prompt=types.ModelInput.from_ints(list(prompt_tokens)),
+            sampling_params=types.SamplingParams(
+                max_tokens=MAX_TOKENS_PER_TURN,
+                temperature=0.7,
+                seed=seed + 100 * trajectory_idx + turn,
+            ),
+        )
+        tokens = list(result.sequences[0].tokens)
+        text = tokenizer.decode(tokens, skip_special_tokens=True)
+        outputs.append(text)
+        chat.append({"role": "assistant", "content": text})
+        chat.append({"role": "user", "content": "Continue."})
+    return outputs
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    args = parse_args()
+
+    service_client = tinker.ServiceClient(base_url=args.base_url, api_key=args.api_key)
+    # rank=0 picks the FFT path on the SkyRL-Train backend (no LoRA).
+    training_client = service_client.create_lora_training_client(base_model=args.model, rank=0)
+    sampling_client = training_client.save_weights_and_get_sampling_client(name="routing_demo")
+    # _sampling_session_id is the only way to read the SDK-issued session id at
+    # this version; the public API does not expose it.
+    sampling_session_id: str = sampling_client._sampling_session_id
+    holder = sampling_client.holder
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    logger.info(
+        "base_model=%s sampling_session_id=%s num_trajectories=%d turns=%d",
+        args.model,
+        sampling_session_id,
+        args.num_trajectories,
+        args.turns,
+    )
+
+    try:
+        # The SDK's holder owns its own event loop; submit onto it and block.
+        futures = [
+            holder.run_coroutine_threadsafe(
+                run_trajectory(
+                    holder,
+                    tokenizer,
+                    sampling_session_id=sampling_session_id,
+                    trajectory_idx=i,
+                    num_turns=args.turns,
+                    seed=args.seed,
+                )
+            ).future()
+            for i in range(args.num_trajectories)
+        ]
+        results = [f.result() for f in futures]
+    finally:
+        service_client.holder.close()
+
+    for i, turns in enumerate(results):
+        logger.info("trajectory=%d turns=%d first_turn=%r", i, len(turns), turns[0][:80] if turns else "")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# What does this PR do?


Adds an example client under `examples/tinker/session_based_routing/` that exercises the deterministic sampling-session routing: builds `tinker.types.SampleRequest` with caller-controlled `sampling_session_id` + `seq_id` and dispatches via `client.sampling.asample` so multi-turn trajectories pin to one inference backend (warm prefix cache). Also adds a Tinker docs page.