### PR TITLE
[ci] add commit names to gpu ci jobs to avoid collisions with `anyscale job wait`

### DIFF
--- a/.github/workflows/gpu_ci_h100.yaml
+++ b/.github/workflows/gpu_ci_h100.yaml
@@ -65,5 +65,7 @@ jobs:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN_STAGING }}
           ANYSCALE_HOST: https://console.anyscale-staging.com
         run: |
-          anyscale job submit -f ci/anyscale_gpu_ci_h100.yaml --timeout 5400
-          anyscale job wait --name skyrl-train-gpu-ci-h100 --timeout 5400
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-ci-h100-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_ci_h100.yaml --name "$JOB_NAME" --timeout 5400
+          anyscale job wait --name "$JOB_NAME" --timeout 5400

--- a/.github/workflows/gpu_e2e_ci.yaml
+++ b/.github/workflows/gpu_e2e_ci.yaml
@@ -42,6 +42,8 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
           envsubst < ci/anyscale_gpu_e2e_test.yaml > ci/anyscale_gpu_e2e_test_envsubst.yaml
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_envsubst.yaml --timeout 5000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test --timeout 5000
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_e2e_test_envsubst.yaml --name "$JOB_NAME" --timeout 5000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 5000
           rm -f ci/anyscale_gpu_e2e_test_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_fully_async.yaml
+++ b/.github/workflows/gpu_e2e_ci_fully_async.yaml
@@ -42,6 +42,8 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_fully_async.yaml > ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml --timeout 5000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test-fully-async --timeout 5000
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-fully-async-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml --name "$JOB_NAME" --timeout 5000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 5000
           rm -f ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_megatron.yaml
+++ b/.github/workflows/gpu_e2e_ci_megatron.yaml
@@ -42,6 +42,8 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_megatron.yaml > ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml --timeout 4500
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test-megatron --timeout 4500
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-megatron-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml --name "$JOB_NAME" --timeout 4500
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 4500
           rm -f ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_sft.yaml
+++ b/.github/workflows/gpu_e2e_ci_sft.yaml
@@ -42,6 +42,8 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_sft.yaml > ci/anyscale_gpu_e2e_test_sft_envsubst.yaml
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_sft_envsubst.yaml --timeout 4500
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test-sft --timeout 4500
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-sft-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_e2e_test_sft_envsubst.yaml --name "$JOB_NAME" --timeout 4500
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 4500
           rm -f ci/anyscale_gpu_e2e_test_sft_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_tinker.yaml
+++ b/.github/workflows/gpu_e2e_ci_tinker.yaml
@@ -42,6 +42,8 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_tinker.yaml > ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml --timeout 12000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test-tinker --timeout 12000
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-tinker-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml --name "$JOB_NAME" --timeout 12000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 12000
           rm -f ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_tinker_fully_async.yaml
+++ b/.github/workflows/gpu_e2e_ci_tinker_fully_async.yaml
@@ -42,6 +42,8 @@ jobs:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_tinker_fully_async.yaml > ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml --timeout 12000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-e2e-test-tinker-fully-async --timeout 12000
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-tinker-fully-async-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml --name "$JOB_NAME" --timeout 12000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 12000
           rm -f ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml

--- a/.github/workflows/gpu_skyrl.yaml
+++ b/.github/workflows/gpu_skyrl.yaml
@@ -52,5 +52,7 @@ jobs:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
           ANYSCALE_HOST: https://console.anyscale.com
         run: |
-          anyscale job submit -f ci/anyscale_gpu_ci.yaml --timeout 10000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-tx-gpu-ci --timeout 10000
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-tx-gpu-ci-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_ci.yaml --name "$JOB_NAME" --timeout 10000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 10000

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -65,5 +65,7 @@ jobs:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
           ANYSCALE_HOST: https://console.anyscale.com
         run: |
-          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train.yaml --timeout 12000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-ci --timeout 12000
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-ci-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train.yaml --name "$JOB_NAME" --timeout 12000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 12000

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -67,5 +67,7 @@ jobs:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
           ANYSCALE_HOST: https://console.anyscale.com
         run: |
-          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train_megatron.yaml --timeout 7000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-ci-megatron --timeout 7000
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-ci-megatron-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train_megatron.yaml --name "$JOB_NAME" --timeout 7000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 7000

--- a/.github/workflows/gpu_skyrl_train_megatron_models.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron_models.yaml
@@ -67,5 +67,7 @@ jobs:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
           ANYSCALE_HOST: https://console.anyscale.com
         run: |
-          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train_megatron_models.yaml --timeout 1000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-ci-megatron-models --timeout 1000
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-ci-megatron-models-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train_megatron_models.yaml --name "$JOB_NAME" --timeout 1000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 1000

--- a/.github/workflows/gpu_skyrl_train_old_inference.yaml
+++ b/.github/workflows/gpu_skyrl_train_old_inference.yaml
@@ -70,5 +70,7 @@ jobs:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
           ANYSCALE_HOST: https://console.anyscale.com
         run: |
-          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train_old_inference.yaml --timeout 5000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name skyrl-train-gpu-ci-old-inference --timeout 5000
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="skyrl-train-gpu-ci-old-inference-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train_old_inference.yaml --name "$JOB_NAME" --timeout 5000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 5000

--- a/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
+++ b/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
@@ -68,5 +68,7 @@ jobs:
           ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
           ANYSCALE_HOST: https://console.anyscale.com
         run: |
-          anyscale job submit -f ci/anyscale_tinker_skyrl_train_backend_gpu.yaml --timeout 5000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name tinker-skyrl-train-backend-gpu --timeout 5000
+          COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          JOB_NAME="tinker-skyrl-train-backend-gpu-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          anyscale job submit -f ci/anyscale_tinker_skyrl_train_backend_gpu.yaml --name "$JOB_NAME" --timeout 5000
+          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 5000


### PR DESCRIPTION
## Make Anyscale CI job names unique per run

**Problem:** All CI workflows submitted Anyscale jobs with a hardcoded `name`, then called `anyscale job wait --name <name>`. When two runs of the same workflow overlap, `job wait` resolves to the *most recently created* job of that name (per Anyscale's API), so a passing run and a failing run can report each other's status — marking both GitHub checks failed.

**Fix:** Each workflow now derives a unique job name `<base>-<short-sha>-<run_id>` and passes it to both `submit --name` and `wait --name`. The short SHA keeps names identifiable in the Anyscale console; `github.run_id` guarantees uniqueness even across concurrent runs of the same commit. Applied to all 13 submit/wait workflows; no `ci/*.yaml` configs needed changing since `--name` overrides the file's `name:`.