### PR TITLE
[CI] Add anyscale cloud for H100 CI

### DIFF
--- a/.github/workflows/cpu_skyrl.yaml
+++ b/.github/workflows/cpu_skyrl.yaml
@@ -44,8 +44,7 @@ jobs:
         uvx ruff check
     - name: Run pytest
       run: |
-        # Note: Qwen 3.5 currently needs transformers v5, but we are not ready to fully migrate to it yet
-        uv run --extra tinker --extra jax --extra dev --with transformers==5.2.0 pytest --forked -s tests/tx/models/test_qwen3_5.py
+        uv run --extra tinker --extra jax --extra dev pytest --forked -s tests/tx/models/test_qwen3_5.py
         uv run --extra tinker --extra jax --extra dev pytest --forked -s tests --ignore=tests/tx/gpu --ignore=tests/train --ignore=tests/backends/skyrl_train --ignore=tests/tx/models/test_qwen3_5.py
     - name: Run engine benchmarks
       run: |

--- a/ci/anyscale_gpu_ci_h100.yaml
+++ b/ci/anyscale_gpu_ci_h100.yaml
@@ -3,5 +3,6 @@ entrypoint: bash ci/gpu_ci_run_h100.sh
 image_uri: novaskyai/skyrl-train-ray-2.51.1-py3.12-cu12.8-megatron
 ray_version: "2.51.1"
 compute_config: llm-team-h100-4x:1
+cloud: sky-anyscale-aws-us-east-1
 working_dir: .
 max_retries: 0


### PR DESCRIPTION
# What does this PR do?

Fixes an issue with the Anyscale job YAML for the H100 CI: It's missing the `cloud` field