### PR TITLE
[CI] Use the right cloud for H100 CI

### DIFF
--- a/ci/anyscale_gpu_ci_h100.yaml
+++ b/ci/anyscale_gpu_ci_h100.yaml
@@ -1,6 +1,6 @@
 name: skyrl-train-gpu-ci-h100
 entrypoint: bash ci/gpu_ci_run_h100.sh
-image_uri: skyrl-train-ray-2.51.1-slim-py312-cu128-megatron-2.10-te-efa-1.47
+image_uri: anyscale/image/skyrl-train-ray-2.51.1-slim-py312-cu128-megatron-2.10-te-efa-1.47:1
 ray_version: "2.51.1"
 compute_config: llm-team-h100-4x:1
 cloud: rkn-gpu-cloud

--- a/ci/anyscale_gpu_ci_h100.yaml
+++ b/ci/anyscale_gpu_ci_h100.yaml
@@ -1,6 +1,6 @@
 name: skyrl-train-gpu-ci-h100
 entrypoint: bash ci/gpu_ci_run_h100.sh
-image_uri: novaskyai/skyrl-train-ray-2.51.1-py3.12-cu12.8-megatron
+image_uri: skyrl-train-ray-2.51.1-slim-py312-cu128-megatron-2.10-te-efa-1.47
 ray_version: "2.51.1"
 compute_config: llm-team-h100-4x:1
 cloud: rkn-gpu-cloud

--- a/ci/anyscale_gpu_ci_h100.yaml
+++ b/ci/anyscale_gpu_ci_h100.yaml
@@ -3,6 +3,6 @@ entrypoint: bash ci/gpu_ci_run_h100.sh
 image_uri: novaskyai/skyrl-train-ray-2.51.1-py3.12-cu12.8-megatron
 ray_version: "2.51.1"
 compute_config: llm-team-h100-4x:1
-cloud: sky-anyscale-aws-us-east-1
+cloud: rkn-gpu-cloud
 working_dir: .
 max_retries: 0


### PR DESCRIPTION
# What does this PR do?

The cloud for the H100 CI should be `rkn-gpu-cloud` 

Test 1 (used the skyrl image from docker): https://console.anyscale-staging.com/cld_82np1njz31y9lwk56mc2xcc23x/prj_69fd51u496ygpnaza62xsmis64/jobs/prodjob_wdxwfpfy96bxd31c6svpe8a6hz?job-logs-section-tabs=application_logs&job-tab=overview 

Test 2 (used the same image from internal registry): https://console.anyscale-staging.com/jobs/prodjob_g74nmtt91nckgdkrmfpn8nihs3