### PR TITLE
Avoid dense packed logits in Megatron logprobs

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -12,13 +12,13 @@ from omegaconf import OmegaConf
 from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
     get_model_config,
     make_batch_generator,
-    postprocess_packed_seqs,
     preprocess_packed_seqs,
     recover_left_padding,
     remove_left_padding,
 )
 from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
     from_parallel_logits_to_logprobs,
+    from_parallel_logits_to_logprobs_packed_sequences,
     vocab_parallel_entropy,
 )
 from skyrl.backends.skyrl_train.utils.ppo_utils import (
@@ -31,6 +31,24 @@ from skyrl.backends.skyrl_train.utils.replay_utils import (
 )
 from skyrl.backends.skyrl_train.utils.torch_utils import masked_mean
 from skyrl.train.config import TrainerConfig
+
+
+def _build_packed_targets(
+    sequences: torch.Tensor,
+    attention_mask: torch.Tensor,
+    packed_seq_params,
+) -> torch.Tensor:
+    """Pack full target token IDs without context-parallel sharding."""
+    cu_padded_cpu = packed_seq_params.cu_seqlens_q_padded.tolist()
+    seq_lens_cpu = attention_mask.sum(dim=1, dtype=torch.int32).cpu().tolist()
+    total_padded_tokens = cu_padded_cpu[-1]
+
+    targets = torch.zeros(total_padded_tokens, dtype=sequences.dtype, device=sequences.device)
+    for i, seq_len in enumerate(seq_lens_cpu):
+        start = cu_padded_cpu[i]
+        if seq_len > 0:
+            targets[start : start + seq_len] = sequences[i, attention_mask[i]]
+    return targets.unsqueeze(0)
 
 
 class MegatronModelWrapper:
@@ -90,22 +108,38 @@ class MegatronModelWrapper:
 
         def collection_func(logits, data):
             sequences = data["sequences"]
+            packed_seq_params = data.get("packed_seq_params")
+            packed_targets = data.get("packed_targets")
             tp_grp = mpu.get_tensor_model_parallel_group()
             tp_rank = mpu.get_tensor_model_parallel_rank()
 
             if temperature != 1.0:
                 logits.div_(temperature)
 
-            token_logprobs = from_parallel_logits_to_logprobs(
-                logits,
-                sequences,
-                vocab_start_index=tp_rank * logits.shape[-1],
-                vocab_end_index=(tp_rank + 1) * logits.shape[-1],
-                tp_group=tp_grp,
-                inference_only=True,
-                cp_group=None,  # we handle cp gathering in `postprocess_packed_seqs`
-                chunk_size=self.cfg.logprobs_chunk_size,  # chunk seq dim to bound peak memory
-            )
+            if packed_seq_params is not None:
+                token_logprobs = from_parallel_logits_to_logprobs_packed_sequences(
+                    logits,
+                    packed_targets,
+                    packed_seq_params.cu_seqlens_q_padded,
+                    sequences.shape[1],
+                    vocab_start_index=tp_rank * logits.shape[-1],
+                    vocab_end_index=(tp_rank + 1) * logits.shape[-1],
+                    group=tp_grp,
+                    inference_only=True,
+                    cp_group=mpu.get_context_parallel_group(),
+                    chunk_size=self.cfg.logprobs_chunk_size,
+                )
+            else:
+                token_logprobs = from_parallel_logits_to_logprobs(
+                    logits,
+                    sequences,
+                    vocab_start_index=tp_rank * logits.shape[-1],
+                    vocab_end_index=(tp_rank + 1) * logits.shape[-1],
+                    tp_group=tp_grp,
+                    inference_only=True,
+                    cp_group=None,
+                    chunk_size=self.cfg.logprobs_chunk_size,  # chunk seq dim to bound peak memory
+                )
             return torch.tensor(0.0, device=token_logprobs.device), {"log_probs": token_logprobs}
 
         def forward_step(batch_iter, model):
@@ -130,6 +164,8 @@ class MegatronModelWrapper:
                     attention_mask,
                     pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
                 )
+                batch["packed_seq_params"] = packed_seq_params
+                batch["packed_targets"] = _build_packed_targets(sequences, attention_mask, packed_seq_params)
                 new_attention_mask = None
                 new_position_ids = None
             else:
@@ -148,16 +184,7 @@ class MegatronModelWrapper:
                 packed_seq_params=packed_seq_params,
             )
 
-            if self.remove_microbatch_padding:
-                outputs = postprocess_packed_seqs(
-                    outputs,
-                    packed_seq_params,
-                    attention_mask,
-                    micro_batch_size,
-                    seq_len,
-                    post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
-                )
-            else:
+            if not self.remove_microbatch_padding:
                 outputs = recover_left_padding(
                     outputs,
                     new_attention_mask,
@@ -243,6 +270,8 @@ class MegatronModelWrapper:
 
         def loss_func(logits, data):
             sequences = data["sequences"]
+            packed_seq_params = data.get("packed_seq_params")
+            packed_targets = data.get("packed_targets")
             num_actions = data["num_actions"]
             old_action_log_probs = data["old_action_log_probs"]
             base_action_log_probs = data["base_action_log_probs"]
@@ -260,16 +289,30 @@ class MegatronModelWrapper:
             if temperature != 1.0:
                 logits.div_(temperature)
 
-            token_logprobs = from_parallel_logits_to_logprobs(
-                logits,
-                sequences,
-                vocab_start_index=tp_rank * logits.shape[-1],
-                vocab_end_index=(tp_rank + 1) * logits.shape[-1],
-                tp_group=tp_grp,
-                inference_only=False,
-                cp_group=None,  # we handle cp gathering in `postprocess_packed_seqs`
-                chunk_size=self.cfg.logprobs_chunk_size,  # chunk seq dim to bound peak memory
-            )
+            if packed_seq_params is not None:
+                token_logprobs = from_parallel_logits_to_logprobs_packed_sequences(
+                    logits,
+                    packed_targets,
+                    packed_seq_params.cu_seqlens_q_padded,
+                    sequences.shape[1],
+                    vocab_start_index=tp_rank * logits.shape[-1],
+                    vocab_end_index=(tp_rank + 1) * logits.shape[-1],
+                    group=tp_grp,
+                    inference_only=False,
+                    cp_group=mpu.get_context_parallel_group(),
+                    chunk_size=self.cfg.logprobs_chunk_size,
+                )
+            else:
+                token_logprobs = from_parallel_logits_to_logprobs(
+                    logits,
+                    sequences,
+                    vocab_start_index=tp_rank * logits.shape[-1],
+                    vocab_end_index=(tp_rank + 1) * logits.shape[-1],
+                    tp_group=tp_grp,
+                    inference_only=False,
+                    cp_group=None,
+                    chunk_size=self.cfg.logprobs_chunk_size,  # chunk seq dim to bound peak memory
+                )
 
             action_log_probs = token_logprobs[:, -num_actions:]
 
@@ -332,15 +375,16 @@ class MegatronModelWrapper:
 
             # RL path: add optional KL/entropy terms
             # entropy loss
-            with torch.set_grad_enabled(loss_config.use_entropy_loss):
+            if packed_seq_params is not None and loss_config.use_entropy_loss:
+                raise NotImplementedError("Entropy loss is not implemented for packed Megatron logits")
+            if loss_config.use_entropy_loss:
                 action_logits = logits[:, -num_actions - 1 : -1, :]
                 entropy_BS = vocab_parallel_entropy(action_logits)
                 entropy = masked_mean(entropy_BS, loss_mask)
-
-            if loss_config.use_entropy_loss:
                 entropy_loss_term = entropy * loss_config.entropy_loss_coef
             else:
-                entropy_loss_term = torch.tensor(0.0)
+                entropy = torch.tensor(0.0, device=logits.device)
+                entropy_loss_term = torch.tensor(0.0, device=logits.device)
 
             if loss_config.use_kl_loss:
                 kl_loss = compute_approx_kl(
@@ -429,6 +473,8 @@ class MegatronModelWrapper:
                     attention_mask,
                     pre_process=mpu.is_pipeline_first_stage(ignore_virtual=True),
                 )
+                batch["packed_seq_params"] = packed_seq_params
+                batch["packed_targets"] = _build_packed_targets(sequences, attention_mask, packed_seq_params)
                 new_attention_mask = None
                 new_position_ids = None
             else:
@@ -447,16 +493,7 @@ class MegatronModelWrapper:
                 packed_seq_params=packed_seq_params,
             )
 
-            if self.remove_microbatch_padding:
-                outputs = postprocess_packed_seqs(
-                    outputs,
-                    packed_seq_params,
-                    attention_mask,
-                    micro_batch_size,
-                    seq_len,
-                    post_process=mpu.is_pipeline_last_stage(ignore_virtual=True),
-                )
-            else:
+            if not self.remove_microbatch_padding:
                 outputs = recover_left_padding(
                     outputs,
                     new_attention_mask,


### PR DESCRIPTION
# README: Memory-safe Megatron packed logprobs

## Problem

With Megatron context parallelism and packed microbatches enabled, the old wrapper path
postprocessed packed logits back into dense batch form before computing token logprobs:

```text
packed CP logits [1, T_local, V_tp]
  -> postprocess_packed_seqs(...)
  -> dense logits [B, S, V_tp]
  -> selected token logprobs [B, S-1]
```

That dense `[B, S, V_tp]` materialization causes a large transient memory spike.

## 8k memory comparison

At the same 8k setup on `Qwen/Qwen3-4B-Instruct-2507`, the new packed-logprob path removes the
dense-logit spike:

| path | profile | peak allocated | peak reserved |
| --- | --- | ---: | ---: |
| old dense packed-logit path | 8k CUDA memory snapshot | 41.31 GiB | 47.06 GiB |
| new packed-logprob path | 8k CUDA memory snapshots, max across ranks | 29.97 GiB | 30.03 GiB |

This is an 11.34 GiB allocated-memory reduction and a 17.03 GiB reserved-memory reduction at 8k.
Both numbers were reconstructed from PyTorch CUDA memory snapshots of the policy forward/backward
region.

## Test setup

Benchmarks used:

```text
model: Qwen/Qwen3-4B-Instruct-2507
node config: 1 node, 8 GPUs
Megatron parallelism: TP=1, PP=1, CP=8
policy/ref placement: 8 GPUs per node, colocate_all=true
CP communication: p2p and a2a
micro train/forward batch size per GPU: 1
train batch size: 1
response length: 1024
```

## Change

The new wrapper path keeps logits in packed/context-parallel form and computes only the selected
token logprobs:

```text
packed CP logits [1, T_local, V_tp]
  + packed target ids [1, T_padded]
  -> from_parallel_logits_to_logprobs_packed_sequences(...)
  -> packed scalar logprobs [B, S-1]
  -> action logprobs [B, num_actions]
```

Concretely, when `remove_microbatch_padding` creates `packed_seq_params`, the wrapper now:

1. Builds matching packed target token IDs.
2. Calls `from_parallel_logits_to_logprobs_packed_sequences(...)`.
3. All-gathers only scalar logprobs across CP ranks.
4. Skips `postprocess_packed_seqs(...)` for packed logits.

The normal non-packed logprob path is unchanged.

## 128k result

After removing the 8k dense-logit memory spike, the patched path completed the final CP benchmark
sweep through 128k total length:

At 128k total tokens (`max_total_len=131072`, prompt `130048`, response `1024`):

```text
p2p peak allocated: 53.53 GiB
p2p peak reserved:  57.26 GiB
a2a peak allocated: 53.53 GiB
a2a peak reserved:  56.68 GiB
```

So the patch reduces 8k peak memory substantially and enables clean 128k packed Megatron runs,
without gathering dense `[B, S, V]` logits.
