### PR TITLE
[docs] Fix prod build: alias unknown `promql` Shiki grammar to text

### DIFF
--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
+import { rehypeCodeDefaultOptions } from 'fumadocs-core/mdx-plugins';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 
@@ -11,5 +12,14 @@ export default defineConfig({
     remarkPlugins: [remarkMath],
     // rehypeKatex must run before shiki to process math blocks first
     rehypePlugins: (v) => [rehypeKatex, ...v],
+    rehypeCodeOptions: {
+      ...rehypeCodeDefaultOptions,
+      // Shiki ships no `promql` grammar; alias it to `text` so PromQL code
+      // fences render (unhighlighted) instead of failing `next build`.
+      langAlias: {
+        ...rehypeCodeDefaultOptions.langAlias,
+        promql: 'text',
+      },
+    },
   },
 });


### PR DESCRIPTION
The vllm-metrics doc (#1662) uses a ```promql code fence, but Shiki ships no `promql` grammar, so `next build` aborts with a ShikiError and the Vercel docs deploy fails. Alias `promql` to `text` in the rehype-code options (spreading Fumadocs' defaults so themes/transformers are kept) so the fence renders unhighlighted instead of breaking the build.