### PR TITLE
[examples] Reduce train batch size for GLM 4.7 30B script

### DIFF
--- a/examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
+++ b/examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
@@ -57,8 +57,6 @@ MOE_ROUTER_EXPERT_BIAS=true
 OPTIMIZER_CPU_OFFLOAD=true
 OPTIMIZER_OFFLOAD_FRACTION=1.0
 
-export _SKYRL_USE_NEW_INFERENCE=0
-
 uv run --isolated --extra megatron -m skyrl.train.entrypoints.main_base \
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \

--- a/examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
+++ b/examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
@@ -110,7 +110,7 @@ uv run --isolated --extra megatron -m skyrl.train.entrypoints.main_base \
   generator.batched=true \
   environment.env_class=gsm8k \
   generator.n_samples_per_prompt=5 \
-  generator.inference_engine.gpu_memory_utilization=0.45 \
+  generator.inference_engine.gpu_memory_utilization=0.5 \
   trainer.logger="$LOGGER" \
   trainer.project_name="glm4_7_30b_grpo" \
   trainer.run_name="glm4_7_30b_a3b_grpo_megatron_tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}_ep${MEGATRON_EP}_etp${MEGATRON_ETP}" \

--- a/examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
+++ b/examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
@@ -94,7 +94,7 @@ uv run --isolated --extra megatron -m skyrl.train.entrypoints.main_base \
   trainer.update_epochs_per_batch=1 \
   trainer.train_batch_size=128 \
   trainer.policy_mini_batch_size=64 \
-  trainer.micro_forward_batch_size_per_gpu=2 \
+  trainer.micro_forward_batch_size_per_gpu=4 \
   trainer.micro_train_batch_size_per_gpu=1 \
   trainer.ckpt_interval=10 \
   trainer.max_prompt_length=512 \
@@ -110,7 +110,7 @@ uv run --isolated --extra megatron -m skyrl.train.entrypoints.main_base \
   generator.batched=true \
   environment.env_class=gsm8k \
   generator.n_samples_per_prompt=5 \
-  generator.inference_engine.gpu_memory_utilization=0.5 \
+  generator.inference_engine.gpu_memory_utilization=0.45 \
   trainer.logger="$LOGGER" \
   trainer.project_name="glm4_7_30b_grpo" \
   trainer.run_name="glm4_7_30b_a3b_grpo_megatron_tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}_ep${MEGATRON_EP}_etp${MEGATRON_ETP}" \

--- a/examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
+++ b/examples/train/megatron/run_megatron_grpo_glm4_7_30b.sh
@@ -94,8 +94,8 @@ uv run --isolated --extra megatron -m skyrl.train.entrypoints.main_base \
   trainer.update_epochs_per_batch=1 \
   trainer.train_batch_size=128 \
   trainer.policy_mini_batch_size=64 \
-  trainer.micro_forward_batch_size_per_gpu=4 \
-  trainer.micro_train_batch_size_per_gpu=4 \
+  trainer.micro_forward_batch_size_per_gpu=2 \
+  trainer.micro_train_batch_size_per_gpu=1 \
   trainer.ckpt_interval=10 \
   trainer.max_prompt_length=512 \
   generator.sampling_params.max_generate_length=1024 \


### PR DESCRIPTION
# What does this PR do?

Reduces train batch size for GLM 4.7 30 script.

There was a recent OOM reported for GLM 4.7 training #1623 . With latest main https://github.com/NovaSky-AI/SkyRL/commit/b3cd1ac7f171fd3c0369d26b61bbca7b9f5cd2ff, there's no OOM at weight sync with new inference but the OOM happens during the backward pass in the first training step:

```bash
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/ray/default/SkyRL/skyrl/train/entrypoints/main_base.py", line 435, in <module>
    main()
  File "/home/ray/default/SkyRL/skyrl/train/entrypoints/main_base.py", line 431, in main
    ray.get(skyrl_entrypoint.remote(cfg))
  File "/home/ray/.cache/uv/builds-v0/.tmp5eJ7xT/lib/python3.12/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmp5eJ7xT/lib/python3.12/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmp5eJ7xT/lib/python3.12/site-packages/ray/_private/worker.py", line 2961, in get
    values, debugger_breakpoint = worker.get_objects(
                                  ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmp5eJ7xT/lib/python3.12/site-packages/ray/_private/worker.py", line 1026, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(DistBackendError): [36mray::skyrl_entrypoint()[39m (pid=34317, ip=10.1.151.135)
  File "/home/ray/default/SkyRL/skyrl/train/entrypoints/main_base.py", line 420, in skyrl_entrypoint
    exp.run()
  File "/home/ray/default/SkyRL/skyrl/train/entrypoints/main_base.py", line 403, in run
    asyncio.run(trainer.train())
  File "/home/ray/anaconda3/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/tmp/ray/session_2026-06-06_05-43-45_413839_979/runtime_resources/working_dir_files/_ray_pkg_d651646a07ea2943/skyrl/train/trainer.py", line 371, in train
    status = self.train_critic_and_policy(training_input)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-06-06_05-43-45_413839_979/runtime_resources/working_dir_files/_ray_pkg_d651646a07ea2943/skyrl/train/trainer.py", line 1323, in train_critic_and_policy
    policy_status = self._execute_training_step("policy", data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-06-06_05-43-45_413839_979/runtime_resources/working_dir_files/_ray_pkg_d651646a07ea2943/skyrl/train/trainer.py", line 1296, in _execute_training_step
    status = self.dispatch.forward_backward_from_staged(model, chunk_refs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-06-06_05-43-45_413839_979/runtime_resources/working_dir_files/_ray_pkg_d651646a07ea2943/skyrl/backends/skyrl_train/workers/worker_dispatch.py", line 343, in forward_backward_from_staged
    statuses = ray.get(refs)
               ^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^
                                  ^^^^^^^^^^^^^^^^^^^
ray.exceptions.RayTaskError(DistBackendError): [36mray::MegatronPolicyWorkerBase.forward_backward()[39m (pid=46044, ip=10.1.151.135, actor_id=339dc698e548804efeb9399603000000, repr=<skyrl.backends.skyrl_train.workers.megatron.megatron_worker.MegatronPolicyWorkerBase object at 0x7efd2287ee70>)
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
           ^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-06-06_05-43-45_413839_979/runtime_resources/working_dir_files/_ray_pkg_d651646a07ea2943/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py", line 870, in forward_backward
    metrics_list = self.model.forward_backward_mini_batch(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-06-06_05-43-45_413839_979/runtime_resources/working_dir_files/_ray_pkg_d651646a07ea2943/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py", line 568, in forward_backward_mini_batch
    metrics_list = forward_backward_func(
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/.cache/uv/builds-v0/.tmpjXBMmk/lib/python3.12/site-packages/megatron/core/pipeline_parallel/schedules.py", line 731, in forward_backward_no_pipelining
    config.finalize_model_grads_func(
  File "/home/ray/.cache/uv/builds-v0/.tmpjXBMmk/lib/python3.12/site-packages/megatron/core/distributed/finalize_model_grads.py", line 447, in finalize_model_grads
    model_chunk.finish_grad_sync(force_all_reduce=force_all_reduce)
  File "/home/ray/.cache/uv/builds-v0/.tmpjXBMmk/lib/python3.12/site-packages/megatron/core/distributed/distributed_data_parallel.py", line 547, in finish_grad_sync
    bucket_group.finish_grad_sync(force_all_reduce=force_all_reduce)
  File "/home/ray/.cache/uv/builds-v0/.tmpjXBMmk/lib/python3.12/site-packages/megatron/core/distributed/param_and_grad_buffer.py", line 674, in finish_grad_sync
    self.start_grad_sync(force_all_reduce=force_all_reduce)
  File "/home/ray/.cache/uv/builds-v0/.tmpjXBMmk/lib/python3.12/site-packages/megatron/core/distributed/param_and_grad_buffer.py", line 588, in start_grad_sync
    with stream_context, _coalescing_manager(communication_group, async_ops=async_op) as cm:
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/contextlib.py", line 144, in __exit__
    next(self.gen)
  File "/home/ray/.cache/uv/builds-v0/.tmpjXBMmk/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py", line 2776, in _coalescing_manager
    work = group.reduce_scatter_tensor_coalesced(outputs, inputs, reduce_opts)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch.distributed.DistBackendError: NCCL error in: /pytorch/torch/csrc/distributed/c10d/NCCLUtils.cpp:93, unhandled cuda error (run with NCCL_DEBUG=INFO for details), NCCL version 2.28.9
ncclUnhandledCudaError: Call to CUDA function failed.
```

I did a bisect and went back to March 26 at this commit - 72c7834c779fab49350c437ca9205f9ccd6dde6b. A run at 72c7834c779fab49350c437ca9205f9ccd6dde6b with old inference also OOMs at the same backward pass. 

I reduced the `micro_train_batch_size_per_gpu` to 1 and the script runs for 20 steps without issues (old and new commit)

## Memory consumption analysis

I analysed peak reserved and allocatd memory with this script comparing new inference vs old inference at HEAD on 8xH100

| metric (per vLLM worker, during weight sync) | **new inference** (`=1`) | **legacy inference** (`=0`) |
|---|---|---|
| `max_memory_reserved` | 37.152 GiB | 37.152 GiB |
| `max_memory_allocated` | 36.680 GiB | 36.680 GiB |

# TODO
- [x] Memory consumption analysis on 8xH100 for peak reserved memory during weight sync