### PR TITLE
[logging] Flush pending step metrics to the tracker when training crashes

### DIFF
--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -410,7 +410,7 @@ class BasePPOExp:
             if self.trainer is not None and self.trainer.tracker is not None:
                 # Flush metrics already recorded for the in-flight step (e.g.
                 # reward/timing metrics from a completed generation phase)
-                # before log_exception finishes the wandb run. See #1687.
+                # before log_exception finishes the wandb run.
                 self.trainer.flush_pending_metrics()
                 self.trainer.tracker.log_exception(e, step=self.trainer.global_step)
             else:

--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -408,6 +408,10 @@ class BasePPOExp:
             # worker logs; route them through the tracker so wandb users see
             # them as an `error/tracebacks` table row.
             if self.trainer is not None and self.trainer.tracker is not None:
+                # Flush metrics already recorded for the in-flight step (e.g.
+                # reward/timing metrics from a completed generation phase)
+                # before log_exception finishes the wandb run. See #1687.
+                self.trainer.flush_pending_metrics()
                 self.trainer.tracker.log_exception(e, step=self.trainer.global_step)
             else:
                 logger.error(f"Setup failed before tracker was initialized:\n{e}")

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -489,6 +489,7 @@ class RayPPOTrainer:
 
     def flush_pending_metrics(self):
         """Best-effort flush of metrics accumulated for the in-flight step.
+        
         Idempotent: the accumulators are cleared after the flush attempt, so a
         second call is a no-op. Never raises.
         """

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -489,7 +489,7 @@ class RayPPOTrainer:
 
     def flush_pending_metrics(self):
         """Best-effort flush of metrics accumulated for the in-flight step.
-        
+
         Idempotent: the accumulators are cleared after the flush attempt, so a
         second call is a no-op. Never raises.
         """

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -487,6 +487,32 @@ class RayPPOTrainer:
         self.tracker.finish()
         logger.info("Training done!")
 
+    def flush_pending_metrics(self):
+        """Best-effort flush of metrics accumulated for the in-flight step.
+
+        `train()` only logs `all_metrics`/`all_timings` once a step fully
+        completes, so a crash mid-step (e.g. an OOM in
+        `fwd_logprobs_values_reward` after a long generation phase) would
+        otherwise drop everything already recorded for that step. Called from
+        the except block in `BasePPOExp.run` before `tracker.log_exception`
+        (which finishes the wandb run, so the flush must happen first).
+
+        Idempotent: the accumulators are cleared after the flush attempt, so a
+        second call is a no-op. Never raises.
+        """
+        if not self.all_metrics and not self.all_timings:
+            return
+        log_payload = {
+            **self.all_metrics,
+            **{f"timing/{k}": v for k, v in self.all_timings.items()},
+        }
+        try:
+            self.tracker.log(log_payload, step=self.global_step, commit=True)
+        except Exception as e:
+            logger.warning(f"Failed to flush pending metrics at step {self.global_step}: {e}")
+        self.all_metrics = {}
+        self.all_timings = {}
+
     def _remove_tail_data(self, entries: List[Any]) -> List[Any]:
         """Remove tail data to have even shards in terms of *effective* samples.
 

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -489,14 +489,6 @@ class RayPPOTrainer:
 
     def flush_pending_metrics(self):
         """Best-effort flush of metrics accumulated for the in-flight step.
-
-        `train()` only logs `all_metrics`/`all_timings` once a step fully
-        completes, so a crash mid-step (e.g. an OOM in
-        `fwd_logprobs_values_reward` after a long generation phase) would
-        otherwise drop everything already recorded for that step. Called from
-        the except block in `BasePPOExp.run` before `tracker.log_exception`
-        (which finishes the wandb run, so the flush must happen first).
-
         Idempotent: the accumulators are cleared after the flush attempt, so a
         second call is a no-op. Never raises.
         """

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -253,10 +253,7 @@ def test_calc_advantages_and_returns_step_wise_broadcast(dummy_config):
 
 
 def test_flush_pending_metrics_logs_and_clears(dummy_config):
-    """Metrics accumulated for an in-flight step are flushed to the tracker.
-
-    See https://github.com/NovaSky-AI/SkyRL/issues/1687.
-    """
+    """Metrics accumulated for an in-flight step are flushed to the tracker."""
     trainer = RayPPOTrainer(
         cfg=dummy_config,
         tracker=None,
@@ -306,11 +303,7 @@ def test_flush_pending_metrics_swallows_tracker_errors(dummy_config):
 
 
 def test_run_flushes_pending_metrics_before_logging_exception():
-    """`BasePPOExp.run` flushes pending step metrics before `log_exception`
-    finishes the wandb run.
-
-    See https://github.com/NovaSky-AI/SkyRL/issues/1687.
-    """
+    """`BasePPOExp.run` flushes pending step metrics before `log_exception` finishes the wandb run."""
     from skyrl.train.entrypoints.main_base import BasePPOExp
 
     exp = BasePPOExp.__new__(BasePPOExp)

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -252,6 +252,90 @@ def test_calc_advantages_and_returns_step_wise_broadcast(dummy_config):
     assert torch.allclose(data["returns"], expected_advantages)
 
 
+def test_flush_pending_metrics_logs_and_clears(dummy_config):
+    """Metrics accumulated for an in-flight step are flushed to the tracker.
+
+    See https://github.com/NovaSky-AI/SkyRL/issues/1687.
+    """
+    trainer = RayPPOTrainer(
+        cfg=dummy_config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=DummyDataset(),
+        inference_engine_client=None,
+        generator=dummy_generator,
+    )
+    trainer.tracker = MagicMock()
+    trainer.global_step = 7
+    trainer.all_metrics = {"reward/avg_raw_reward": 0.5}
+    trainer.all_timings = {"generate": 42.0}
+
+    trainer.flush_pending_metrics()
+
+    trainer.tracker.log.assert_called_once_with(
+        {"reward/avg_raw_reward": 0.5, "timing/generate": 42.0}, step=7, commit=True
+    )
+    assert trainer.all_metrics == {}
+    assert trainer.all_timings == {}
+
+    # Second call is a no-op once the accumulators are empty.
+    trainer.flush_pending_metrics()
+    trainer.tracker.log.assert_called_once()
+
+
+def test_flush_pending_metrics_swallows_tracker_errors(dummy_config):
+    """A tracker failure during the crash-path flush must not mask the original error."""
+    trainer = RayPPOTrainer(
+        cfg=dummy_config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=DummyDataset(),
+        inference_engine_client=None,
+        generator=dummy_generator,
+    )
+    trainer.tracker = MagicMock()
+    trainer.tracker.log.side_effect = RuntimeError("tracker down")
+    trainer.all_metrics = {"reward/avg_raw_reward": 0.5}
+
+    trainer.flush_pending_metrics()  # must not raise
+
+    assert trainer.all_metrics == {}
+    assert trainer.all_timings == {}
+
+
+def test_run_flushes_pending_metrics_before_logging_exception():
+    """`BasePPOExp.run` flushes pending step metrics before `log_exception`
+    finishes the wandb run.
+
+    See https://github.com/NovaSky-AI/SkyRL/issues/1687.
+    """
+    from skyrl.train.entrypoints.main_base import BasePPOExp
+
+    exp = BasePPOExp.__new__(BasePPOExp)
+    trainer = MagicMock()
+    trainer.global_step = 7
+
+    def fake_setup_trainer():
+        # Mirror _setup_trainer: expose the trainer on the exp, then crash
+        # (e.g. an OOM raised from a worker mid-step).
+        exp.trainer = trainer
+        raise RuntimeError("boom")
+
+    exp._setup_trainer = fake_setup_trainer
+
+    with pytest.raises(RuntimeError, match="boom"):
+        exp.run()
+
+    ordered_calls = [
+        name for name, _, _ in trainer.mock_calls if name in ("flush_pending_metrics", "tracker.log_exception")
+    ]
+    assert ordered_calls == ["flush_pending_metrics", "tracker.log_exception"]
+    trainer.tracker.log_exception.assert_called_once()
+    assert trainer.tracker.log_exception.call_args.kwargs["step"] == 7
+
+
 def test_micro_batches_accumulated_initialized():
     """Test that _micro_batches_accumulated is initialized to 0 in worker __init__."""
 


### PR DESCRIPTION
Fixes #1687.

`train()` only logs `all_metrics`/`all_timings` once a step fully completes, so a mid-step crash drops everything already recorded for that step.

#1706 added the crash path that surfaces the exception itself to the tracker (`BasePPOExp.run` → `Tracking.log_exception`); this PR extends that same path to first flush the pending step metrics. A new `RayPPOTrainer.flush_pending_metrics()` logs the same `timing/`-prefixed payload shape as the per-step log at the current `global_step`. The flush must run before `log_exception`, because `log_exception` finishes the wandb run to push the traceback table. It never raises (a tracker failure must not mask the original exception) and clears the accumulators, so it is idempotent.

Keeping the flush on the `run()` except path rather than a `try/finally` inside `train()` keeps crash handling in the one place #1706 created, and covers `FullyAsyncRayPPOTrainer` (which inherits the method) for free.

## Test plan
- New CPU unit tests in `tests/train/test_trainer.py`: payload shape/step/clearing + idempotence, tracker failures swallowed, and `BasePPOExp.run` ordering (flush before `log_exception`, exception still re-raised).
