### PR TITLE
[train] Save HF processor on checkpoint export for VLMs

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -35,6 +35,7 @@ from skyrl.backends.skyrl_train.distributed.utils import ModelOrModelOptimPair
 from skyrl.backends.skyrl_train.utils.io import io
 from skyrl.backends.skyrl_train.workers.model_wrapper import HFModelWrapper
 from skyrl.train.config import FSDPConfig, ModelConfig, OptimizerConfig
+from skyrl.utils.tok import check_is_vlm, get_processor
 
 if version.parse(torch.__version__) >= version.parse("2.6"):
     from torch.distributed.fsdp import (
@@ -582,6 +583,16 @@ class FSDPStrategy(DistributedStrategy):
                 # Save tokenizer if provided
                 if tokenizer is not None:
                     tokenizer.save_pretrained(work_dir)
+
+                # This export path bypasses save_hf_configs, so replicate its VLM handling:
+                # AutoProcessor/vLLM can't reload a VLM without preprocessor_config.json.
+                # Guarded so a resolution failure can't abort the save; no-op for text-only.
+                try:
+                    if check_is_vlm(model_to_save.config):
+                        processor = get_processor(model_to_save.config.name_or_path)
+                        processor.save_pretrained(work_dir)
+                except Exception as e:
+                    logger.warning(f"Could not save processor for '{model_to_save.config.name_or_path}'. Error: {e}")
 
             self.print(f"[rank-0]: Successfully saved model to {output_dir}")
 

--- a/skyrl/backends/skyrl_train/distributed/strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/strategy.py
@@ -11,6 +11,7 @@ from torch import distributed as dist
 from transformers import GenerationConfig, PretrainedConfig, PreTrainedTokenizer
 
 from skyrl.backends.skyrl_train.utils.io import io
+from skyrl.utils.tok import check_is_vlm, get_processor
 
 DataT = TypeVar("DataT", bound=Union[Dict[str, Any], torch.Tensor])
 
@@ -137,6 +138,17 @@ class DistributedStrategy(ABC):
                 except Exception as e:
                     # if the generation config isn't available, we don't save it
                     logger.warning(f"Could not save generation config for '{model_config.name_or_path}'. Error: {e}")
+
+                # VLMs need preprocessor_config.json (+ image/video processor configs) to be
+                # reloadable by AutoProcessor; the tokenizer alone is insufficient and vLLM
+                # crashes on load without it. Resolve from the original base model, same as
+                # generation_config above. No-op for text-only models (no vision_config).
+                if check_is_vlm(model_config.name_or_path):
+                    try:
+                        processor = get_processor(model_config.name_or_path)
+                        processor.save_pretrained(work_dir)
+                    except Exception as e:
+                        logger.warning(f"Could not save processor for '{model_config.name_or_path}'. Error: {e}")
 
     @staticmethod
     def get_rng_state():

--- a/skyrl/backends/skyrl_train/distributed/strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/strategy.py
@@ -143,12 +143,14 @@ class DistributedStrategy(ABC):
                 # reloadable by AutoProcessor; the tokenizer alone is insufficient and vLLM
                 # crashes on load without it. Resolve from the original base model, same as
                 # generation_config above. No-op for text-only models (no vision_config).
-                if check_is_vlm(model_config.name_or_path):
-                    try:
+                # The VLM check reuses the already-loaded model_config (no extra I/O) and the
+                # whole block is guarded so a processor-resolution failure can't abort the save.
+                try:
+                    if check_is_vlm(model_config):
                         processor = get_processor(model_config.name_or_path)
                         processor.save_pretrained(work_dir)
-                    except Exception as e:
-                        logger.warning(f"Could not save processor for '{model_config.name_or_path}'. Error: {e}")
+                except Exception as e:
+                    logger.warning(f"Could not save processor for '{model_config.name_or_path}'. Error: {e}")
 
     @staticmethod
     def get_rng_state():

--- a/skyrl/utils/tok.py
+++ b/skyrl/utils/tok.py
@@ -28,9 +28,16 @@ def get_tokenizer(model_name_or_path, **tokenizer_kwargs) -> AutoTokenizer:
     return tokenizer
 
 
-def check_is_vlm(model_name_or_path) -> bool:
-    """Returns True if the model config declares a non-null ``vision_config``."""
-    model_config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=True)
+def check_is_vlm(model_config_or_path) -> bool:
+    """Returns True if the model config declares a non-null ``vision_config``.
+
+    Accepts either an already-loaded ``PretrainedConfig`` or a model name/path.
+    Passing the config avoids a redundant ``AutoConfig.from_pretrained`` round-trip
+    when the caller already holds it."""
+    if isinstance(model_config_or_path, str):
+        model_config = AutoConfig.from_pretrained(model_config_or_path, trust_remote_code=True)
+    else:
+        model_config = model_config_or_path
     return hasattr(model_config, "vision_config") and getattr(model_config, "vision_config") is not None
 
 

--- a/tests/backends/skyrl_train/distributed/test_save_hf_configs_processor.py
+++ b/tests/backends/skyrl_train/distributed/test_save_hf_configs_processor.py
@@ -50,27 +50,42 @@ class TestSaveHfConfigsProcessor:
     def test_saves_processor_for_vlm(self, tmp_path):
         """A VLM export resolves the processor and saves it into the HF dir."""
         processor = MagicMock()
+        model_config = _make_model_config()
         with (
             patch(f"{_STRATEGY_MOD}.check_is_vlm", return_value=True) as check_is_vlm,
             patch(f"{_STRATEGY_MOD}.get_processor", return_value=processor) as get_processor,
             patch(f"{_STRATEGY_MOD}.GenerationConfig"),
         ):
-            _StubStrategy().save_hf_configs(_make_model_config(), str(tmp_path))
+            _StubStrategy().save_hf_configs(model_config, str(tmp_path))
 
-        check_is_vlm.assert_called_once_with("some/base-model")
+        # The check reuses the loaded config object (no redundant AutoConfig I/O).
+        check_is_vlm.assert_called_once_with(model_config)
         get_processor.assert_called_once_with("some/base-model")
         processor.save_pretrained.assert_called_once_with(str(tmp_path))
 
     def test_no_processor_for_text_only(self, tmp_path):
         """A text-only export never resolves or saves a processor."""
+        model_config = _make_model_config()
         with (
             patch(f"{_STRATEGY_MOD}.check_is_vlm", return_value=False) as check_is_vlm,
             patch(f"{_STRATEGY_MOD}.get_processor") as get_processor,
             patch(f"{_STRATEGY_MOD}.GenerationConfig"),
         ):
+            _StubStrategy().save_hf_configs(model_config, str(tmp_path))
+
+        check_is_vlm.assert_called_once_with(model_config)
+        get_processor.assert_not_called()
+
+    def test_vlm_check_failure_does_not_raise(self, tmp_path):
+        """A VLM-detection error is swallowed (export must not crash)."""
+        with (
+            patch(f"{_STRATEGY_MOD}.check_is_vlm", side_effect=RuntimeError("config unavailable")),
+            patch(f"{_STRATEGY_MOD}.get_processor") as get_processor,
+            patch(f"{_STRATEGY_MOD}.GenerationConfig"),
+        ):
+            # Should not raise even though the VLM check blew up.
             _StubStrategy().save_hf_configs(_make_model_config(), str(tmp_path))
 
-        check_is_vlm.assert_called_once_with("some/base-model")
         get_processor.assert_not_called()
 
     def test_processor_failure_does_not_raise(self, tmp_path):

--- a/tests/backends/skyrl_train/distributed/test_save_hf_configs_processor.py
+++ b/tests/backends/skyrl_train/distributed/test_save_hf_configs_processor.py
@@ -1,0 +1,96 @@
+"""CPU tests for DistributedStrategy.save_hf_configs processor handling.
+
+Verifies that a vision-language checkpoint export writes the HF processor
+(``preprocessor_config.json`` etc.) and that text-only exports do not, without
+requiring GPUs, distributed init, or network access.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from skyrl.backends.skyrl_train.distributed.strategy import DistributedStrategy
+
+
+class _StubStrategy(DistributedStrategy):
+    """Concrete strategy that stubs every abstractmethod so the CPU-only
+    ``save_hf_configs`` path can be exercised in isolation."""
+
+    def setup_distributed(self):  # pragma: no cover - stub
+        pass
+
+    def backward(self, loss, model, optimizer, **kwargs):  # pragma: no cover - stub
+        pass
+
+    def optimizer_step(self, optimizer, model, scheduler, name="model", **kwargs):  # pragma: no cover - stub
+        pass
+
+    def save_checkpoint(self, model, ckpt_dir, node_local_rank, optimizer, scheduler, tokenizer):  # pragma: no cover
+        pass
+
+    def load_checkpoint(
+        self, model, ckpt_dir, optimizer, scheduler, load_module_strict, load_optimizer_states, load_lr_scheduler_states
+    ):  # pragma: no cover - stub
+        pass
+
+    def save_hf_model(self, model, output_dir, tokenizer=None, **kwargs):  # pragma: no cover - stub
+        pass
+
+
+def _make_model_config(name_or_path="some/base-model"):
+    model_config = MagicMock()
+    model_config.name_or_path = name_or_path
+    # save_pretrained is a no-op for the test; we only care about the processor.
+    model_config.save_pretrained = MagicMock()
+    return model_config
+
+
+_STRATEGY_MOD = "skyrl.backends.skyrl_train.distributed.strategy"
+
+
+class TestSaveHfConfigsProcessor:
+    def test_saves_processor_for_vlm(self, tmp_path):
+        """A VLM export resolves the processor and saves it into the HF dir."""
+        processor = MagicMock()
+        with (
+            patch(f"{_STRATEGY_MOD}.check_is_vlm", return_value=True) as check_is_vlm,
+            patch(f"{_STRATEGY_MOD}.get_processor", return_value=processor) as get_processor,
+            patch(f"{_STRATEGY_MOD}.GenerationConfig"),
+        ):
+            _StubStrategy().save_hf_configs(_make_model_config(), str(tmp_path))
+
+        check_is_vlm.assert_called_once_with("some/base-model")
+        get_processor.assert_called_once_with("some/base-model")
+        processor.save_pretrained.assert_called_once_with(str(tmp_path))
+
+    def test_no_processor_for_text_only(self, tmp_path):
+        """A text-only export never resolves or saves a processor."""
+        with (
+            patch(f"{_STRATEGY_MOD}.check_is_vlm", return_value=False) as check_is_vlm,
+            patch(f"{_STRATEGY_MOD}.get_processor") as get_processor,
+            patch(f"{_STRATEGY_MOD}.GenerationConfig"),
+        ):
+            _StubStrategy().save_hf_configs(_make_model_config(), str(tmp_path))
+
+        check_is_vlm.assert_called_once_with("some/base-model")
+        get_processor.assert_not_called()
+
+    def test_processor_failure_does_not_raise(self, tmp_path):
+        """A processor resolution error is swallowed (export must not crash)."""
+        with (
+            patch(f"{_STRATEGY_MOD}.check_is_vlm", return_value=True),
+            patch(f"{_STRATEGY_MOD}.get_processor", side_effect=RuntimeError("no processor")),
+            patch(f"{_STRATEGY_MOD}.GenerationConfig"),
+        ):
+            # Should not raise.
+            _StubStrategy().save_hf_configs(_make_model_config(), str(tmp_path))
+
+    def test_skipped_when_no_name_or_path(self, tmp_path):
+        """Models initialized without a base path skip processor + gen config."""
+        with (
+            patch(f"{_STRATEGY_MOD}.check_is_vlm") as check_is_vlm,
+            patch(f"{_STRATEGY_MOD}.get_processor") as get_processor,
+            patch(f"{_STRATEGY_MOD}.GenerationConfig"),
+        ):
+            _StubStrategy().save_hf_configs(_make_model_config(name_or_path=""), str(tmp_path))
+
+        check_is_vlm.assert_not_called()
+        get_processor.assert_not_called()


### PR DESCRIPTION
## Summary

VLM checkpoints exported via `DistributedStrategy.save_hf_configs` are missing `preprocessor_config.json` (and the image/video processor configs). Only the model config, tokenizer, and generation config are written. As a result, `AutoProcessor.from_pretrained()` cannot reload the exported checkpoint and downstream vLLM serving crashes on load.

This adds processor saving to the HF export path:

- Adds `check_is_vlm()` and `get_processor()` helpers to `skyrl/utils/tok.py`.
- In `save_hf_configs`, when the model is a VLM, resolves the processor from `model_config.name_or_path` and writes it alongside the other configs. This mirrors the existing `generation_config` handling, which already resolves from `name_or_path`.
- No-op for text-only models (no `vision_config`), and wrapped in `try/except` so a processor-resolution failure cannot abort a checkpoint save.

Both export paths funnel through `save_hf_configs` (FSDP passes the live model `.config`; Megatron passes `hf_config` loaded via `AutoConfig.from_pretrained(model_path)`), so the fix covers both backends.

## Test plan

- [x] New CPU unit tests in `tests/backends/skyrl_train/distributed/test_save_hf_configs_processor.py`:
  - processor saved for VLM
  - processor not resolved for text-only
  - processor-resolution failure does not raise
  - skipped when `name_or_path` is empty
- [ ] End-to-end: export a VLM checkpoint and confirm `preprocessor_config.json` is present and `AutoProcessor.from_pretrained()` reloads it.