### PR TITLE
Fix FSDP Tinker backend crash on model creation

### DIFF
--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -278,12 +278,10 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
 
             # Multi-tenant: per-adapter subdir + per-adapter vLLM name.
             # Single-tenant (model_id=None) keeps the legacy shared path +
-            # name. basename guards against a malformed model_id escaping
-            # lora_sync_path even though api.py already validates IDs.
-            base_sync_path = self.cfg.policy.model.lora.lora_sync_path
-            safe_model_id = os.path.basename(model_id) if model_id is not None else None
-            lora_name = safe_model_id if safe_model_id else SKYRL_LORA_ADAPTER_NAME
-            lora_sync_path = os.path.join(base_sync_path, safe_model_id) if safe_model_id else base_sync_path
+            # name. _resolve_lora_sync_target (shared with Megatron, defined on
+            # PolicyWorkerBase) basename-guards against a malformed model_id
+            # escaping lora_sync_path even though api.py already validates IDs.
+            lora_name, lora_sync_path = self._resolve_lora_sync_target(model_id)
             await self._save_lora_adapters_and_sync(
                 peft_model, lora_sync_path, inference_engine_client, lora_name=lora_name
             )

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1095,19 +1095,6 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             raise RuntimeError("register_adapter called before register_pristine_adapter")
         self.adapter_store.create(model_id, self.actor_module, self.optimizer, signature)
 
-    def _resolve_lora_sync_target(self, model_id: Optional[str]) -> tuple[str, str]:
-        """Return ``(lora_name, lora_sync_path)`` for a given Tinker model_id.
-
-        The single-tenant fallback (``model_id=None``) uses the default
-        shared adapter name + shared sync path. Multi-tenant routes through
-        ``os.path.basename`` on the lora_sync_path.
-        """
-        base_sync_path = self.cfg.policy.model.lora.lora_sync_path
-        safe_model_id = os.path.basename(model_id) if model_id is not None else None
-        if safe_model_id:
-            return safe_model_id, os.path.join(base_sync_path, safe_model_id)
-        return SKYRL_LORA_ADAPTER_NAME, base_sync_path
-
     def delete_adapter(self, model_id: str) -> None:
         if self.adapter_store is None:
             raise RuntimeError("AdapterStore not initialised (FFT path)")

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -1124,6 +1124,83 @@ class PolicyWorkerBase(Worker):
         output.metadata = micro_batch.metadata
         return output
 
+    # ------------------------------------------------------------------
+    # Multi-LoRA / adapter-store interface
+    #
+    # These methods back the Tinker multi-tenant LoRA path, where a single set
+    # of policy workers hosts several LoRA adapters and swaps the live one in
+    # and out of the GPU-resident model + optimizer. The full implementation
+    # (an ``AdapterStore``) currently lives in the Megatron policy worker. The
+    # base class provides:
+    #   * a shared, backend-agnostic helper (``_resolve_lora_sync_target``),
+    #   * safe no-ops for the dispatch hot path on backends without an adapter
+    #     store (``swap_to_adapter``, ``adapter_store_state``), and
+    #   * ``NotImplementedError`` stubs for the adapter-store lifecycle so that
+    #     unsupported backends (currently FSDP) fail loudly and clearly rather
+    #     than with an opaque ``AttributeError`` from the Ray dispatch layer.
+    # ------------------------------------------------------------------
+
+    def _resolve_lora_sync_target(self, model_id: Optional[str]) -> tuple[str, str]:
+        """Return ``(lora_name, lora_sync_path)`` for a given Tinker ``model_id``.
+
+        The single-tenant fallback (``model_id is None``) uses the default
+        shared adapter name + shared sync path. Multi-tenant routes through
+        ``os.path.basename`` on ``lora_sync_path`` so each adapter is written to
+        its own subdir and registered on the inference engine under that name.
+
+        Shared by the FSDP and Megatron policy workers.
+        """
+        from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
+            SKYRL_LORA_ADAPTER_NAME,
+        )
+
+        base_sync_path = self.cfg.policy.model.lora.lora_sync_path
+        safe_model_id = os.path.basename(model_id) if model_id is not None else None
+        if safe_model_id:
+            return safe_model_id, os.path.join(base_sync_path, safe_model_id)
+        return SKYRL_LORA_ADAPTER_NAME, base_sync_path
+
+    def swap_to_adapter(self, model_id: str) -> None:
+        """Make ``model_id`` the live LoRA adapter on this worker.
+
+        No-op on backends without an adapter store (e.g. FSDP) and on the FFT
+        path: there is only ever one set of live weights, so there is nothing
+        to swap. The dispatch layer calls this before every forward / optim
+        step with the request's ``model_id``, so it must stay cheap and must
+        not raise on the single-tenant path.
+        """
+        return None
+
+    def adapter_store_state(self) -> dict:
+        """Diagnostic snapshot of the adapter store. Backends without an
+        adapter store report it as disabled."""
+        return {"enabled": False}
+
+    def _adapter_store_unsupported(self, op: str) -> None:
+        raise NotImplementedError(
+            f"{type(self).__name__}.{op} is not implemented: multi-tenant LoRA "
+            "adapter management (the adapter store) is currently only supported "
+            "on the Megatron backend. The FSDP backend supports a single LoRA "
+            "adapter (or full fine-tuning) per worker group."
+        )
+
+    def prime_optimizer_state(self) -> None:
+        """Materialise optimizer state so it can be snapshotted into the
+        pristine adapter slot. Only meaningful for adapter-store backends."""
+        self._adapter_store_unsupported("prime_optimizer_state")
+
+    def register_pristine_adapter(self) -> None:
+        """Capture the freshly-initialised LoRA state as the pristine slot."""
+        self._adapter_store_unsupported("register_pristine_adapter")
+
+    def register_adapter(self, model_id: str) -> None:
+        """Register a new LoRA adapter slot keyed by ``model_id``."""
+        self._adapter_store_unsupported("register_adapter")
+
+    def delete_adapter(self, model_id: str) -> None:
+        """Remove the LoRA adapter slot keyed by ``model_id``."""
+        self._adapter_store_unsupported("delete_adapter")
+
 
 class CriticWorkerBase(Worker):
     def __init__(self, **kwargs):

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -1126,18 +1126,6 @@ class PolicyWorkerBase(Worker):
 
     # ------------------------------------------------------------------
     # Multi-LoRA / adapter-store interface
-    #
-    # These methods back the Tinker multi-tenant LoRA path, where a single set
-    # of policy workers hosts several LoRA adapters and swaps the live one in
-    # and out of the GPU-resident model + optimizer. The full implementation
-    # (an ``AdapterStore``) currently lives in the Megatron policy worker. The
-    # base class provides:
-    #   * a shared, backend-agnostic helper (``_resolve_lora_sync_target``),
-    #   * safe no-ops for the dispatch hot path on backends without an adapter
-    #     store (``swap_to_adapter``, ``adapter_store_state``), and
-    #   * ``NotImplementedError`` stubs for the adapter-store lifecycle so that
-    #     unsupported backends (currently FSDP) fail loudly and clearly rather
-    #     than with an opaque ``AttributeError`` from the Ray dispatch layer.
     # ------------------------------------------------------------------
 
     def _resolve_lora_sync_target(self, model_id: Optional[str]) -> tuple[str, str]:
@@ -1147,8 +1135,6 @@ class PolicyWorkerBase(Worker):
         shared adapter name + shared sync path. Multi-tenant routes through
         ``os.path.basename`` on ``lora_sync_path`` so each adapter is written to
         its own subdir and registered on the inference engine under that name.
-
-        Shared by the FSDP and Megatron policy workers.
         """
         from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
             SKYRL_LORA_ADAPTER_NAME,
@@ -1161,14 +1147,7 @@ class PolicyWorkerBase(Worker):
         return SKYRL_LORA_ADAPTER_NAME, base_sync_path
 
     def swap_to_adapter(self, model_id: str) -> None:
-        """Make ``model_id`` the live LoRA adapter on this worker.
-
-        No-op on backends without an adapter store (e.g. FSDP) and on the FFT
-        path: there is only ever one set of live weights, so there is nothing
-        to swap. The dispatch layer calls this before every forward / optim
-        step with the request's ``model_id``, so it must stay cheap and must
-        not raise on the single-tenant path.
-        """
+        """Make ``model_id`` the live LoRA adapter on this worker."""
         return None
 
     def adapter_store_state(self) -> dict:

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -260,11 +260,19 @@ class SkyRLTrainBackend(AbstractBackend):
         )
         ray.get(policy_model.async_run_ray_method("pass_through", "_set_pad_token_id", self._tokenizer.pad_token_id))
 
-        if is_lora:
-            # For multi-tenant LoRA training: prime DistributedOptimizer state and snapshot
-            # the freshly-initialised LoRA into a per-worker pristine slot, then
-            # register the first adapter under `model_id`. Must happen while the
-            # model + optimizer are still GPU-resident (i.e. before the offload).
+        if is_lora and cfg.trainer.strategy == "megatron":
+            # Multi-tenant LoRA training via the worker-side AdapterStore is
+            # currently only implemented for the Megatron backend: prime
+            # DistributedOptimizer state and snapshot the freshly-initialised
+            # LoRA into a per-worker pristine slot, then register the first
+            # adapter under `model_id`. Must happen while the model + optimizer
+            # are still GPU-resident (i.e. before the offload).
+            #
+            # FSDP serves single-tenant LoRA by syncing the live adapter
+            # directly (FSDPPolicyWorkerBase.broadcast_to_inference_engines) and
+            # needs no priming/pristine snapshot. Registering a *second* FSDP
+            # adapter routes through `register_adapter` below, which raises a
+            # clear NotImplementedError (multi-tenant LoRA is Megatron-only).
             ray.get(policy_model.async_run_ray_method("pass_through", "prime_optimizer_state"))
             ray.get(policy_model.async_run_ray_method("pass_through", "register_pristine_adapter"))
             ray.get(policy_model.async_run_ray_method("pass_through", "register_adapter", model_id))

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -261,18 +261,11 @@ class SkyRLTrainBackend(AbstractBackend):
         ray.get(policy_model.async_run_ray_method("pass_through", "_set_pad_token_id", self._tokenizer.pad_token_id))
 
         if is_lora and cfg.trainer.strategy == "megatron":
-            # Multi-tenant LoRA training via the worker-side AdapterStore is
-            # currently only implemented for the Megatron backend: prime
-            # DistributedOptimizer state and snapshot the freshly-initialised
-            # LoRA into a per-worker pristine slot, then register the first
-            # adapter under `model_id`. Must happen while the model + optimizer
-            # are still GPU-resident (i.e. before the offload).
-            #
-            # FSDP serves single-tenant LoRA by syncing the live adapter
-            # directly (FSDPPolicyWorkerBase.broadcast_to_inference_engines) and
-            # needs no priming/pristine snapshot. Registering a *second* FSDP
-            # adapter routes through `register_adapter` below, which raises a
-            # clear NotImplementedError (multi-tenant LoRA is Megatron-only).
+            # For multi-tenant LoRA training: prime DistributedOptimizer state and snapshot
+            # the freshly-initialised LoRA into a per-worker pristine slot, then
+            # register the first adapter under `model_id`. Must happen while the
+            # model + optimizer are still GPU-resident (i.e. before the offload).
+            # currently, this is only supported for megatron backend
             ray.get(policy_model.async_run_ray_method("pass_through", "prime_optimizer_state"))
             ray.get(policy_model.async_run_ray_method("pass_through", "register_pristine_adapter"))
             ray.get(policy_model.async_run_ray_method("pass_through", "register_adapter", model_id))

--- a/tests/tinker/skyrl_train/test_fsdp_tinker.py
+++ b/tests/tinker/skyrl_train/test_fsdp_tinker.py
@@ -174,9 +174,7 @@ def _sum_loss(out) -> float:
 
 
 def test_forward_backward_optim_step_improves_loss(training_client):
-    """The core regression test for issue #1717: creating an FSDP-backed LoRA
-    training client and running forward_backward + optim_step must work end to
-    end (previously crashed with AttributeError: 'prime_optimizer_state').
+    """Test that creating an FSDP-backed LoRA training client and running forward_backward + optim_step works.
 
     Single-step convergence on a fixed micro-batch with a tiny model + a
     nontrivial LR is a reliable signal that gradients flow and the optimizer
@@ -211,25 +209,16 @@ def test_forward_only_returns_logprobs(training_client):
 
 
 def test_second_adapter_rejected(training_client, service_client):
-    """Creating a second adapter against the same FSDP server is rejected.
-
-    Multi-tenant LoRA needs the worker-side AdapterStore, which is Megatron-only;
-    the FSDP worker's ``register_adapter`` raises NotImplementedError. The
-    failure is surfaced to the client as an API error referencing the
-    limitation. (Depends on ``training_client`` so the first adapter exists.)
-    """
+    """Test that creating a second adapter against the same FSDP server is rejected."""
     with pytest.raises(Exception) as exc:
         service_client.create_lora_training_client(base_model=BASE_MODEL, rank=8)
     msg = str(exc.value).lower()
-    assert "not implemented" in msg or "megatron" in msg or "single lora" in msg, msg
+    assert "not implemented" in msg
 
 
 @pytest.mark.skipif(cuda_device_count < 2, reason="sampling brings up a separate vLLM engine (needs a 2nd GPU)")
 def test_sample_after_training(training_client):
-    """Weight-sync the trained adapter to vLLM and greedy-sample. With
-    temperature=0 + a fixed seed the generated tokens are deterministic, so a
-    non-empty, stable sequence confirms the FSDP LoRA -> vLLM sync path works.
-    """
+    """Test that weight-sync the trained adapter to vLLM and greedy-sample works."""
     tok = training_client.get_tokenizer()
     data = [_make_datum(tok, "Question: 1+1?\nAnswer:", " 2")]
 

--- a/tests/tinker/skyrl_train/test_fsdp_tinker.py
+++ b/tests/tinker/skyrl_train/test_fsdp_tinker.py
@@ -1,0 +1,248 @@
+"""End-to-end smoke tests against a Tinker server backed by SkyRL-Train FSDP.
+
+GPU-gated: skipped automatically when no CUDA device is visible to the test
+process. The server starts a real FSDP policy worker, which means tests in this
+module need at least one GPU and the ``tinker`` + ``fsdp`` extras installed. The
+sampling test additionally brings up a vLLM engine (non-colocated), so a second
+GPU is required for it.
+
+Scope: this mirrors ``test_multi_lora_megatron.py`` but exercises only the
+*single-adapter* (non multi-LoRA) path on FSDP — multi-tenant LoRA / the
+worker-side AdapterStore is currently Megatron-only and the FSDP worker raises
+a clear ``NotImplementedError`` for it. FSDP therefore supports exactly one
+adapter for the lifetime of a server, so every test shares one module-scoped
+training client. These tests confirm that initialising an FSDP Tinker engine
+and sending basic requests works:
+
+  - test_forward_backward_optim_step_improves_loss: the adapter trains; loss on
+    a fixed micro-batch decreases after an optim step.
+  - test_forward_only_returns_logprobs: a forward-only pass returns per-token
+    logprobs + elementwise loss without mutating optimizer state.
+  - test_second_adapter_rejected: creating a second adapter is rejected with a
+    clear NotImplementedError (multi-tenant LoRA is Megatron-only for now).
+  - test_sample_after_training: weight-sync to vLLM + greedy sampling returns a
+    deterministic token sequence.
+
+Run with:
+  uv run --extra tinker --extra fsdp --with pytest --with pytest-timeout \\
+    pytest -s tests/tinker/skyrl_train/test_fsdp_tinker.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from contextlib import contextmanager
+
+import pytest
+
+cuda_available = False
+cuda_device_count = 0
+try:  # pragma: no cover - import guard
+    import torch
+
+    cuda_device_count = torch.cuda.device_count() if torch.cuda.is_available() else 0
+    cuda_available = cuda_device_count > 0
+except Exception:
+    cuda_available = False
+
+pytestmark = pytest.mark.skipif(not cuda_available, reason="FSDP Tinker tests require at least one CUDA GPU")
+
+tinker = pytest.importorskip("tinker")
+from tinker import types as tinker_types  # noqa: E402
+
+from tests.tinker.conftest import wait_for_condition  # noqa: E402
+
+BASE_MODEL = "trl-internal-testing/tiny-Qwen3ForCausalLM"
+TINKER_API_KEY = "tml-dummy"
+TEST_PORT = 8012
+
+# Tiny config: 1 GPU for the FSDP policy worker, 1 for vLLM (non-colocated).
+# With a tiny model + LoRA rank 8 this fits comfortably on any modern GPU pair.
+# FSDP always serves LoRA adapters by name (it never merges), so the single
+# adapter created here is reachable for sampling. max_loras > 1 keeps vLLM's
+# LoRA slots warm even though we only register one adapter.
+BACKEND_CONFIG = {
+    "strategy": "fsdp",
+    "trainer.placement.policy_num_gpus_per_node": 1,
+    "trainer.placement.policy_num_nodes": 1,
+    "trainer.placement.colocate_all": False,
+    "trainer.policy.model.lora.max_loras": 4,
+    "trainer.policy.model.lora.max_cpu_loras": 4,
+}
+
+
+@contextmanager
+def _api_server(port: int, backend_config: dict | None = None):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        log_path = os.path.join(tmp_dir, "server.log")
+        db_path = os.path.join(tmp_dir, "server.db")
+        cfg = dict(backend_config or BACKEND_CONFIG)
+        cmd = [
+            "uv",
+            "run",
+            "--extra",
+            "tinker",
+            "--extra",
+            "fsdp",
+            "-m",
+            "skyrl.tinker.api",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(port),
+            "--base-model",
+            BASE_MODEL,
+            "--backend",
+            "fsdp",
+            "--backend-config",
+            json.dumps(cfg),
+            "--database-url",
+            f"sqlite:///{db_path}",
+        ]
+        with open(log_path, "w") as log_file:
+            proc = subprocess.Popen(cmd, stdout=log_file, stderr=log_file)
+            try:
+                ok = wait_for_condition(
+                    lambda: _server_is_up(port),
+                    timeout_sec=120,
+                    poll_interval_sec=2,
+                )
+                if not ok:
+                    with open(log_path) as f:
+                        print(f"=== Server failed to start ===\n{f.read()}")
+                    pytest.fail("Tinker API server did not come up in time")
+                yield proc
+            finally:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+
+
+def _server_is_up(port: int) -> bool:
+    import urllib.error
+    import urllib.request
+
+    try:
+        urllib.request.urlopen(f"http://0.0.0.0:{port}/api/v1/healthz", timeout=2).read()
+        return True
+    except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError, TimeoutError):
+        return False
+
+
+def _make_datum(tokenizer, prompt: str, completion: str):
+    prompt_tokens = tokenizer.encode(prompt, add_special_tokens=True)
+    completion_tokens = tokenizer.encode(f"{completion}\n\n", add_special_tokens=False)
+    all_tokens = prompt_tokens + completion_tokens
+    target_tokens = all_tokens[1:] + [tokenizer.eos_token_id]
+    weights = [0.0] * len(prompt_tokens) + [1.0] * len(completion_tokens)
+    return tinker_types.Datum(
+        model_input=tinker_types.ModelInput.from_ints(all_tokens),
+        loss_fn_inputs={"target_tokens": target_tokens, "weights": weights[1:] + [1.0]},
+    )
+
+
+@pytest.fixture(scope="module")
+def server():
+    with _api_server(TEST_PORT) as proc:
+        yield proc
+
+
+@pytest.fixture
+def service_client(server):
+    return tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
+
+
+@pytest.fixture(scope="module")
+def training_client(server):
+    """A single LoRA training client shared by every test.
+
+    FSDP supports exactly one adapter per server (multi-tenant LoRA is
+    Megatron-only), so all tests must reuse the same client. Tests are additive
+    (each mutates the shared adapter) but their assertions are self-contained.
+    """
+    sc = tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
+    return sc.create_lora_training_client(base_model=BASE_MODEL, rank=8)
+
+
+def _sum_loss(out) -> float:
+    return sum(sum(o["elementwise_loss"].data) for o in out.loss_fn_outputs)
+
+
+def test_forward_backward_optim_step_improves_loss(training_client):
+    """The core regression test for issue #1717: creating an FSDP-backed LoRA
+    training client and running forward_backward + optim_step must work end to
+    end (previously crashed with AttributeError: 'prime_optimizer_state').
+
+    Single-step convergence on a fixed micro-batch with a tiny model + a
+    nontrivial LR is a reliable signal that gradients flow and the optimizer
+    actually updates the adapter.
+    """
+    tok = training_client.get_tokenizer()
+    data = [_make_datum(tok, "Question: 1+1?\nAnswer:", " 2")]
+
+    # Prime once (allocates optimizer state), then measure pre/post-step loss.
+    training_client.forward_backward(data, "cross_entropy").result()
+    training_client.optim_step(tinker_types.AdamParams(learning_rate=1e-3)).result()
+
+    pre = _sum_loss(training_client.forward_backward(data, "cross_entropy").result())
+    training_client.optim_step(tinker_types.AdamParams(learning_rate=1e-3)).result()
+    post = _sum_loss(training_client.forward_backward(data, "cross_entropy").result())
+
+    assert post <= pre + 1e-3, f"loss did not improve after an optim step (pre={pre}, post={post})"
+
+
+def test_forward_only_returns_logprobs(training_client):
+    """A forward-only pass returns per-token logprobs and does not require an
+    optimizer step. (The forward endpoint emits ``logprobs``; the
+    ``elementwise_loss`` shape is specific to forward_backward.)"""
+    tok = training_client.get_tokenizer()
+    data = [_make_datum(tok, "Question: 2+2?\nAnswer:", " 4")]
+
+    out = training_client.forward(data, "cross_entropy").result()
+    assert len(out.loss_fn_outputs) == 1
+    logprobs = out.loss_fn_outputs[0]["logprobs"].data
+    assert len(logprobs) > 0
+    assert all(isinstance(x, float) for x in logprobs)
+
+
+def test_second_adapter_rejected(training_client, service_client):
+    """Creating a second adapter against the same FSDP server is rejected.
+
+    Multi-tenant LoRA needs the worker-side AdapterStore, which is Megatron-only;
+    the FSDP worker's ``register_adapter`` raises NotImplementedError. The
+    failure is surfaced to the client as an API error referencing the
+    limitation. (Depends on ``training_client`` so the first adapter exists.)
+    """
+    with pytest.raises(Exception) as exc:
+        service_client.create_lora_training_client(base_model=BASE_MODEL, rank=8)
+    msg = str(exc.value).lower()
+    assert "not implemented" in msg or "megatron" in msg or "single lora" in msg, msg
+
+
+@pytest.mark.skipif(cuda_device_count < 2, reason="sampling brings up a separate vLLM engine (needs a 2nd GPU)")
+def test_sample_after_training(training_client):
+    """Weight-sync the trained adapter to vLLM and greedy-sample. With
+    temperature=0 + a fixed seed the generated tokens are deterministic, so a
+    non-empty, stable sequence confirms the FSDP LoRA -> vLLM sync path works.
+    """
+    tok = training_client.get_tokenizer()
+    data = [_make_datum(tok, "Question: 1+1?\nAnswer:", " 2")]
+
+    for _ in range(2):
+        training_client.forward_backward(data, "cross_entropy").result()
+        training_client.optim_step(tinker_types.AdamParams(learning_rate=1e-3)).result()
+
+    sampler = training_client.save_weights_and_get_sampling_client(name="fsdp_smoke")
+    prompt_ids = tok.encode("Question: 2+2?\nAnswer:", add_special_tokens=True)
+    out = sampler.sample(
+        prompt=tinker_types.ModelInput.from_ints(prompt_ids),
+        num_samples=1,
+        sampling_params=tinker_types.SamplingParams(max_tokens=8, temperature=0.0, top_k=1, seed=0),
+    ).result()
+    tokens = list(out.sequences[0].tokens)
+    assert len(tokens) > 0, "expected at least one sampled token from the FSDP-synced adapter"


### PR DESCRIPTION

## Problem

  Creating a model against the FSDP Tinker backend crashed with:

  AttributeError: 'ActorHandle' object has no attribute 'prime_optimizer_state'

  `SkyRLTrainBackend._build_policy` calls `prime_optimizer_state` / `register_pristine_adapter` / `register_adapter` on the policy worker for *every* LoRA model. Those methods only existed on the Megatron worker (which owns an `AdapterStore`).
  Because the Tinker SDK only exposes `create_lora_training_client`, even a single-adapter FSDP run hit the missing methods and failed during `create_model` (e.g. the cookbook `sl_loop` recipe in #1717).

  ## Changes

  - **Lift the multi-LoRA / adapter-store interface to `PolicyWorkerBase`** (`workers/worker.py`):
    - `_resolve_lora_sync_target()` — the `(lora_name, lora_sync_path)` resolver, previously duplicated in both backends, now lives once in the base.
    - `swap_to_adapter()` / `adapter_store_state()` — safe no-ops by default. The dispatch hot path calls `swap_to_adapter` before every forward/optim step with the request's `model_id`, so it must not raise on the single-tenant/FFT path.
    - `prime_optimizer_state` / `register_pristine_adapter` / `register_adapter` / `delete_adapter` — raise a clear `NotImplementedError` (via a shared `_adapter_store_unsupported` helper) instead of surfacing an opaque `AttributeError` from the
  Ray dispatch layer.
  - **Megatron worker** keeps its real `AdapterStore` overrides; its duplicated `_resolve_lora_sync_target` is removed in favor of the inherited one.
  - **FSDP worker** `broadcast_to_inference_engines` now uses the lifted `_resolve_lora_sync_target` instead of inlining the path logic.
  - **`skyrl_train_backend.py`** — gate the `_build_policy` adapter-store priming to `strategy == "megatron"`. Single-tenant FSDP LoRA works (it syncs the live adapter directly via `broadcast_to_inference_engines`); registering a *second* FSDP adapter routes through `register_adapter` → clear `NotImplementedError`.

  ## Scope
Multi-tenant LoRA (the worker-side `AdapterStore`) remains **Megatron-only**. This PR makes the FSDP backend work end-to-end for a single adapter and fail loudly (not cryptically) when multi-tenant LoRA is requested. Full FSDP multi-LoRA support is future work.

  ## Tests

  New GPU-gated `tests/tinker/skyrl_train/test_fsdp_tinker.py`, modeled on `test_multi_lora_megatron.py`. It boots a real FSDP-backed Tinker server and verifies:

  - `forward_backward` + `optim_step` train the adapter (loss decreases) — the direct regression test for #1717
  - forward-only pass returns per-token logprobs
  - a second adapter is rejected with the clear `NotImplementedError`
  - weight-sync to vLLM + greedy sampling returns a deterministic sequence

```bash
  uv run --extra tinker --extra fsdp --with pytest --with pytest-timeout
    pytest -s tests/tinker/skyrl_train/test_fsdp_tinker.py
```