### PR TITLE
[chore] Exclude  `nixl-cu13` from packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,11 @@ override-dependencies = [
     "transformers>=5.6.1,<=5.8.0; sys_platform == 'linux'",
     "megatron-core>=0.16.0; sys_platform == 'linux'",
     "ml_dtypes>=0.5.0; sys_platform == 'linux'",
+    # The `nixl` meta-package pulls BOTH nixl-cu12 and nixl-cu13 on Linux; both
+    # ship a top-level `nixl_ep` that collide, and cu13 (libcudart.so.13) wins,
+    # breaking vLLM model inspection on this CUDA-12 env (torch cu128 / vllm
+    # cu129). Exclude cu13 so only nixl-cu12 (libcudart.so.12) is installed.
+    "nixl-cu13; sys_platform == 'never'",
 ]
 
 [tool.uv.extra-build-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -272,6 +272,7 @@ constraints = [
 overrides = [
     { name = "megatron-core", marker = "sys_platform == 'linux'", git = "https://github.com/NVIDIA/Megatron-LM?rev=cefc2520158c7ceba3f9adbe4b547a6f7a118da1" },
     { name = "ml-dtypes", marker = "sys_platform == 'linux'", specifier = ">=0.5.0" },
+    { name = "nixl-cu13", marker = "sys_platform == 'never'" },
     { name = "nvidia-resiliency-ext", marker = "sys_platform == 'never'" },
     { name = "transformer-engine", extras = ["pytorch"], marker = "sys_platform == 'linux'", specifier = "==2.11.0" },
     { name = "transformers", marker = "sys_platform == 'linux'", specifier = ">=5.6.1,<=5.8.0" },


### PR DESCRIPTION
# What does this PR do?

Excludes nixl cu13 from the packages. 

After #1601 , vllm model resolution fails with

```bash
, ip=10.0.53.33, actor_id=4bb0516283686471f260700b04000000, repr=<skyrl.backends.skyrl_train.inference_servers.vllm_server_actor.VLLMServerActor object at 0x706173dea0f0>)
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-06-07_06-36-06_373207_3903/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_78d2d462c60fbf0f44597ff416ba6c12/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py", line 279, in start
    await self._wait_until_healthy()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-06-07_06-36-06_373207_3903/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_78d2d462c60fbf0f44597ff416ba6c12/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py", line 294, in _wait_until_healthy
    raise exc
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-06-07_06-36-06_373207_3903/runtime_resources/working_dir_files/s3_anyscale-production-data-cld-hxkifz7xa22mwicp21nzkds1lw_org_xc6lv84h3d7m9dljcc17esfw2i_cld_hxkifz7xa22mwicp21nzkds1lw_runtime_env_packages_pkg_78d2d462c60fbf0f44597ff416ba6c12/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py", line 335, in _run_server
    self._engine = AsyncLLMEngine.from_engine_args(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmpHNSj9v/lib/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 242, in from_engine_args
    vllm_config = engine_args.create_engine_config(usage_context)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmpHNSj9v/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 1627, in create_engine_config
    model_config = self.create_model_config()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmpHNSj9v/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 1475, in create_model_config
    return ModelConfig(
           ^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmpHNSj9v/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
  Value error, Model architectures ['Qwen3MoeForCausalLM'] failed to be inspected. Please check the logs for more details. [type=value_error, input_value=ArgsKwargs((), {'model': ...nderer_num_workers': 1}), input_type=ArgsKwargs]
    For further information visit https://errors.pydantic.dev/2.13/v/value_error
```

The root cause is the `nixl` package. The `nixl` package on PyPI is a meta package that includes both `nixl-cu12` and `nixl-cu13`. `nixl-cu13` ships a binary that breaks vllm model inspection. 

I haven't figured out why the vllm-router upgrade triggered this, but the fix seems to work