### PR TITLE
[fix] Use masked mean in advantage batch normalization

### DIFF
--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -1392,7 +1392,7 @@ class RayPPOTrainer:
         # Step 1: Z-score normalization (if enabled)
         if self.cfg.trainer.algorithm.advantage_batch_normalize:
             num_actions = response_mask.sum()
-            mean = advantages.mean()
+            mean = masked_mean(advantages, response_mask)
             std = ((advantages - mean).pow(2) * response_mask).sum()
             rstd = (std / num_actions).clamp(min=1e-8).rsqrt()
             data["advantages"] = (advantages - mean) * rstd

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -1481,7 +1481,7 @@ class RayPPOTrainer:
         # Step 1: Z-score normalization (if enabled)
         if self.cfg.trainer.algorithm.advantage_batch_normalize:
             num_actions = response_mask.sum()
-            mean = advantages.mean()
+            mean = masked_mean(advantages, response_mask)
             std = ((advantages - mean).pow(2) * response_mask).sum()
             rstd = (std / num_actions).clamp(min=1e-8).rsqrt()
             data["advantages"] = (advantages - mean) * rstd

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -1480,7 +1480,7 @@ class RayPPOTrainer:
 
         # Step 1: Z-score normalization (if enabled)
         if self.cfg.trainer.algorithm.advantage_batch_normalize:
-            num_actions = response_mask.sum()
+            num_actions = response_mask.sum().clamp(min=1)
             mean = masked_mean(advantages, response_mask)
             std = ((advantages - mean).pow(2) * response_mask).sum()
             rstd = (std / num_actions).clamp(min=1e-8).rsqrt()

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -252,6 +252,68 @@ def test_calc_advantages_and_returns_step_wise_broadcast(dummy_config):
     assert torch.allclose(data["returns"], expected_advantages)
 
 
+def test_normalize_advantages_batch_normalize_masks_padding(dummy_config):
+    """Regression test for advantage batch normalization over padding positions.
+
+    The z-score mean must be computed only over valid response positions so that padding
+    contents (zeros, or non-zero GAE leftovers) cannot bias the statistics.
+    See https://github.com/NovaSky-AI/SkyRL/issues/1305.
+    """
+    dummy_config.trainer.algorithm.advantage_batch_normalize = True
+
+    trainer = RayPPOTrainer(
+        cfg=dummy_config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=DummyDataset(),
+        inference_engine_client=None,
+        generator=dummy_generator,
+    )
+
+    batch_size = 2
+    response_mask = torch.tensor(
+        [
+            [0, 0, 1, 1, 1],
+            [0, 0, 0, 1, 1],
+        ],
+        dtype=torch.int32,
+    )
+    advantages = torch.tensor(
+        [
+            [0.0, 0.0, 1.0, 2.0, 3.0],
+            [0.0, 0.0, 0.0, -1.0, -2.0],
+        ]
+    )
+    # GAE leaves non-zero leftovers at padding positions (``masked_whiten`` does not zero
+    # them out), so normalization must be invariant to whatever lives under the mask.
+    polluted_advantages = advantages.clone()
+    polluted_advantages[response_mask == 0] = 100.0
+
+    def normalize(adv: torch.Tensor) -> torch.Tensor:
+        data = TrainingInputBatch(
+            {
+                "advantages": adv.clone(),
+                "response_mask": response_mask,
+                "loss_mask": response_mask.clone(),
+            }
+        )
+        return trainer._normalize_advantages(data, [(0, batch_size)])["advantages"]
+
+    normalized = normalize(advantages)
+    normalized_polluted = normalize(polluted_advantages)
+
+    valid = response_mask.bool()
+    assert torch.allclose(normalized[valid], normalized_polluted[valid])
+
+    # Undo the uniform 1 / num_loss_tokens scaling from the "token_mean" loss reduction so
+    # the z-score statistics can be checked directly: over valid positions, the mean must
+    # be 0 and the (biased) std must be 1.
+    z_scores = (normalized * response_mask.sum())[valid]
+    assert z_scores.mean().item() == approx(0.0, abs=1e-5)
+    assert z_scores.pow(2).mean().sqrt().item() == approx(1.0, abs=1e-4)
+
+
 def test_flush_pending_metrics_logs_and_clears(dummy_config):
     """Metrics accumulated for an in-flight step are flushed to the tracker."""
     trainer = RayPPOTrainer(

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -314,6 +314,37 @@ def test_normalize_advantages_batch_normalize_masks_padding(dummy_config):
     assert z_scores.pow(2).mean().sqrt().item() == approx(1.0, abs=1e-4)
 
 
+def test_normalize_advantages_batch_normalize_all_zero_mask(dummy_config):
+    """An all-zero response mask (no trainable tokens) must not produce NaNs.
+
+    Without clamping ``num_actions``, ``std / num_actions`` is 0 / 0 = NaN, which
+    ``clamp`` does not remove, corrupting the advantages and everything downstream.
+    """
+    dummy_config.trainer.algorithm.advantage_batch_normalize = True
+
+    trainer = RayPPOTrainer(
+        cfg=dummy_config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=DummyDataset(),
+        inference_engine_client=None,
+        generator=dummy_generator,
+    )
+
+    batch_size = 2
+    response_mask = torch.zeros((batch_size, 5), dtype=torch.int32)
+    data = TrainingInputBatch(
+        {
+            "advantages": torch.randn(batch_size, 5),
+            "response_mask": response_mask,
+            "loss_mask": response_mask.clone(),
+        }
+    )
+    normalized = trainer._normalize_advantages(data, [(0, batch_size)])["advantages"]
+    assert torch.isfinite(normalized).all()
+
+
 def test_flush_pending_metrics_logs_and_clears(dummy_config):
     """Metrics accumulated for an in-flight step are flushed to the tracker."""
     trainer = RayPPOTrainer(


### PR DESCRIPTION
Fixes #1305.

The issue predates a refactor: `normalize_advantages_dict` has since moved byte-for-byte from `ppo_utils.py` into `RayPPOTrainer._normalize_advantages` on current main, bug intact, so the fix lands there. `FullyAsyncRayPPOTrainer` inherits the method, so the one change covers both the sync and fully-async paths.

The new regression test normalizes the same padded batch twice — once with zeros and once with garbage in the padding positions — and asserts identical results on valid positions, with masked mean 0 and masked std 1. It fails before the fix (padding garbage completely rewrites the normalized advantages on valid positions) and passes after, along with the rest of `tests/train/test_trainer.py` and `tests/backends/skyrl_train/utils/test_ppo_utils.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PPO policy training advantage scaling on every step when batch normalization is enabled; behavior change is intentional but can shift training dynamics for padded batches.
> 
> **Overview**
> Fixes **advantage batch z-score normalization** in `RayPPOTrainer._normalize_advantages` when `advantage_batch_normalize` is on (#1305).
> 
> The batch mean for normalization now uses **`masked_mean` over `response_mask`** instead of a plain tensor mean, so padding (zeros or stray GAE values) no longer skews statistics on real response tokens. **`num_actions`** is **`clamp(min=1)`** so an all-zero mask does not produce `0/0` NaNs in the variance scaling.
> 
> Adds regression tests: normalization is identical on valid tokens whether padding holds garbage, and outputs stay finite with an empty mask. Inherited trainers (e.g. fully async) pick up the same fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 462d39193b2437af2dfebe52d681f8df7f1a1d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->