### PR TITLE
Make prompt dataloader `num_workers`/`persistent_workers` configurable

### DIFF
--- a/skyrl/train/config/__init__.py
+++ b/skyrl/train/config/__init__.py
@@ -6,6 +6,7 @@ from skyrl.train.config.config import (
     ClipCovConfig,
     CriticConfig,
     DataConfig,
+    DataLoaderConfig,
     DynamicSamplingConfig,
     EnvironmentConfig,
     FSDPConfig,
@@ -47,6 +48,7 @@ from skyrl.train.config.sft_config import (
 __all__ = [
     "SkyRLTrainConfig",
     "DataConfig",
+    "DataLoaderConfig",
     "TrainerConfig",
     "PolicyConfig",
     "CriticConfig",

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -55,7 +55,7 @@ class DataLoaderConfig(BaseConfig):
         metadata={
             "help": (
                 "Keep DataLoader workers alive across epochs instead of respawning them at "
-                "every epoch boundary. Setting this requires num_workers above 0."
+                "every epoch boundary. Setting this requires `num_workers > 0`"
             )
         },
     )

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -39,9 +39,37 @@ class BaseConfig(ABC):
 
 
 @dataclass
+class DataLoaderConfig(BaseConfig):
+    num_workers: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Prompt DataLoader worker processes. Default of None auto-derives the value "
+                "(0 with the inference HTTP endpoint, else 8). Set 0 for in-process loading "
+                "that never respawns workers at epoch boundaries."
+            )
+        },
+    )
+    persistent_workers: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Keep DataLoader workers alive across epochs instead of respawning them at "
+                "every epoch boundary. Setting this requires num_workers above 0."
+            )
+        },
+    )
+
+    def __post_init__(self) -> None:
+        if self.num_workers is not None and self.num_workers < 0:
+            raise ValueError(f"data.dataloader.num_workers must be None or >= 0, got {self.num_workers}.")
+
+
+@dataclass
 class DataConfig(BaseConfig):
     train_data: List[str] = field(default_factory=lambda: [os.path.expanduser("~/data/gsm8k/train.parquet")])
     val_data: List[str] = field(default_factory=lambda: [os.path.expanduser("~/data/gsm8k/validation.parquet")])
+    dataloader: DataLoaderConfig = field(default_factory=DataLoaderConfig)
 
 
 # ---------------------------------------------------------------------------
@@ -811,6 +839,15 @@ class SkyRLTrainConfig(BaseConfig):
         # so workers can access it without needing the generator config
         if self.trainer.algorithm.temperature is None:
             self.trainer.algorithm.temperature = self.generator.sampling_params.temperature
+
+        if self.data.dataloader.num_workers is None:
+            # TODO(Charlie): debug why inference http endpoint is slow when num_workers is 8
+            self.data.dataloader.num_workers = 0 if self.generator.inference_engine.enable_http_endpoint else 8
+        if self.data.dataloader.persistent_workers and self.data.dataloader.num_workers == 0:
+            raise ValueError(
+                "data.dataloader.persistent_workers requires num_workers > 0, but it was either"
+                " set explicitly to 0 or forced to 0 by the inference HTTP endpoint."
+            )
 
         # TODO(devpatel): Bandaid solution, replace this once we have a better
         # solution for LoRA performance degradation on the vLLM side

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -771,7 +771,7 @@ def build_dataloader(
     seeded_generator.manual_seed(cfg.trainer.seed)
 
     num_workers = cfg.data.dataloader.num_workers
-    assert num_workers is not None, "num_workers is resolved to an int in SkyRLTrainConfig.__post_init__"
+    assert num_workers is not None, "dataloader `num_workers` should be non-null"
 
     dataloader = StatefulDataLoader(
         dataset,

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -751,7 +751,7 @@ def _validate_step_wise_fields(generator_output: GeneratorOutput, num_responses:
 
 
 def build_dataloader(
-    cfg: SkyRLTrainConfig, dataset: PromptDataset, is_train=True, is_fully_async=False
+    cfg: SkyRLTrainConfig, dataset: PromptDataset, is_train: bool = True, is_fully_async: bool = False
 ) -> StatefulDataLoader:
     """
     Build the dataloader for the training or evaluation dataset.
@@ -770,19 +770,24 @@ def build_dataloader(
     seeded_generator = torch.Generator()
     seeded_generator.manual_seed(cfg.trainer.seed)
 
+    num_workers = cfg.data.dataloader.num_workers
+    assert num_workers is not None, "num_workers is resolved to an int in SkyRLTrainConfig.__post_init__"
+
     dataloader = StatefulDataLoader(
         dataset,
         batch_size=batch_size if not is_fully_async else 1,
         shuffle=True if is_train else False,
         collate_fn=dataset.collate_fn,
-        # TODO(Charlie): debug why inference http endpoint is slow when num_workers is 8
-        num_workers=0 if cfg.generator.inference_engine.enable_http_endpoint else 8,
+        num_workers=num_workers,
+        # Unlike `shuffle`/`drop_last`, not branched on `is_train`: both dataloaders are
+        # reused (train across epochs, eval across evaluations) to avoid worker respawn
+        persistent_workers=cfg.data.dataloader.persistent_workers,
         drop_last=True if is_train else False,
         generator=seeded_generator,
         # NOTE (sumanthrh): We use ray and thus use `spawn` start method.
         # forking within ray leads to undefined behaviour and often causes hard to debug
         # memory leaks.  See: https://docs.ray.io/en/latest/ray-core/patterns/fork-new-processes.html
-        multiprocessing_context="spawn" if not cfg.generator.inference_engine.enable_http_endpoint else None,
+        multiprocessing_context="spawn" if num_workers > 0 else None,
     )
     if is_train:
         if not is_fully_async:

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -187,6 +187,43 @@ class TestTrainerUseSamplePackingAlias:
             )
 
 
+class TestSkyRLTrainConfig:
+    @pytest.mark.parametrize(
+        ("overrides", "expected_num_workers", "expected_persistent"),
+        [
+            pytest.param([], 8, False, id="default-no-http"),
+            pytest.param(["generator.inference_engine.enable_http_endpoint=true"], 0, False, id="http-endpoint"),
+            pytest.param(
+                ["generator.inference_engine.enable_http_endpoint=true", "data.dataloader.num_workers=4"],
+                4,
+                False,
+                id="explicit-overrides-http",
+            ),
+            pytest.param(["data.dataloader.num_workers=0"], 0, False, id="explicit-zero"),
+            pytest.param(["data.dataloader.persistent_workers=true"], 8, True, id="persistent-keeps-default-workers"),
+        ],
+    )
+    def test_resolution(self, overrides: list[str], expected_num_workers: int, expected_persistent: bool) -> None:
+        cfg = SkyRLTrainConfig.from_cli_overrides(overrides)
+        assert cfg.data.dataloader.num_workers == expected_num_workers
+        assert cfg.data.dataloader.persistent_workers == expected_persistent
+
+    @pytest.mark.parametrize(
+        ("overrides", "match"),
+        [
+            pytest.param(
+                ["data.dataloader.num_workers=0", "data.dataloader.persistent_workers=true"],
+                "persistent_workers requires num_workers > 0",
+                id="persistent-without-workers",
+            ),
+            pytest.param(["data.dataloader.num_workers=-1"], "num_workers must be None or >= 0", id="negative-workers"),
+        ],
+    )
+    def test_invalid_raises(self, overrides: list[str], match: str) -> None:
+        with pytest.raises(ValueError, match=match):
+            SkyRLTrainConfig.from_cli_overrides(overrides)
+
+
 class TestMaxSeqLenValidation:
     """Tests for max_seq_len defaults and validation behavior."""
 

--- a/tests/train/test_trainer_utils.py
+++ b/tests/train/test_trainer_utils.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock, mock_open, patch
 import pytest
 import ray
 
+from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.generators.base import GeneratorInput, GeneratorOutput, TrajectoryID
 from skyrl.train.utils.trainer_utils import (
     build_dataloader,
@@ -895,6 +896,36 @@ def test_build_dataloader_seeding(dummy_config):
     assert (
         first_batch1 != first_batch3
     ), f"Different seeds should produce different first batches, but both gave {first_batch1}"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_num_workers", "expected_persistent", "expected_start_method"),
+    [
+        pytest.param(["data.dataloader.num_workers=0"], 0, False, None, id="workerless"),
+        pytest.param(
+            ["data.dataloader.num_workers=2", "data.dataloader.persistent_workers=true"],
+            2,
+            True,
+            "spawn",
+            id="persistent-spawn-workers",
+        ),
+    ],
+)
+def test_build_dataloader_worker_config(
+    overrides: list[str],
+    expected_num_workers: int,
+    expected_persistent: bool,
+    expected_start_method: str | None,
+) -> None:
+    """build_dataloader passes num_workers/persistent_workers through and derives the spawn context."""
+    config = SkyRLTrainConfig.from_cli_overrides(["trainer.train_batch_size=2", *overrides])
+    dataloader = build_dataloader(config, MultiItemDataset(size=8), is_train=True)
+    assert dataloader.num_workers == expected_num_workers
+    assert dataloader.persistent_workers == expected_persistent
+    start_method = (
+        None if dataloader.multiprocessing_context is None else dataloader.multiprocessing_context.get_start_method()
+    )
+    assert start_method == expected_start_method
 
 
 def test_validate_generator_output_invalid_rewards():


### PR DESCRIPTION
Adds a `data.dataloader` config section exposing `num_workers` and `persistent_workers`(previously hardcoded) with backward-compatible defaults.

Closes https://github.com/NovaSky-AI/SkyRL/issues/1744.