### PR TITLE
[docs] Add docs for session based routing

### DIFF
--- a/docs/content/docs/getting-started/inference_architecture.mdx
+++ b/docs/content/docs/getting-started/inference_architecture.mdx
@@ -46,6 +46,29 @@ The split exists because generation scales out via routing (the router picks a b
 
 `client.generate(input_batch, model=...)` sends each prompt as a separate POST to `proxy_url`. Requests are issued concurrently (capped by `SKYRL_GENERATE_CONCURRENCY_PER_ENGINE × num_engines`) and the router distributes them across backends; an optional `X-Session-ID` header drives session-aware routing. `chat_completion`, `completion`, and `sample` are thin wrappers over the same routed proxy.
 
+## Session-aware Routing
+
+`VLLMRouter` is started with vLLM's `consistent_hash` routing policy (see `inference_servers/utils.py`). When a request carries an `X-Session-ID` HTTP header, the router hashes on that header so all requests with the same session ID are pinned to the same backend replica. Without the header, the router still applies consistent hashing, but there is no trajectory-level pinning - the turns of a single rollout aren't guaranteed to land on the same backend.
+
+Pinning a logical request to one backend keeps that backend's **prefix cache** warm across the turns of a multi-turn rollout (and across retries of one request), which is a large throughput win for agentic / multi-turn generation. Distinct sessions still spread across replicas.
+
+`RemoteInferenceClient` sets this header automatically: every routed call (`generate`, `chat_completion`, `completion`, `sample`, and the `render` paths) accepts a `session_id`, and when one is present the client attaches `X-Session-ID: <session_id>` to the outgoing request (`inference_servers/remote_inference_client.py`). SkyRL's built-in generators pass the trajectory ID as the session ID so all turns of a trajectory co-locate.
+
+### Passing it from a custom agent
+
+If you write a custom agent / generator that talks to the data-plane proxy directly (instead of going through `RemoteInferenceClient`), set the header yourself on each request to get sticky routing. Use a **stable** ID per logical rollout - e.g. the trajectory or conversation ID - and reuse it across every turn and retry of that rollout:
+
+```python
+# OpenAI-compatible client talking to the VLLMRouter proxy
+resp = await client.chat.completions.create(
+    model=model,
+    messages=messages,
+    extra_headers={"X-Session-ID": trajectory_id},  # stable across all turns of this rollout
+)
+```
+
+If you don't set the header, you lose trajectory-level pinning: turns of the same rollout aren't guaranteed to share a backend, so the cross-turn prefix-cache benefit is lost. Correctness is unaffected, but throughput on multi-turn workloads drops. See the [Harbor integration](/docs/harbor) for a concrete example of wiring this through an agent's LLM client.
+
 ## Pause / Resume
 
 We use the native `/pause` and `/resume` APIs in vLLM:

--- a/docs/content/docs/harbor/index.mdx
+++ b/docs/content/docs/harbor/index.mdx
@@ -160,6 +160,23 @@ task-dir/
 
 SkyRL never manages the sandbox or agent directly. The vLLM inference engine is exposed as an HTTP endpoint, and the Harbor agent calls it through LiteLLM as if it were any OpenAI-compatible API.
 
+### Session-aware Routing
+
+`HarborGenerator` injects a unique `session_id` (via `uuid4().hex`) into each trial's config, so all of a trajectory's LLM calls share one ID. SkyRL's data-plane router (`VLLMRouter`) uses vLLM's `consistent_hash` policy, which keys on the `X-Session-ID` HTTP header to pin a session to a single backend replica and keep its prefix cache warm across turns - see [Session-aware Routing](/docs/getting-started/inference_architecture#session-aware-routing).
+
+For this to take effect, the agent's LLM client must forward the session ID as the `X-Session-ID` header. Harbor's `LiteLLM` wrapper does exactly this - alongside `extra_body["session_id"]`, it also sets the header so the vLLM router can route on it:
+
+```python
+# src/harbor/llms/lite_llm.py
+if self._session_id is not None:
+    extra_body["session_id"] = self._session_id
+    # Also send the session id as the X-Session-ID HTTP header. Routers like the
+    # vLLM router (consistent_hash policy) key session affinity on this header.
+    completion_kwargs.setdefault("extra_headers", {})["X-Session-ID"] = self._session_id
+```
+
+If you build your own agent (instead of using Harbor's `terminus-2` / `LiteLLM` path), implement something similar: set the `X-Session-ID` header to a stable per-rollout ID on every request. Without it, the router still consistent-hashes requests but there's no trajectory-level pinning — turns of the same rollout aren't guaranteed to share a backend, so you lose the cross-turn prefix-cache reuse (correctness is unaffected, but multi-turn throughput drops).
+
 ## Error Handling, Masking, and Retries
 
 ### Per-Trajectory Retries

--- a/examples/train_integrations/harbor/run_codecontest.sh
+++ b/examples/train_integrations/harbor/run_codecontest.sh
@@ -62,7 +62,7 @@ TRAJECTORIES_PER_SECOND=5  # Maximum trajectories per second (must be >= 1.0, fr
 MAX_CONCURRENCY=512        # Maximum concurrent trial.run() calls allowed (must be >= 1). null or omit to disable concurrency limiting
 
 # Run SkyRL command
-_SKYRL_USE_NEW_INFERENCE=0 uv run --isolated --extra fsdp --extra harbor -m examples.train_integrations.harbor.entrypoints.main_harbor \
+uv run --isolated --extra fsdp --extra harbor -m examples.train_integrations.harbor.entrypoints.main_harbor \
   data.train_data=$TRAIN_DATA \
   data.val_data=$EVAL_DATA \
   trainer.policy.model.path=Qwen/Qwen3-8B \

--- a/examples/train_integrations/harbor/run_codecontest_fully_async.sh
+++ b/examples/train_integrations/harbor/run_codecontest_fully_async.sh
@@ -73,7 +73,7 @@ TRAJECTORIES_PER_SECOND=5  # Maximum trajectories per second (must be >= 1.0, fr
 MAX_CONCURRENCY=128        # Maximum concurrent trial.run() calls allowed (must be >= 1). null or omit to disable concurrency limiting
 
 # Run SkyRL command
-_SKYRL_USE_NEW_INFERENCE=0 uv run --isolated --extra fsdp --extra harbor -m examples.train_integrations.harbor.entrypoints.main_harbor_fully_async \
+uv run --isolated --extra fsdp --extra harbor -m examples.train_integrations.harbor.entrypoints.main_harbor_fully_async \
   data.train_data=$TRAIN_DATA \
   data.val_data=$EVAL_DATA \
   trainer.policy.model.path=Qwen/Qwen3-8B \


### PR DESCRIPTION
# What does this PR do?

Adds documents for session based routing with new inference. 

Pre-req: merging https://github.com/harbor-framework/harbor/pull/1855

Also removes the pin to old inference codepath for Harbor

