### PR TITLE
Support top-K distillation (SDFT/OPSD): teacher top-K sampling + soft-target CE training

### DIFF
--- a/skyrl/backends/jax.py
+++ b/skyrl/backends/jax.py
@@ -39,7 +39,7 @@ from transformers import AutoConfig, AutoTokenizer
 
 from skyrl.backends.backend import AbstractBackend
 from skyrl.backends.renderer import render_model_input
-from skyrl.backends.utils import pad, pad_batch, pad_to_fsdp
+from skyrl.backends.utils import pad, pad_batch, pad_batch_topk, pad_to_fsdp
 from skyrl.tinker import types
 from skyrl.tinker.loss_fns import LOSS_FUNCTIONS, LossFnConfig
 from skyrl.tinker.types import LOSS_TYPES
@@ -472,10 +472,148 @@ class JaxBackendImpl(AbstractBackend):
             new_accumulated_grads = accumulated_grads.add(lora_grads, adapter_indices)
             return new_accumulated_grads, per_token_losses, target_logprobs
 
+        # Soft top-K distillation variants (e.g. SDFT / OPSD forward-KL CE).
+        # Identical loss machinery, but each position carries K candidate target
+        # tokens and a teacher weight per candidate. The per-position target
+        # logprob is the teacher-weighted sum over the K student logprobs:
+        #   target_logprobs[b,t] = sum_k weights[b,t,k] * logp_student(target_ids[b,t,k])
+        # loss_mask is the completion indicator (weights sum > 0 at that position),
+        # so downstream (loss switch + normalization + accumulation) is unchanged.
+        def _model_forward_topk(
+            graphdef: nnx.GraphDef,
+            lora_params: nnx.State,
+            non_lora_params: nnx.State,
+            input_ids: jax.Array,
+            attention_mask: jax.Array,
+            adapter_indices: jax.Array,
+            target_ids: jax.Array,  # [B, T, K]
+            target_weights: jax.Array,  # [B, T, K]
+        ) -> jax.Array:
+            model = nnx.merge(graphdef, lora_params, non_lora_params)
+            output = model(
+                input_ids,
+                attention_mask=attention_mask,
+                adapter_indices=adapter_indices,
+                is_training=True,
+            )
+            topk_logprobs = model.compute_topk_logprobs(output.last_hidden_state, target_ids, adapter_indices)
+            return (target_weights * topk_logprobs).sum(axis=-1)  # [B, T]
+
+        def loss_for_lora_topk(
+            lora_params: nnx.State,
+            non_lora_params: nnx.State,
+            input_ids: jax.Array,
+            attention_mask: jax.Array,
+            adapter_indices: jax.Array,
+            target_ids: jax.Array,
+            target_weights: jax.Array,
+            loss_mask: jax.Array,
+            loss_fn_types: jax.Array,
+            sampling_logprobs: jax.Array,
+            advantages: jax.Array,
+            loss_fn_config: LossFnConfig,
+        ) -> tuple[jax.Array, tuple[jax.Array, jax.Array]]:
+            target_logprobs = _model_forward_topk(
+                self.graphdef,
+                lora_params,
+                non_lora_params,
+                input_ids,
+                attention_mask,
+                adapter_indices,
+                target_ids,
+                target_weights,
+            )
+
+            def compute_loss_per_example(
+                loss_fn_type, target_logprobs, loss_mask, sampling_logprobs, advantages, loss_fn_config
+            ):
+                return jax.lax.switch(
+                    loss_fn_type,
+                    LOSS_FUNCTIONS,
+                    target_logprobs,
+                    loss_mask,
+                    sampling_logprobs,
+                    advantages,
+                    loss_fn_config,
+                )
+
+            per_token_losses = jax.vmap(compute_loss_per_example)(
+                loss_fn_types, target_logprobs, loss_mask, sampling_logprobs, advantages, loss_fn_config
+            )
+            per_seq_loss = per_token_losses.sum(axis=-1) / jnp.maximum(loss_mask.sum(axis=-1), 1e-9)
+            return per_seq_loss.sum(), (target_logprobs, per_token_losses)
+
+        loss_and_grad_fn_topk = jax.value_and_grad(loss_for_lora_topk, argnums=0, has_aux=True)
+
+        def forward_only_topk(
+            accumulated_grads,
+            lora_params,
+            non_lora_params,
+            input_ids,
+            attention_mask,
+            adapter_indices,
+            target_ids,
+            target_weights,
+            loss_mask,
+            loss_fn_types,
+            sampling_logprobs,
+            advantages,
+            loss_fn_config,
+        ):
+            _, (target_logprobs, per_token_losses) = loss_for_lora_topk(
+                lora_params,
+                non_lora_params,
+                input_ids,
+                attention_mask,
+                adapter_indices,
+                target_ids,
+                target_weights,
+                loss_mask,
+                loss_fn_types,
+                sampling_logprobs,
+                advantages,
+                loss_fn_config,
+            )
+            return accumulated_grads, per_token_losses, target_logprobs
+
+        def forward_backward_and_accumulate_topk(
+            accumulated_grads,
+            lora_params,
+            non_lora_params,
+            input_ids,
+            attention_mask,
+            adapter_indices,
+            target_ids,
+            target_weights,
+            loss_mask,
+            loss_fn_types,
+            sampling_logprobs,
+            advantages,
+            loss_fn_config,
+        ):
+            (_, (target_logprobs, per_token_losses)), lora_grads = loss_and_grad_fn_topk(
+                lora_params,
+                non_lora_params,
+                input_ids,
+                attention_mask,
+                adapter_indices,
+                target_ids,
+                target_weights,
+                loss_mask,
+                loss_fn_types,
+                sampling_logprobs,
+                advantages,
+                loss_fn_config,
+            )
+            new_accumulated_grads = accumulated_grads.add(lora_grads, adapter_indices)
+            return new_accumulated_grads, per_token_losses, target_logprobs
+
         if self.config.enforce_eager:
             # Disable JIT compilation for debugging
             self._forward_backward_and_accumulate = forward_backward_and_accumulate
             self._forward = forward_only
+            self._forward_backward_and_accumulate_topk = forward_backward_and_accumulate_topk
+            self._forward_topk = forward_only_topk
 
         else:
             # Retrieve the sharding of lora and non_lora params and compute the sharding of inputs and outputs
@@ -525,6 +663,36 @@ class JaxBackendImpl(AbstractBackend):
                 forward_only,
                 in_shardings=(accumulated_grads_shardings, lora_shardings, non_lora_shardings)
                 + input_shardings
+                + (loss_fn_config_shardings,),
+                out_shardings=(accumulated_grads_shardings, batch_sharded_2d, batch_sharded_2d),
+            )
+
+            # Soft top-K variants: target_ids and target_weights are 3D [B, T, K],
+            # sharded along the batch (fsdp) axis.
+            batch_sharded_3d = jax.NamedSharding(self.mesh, jax.P("fsdp", None, None))
+            input_shardings_topk = (
+                batch_sharded_2d,  # input_ids
+                batch_sharded_2d,  # attention_mask
+                batch_sharded_1d,  # adapter_indices
+                batch_sharded_3d,  # target_ids [B, T, K]
+                batch_sharded_3d,  # target_weights [B, T, K]
+                batch_sharded_2d,  # loss_mask
+                batch_sharded_1d,  # loss_fn_types
+                batch_sharded_2d,  # sampling_logprobs
+                batch_sharded_2d,  # advantages
+            )
+            self._forward_backward_and_accumulate_topk = jax.jit(
+                forward_backward_and_accumulate_topk,
+                in_shardings=(accumulated_grads_shardings, lora_shardings, non_lora_shardings)
+                + input_shardings_topk
+                + (loss_fn_config_shardings,),
+                out_shardings=(accumulated_grads_shardings, batch_sharded_2d, batch_sharded_2d),
+                donate_argnames=("accumulated_grads",),
+            )
+            self._forward_topk = jax.jit(
+                forward_only_topk,
+                in_shardings=(accumulated_grads_shardings, lora_shardings, non_lora_shardings)
+                + input_shardings_topk
                 + (loss_fn_config_shardings,),
                 out_shardings=(accumulated_grads_shardings, batch_sharded_2d, batch_sharded_2d),
             )
@@ -654,18 +822,32 @@ class JaxBackendImpl(AbstractBackend):
 
         # Pad sequences to same length. Also bin it so the JIT has to compile fewer kernels.
         max_len = round_up_seq_len(max(len(seq) for seq in all_input_ids))
+        topk = prepared_batch.target_topk
+        is_topk = topk > 1
 
         input_ids = pad_batch(all_input_ids, max_len, np.int32)
-        target_ids = pad_batch(all_targets, max_len, np.int32)
         adapter_indices = np.array(all_adapter_indices, dtype=np.int32)
         loss_fn_types = np.array(all_loss_fn_types, dtype=np.int32)
         loss_fn_config = self._build_loss_fn_config(all_loss_fn_configs)
 
         # Create attention mask (1 for real tokens, 0 for padding)
         attention_mask = pad_batch([[1] * len(seq) for seq in all_input_ids], max_len, np.int32)
-        loss_mask = pad_batch(all_token_weights, max_len, np.float32)
         sampling_logprobs = pad_batch(all_sampling_logprobs, max_len, np.float32)
         advantages = pad_batch(all_advantages, max_len, np.float32)
+
+        if is_topk:
+            # Soft top-K distillation: targets/weights are (num_tokens, K) per example.
+            seq_lens_in = [len(seq) for seq in all_input_ids]
+            target_ids = pad_batch_topk(all_targets, seq_lens_in, max_len, topk, np.int32)  # [B, max_len, K]
+            target_weights = pad_batch_topk(
+                all_token_weights, seq_lens_in, max_len, topk, np.float32
+            )  # [B, max_len, K]
+            # Completion indicator: positions that carry any teacher weight.
+            loss_mask = (target_weights.sum(axis=-1) > 0).astype(np.float32)  # [B, max_len]
+        else:
+            target_ids = pad_batch(all_targets, max_len, np.int32)
+            target_weights = None
+            loss_mask = pad_batch(all_token_weights, max_len, np.float32)
 
         total_bs = int(input_ids.shape[0])
         micro_bs = self._micro_batch_size(total_bs)
@@ -679,58 +861,65 @@ class JaxBackendImpl(AbstractBackend):
         # Sharding specs for batch inputs
         sharding_2d = jax.NamedSharding(self.mesh, jax.P("fsdp", None))
         sharding_1d = jax.NamedSharding(self.mesh, jax.P("fsdp"))
+        sharding_3d = jax.NamedSharding(self.mesh, jax.P("fsdp", None, None))
         fsdp_size = self.mesh.shape["fsdp"]
+
+        def _shard(arr, sharding):
+            return jax.device_put(pad_to_fsdp(arr[mb_start:mb_end], fsdp_size), sharding)
 
         with jax.set_mesh(self.mesh), self._jit_timing_context(seq_len, mode="train"):
             for mb_start in range(0, total_bs, micro_bs):
                 mb_end = min(mb_start + micro_bs, total_bs)
 
-                # Pad and shard the micro-batch inputs
-                (
-                    mb_input_ids,
-                    mb_attention_mask,
-                    mb_target_ids,
-                    mb_loss_mask,
-                    mb_sampling_logprobs,
-                    mb_advantages,
-                    mb_adapter_indices,
-                    mb_loss_fn_types,
-                    mb_clip_low_threshold,
-                    mb_clip_high_threshold,
-                ) = jax.device_put(
-                    (
-                        pad_to_fsdp(input_ids[mb_start:mb_end], fsdp_size),
-                        pad_to_fsdp(attention_mask[mb_start:mb_end], fsdp_size),
-                        pad_to_fsdp(target_ids[mb_start:mb_end], fsdp_size),
-                        pad_to_fsdp(loss_mask[mb_start:mb_end], fsdp_size),
-                        pad_to_fsdp(sampling_logprobs[mb_start:mb_end], fsdp_size),
-                        pad_to_fsdp(advantages[mb_start:mb_end], fsdp_size),
-                        pad_to_fsdp(adapter_indices[mb_start:mb_end], fsdp_size),
-                        pad_to_fsdp(loss_fn_types[mb_start:mb_end], fsdp_size),
-                        pad_to_fsdp(loss_fn_config.clip_low_threshold[mb_start:mb_end], fsdp_size),
-                        pad_to_fsdp(loss_fn_config.clip_high_threshold[mb_start:mb_end], fsdp_size),
-                    ),
-                    (sharding_2d,) * 6 + (sharding_1d,) * 4,
-                )
+                # Pad and shard the micro-batch inputs (shared across both paths)
+                mb_input_ids = _shard(input_ids, sharding_2d)
+                mb_attention_mask = _shard(attention_mask, sharding_2d)
+                mb_loss_mask = _shard(loss_mask, sharding_2d)
+                mb_sampling_logprobs = _shard(sampling_logprobs, sharding_2d)
+                mb_advantages = _shard(advantages, sharding_2d)
+                mb_adapter_indices = _shard(adapter_indices, sharding_1d)
+                mb_loss_fn_types = _shard(loss_fn_types, sharding_1d)
                 mb_loss_fn_config = LossFnConfig(
-                    clip_low_threshold=mb_clip_low_threshold,
-                    clip_high_threshold=mb_clip_high_threshold,
+                    clip_low_threshold=_shard(loss_fn_config.clip_low_threshold, sharding_1d),
+                    clip_high_threshold=_shard(loss_fn_config.clip_high_threshold, sharding_1d),
                 )
 
-                self.accumulated_grads, per_token_losses, target_logprobs = model_pass_fn(
-                    self.accumulated_grads,
-                    self.lora_params,
-                    self.non_lora_params,
-                    mb_input_ids,
-                    mb_attention_mask,
-                    mb_adapter_indices,
-                    mb_target_ids,
-                    mb_loss_mask,
-                    mb_loss_fn_types,
-                    mb_sampling_logprobs,
-                    mb_advantages,
-                    mb_loss_fn_config,
-                )
+                if is_topk:
+                    # target_ids/target_weights are 3D [B, T, K]; loss_mask is the
+                    # completion indicator. Uses the soft top-K model pass fn.
+                    mb_target_ids = _shard(target_ids, sharding_3d)
+                    mb_target_weights = _shard(target_weights, sharding_3d)
+                    self.accumulated_grads, per_token_losses, target_logprobs = model_pass_fn(
+                        self.accumulated_grads,
+                        self.lora_params,
+                        self.non_lora_params,
+                        mb_input_ids,
+                        mb_attention_mask,
+                        mb_adapter_indices,
+                        mb_target_ids,
+                        mb_target_weights,
+                        mb_loss_mask,
+                        mb_loss_fn_types,
+                        mb_sampling_logprobs,
+                        mb_advantages,
+                        mb_loss_fn_config,
+                    )
+                else:
+                    mb_target_ids = _shard(target_ids, sharding_2d)
+                    self.accumulated_grads, per_token_losses, target_logprobs = model_pass_fn(
+                        self.accumulated_grads,
+                        self.lora_params,
+                        self.non_lora_params,
+                        mb_input_ids,
+                        mb_attention_mask,
+                        mb_adapter_indices,
+                        mb_target_ids,
+                        mb_loss_mask,
+                        mb_loss_fn_types,
+                        mb_sampling_logprobs,
+                        mb_advantages,
+                        mb_loss_fn_config,
+                    )
                 # Slice back to original size (remove FSDP padding)
                 token_losses_device.append(per_token_losses[: mb_end - mb_start])
                 logprobs_device.append(target_logprobs[: mb_end - mb_start])
@@ -789,14 +978,20 @@ class JaxBackendImpl(AbstractBackend):
         prepared_batch: types.PreparedModelPassBatch,
     ) -> dict[str, types.ForwardBackwardOutput | types.ErrorResponse]:
         """Run forward and backward pass on a batch."""
-        return self._model_pass(prepared_batch, self._forward_backward_and_accumulate)
+        fn = (
+            self._forward_backward_and_accumulate_topk
+            if prepared_batch.target_topk > 1
+            else self._forward_backward_and_accumulate
+        )
+        return self._model_pass(prepared_batch, fn)
 
     def forward(
         self,
         prepared_batch: types.PreparedModelPassBatch,
     ) -> dict[str, types.ForwardBackwardOutput | types.ErrorResponse]:
         """Run forward-only pass on a batch (no gradient computation)."""
-        return self._model_pass(prepared_batch, self._forward)
+        fn = self._forward_topk if prepared_batch.target_topk > 1 else self._forward
+        return self._model_pass(prepared_batch, fn)
 
     def optim_step(self, model_id: str, request_data: types.OptimStepInput) -> types.OptimStepOutput:
         """Apply an optimizer step using accumulated gradients."""

--- a/skyrl/backends/jax.py
+++ b/skyrl/backends/jax.py
@@ -851,6 +851,7 @@ class JaxBackendImpl(AbstractBackend):
         all_sampling_params = prepared_batch.all_sampling_params
         request_batch_slices = prepared_batch.request_batch_slices
         needs_prompt_logprobs = prepared_batch.needs_prompt_logprobs
+        max_topk_prompt_logprobs = prepared_batch.max_topk_prompt_logprobs
 
         # Load sampler weights and get adapter indices
         all_adapter_indices = self.load_sampler_weights(prepared_batch)
@@ -862,6 +863,7 @@ class JaxBackendImpl(AbstractBackend):
         # Collect generated sequences and prompt logprobs across batches
         all_sequences: list[types.GeneratedSequence] = []
         all_prompt_logprobs: list[list[float]] = []
+        all_topk_prompt_logprobs: list = []
 
         # Sharding specs for sampling inputs
         sharding_2d = jax.NamedSharding(self.mesh, jax.P("fsdp", None))
@@ -896,6 +898,7 @@ class JaxBackendImpl(AbstractBackend):
                         sampling_params=sampling_params,
                         adapter_indices=adapter_indices,
                         prompt_logprobs=needs_prompt_logprobs,
+                        topk_prompt=max_topk_prompt_logprobs,
                         tokenizer=self.tokenizer,
                     )
                 # Only take the actual results, not the padded ones
@@ -910,14 +913,23 @@ class JaxBackendImpl(AbstractBackend):
                 )
                 if needs_prompt_logprobs and result.prompt_logprobs:
                     all_prompt_logprobs.extend(result.prompt_logprobs[:batch_size])
+                if max_topk_prompt_logprobs > 0 and result.topk_prompt_logprobs:
+                    all_topk_prompt_logprobs.extend(result.topk_prompt_logprobs[:batch_size])
 
-        for request_id, _, start_idx, end_idx, prompt_logprobs_requested in request_batch_slices:
+        for request_id, _, start_idx, end_idx, prompt_logprobs_requested, topk_requested in request_batch_slices:
             sequences = [all_sequences[i] for i in range(start_idx, end_idx)]
             # Each of `num_samples` samples in a request share the same prompt; use the first's prompt logprobs
             prompt_logprobs = (
                 all_prompt_logprobs[start_idx] if prompt_logprobs_requested and all_prompt_logprobs else None
             )
-            results[request_id] = types.SampleOutput(sequences=sequences, prompt_logprobs=prompt_logprobs)
+            topk_prompt_logprobs = (
+                all_topk_prompt_logprobs[start_idx] if topk_requested > 0 and all_topk_prompt_logprobs else None
+            )
+            results[request_id] = types.SampleOutput(
+                sequences=sequences,
+                prompt_logprobs=prompt_logprobs,
+                topk_prompt_logprobs=topk_prompt_logprobs,
+            )
 
         return results
 

--- a/skyrl/backends/utils.py
+++ b/skyrl/backends/utils.py
@@ -43,6 +43,32 @@ def pad_batch(sequences: list[list], max_length: int, dtype) -> np.ndarray:
     return padded
 
 
+def pad_batch_topk(flat_sequences: list[list], lengths: list[int], max_length: int, topk: int, dtype) -> np.ndarray:
+    """Pad row-major-flattened (n_i, K) sequences to (batch, max_length, K).
+
+    Used for soft top-K distillation targets/weights, which arrive as
+    row-major-flattened 2D tensors. ``flat_sequences[i]`` has length
+    ``lengths[i] * topk``.
+
+    Args:
+        flat_sequences: Per-example flat (row-major) data of length n_i * topk.
+        lengths: Per-example number of tokens n_i.
+        max_length: Target sequence length to pad to.
+        topk: Number of candidate tokens per position (K).
+        dtype: NumPy dtype for the output array.
+
+    Returns:
+        A NumPy array of shape (batch_size, max_length, topk).
+    """
+    batch_size = len(flat_sequences)
+    padded = np.zeros((batch_size, max_length, topk), dtype=dtype)
+    for i, (flat, n) in enumerate(zip(flat_sequences, lengths)):
+        assert n <= max_length, f"Sequence length {n} exceeds max_length {max_length}"
+        assert len(flat) == n * topk, f"Expected {n * topk} values for (n={n}, K={topk}), got {len(flat)}"
+        padded[i, :n, :] = np.asarray(flat, dtype=dtype).reshape(n, topk)
+    return padded
+
+
 def pad_to_fsdp(arr: np.ndarray, fsdp_size: int) -> np.ndarray:
     """Pad array's first dimension to be divisible by FSDP size."""
     batch_size = arr.shape[0]

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -415,9 +415,13 @@ class ModelInput(BaseModel):
 
 class TensorData(BaseModel):
     data: list[int] | list[float]
+    # Shape of the (row-major flattened) tensor. Preserved so 2D loss-fn inputs
+    # such as (num_tokens, K) soft top-K distillation targets survive the request
+    # boundary; None / 1D is the common per-token case.
+    shape: list[int] | None = None
 
     def to_types(self) -> types.TensorData:
-        return types.TensorData(data=self.data)
+        return types.TensorData(data=self.data, shape=self.shape)
 
 
 class Datum(BaseModel):
@@ -1094,9 +1098,7 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
             checkpoint_id=checkpoint_id,
             # top-K prompt logprobs require the full prompt logits path, so enable
             # prompt_logprobs whenever top-K is requested.
-            prompt_logprobs=(
-                (request.prompt_logprobs is True) or (request.topk_prompt_logprobs > 0)
-            ),
+            prompt_logprobs=((request.prompt_logprobs is True) or (request.topk_prompt_logprobs > 0)),
             topk_prompt_logprobs=request.topk_prompt_logprobs,
             seq_id=request.seq_id,
             sampling_session_id=request.sampling_session_id,

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1092,7 +1092,12 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
             sampling_params=request.sampling_params.to_types(),
             num_samples=request.num_samples,
             checkpoint_id=checkpoint_id,
-            prompt_logprobs=request.prompt_logprobs if request.prompt_logprobs is not None else False,
+            # top-K prompt logprobs require the full prompt logits path, so enable
+            # prompt_logprobs whenever top-K is requested.
+            prompt_logprobs=(
+                (request.prompt_logprobs is True) or (request.topk_prompt_logprobs > 0)
+            ),
+            topk_prompt_logprobs=request.topk_prompt_logprobs,
             seq_id=request.seq_id,
             sampling_session_id=request.sampling_session_id,
         ),

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -64,6 +64,9 @@ def prepare_sample_batch(
     request_batch_slices = []
 
     needs_prompt_logprobs = any(request_data.prompt_logprobs for (_, request_data) in requests.values())
+    max_topk_prompt_logprobs = max(
+        (request_data.topk_prompt_logprobs for (_, request_data) in requests.values()), default=0
+    )
 
     for request_id, (model_id, request_data) in requests.items():
         request_start = len(all_model_inputs)
@@ -89,7 +92,14 @@ def prepare_sample_batch(
             all_session_ids.append(session_id)
 
         request_batch_slices.append(
-            (request_id, model_id, request_start, len(all_model_inputs), request_data.prompt_logprobs)
+            (
+                request_id,
+                model_id,
+                request_start,
+                len(all_model_inputs),
+                request_data.prompt_logprobs,
+                request_data.topk_prompt_logprobs,
+            )
         )
 
     return types.PreparedSampleBatch(
@@ -100,6 +110,7 @@ def prepare_sample_batch(
         all_checkpoint_paths=all_checkpoint_paths,
         all_session_ids=all_session_ids,
         needs_prompt_logprobs=needs_prompt_logprobs,
+        max_topk_prompt_logprobs=max_topk_prompt_logprobs,
         request_batch_slices=request_batch_slices,
     )
 

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -140,6 +140,7 @@ def prepare_model_pass_batch(
     all_loss_fns = []
     all_loss_fn_configs = []
     request_batch_slices = []
+    target_topk = 0  # K for soft top-K distillation targets (0 => standard 1D)
 
     for request_id, (model_id, request_data) in requests.items():
         if request_data.loss_fn not in types.SUPPORTED_LOSS_FNS:
@@ -150,6 +151,13 @@ def prepare_model_pass_batch(
         for item in request_data.data:
             all_model_inputs.append(item.model_input)
             loss_fn_inputs = item.loss_fn_inputs
+            # Detect 2D (num_tokens, K) targets => soft top-K distillation. The wire
+            # data is row-major flattened; the backend reshapes using target_topk.
+            tt_shape = loss_fn_inputs.target_tokens.shape
+            if tt_shape is not None and len(tt_shape) == 2:
+                if target_topk not in (0, tt_shape[1]):
+                    raise ValueError(f"Inconsistent top-K across batch: {target_topk} vs {tt_shape[1]}")
+                target_topk = tt_shape[1]
             all_targets.append(loss_fn_inputs.target_tokens.data)
             all_token_weights.append(loss_fn_inputs.weights.data)
             all_sampling_logprobs.append(loss_fn_inputs.logprobs.data)
@@ -173,6 +181,7 @@ def prepare_model_pass_batch(
         all_model_ids=all_model_ids,
         all_loss_fns=all_loss_fns,
         all_loss_fn_configs=all_loss_fn_configs,
+        target_topk=target_topk,
         request_batch_slices=request_batch_slices,
     )
 

--- a/skyrl/tinker/types.py
+++ b/skyrl/tinker/types.py
@@ -142,6 +142,10 @@ class RenderedModelInput(BaseModel):
 
 class TensorData(BaseModel):
     data: list[int] | list[float]
+    # Shape of the tensor (row-major flattened into `data`). Used to recover 2D
+    # loss-fn inputs such as the (num_tokens, K) targets/weights for soft top-K
+    # distillation. None / 1D means a flat per-token sequence (the common case).
+    shape: list[int] | None = None
 
 
 class LossFnInputs(BaseModel):
@@ -300,6 +304,9 @@ class PreparedModelPassBatch(BaseModel):
     all_advantages: list[list[float]]
     all_values: list[list[float]]
     all_returns: list[list[float]]
+
+    # K for soft top-K distillation targets (0/1 => standard hard 1D targets).
+    target_topk: int = 0
 
     # Per-example scalars
     all_model_ids: list[str]

--- a/skyrl/tinker/types.py
+++ b/skyrl/tinker/types.py
@@ -255,6 +255,8 @@ class SampleInput(BaseModel):
     num_samples: int
     checkpoint_id: str
     prompt_logprobs: bool
+    # Number of top-K teacher logprobs to return per prompt position (0 = disabled).
+    topk_prompt_logprobs: int = 0
     # See make_routing_session_id.
     seq_id: int | None = None
     sampling_session_id: str | None = None
@@ -269,6 +271,9 @@ class GeneratedSequence(BaseModel):
 class SampleOutput(BaseModel):
     sequences: list[GeneratedSequence]
     prompt_logprobs: list[float] | None = None
+    # Per prompt position: None, or a list of (token_id, logprob) for the top-K
+    # tokens predicting that position. Matches the Tinker SDK's expected shape.
+    topk_prompt_logprobs: list[list[tuple[int, float]] | None] | None = None
 
 
 # Metrics tracked in the engine
@@ -323,8 +328,12 @@ class PreparedSampleBatch(BaseModel):
     # Whether any request needs prompt logprobs
     needs_prompt_logprobs: bool
 
-    # Mapping from samples back to requests: (request_id, model_id, start_idx, end_idx, prompt_logprobs_requested)
-    request_batch_slices: list[tuple[str, str, int, int, bool]]
+    # Max top-K prompt logprobs requested across the batch (0 = none). The backend
+    # computes this many for every sample; each request slices what it asked for.
+    max_topk_prompt_logprobs: int = 0
+
+    # Mapping: (request_id, model_id, start_idx, end_idx, prompt_logprobs_requested, topk_requested)
+    request_batch_slices: list[tuple[str, str, int, int, bool, int]]
 
 
 # All accepted loss functions across backends.

--- a/skyrl/tx/utils/generator.py
+++ b/skyrl/tx/utils/generator.py
@@ -149,6 +149,10 @@ class GenerateOutput:
     stop_reasons: list[str]
     logprobs: list[list[float]]
     prompt_logprobs: list[list[float]] | None = None
+    # Top-K teacher distribution at each prompt position (Tinker convention):
+    # one entry per prompt position; index 0 is None (no predictor), index i is a
+    # list of (token_id, logprob) for the top-K tokens predicting position i.
+    topk_prompt_logprobs: list[list[list[tuple[int, float]] | None]] | None = None
 
 
 def find_string_stop_position(
@@ -191,7 +195,8 @@ class GeneratorMixin:
 
     @staticmethod
     @functools.partial(
-        jax.jit, static_argnames=("max_length", "max_new_tokens", "max_top_k", "use_top_p", "prompt_logprobs")
+        jax.jit,
+        static_argnames=("max_length", "max_new_tokens", "max_top_k", "use_top_p", "prompt_logprobs", "topk_prompt"),
     )
     def _prefill_and_decode(
         model,
@@ -208,6 +213,7 @@ class GeneratorMixin:
         max_top_k: int,
         use_top_p: bool,
         prompt_logprobs: bool = False,
+        topk_prompt: int = 0,
     ):
         """JIT-compiled prefill + decode loop. Fuses everything for maximum efficiency."""
         # Prefill: process full prompt (left-aligned, so positions start at 0)
@@ -221,12 +227,28 @@ class GeneratorMixin:
         last_token_idx = attention_mask.sum(axis=1) - 1  # Shape: [B]
         batch_idx = jnp.arange(input_ids.shape[0])
 
+        # top_k teacher distribution needs the full prompt logits, same as prompt_logprobs.
+        need_all_logits = prompt_logprobs or topk_prompt > 0
+
         # Compute logits for sampling and optionally for prompt logprobs
-        if prompt_logprobs:
+        topk_prompt_logprobs_array = None
+        topk_prompt_indices_array = None
+        if need_all_logits:
             # Compute all logits for prompt logprobs and sampling the first token
             all_logits = model.compute_logits(outputs.last_hidden_state, adapter_indices)
             last_logits = all_logits[batch_idx, last_token_idx, :]  # Shape: [B, vocab_size]
-            prompt_logprobs_array = model.logits_to_logprobs(all_logits[:, :-1, :], input_ids[:, 1:])
+            prompt_logprobs_array = (
+                model.logits_to_logprobs(all_logits[:, :-1, :], input_ids[:, 1:]) if prompt_logprobs else None
+            )
+            if topk_prompt > 0:
+                # Top-K over the next-token distribution at each prompt position.
+                # Memory-efficient: take top-K logits, then convert to true logprobs by
+                # subtracting the full-vocab logsumexp (avoids a second full-vocab array).
+                sliced = all_logits[:, :-1, :]  # [B, seq-1, vocab]
+                topk_vals, topk_idx = jax.lax.top_k(sliced, topk_prompt)  # [B, seq-1, K]
+                lse = jax.nn.logsumexp(sliced, axis=-1, keepdims=True)  # [B, seq-1, 1]
+                topk_prompt_logprobs_array = topk_vals - lse
+                topk_prompt_indices_array = topk_idx
         else:
             # Only compute logits for the last position for sampling
             last_hidden = outputs.last_hidden_state[batch_idx, last_token_idx][:, None, :]  # Shape: [B, 1, H]
@@ -317,7 +339,14 @@ class GeneratorMixin:
         new_tokens = final_state.generated_tokens
         new_logprobs = final_state.generated_logprobs
 
-        return new_tokens, new_logprobs, final_state.stop_pos, prompt_logprobs_array
+        return (
+            new_tokens,
+            new_logprobs,
+            final_state.stop_pos,
+            prompt_logprobs_array,
+            topk_prompt_logprobs_array,
+            topk_prompt_indices_array,
+        )
 
     def generate(
         self,
@@ -327,6 +356,7 @@ class GeneratorMixin:
         sampling_params: list[types.SamplingParams],
         adapter_indices: jax.Array | None = None,
         prompt_logprobs: bool = False,
+        topk_prompt: int = 0,
         tokenizer=None,
     ) -> GenerateOutput:
         """Generate text autoregressively with KV caching.
@@ -358,14 +388,21 @@ class GeneratorMixin:
             stop_tokens.append(stop + [-1] * (max_stop_tokens - len(stop)))
         stop_tokens = jnp.array(stop_tokens, dtype=jnp.int32)
 
-        # Capture prompt lengths for prompt_logprobs if requested
-        prompt_lengths = attention_mask.sum(axis=1) if prompt_logprobs else None
+        # Capture prompt lengths for prompt_logprobs / topk_prompt_logprobs if requested
+        prompt_lengths = attention_mask.sum(axis=1) if (prompt_logprobs or topk_prompt > 0) else None
 
         # Compute static flags for top_k and top_p filtering
         max_top_k = max((sp.top_k for sp in sampling_params if sp.top_k > 0), default=0)
         use_top_p = any(sp.top_p < 1.0 for sp in sampling_params)
 
-        new_tokens, new_logprobs, stop_pos, prompt_logprobs_array = self._prefill_and_decode(
+        (
+            new_tokens,
+            new_logprobs,
+            stop_pos,
+            prompt_logprobs_array,
+            topk_prompt_logprobs_array,
+            topk_prompt_indices_array,
+        ) = self._prefill_and_decode(
             self,
             input_ids,
             attention_mask,
@@ -380,6 +417,7 @@ class GeneratorMixin:
             max_top_k,
             use_top_p,
             prompt_logprobs=prompt_logprobs,
+            topk_prompt=topk_prompt,
         )
 
         max_tokens = jnp.array([sp.max_tokens for sp in sampling_params])
@@ -391,9 +429,27 @@ class GeneratorMixin:
         if jax.process_count() > 1:
             from jax.experimental import multihost_utils
 
-            (new_tokens, has_stop, new_logprobs, end_positions, prompt_logprobs_array, prompt_lengths) = jax.tree.map(
+            (
+                new_tokens,
+                has_stop,
+                new_logprobs,
+                end_positions,
+                prompt_logprobs_array,
+                prompt_lengths,
+                topk_prompt_logprobs_array,
+                topk_prompt_indices_array,
+            ) = jax.tree.map(
                 lambda x: multihost_utils.process_allgather(x, tiled=True),
-                (new_tokens, has_stop, new_logprobs, end_positions, prompt_logprobs_array, prompt_lengths),
+                (
+                    new_tokens,
+                    has_stop,
+                    new_logprobs,
+                    end_positions,
+                    prompt_logprobs_array,
+                    prompt_lengths,
+                    topk_prompt_logprobs_array,
+                    topk_prompt_indices_array,
+                ),
             )
 
         # Single device-to-host transfer
@@ -404,7 +460,20 @@ class GeneratorMixin:
             end_positions_host,
             prompt_logprobs_host,
             prompt_lengths_host,
-        ) = jax.device_get((new_tokens, has_stop, new_logprobs, end_positions, prompt_logprobs_array, prompt_lengths))
+            topk_prompt_logprobs_host,
+            topk_prompt_indices_host,
+        ) = jax.device_get(
+            (
+                new_tokens,
+                has_stop,
+                new_logprobs,
+                end_positions,
+                prompt_logprobs_array,
+                prompt_lengths,
+                topk_prompt_logprobs_array,
+                topk_prompt_indices_array,
+            )
+        )
 
         # Build output lists, applying string stop detection where needed
         generated_ids = []
@@ -430,6 +499,24 @@ class GeneratorMixin:
             stop_reasons.append(stop_reason)
             logprobs_out.append(token_logprobs)
 
+        # Build top-K prompt logprobs per example, following Tinker's convention:
+        # one entry per prompt position, index 0 is None (no predictor), index i is
+        # the top-K (token_id, logprob) distribution predicting token i.
+        topk_prompt_logprobs_out = None
+        if topk_prompt > 0 and topk_prompt_logprobs_host is not None:
+            topk_prompt_logprobs_out = []
+            for i in range(batch_size):
+                length = int(prompt_lengths_host[i])
+                per_pos: list[list[tuple[int, float]] | None] = [None]
+                vals_i = topk_prompt_logprobs_host[i]
+                idx_i = topk_prompt_indices_host[i]
+                for j in range(length - 1):
+                    entries = [
+                        (int(idx_i[j, k]), float(vals_i[j, k])) for k in range(topk_prompt)
+                    ]
+                    per_pos.append(entries)
+                topk_prompt_logprobs_out.append(per_pos)
+
         return GenerateOutput(
             generated_ids=generated_ids,
             stop_reasons=stop_reasons,
@@ -439,6 +526,7 @@ class GeneratorMixin:
                 if prompt_logprobs
                 else None
             ),
+            topk_prompt_logprobs=topk_prompt_logprobs_out,
         )
 
 

--- a/skyrl/tx/utils/logits_processor.py
+++ b/skyrl/tx/utils/logits_processor.py
@@ -79,6 +79,49 @@ class LogitsProcessorMixin(ABC):
         target_logits = jnp.take_along_axis(logits, target_ids[..., None], axis=-1)
         return (target_logits - log_sum_exp).squeeze(-1)
 
+    def compute_topk_logprobs(
+        self,
+        hidden_states: jax.Array,
+        target_ids_topk: jax.Array,
+        adapter_indices: jax.Array | None = None,
+    ) -> jax.Array:
+        """Compute logprobs for K target tokens per position.
+
+        Used for soft top-K distillation (e.g. SDFT/OPSD forward-KL), where each
+        position has a distribution over K teacher tokens rather than a single
+        hard target.
+
+        Args:
+            hidden_states: Hidden states [B, T, H].
+            target_ids_topk: Target token IDs [B, T, K].
+            adapter_indices: Adapter indices for LoRA on lm_head.
+
+        Returns:
+            Log probabilities for the K target tokens [B, T, K].
+
+        Note: unlike :meth:`compute_logprobs`, this does not use the chunked
+        lm_head path (``loss_chunk_size``); it materializes the full logits once.
+        For the default config (``loss_chunk_size == 0``) this matches the
+        standard path exactly.
+        """
+        logits = self.compute_logits(hidden_states, adapter_indices)
+        return self.logits_to_topk_logprobs(logits, target_ids_topk)
+
+    @staticmethod
+    def logits_to_topk_logprobs(logits: jax.Array, target_ids_topk: jax.Array) -> jax.Array:
+        """Convert logits to logprobs for K targets per position.
+
+        Args:
+            logits: Logits [B, T, V].
+            target_ids_topk: Target token IDs [B, T, K].
+
+        Returns:
+            Log probabilities for the K target tokens [B, T, K].
+        """
+        log_sum_exp = jax.nn.logsumexp(logits, axis=-1, keepdims=True)
+        target_logits = jnp.take_along_axis(logits, target_ids_topk, axis=-1)
+        return target_logits - log_sum_exp
+
     def _compute_chunked_logprobs(
         self,
         hidden_states: jax.Array,

--- a/tests/tx/utils/test_topk_logprobs.py
+++ b/tests/tx/utils/test_topk_logprobs.py
@@ -1,0 +1,63 @@
+"""Unit tests for LogitsProcessorMixin top-K logprobs (soft distillation)."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tests.tx.utils.test_generator import DummyModel
+
+
+def _np_log_softmax(x: np.ndarray) -> np.ndarray:
+    x = x - x.max(axis=-1, keepdims=True)
+    return x - np.log(np.exp(x).sum(axis=-1, keepdims=True))
+
+
+class TestTopkLogprobs:
+    """Tests for compute_topk_logprobs / logits_to_topk_logprobs."""
+
+    @pytest.mark.parametrize("B,T,K", [(2, 4, 3), (1, 8, 5), (3, 2, 1), (1, 1, 1)])
+    def test_matches_numpy_reference(self, B, T, K):
+        """Top-K gathered logprobs match a numpy log-softmax + gather reference."""
+        V = 16  # identity lm_head => logits == hidden_states
+        rng = np.random.default_rng(0)
+        hidden = rng.standard_normal((B, T, V)).astype(np.float32)
+        target_topk = rng.integers(0, V, (B, T, K)).astype(np.int32)
+
+        model = DummyModel(vocab_size=V, loss_chunk_size=0)
+        got = np.asarray(model.compute_topk_logprobs(jnp.array(hidden), jnp.array(target_topk)))
+
+        ref = np.take_along_axis(_np_log_softmax(hidden), target_topk, axis=-1)
+        assert got.shape == (B, T, K)
+        np.testing.assert_allclose(got, ref, rtol=1e-5, atol=1e-5)
+
+    def test_k1_equals_compute_logprobs(self):
+        """K=1 top-K logprobs equal the standard 1D compute_logprobs."""
+        B, T, V = 2, 5, 16
+        rng = np.random.default_rng(1)
+        hidden = jnp.array(rng.standard_normal((B, T, V)).astype(np.float32))
+        target_ids = jnp.array(rng.integers(0, V, (B, T)).astype(np.int32))
+
+        model = DummyModel(vocab_size=V, loss_chunk_size=0)
+        topk = model.compute_topk_logprobs(hidden, target_ids[..., None])  # [B, T, 1]
+        flat = model.compute_logprobs(hidden, target_ids)  # [B, T]
+
+        np.testing.assert_allclose(np.asarray(topk.squeeze(-1)), np.asarray(flat), rtol=1e-6, atol=1e-6)
+
+    def test_weighted_sum_is_forward_cross_entropy(self):
+        """sum_k w_k * logp_k equals the (negative) forward cross-entropy target."""
+        B, T, V, K = 2, 4, 16, 4
+        rng = np.random.default_rng(2)
+        hidden = rng.standard_normal((B, T, V)).astype(np.float32)
+        target_topk = rng.integers(0, V, (B, T, K)).astype(np.int32)
+        weights = rng.random((B, T, K)).astype(np.float32)
+        weights /= weights.sum(axis=-1, keepdims=True)
+        weights[0, 0] = 0.0  # masked (non-completion) position
+
+        model = DummyModel(vocab_size=V, loss_chunk_size=0)
+        topk_lp = np.asarray(model.compute_topk_logprobs(jnp.array(hidden), jnp.array(target_topk)))
+        got = (weights * topk_lp).sum(axis=-1)  # [B, T]
+
+        ref_lp = np.take_along_axis(_np_log_softmax(hidden), target_topk, axis=-1)
+        ref = (weights * ref_lp).sum(axis=-1)
+        np.testing.assert_allclose(got, ref, rtol=1e-5, atol=1e-5)
+        assert np.isclose(got[0, 0], 0.0)  # masked position contributes 0


### PR DESCRIPTION
## Summary

Adds support for **top-K distillation** (forward-KL, e.g. SDFT / OPSD) on the JAX/tinker backend. Two pieces are needed end-to-end and this PR adds both:

1. **Teacher side — `topk_prompt_logprobs`** (sampling): return the top-K token distribution at each prompt position. The Tinker API already accepts the `topk_prompt_logprobs` request field, but the engine left it unimplemented (the response came back `null`).
2. **Student side — soft top-K cross-entropy** (training): train against a per-position distribution over K teacher tokens (a weighted cross-entropy), instead of a single hard target.

Together these let cookbook recipes like SDFT (`tinker_cookbook.recipes.sdft`, forward-KL `topk>0`) run against a self-hosted skyrl-tx server.

## Motivation

Top-K distillation needs, at each completion position, the teacher's top-K distribution as the training target. Previously:
- `topk_prompt_logprobs` returned `null`, so the teacher distribution couldn't be obtained; and
- the trainer only supported hard 1-D targets (`compute_logprobs` + `-logprob*mask`), so the `(num_tokens, K)` target/weight tensors were flattened to length `N*K` and overflowed the `N`-based `max_length`, crashing `forward_backward`.

## What changed

**Teacher top-K sampling**
- `generator.py`: compute top-K over the prompt logits already materialized for `prompt_logprobs` (top-K of the logits minus full-vocab logsumexp = true logprobs), returned per position as `[(token_id, logprob), ...]` with index 0 = `None` (Tinker convention).
- Plumbed `topk_prompt_logprobs` through `SampleInput` → engine → backend → `SampleOutput`.

**Soft top-K cross-entropy training** (opt-in; standard hard-target path is byte-for-byte unchanged)
- `TensorData` gains `shape` (api + internal types) so 2-D `(N, K)` loss-fn inputs survive the request boundary; the engine recovers `K` and sets `target_topk`.
- `logits_processor.py`: `compute_topk_logprobs` / `logits_to_topk_logprobs` gather K logprobs per position (≡ `compute_logprobs` for K=1).
- JAX backend: separate jitted `_forward[_backward]_topk` compute the teacher-weighted per-position logprob `sum_k w[t,k]·logp(target[t,k])` and use the completion indicator (`weights.sum(-1) > 0`) as the loss mask — so the existing loss switch, per-sequence normalization and grad accumulation are reused unchanged. Gated on 2-D targets via `target_topk > 1`.
- `pad_batch_topk` pads row-major-flattened `(N, K)` data to `[B, T, K]`.

## Backward compatibility

The standard hard-target (1-D) path is unchanged and selected whenever `target_topk <= 1` (i.e. all existing RL/SFT). `compute_topk_logprobs` with K=1 equals `compute_logprobs`.

## Testing

- `tests/tx/utils/test_topk_logprobs.py` (added): top-K gather vs numpy reference, K=1 equivalence with `compute_logprobs`, weighted-sum == forward cross-entropy. Existing `test_logits_processor.py` still passes.
- End-to-end against a deployed skyrl-tx (Qwen3.5-2B): a soft `forward_backward` with `N*K` ≫ `max_length` (would crash pre-fix) succeeds, and the soft-CE loss decreases monotonically over optim steps (≈155 → 111), confirming gradients flow through the weighted top-K CE. `topk_prompt_logprobs` returns populated top-K `(token_id, logprob)` per position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
