### PR TITLE
fix: release slot on CancelledError instead of hard-exit at epoch boundaries

### DIFF
--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -193,6 +193,8 @@ class _AsyncStalenessManager:
         This is expected at epoch boundaries when the trainer cancels in-flight workers.
         """
         async with self._cond:
+            assert self._stat.submitted > 0, f"Cannot decrement submitted count below zero (current: {self._stat.submitted})"
+            assert self._stat.running > 0, f"Cannot decrement running count below zero (current: {self._stat.running})"
             self._stat.submitted -= 1
             self._stat.running -= 1
             self._cond.notify_all()

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -193,7 +193,9 @@ class _AsyncStalenessManager:
         This is expected at epoch boundaries when the trainer cancels in-flight workers.
         """
         async with self._cond:
-            assert self._stat.submitted > 0, f"Cannot decrement submitted count below zero (current: {self._stat.submitted})"
+            assert (
+                self._stat.submitted > 0
+            ), f"Cannot decrement submitted count below zero (current: {self._stat.submitted})"
             assert self._stat.running > 0, f"Cannot decrement running count below zero (current: {self._stat.running})"
             self._stat.submitted -= 1
             self._stat.running -= 1

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -187,6 +187,16 @@ class _AsyncStalenessManager:
             self._stat.running -= 1
             self._cond.notify_all()
 
+    async def on_submission_cancelled(self) -> None:
+        """Undo acquire_submission_slot() when a worker is cancelled before completing generation.
+
+        This is expected at epoch boundaries when the trainer cancels in-flight workers.
+        """
+        async with self._cond:
+            self._stat.submitted -= 1
+            self._stat.running -= 1
+            self._cond.notify_all()
+
     async def notify_capacity_change(self, new_global_step: int) -> None:
         # Called when current_global_step changes (e.g., after a training step)
         async with self._cond:
@@ -606,8 +616,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 slot_acquired = False
         except asyncio.CancelledError:
             if "slot_acquired" in locals() and slot_acquired:
-                logger.error("Generation worker cancelled mid-flight (slot acquired). Exiting.")
-                os._exit(1)
+                await self._staleness_manager.on_submission_cancelled()
             return
         except Exception as e:
             logger.error(f"Generator worker errored out with exception: {e}")


### PR DESCRIPTION
## Summary

At epoch boundaries, the trainer cancels in-flight generation workers via `task.cancel()`. Workers that have already acquired a submission slot (`slot_acquired=True`) receive `CancelledError` — this is expected behavior during normal epoch transitions, not a fatal error.

Previously (#1691), `os._exit(1)` was called in this case, which killed the entire process during normal epoch transitions and prevented proper error log propagation.

## Changes

- Add `on_submission_cancelled()` to `_AsyncStalenessManager` that properly undoes `acquire_submission_slot()` by decrementing both `submitted` and `running` counters
- Replace `os._exit(1)` in the `CancelledError` handler with `on_submission_cancelled()` + return
- The `os._exit(1)` in the `Exception` handler (for `EngineDeadError` and other real errors) remains unchanged

## Why

`acquire_submission_slot()` increments both `submitted` and `running`. When a worker is cancelled mid-flight:
- `on_rollout_rejected()` only decrements `running`, leaving `submitted != accepted` at epoch end
- `os._exit(1)` kills the process entirely (too aggressive for normal behavior)
- `on_submission_cancelled()` correctly undoes both increments, so `validate_state_at_epoch_end` passes

## Test plan

- Verify multi-epoch training completes without premature exit
- Verify `validate_state_at_epoch_end` assertions pass at epoch boundaries
- Verify `EngineDeadError` still triggers `os._exit(1)` (Exception handler unchanged)