### PR TITLE
[megatron] make `empty_cuda_cache` default true for megatron

### DIFF
--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -188,7 +188,7 @@ class MegatronConfig(BaseConfig):
     transformer_config_kwargs: Dict[str, Any] = field(
         default_factory=lambda: copy.deepcopy(DEFAULT_TRANSFORMER_CONFIG_KWARGS)
     )
-    empty_cuda_cache: Optional[bool] = None
+    empty_cuda_cache: Optional[bool] = True
     model_config_kwargs: dict = field(default_factory=dict)
     dist_ckpt_optim_fully_reshardable: bool = False
     freeze_moe_router: bool = False


### PR DESCRIPTION
This was originally added in #716, but was set to None by default during the config refactoring: https://github.com/NovaSky-AI/SkyRL/commit/d1e1b297717195f9b54cb36f68c79d6aa406baed

Setting back to true, as this can help with unnecessary OOMs during optim step.