### PR TITLE
[docs] Fix prod build: use `text` instead of unknown `promql` code fence

### DIFF
--- a/docs/content/docs/checkpointing-logging/vllm-metrics.mdx
+++ b/docs/content/docs/checkpointing-logging/vllm-metrics.mdx
@@ -96,7 +96,7 @@ stats to be enabled, and are sampled at 1% of blocks via
 Because it's a histogram, query it with `histogram_quantile` over the bucket
 rate — e.g. p95 block lifetime over a 5m window:
 
-```promql
+```text
 # p95 KV block lifetime
 histogram_quantile(
   0.95,


### PR DESCRIPTION
The vllm-metrics doc (#1662) uses a ```promql code fence, but Shiki ships no `promql` grammar, so `next build` aborts with a ShikiError and the Vercel docs deploy fails. Switch the fence to ```text so it renders unhighlighted instead of breaking the build.