### PR TITLE
[script] Add Qwen3.6-35b LoRA DAPO script

### DIFF
--- a/examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora.sh
+++ b/examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora.sh
@@ -1,10 +1,10 @@
 set -x
 
-# Colocated DAPO training+generation for Qwen3.5-35B-A3B-Base on DAPO with Megatron.
-# Should run on 2 node of 8xH100s
+# Colocated DAPO training+generation for Qwen3.6-35B-A3B on DAPO with Megatron.
+# Should run on 4 nodes of 8xH100s
 
 # bash examples/train/algorithms/dapo/prepare_dapo_data.sh
-# bash examples/train/megatron/run_megatron_dapo_qwen3.5_35b_a3b.sh
+# bash examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora.sh
 
 MODEL_NAME="Qwen/Qwen3.6-35B-A3B"
 DATA_DIR="$HOME/data/dapo"

--- a/examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora.sh
+++ b/examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora.sh
@@ -1,0 +1,149 @@
+set -x
+
+# Colocated DAPO training+generation for Qwen3.5-35B-A3B-Base on DAPO with Megatron.
+# Should run on 2 node of 8xH100s
+
+# bash examples/train/algorithms/dapo/prepare_dapo_data.sh
+# bash examples/train/megatron/run_megatron_dapo_qwen3.5_35b_a3b.sh
+
+MODEL_NAME="Qwen/Qwen3.6-35B-A3B"
+DATA_DIR="$HOME/data/dapo"
+TRAIN_FILE="$DATA_DIR/dapo-math-17k-cleaned.parquet"
+TEST_FILE="$DATA_DIR/aime-2024-cleaned.parquet"
+NUM_NODES=4
+NUM_GPUS_PER_NODE=8
+NUM_INFERENCE_ENGINES=4
+INFERENCE_ENGINE_TENSOR_PARALLEL_SIZE=8
+LOGGER="wandb"  # change to "console" to print to stdout
+
+CLIP_RATIO_LOW=0.2
+CLIP_RATIO_HIGH=0.28
+# use token mean loss reduction
+LOSS_REDUCTION="token_mean"
+# applies overlong filtering (but not soft overlong punishment)
+APPLY_OVERLONG_FILTERING=true
+# apply soft overlong punishment with custom trainer impl in main_dapo.py
+OVERLONG_BUFFER_LEN=$((1024 * 4))
+OVERLONG_BUFFER_PENALTY_FACTOR=1.0
+
+# other DAPO parameters
+USE_KL_LOSS=false
+TEMPERATURE=1.0
+TOP_P=1.0
+EVAL_TOP_P=0.7
+CLIP_RATIO_C=10.0
+MAX_PROMPT_LENGTH=$((1024 * 2))
+MAX_RESPONSE_LENGTH=$((1024 * 8))
+
+# repro run parameters
+TRAIN_BATCH_SIZE=128
+MINI_BATCH_SIZE=32
+N_SAMPLES_PER_PROMPT=16
+EVAL_N_SAMPLES_PER_PROMPT=32
+ENFORCE_EAGER=false # cudagraphs SAFE on vLLM 0.20.2 (has PR #42779 padded-input fix); need FULL_DECODE_ONLY below
+LR=1e-5 # LoRA: higher LR for adapters (matches reference lora script; full-FT used 1e-6)
+
+# lora config (rank 32 per request; alpha=rank 1:1 as in reference lora script)
+LORA_RANK=32
+LORA_ALPHA=32
+
+# megatron config
+MEGATRON_TP=4
+MEGATRON_PP=1
+MEGATRON_CP=1
+MEGATRON_EP=8
+MEGATRON_ETP=1
+
+
+# TIS parameters
+TIS_IMP_RATIO_CAP=2.0
+TIS_TYPE=token
+
+# optimizer offload
+OPTIMIZER_OFFLOAD=true
+OPTIMIZER_OFFLOAD_FRACTION=1.0
+
+
+# Qwen3.5 flags
+REMOVE_MICROBATCH_PADDING=false # sample packing is not yet supported for GDN layers in megatron - see: https://github.com/NVIDIA/Megatron-LM/pull/2644
+ENGINE_INIT_KWARGS='{"gdn_prefill_backend": "triton", "compilation_config": {"cudagraph_mode": "FULL_DECODE_ONLY"}}' # auto prefill backend can crash
+DISTRIBUTED_EXECUTOR_BACKEND="mp"
+export _SKYRL_USE_NEW_INFERENCE=0
+export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
+
+uv run --isolated --extra megatron -m examples.train.algorithms.dapo.main_dapo \
+  data.train_data="['$TRAIN_FILE']" \
+  data.val_data="['$TEST_FILE']" \
+  trainer.algorithm.advantage_estimator="grpo" \
+  trainer.algorithm.policy_loss_type="dual_clip" \
+  trainer.algorithm.overlong_buffer_len=$OVERLONG_BUFFER_LEN \
+  trainer.algorithm.overlong_buffer_penalty_factor=$OVERLONG_BUFFER_PENALTY_FACTOR \
+  trainer.algorithm.loss_reduction=$LOSS_REDUCTION \
+  generator.inference_engine.enforce_eager=$ENFORCE_EAGER \
+  generator.apply_overlong_filtering=$APPLY_OVERLONG_FILTERING \
+  generator.sampling_params.temperature=$TEMPERATURE \
+  generator.sampling_params.top_p=$TOP_P \
+  generator.eval_sampling_params.top_p=$EVAL_TOP_P \
+  generator.eval_sampling_params.temperature=$TEMPERATURE \
+  generator.eval_sampling_params.max_generate_length=$MAX_RESPONSE_LENGTH \
+  trainer.algorithm.use_kl_loss=$USE_KL_LOSS \
+  trainer.algorithm.clip_ratio_c=$CLIP_RATIO_C \
+  trainer.policy.model.path="$MODEL_NAME" \
+  trainer.placement.colocate_all=true \
+  trainer.strategy=megatron \
+  generator.inference_engine.distributed_executor_backend="mp" \
+  trainer.placement.policy_num_nodes=$NUM_NODES \
+  trainer.placement.policy_num_gpus_per_node=$NUM_GPUS_PER_NODE \
+  generator.inference_engine.engine_init_kwargs="$ENGINE_INIT_KWARGS" \
+  generator.inference_engine.num_engines=$NUM_INFERENCE_ENGINES \
+  generator.inference_engine.tensor_parallel_size=$INFERENCE_ENGINE_TENSOR_PARALLEL_SIZE \
+  trainer.policy.megatron_config.tensor_model_parallel_size=$MEGATRON_TP \
+  trainer.policy.megatron_config.pipeline_model_parallel_size=$MEGATRON_PP \
+  trainer.policy.megatron_config.context_parallel_size=$MEGATRON_CP \
+  trainer.policy.megatron_config.expert_model_parallel_size=$MEGATRON_EP \
+  trainer.policy.megatron_config.expert_tensor_parallel_size=$MEGATRON_ETP \
+  trainer.policy.model.lora.rank=$LORA_RANK \
+  trainer.policy.model.lora.alpha=$LORA_ALPHA \
+  trainer.policy.megatron_config.optimizer_config_kwargs.overlap_cpu_optimizer_d2h_h2d=$OPTIMIZER_OFFLOAD \
+  trainer.policy.megatron_config.optimizer_config_kwargs.use_precision_aware_optimizer=$OPTIMIZER_OFFLOAD \
+  trainer.policy.megatron_config.optimizer_config_kwargs.optimizer_cpu_offload=$OPTIMIZER_OFFLOAD \
+  trainer.policy.megatron_config.optimizer_config_kwargs.optimizer_offload_fraction=$OPTIMIZER_OFFLOAD_FRACTION \
+  trainer.algorithm.off_policy_correction.tis_ratio_type=$TIS_TYPE \
+  trainer.algorithm.off_policy_correction.token_tis_ratio_clip_high=$TIS_IMP_RATIO_CAP \
+  trainer.remove_microbatch_padding=$REMOVE_MICROBATCH_PADDING \
+  trainer.epochs=20 \
+  trainer.algorithm.eps_clip_low=$CLIP_RATIO_LOW \
+  trainer.algorithm.eps_clip_high=$CLIP_RATIO_HIGH \
+  trainer.eval_batch_size=1024 \
+  trainer.eval_before_train=false \
+  trainer.eval_interval=5 \
+  trainer.update_epochs_per_batch=1 \
+  trainer.train_batch_size=$TRAIN_BATCH_SIZE \
+  trainer.policy_mini_batch_size=$MINI_BATCH_SIZE \
+  trainer.micro_forward_batch_size_per_gpu=1 \
+  trainer.micro_train_batch_size_per_gpu=1 \
+  trainer.ckpt_interval=5 \
+  trainer.max_prompt_length=$MAX_PROMPT_LENGTH \
+  generator.sampling_params.max_generate_length=$MAX_RESPONSE_LENGTH \
+  trainer.policy.optimizer_config.lr=$LR \
+  trainer.policy.optimizer_config.num_warmup_steps=40 \
+  trainer.policy.optimizer_config.weight_decay=0.1 \
+  trainer.policy.optimizer_config.max_grad_norm=1.0 \
+  generator.inference_engine.backend=vllm \
+  generator.inference_engine.run_engines_locally=true \
+  generator.inference_engine.weight_sync_backend=nccl \
+  generator.inference_engine.async_engine=false \
+  generator.batched=true \
+  environment.env_class=aime \
+  generator.n_samples_per_prompt=$N_SAMPLES_PER_PROMPT \
+  generator.eval_n_samples_per_prompt=$EVAL_N_SAMPLES_PER_PROMPT \
+  generator.inference_engine.gpu_memory_utilization=0.7 \
+  trainer.logger="$LOGGER" \
+  trainer.project_name="qwen3_6_dapo_lora" \
+  trainer.run_name="dapo_lora_r32_qwen3_6_35b_a3b_base_megatron_tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}_ep${MEGATRON_EP}_etp${MEGATRON_ETP}" \
+  trainer.export_path="$HOME/exports/dapo_lora_r32_qwen3_6_35b_a3b_base_megatron_tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}_ep${MEGATRON_EP}_etp${MEGATRON_ETP}" \
+  trainer.hf_save_interval=300 \
+  trainer.resume_mode=latest \
+  trainer.max_ckpts_to_keep=3 \
+  trainer.ckpt_path="$HOME/ckpts/dapo_lora_r32_qwen3_6_35b_a3b_base_megatron_tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}_ep${MEGATRON_EP}_etp${MEGATRON_ETP}" \
+  $@

--- a/examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora.sh
+++ b/examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora.sh
@@ -64,7 +64,7 @@ OPTIMIZER_OFFLOAD=true
 OPTIMIZER_OFFLOAD_FRACTION=1.0
 
 
-# Qwen3.5 flags
+# Qwen3.6 flags
 REMOVE_MICROBATCH_PADDING=false # sample packing is not yet supported for GDN layers in megatron - see: https://github.com/NVIDIA/Megatron-LM/pull/2644
 ENGINE_INIT_KWARGS='{"gdn_prefill_backend": "triton", "compilation_config": {"cudagraph_mode": "FULL_DECODE_ONLY"}}' # auto prefill backend can crash
 DISTRIBUTED_EXECUTOR_BACKEND="mp"


### PR DESCRIPTION
Add a script for Qwen3.6-35b LoRA DAPO script, all runs below ran at commit https://github.com/NovaSky-AI/SkyRL/commit/20ccf0682671b46dde12a9b11b8ddfc99447f58d

Various learnings summarized below (ran on 4x8xH200s), over 4 runs

1. (blue) 350 steps of LoRA, enforce_eager=False + cudagraph_mode=FULL_DECODE_ONLY
    - Takeaways:
      - enforce_eager=False + cudagraph_mode=FULL_DECODE_ONLY is fast (3x faster than run 2 for generation phase on DAPO)
        - Note that default `cudagraph_mode` might work as well, only went with this cudagraph mode
      - Have train-inf mismatch issue
2. (brown) 25 steps of LoRA, enforce_eager=True
    - Takeaway: 3x slower, still have mismatch issue
3. (pink) 50 steps of full param, enforce_eager=False + cudagraph_mode=FULL_DECODE_ONLY
    - Takeaway: full param has no train-inf mismatch
4. `gdn_prefill_backend=auto` crashed in 17 steps
    - Takeaway: need to use Triton to prevent hanging (same inference speed). Issue summarized by claude:

```
Decisive line: `[Rank 0] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=155856,
OpType=_ALLGATHER_BASE, NumelIn=11577920, NumelOut=92623360, Timeout(ms)=600000) ran for 600071 ms`.
=> A NCCL **_ALLGATHER_BASE hung for 600s** inside the vLLM **TP=8 inference group** (PG ID 2; NumelOut/In=8
= TP world size => intra-engine, intra-node NVLink, NOT cross-node IB). ProcessGroupNCCL watchdog aborted ->
VllmWorker-3 then -0 "died unexpectedly" (multiproc_executor.py:283) -> executor shut down -> pending
generate() cancelled -> RuntimeError("cancelled") at trainer. So "cancelled" was 3 layers downstream of a
**collective hang/deadlock** (not OOM, not a clean error). A 600s allgather hang = one rank never reached the
collective, typically a CUDA kernel deadlock on one rank (flashinfer/triton) or an NVLink/driver hiccup;
raising the timeout would not fix a true deadlock. flashinfer still the prime suspect (only new generate-path
var) but unproven -> reverted to triton; if triton also hangs, suspect a flaky node/NVLink.
```

### Megatron knob tuning

Did a sweep on 64k context and 128k context over TP4+EP8, TP2+EP8, TP8+EP8, TP4+EP4, TP8+EP8 on par with TP4+EP8 for 64k, and TP4+EP8 OOM for 128k. So TP8+EP8 is a good set of knobs (at least up till 128k).

However, for LoRA, the training speed is currently slower than full fine-tuning (500 seconds vs. 390 seconds for roughly the same number of tokens)

### Curves

LoRA reward is subpar, likely due to the large mismatch. Such mismatch is observed in GLM-4.7-Flash as well, which was also observed in other RL frameworks

<img width="1156" height="661" alt="image" src="https://github.com/user-attachments/assets/422efeec-9898-42b2-9de5-7bea9765a658" />

<img width="1151" height="288" alt="image" src="https://github.com/user-attachments/assets/00dbbbac-1199-4710-a698-1ee99057bc85" />

Timing wise, `enforce_eager=False + cudagraph_mode=FULL_DECODE_ONLY` is much faster (brown vs. blue). And full param trains faster than LoRA (indeed less generation length, but faster nonetheless)

<img width="761" height="606" alt="image" src="https://github.com/user-attachments/assets/5e49b2a7-53a4-49b6-add8-a70442c6536a" />


### TODOs

- [ ] Investigate LoRA mismatch, observed the same issue with GLM-4.7-Flash, then see if reward curve and match full finetuning