### PR TITLE
Log and document that `colocate_all=false` still colocates policy and ref

### DIFF
--- a/docs/content/docs/configuration/placement.mdx
+++ b/docs/content/docs/configuration/placement.mdx
@@ -62,8 +62,18 @@ All training models (policy, critic, reward, reference) share the same GPUs.
 
 The policy and critic models are not colocated, but fine-grained placement of the reference and reward models can be controlled with two additional parameters:
 
-- `trainer.placement.colocate_policy_ref`: Colocate policy and reference models (`true`) or place them on separate GPUs (`false`)
+- `trainer.placement.colocate_policy_ref`: Colocate policy and reference models (`true`, the default) or place them on separate GPUs (`false`)
 - `trainer.placement.colocate_critic_reward`: Colocate critic and reward models (`true`) or place them on separate GPUs (`false`)
+
+<Callout type="warn">
+`colocate_all=false` does not separate the policy and reference models by itself.
+With the default `colocate_policy_ref=true`, policy and reference run on the same physical GPUs
+(one shared placement group): every GPU holds one policy shard and one reference shard at the same time,
+and their combined size must fit in that GPU's memory.
+To give policy and reference their own GPUs
+(separate nodes with whole-node bundles), set `colocate_policy_ref=false`;
+also consider `trainer.policy.fsdp_config.cpu_offload=true`.
+</Callout>
 
 ## Hardware Configuration
 

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -218,6 +218,10 @@ class PlacementConfig(BaseConfig):
     colocate_all: bool = True
     """When True, training and inference share the same GPUs."""
     colocate_policy_ref: bool = True
+    """When colocate_all is False, True (default) still colocates policy and ref
+    on the same GPUs (one shared placement group). Set this item to False to place
+    policy and ref on separate GPUs (their own placement groups); needed when
+    a large model's policy and ref shards can't both fit on one GPU."""
     policy_num_nodes: int = 1
     policy_num_gpus_per_node: int = 1
     critic_num_nodes: int = 1

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -620,6 +620,12 @@ class RayPPOTrainer:
                     colocate_all=False,
                     sequence_parallel_size=cfg.trainer.ref.sequence_parallel_size,
                 )
+                if pg is not None:
+                    # The shared policy/ref placement group `pg` is set only when colocate_policy_ref is enabled
+                    logger.info(
+                        "Colocating policy and ref on the same GPUs across "
+                        f"{cfg.trainer.placement.policy_num_nodes} node(s)."
+                    )
             else:
                 ref_model = None
 


### PR DESCRIPTION
I had a hard time figuring out an OOM happening due to `colocate_policy_ref`'s default of `True`, even though I had `colocate_all=false`. This PR just documents this hyper a bit more, and adds a log line about it.