### PR TITLE
[async] add flag to toggle whether to clear kv cache after weight sync for fully async training, update default max_staleness_steps to 0

### DIFF
--- a/docs/content/docs/configuration/config.mdx
+++ b/docs/content/docs/configuration/config.mdx
@@ -603,11 +603,13 @@ def ppo_policy_loss(
 fully_async:
   max_staleness_steps: 4
   num_parallel_generation_workers: 768
+  clear_kv_cache_on_weight_sync: true
 
 ```
 
 - `fully_async.max_staleness_steps`: Maximum off-policy steps allowed. If a trajectory group is scheduled at step *i* and trained at step *j*, then `j - i <= max_staleness_steps`. Larger values increase throughput but also off-policy-ness.
 - `fully_async.num_parallel_generation_workers`: Number of generation workers to spawn. Should be \>= `policy_mini_batch_size` and \<= `policy_mini_batch_size * (max_staleness_steps + 1)`.
+- `fully_async.clear_kv_cache_on_weight_sync`: Whether to clear the inference engine KV cache on each weight sync. Defaults to `true`, matching synchronous RL. Set to `false` for fully async training to reuse KV cache from stale policies during generation (avoids recomputation at the cost of using slightly stale KV cache).
 
 ## Generator Configuration
 

--- a/examples/train/algorithms/dapo/run_dapo_qwen3_1.7b_aime_fully_async.sh
+++ b/examples/train/algorithms/dapo/run_dapo_qwen3_1.7b_aime_fully_async.sh
@@ -55,6 +55,7 @@ uv run --isolated --extra fsdp -m examples.train.algorithms.dapo.main_dapo_fully
   data.val_data="['$TEST_FILE']" \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
+  trainer.fully_async.clear_kv_cache_on_weight_sync=false \
   trainer.algorithm.off_policy_correction.sequence_mask_metric=$SEQUENCE_MASK_METRIC \
   trainer.algorithm.off_policy_correction.geo_mask_high=$GEO_MASK_HIGH \
   trainer.algorithm.off_policy_correction.geo_mask_low=$GEO_MASK_LOW \

--- a/examples/train/algorithms/dapo/run_dapo_qwen3_1.7b_aime_fully_async_onestep.sh
+++ b/examples/train/algorithms/dapo/run_dapo_qwen3_1.7b_aime_fully_async_onestep.sh
@@ -59,6 +59,7 @@ uv run --isolated --extra fsdp -m examples.train.algorithms.dapo.main_dapo_fully
   data.val_data="['$TEST_FILE']" \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
+  trainer.fully_async.clear_kv_cache_on_weight_sync=false \
   trainer.algorithm.off_policy_correction.sequence_mask_metric=$SEQUENCE_MASK_METRIC \
   trainer.algorithm.off_policy_correction.geo_mask_high=$GEO_MASK_HIGH \
   trainer.algorithm.off_policy_correction.geo_mask_low=$GEO_MASK_LOW \

--- a/examples/train/fully_async/fully_async_run_gsm8k.sh
+++ b/examples/train/fully_async/fully_async_run_gsm8k.sh
@@ -38,6 +38,7 @@ uv run --isolated --extra fsdp -m examples.train.fully_async.main_fully_async \
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
+  trainer.fully_async.clear_kv_cache_on_weight_sync=false \
   trainer.algorithm.advantage_estimator="grpo" \
   trainer.algorithm.off_policy_correction.sequence_mask_metric=$SEQUENCE_MASK_METRIC \
   trainer.algorithm.off_policy_correction.geo_mask_high=$GEO_MASK_HIGH \

--- a/examples/train/fully_async/fully_async_run_gsm8k_megatron_lora.sh
+++ b/examples/train/fully_async/fully_async_run_gsm8k_megatron_lora.sh
@@ -39,6 +39,7 @@ uv run --isolated --extra megatron -m examples.train.fully_async.main_fully_asyn
   data.val_data="['$DATA_DIR/validation.parquet']" \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
+  trainer.fully_async.clear_kv_cache_on_weight_sync=false \
   trainer.algorithm.advantage_estimator="grpo" \
   trainer.algorithm.off_policy_correction.sequence_mask_metric=$SEQUENCE_MASK_METRIC \
   trainer.algorithm.off_policy_correction.geo_mask_high=$GEO_MASK_HIGH \

--- a/examples/train/search/run_search_fully_async.sh
+++ b/examples/train/search/run_search_fully_async.sh
@@ -51,6 +51,7 @@ uv run --isolated --extra fsdp -m examples.train.fully_async.main_fully_async \
   data.val_data="['${DATA_DIR}/validation.parquet']" \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
+  trainer.fully_async.clear_kv_cache_on_weight_sync=false \
   trainer.algorithm.advantage_estimator="grpo" \
   trainer.policy.optimizer_config.lr=1.0e-6 \
   trainer.policy.optimizer_config.max_grad_norm=0.5 \

--- a/examples/train/thunder_agent/scripts/r2egym_32b/run_trainer.sh
+++ b/examples/train/thunder_agent/scripts/r2egym_32b/run_trainer.sh
@@ -291,6 +291,7 @@ fi
   trainer.algorithm.max_seq_len="$TRAIN_MAX_SEQ_LEN" \
   trainer.fully_async.max_staleness_steps="$FULL_MAX_STALENESS_STEPS" \
   trainer.fully_async.num_parallel_generation_workers="$NUM_PARALLEL_GENERATION_WORKERS" \
+  trainer.fully_async.clear_kv_cache_on_weight_sync=false \
   trainer.placement.colocate_all=false \
   trainer.placement.colocate_policy_ref=true \
   trainer.placement.policy_num_nodes="$TRAIN_NUM_NODES" \

--- a/examples/train_integrations/harbor/run_codecontest_fully_async.sh
+++ b/examples/train_integrations/harbor/run_codecontest_fully_async.sh
@@ -84,6 +84,7 @@ uv run --isolated --extra fsdp --extra harbor -m examples.train_integrations.har
   trainer.log_path=$LOG_DIR \
   trainer.fully_async.max_staleness_steps=$MAX_STALENESS_STEPS \
   trainer.fully_async.num_parallel_generation_workers=$NUM_PARALLEL_GENERATION_WORKERS \
+  trainer.fully_async.clear_kv_cache_on_weight_sync=false \
   trainer.algorithm.advantage_estimator=grpo \
   trainer.algorithm.loss_reduction=$LOSS_REDUCTION \
   trainer.algorithm.grpo_norm_by_std=$GRPO_NORM_BY_STD \

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -276,11 +276,7 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
         use_prefix_cache = inference_engine_cfg.enable_prefix_caching
         generator_dtype = str_to_torch_dtype(inference_engine_cfg.model_dtype)
         cache_reset_task = None
-        # skip KV cache reset if max_staleness_steps > 0 and clear_kv_cache_on_weight_sync is False
-        skip_kv_cache_reset = (
-            self.cfg.fully_async.max_staleness_steps > 0 and not self.cfg.fully_async.clear_kv_cache_on_weight_sync
-        )
-        if use_prefix_cache and torch.distributed.get_rank() == 0 and not skip_kv_cache_reset:
+        if use_prefix_cache and torch.distributed.get_rank() == 0 and not self.cfg.fully_async.skip_kv_cache_reset:
             # clear prefix cache
             cache_reset_task = inference_engine_client.reset_prefix_cache()
 

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -276,7 +276,11 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
         use_prefix_cache = inference_engine_cfg.enable_prefix_caching
         generator_dtype = str_to_torch_dtype(inference_engine_cfg.model_dtype)
         cache_reset_task = None
-        if use_prefix_cache and torch.distributed.get_rank() == 0:
+        # skip KV cache reset if max_staleness_steps > 0 and clear_kv_cache_on_weight_sync is False
+        skip_kv_cache_reset = (
+            self.cfg.fully_async.max_staleness_steps > 0 and not self.cfg.fully_async.clear_kv_cache_on_weight_sync
+        )
+        if use_prefix_cache and torch.distributed.get_rank() == 0 and not skip_kv_cache_reset:
             # clear prefix cache
             cache_reset_task = inference_engine_client.reset_prefix_cache()
 

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -276,7 +276,11 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
         use_prefix_cache = inference_engine_cfg.enable_prefix_caching
         generator_dtype = str_to_torch_dtype(inference_engine_cfg.model_dtype)
         cache_reset_task = None
-        if use_prefix_cache and torch.distributed.get_rank() == 0 and not self.cfg.fully_async.skip_kv_cache_reset:
+        if (
+            use_prefix_cache
+            and torch.distributed.get_rank() == 0
+            and self.cfg.fully_async.clear_kv_cache_on_weight_sync
+        ):
             # clear prefix cache
             cache_reset_task = inference_engine_client.reset_prefix_cache()
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1271,7 +1271,11 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         use_prefix_cache = inference_engine_cfg.enable_prefix_caching
         generator_dtype = str_to_torch_dtype(inference_engine_cfg.model_dtype)
         cache_reset_task = None
-        if use_prefix_cache and torch.distributed.get_rank() == 0:
+        # skip KV cache reset if max_staleness_steps > 0 (fully async training) and clear_kv_cache_on_weight_sync is False
+        skip_kv_cache_reset = (
+            self.cfg.fully_async.max_staleness_steps > 0 and not self.cfg.fully_async.clear_kv_cache_on_weight_sync
+        )
+        if use_prefix_cache and torch.distributed.get_rank() == 0 and not skip_kv_cache_reset:
             # clear prefix cache
             cache_reset_task = inference_engine_client.reset_prefix_cache()
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1271,11 +1271,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         use_prefix_cache = inference_engine_cfg.enable_prefix_caching
         generator_dtype = str_to_torch_dtype(inference_engine_cfg.model_dtype)
         cache_reset_task = None
-        # skip KV cache reset if max_staleness_steps > 0 (fully async training) and clear_kv_cache_on_weight_sync is False
-        skip_kv_cache_reset = (
-            self.cfg.fully_async.max_staleness_steps > 0 and not self.cfg.fully_async.clear_kv_cache_on_weight_sync
-        )
-        if use_prefix_cache and torch.distributed.get_rank() == 0 and not skip_kv_cache_reset:
+        if use_prefix_cache and torch.distributed.get_rank() == 0 and not self.cfg.fully_async.skip_kv_cache_reset:
             # clear prefix cache
             cache_reset_task = inference_engine_client.reset_prefix_cache()
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1271,7 +1271,11 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         use_prefix_cache = inference_engine_cfg.enable_prefix_caching
         generator_dtype = str_to_torch_dtype(inference_engine_cfg.model_dtype)
         cache_reset_task = None
-        if use_prefix_cache and torch.distributed.get_rank() == 0 and not self.cfg.fully_async.skip_kv_cache_reset:
+        if (
+            use_prefix_cache
+            and torch.distributed.get_rank() == 0
+            and self.cfg.fully_async.clear_kv_cache_on_weight_sync
+        ):
             # clear prefix cache
             cache_reset_task = inference_engine_client.reset_prefix_cache()
 

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -479,10 +479,6 @@ class FullyAsyncConfig(BaseConfig):
     Set to False for fully async training to reuse KV cache from stale policies during generation
     (avoids recomputation at the cost of using slightly stale KV cache)."""
 
-    @property
-    def skip_kv_cache_reset(self) -> bool:
-        return not self.clear_kv_cache_on_weight_sync
-
 
 # ---------------------------------------------------------------------------
 # Sampling / Chat Template

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -468,9 +468,9 @@ class FullyAsyncConfig(BaseConfig):
     """Knobs for fully async training.
     See https://docs.skyrl.ai/docs/tutorials/fully_async#step-2-config-knobs-to-tune-for-fully-async-training."""
 
-    max_staleness_steps: int = 0
+    max_staleness_steps: int = 4
     """Maximum off-policy steps allowed. If a trajectory group is scheduled at step *i* and trained at step *j*,
-    then ``j - i <= max_staleness_steps``. Larger values increase throughput but also off-policy-ness. Should be set > 0 for fully async training."""
+    then ``j - i <= max_staleness_steps``. Larger values increase throughput but also off-policy-ness."""
     num_parallel_generation_workers: int = 768
     """Number of generation workers to spawn. Should be >= ``policy_mini_batch_size`` and
     <= ``policy_mini_batch_size * (max_staleness_steps + 1)``."""

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -470,7 +470,7 @@ class FullyAsyncConfig(BaseConfig):
 
     max_staleness_steps: int = 0
     """Maximum off-policy steps allowed. If a trajectory group is scheduled at step *i* and trained at step *j*,
-    then ``j - i <= max_staleness_steps``. Larger values increase throughput but also off-policy-ness."""
+    then ``j - i <= max_staleness_steps``. Larger values increase throughput but also off-policy-ness. Should be set > 1 for fully async training."""
     num_parallel_generation_workers: int = 768
     """Number of generation workers to spawn. Should be >= ``policy_mini_batch_size`` and
     <= ``policy_mini_batch_size * (max_staleness_steps + 1)``."""

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -477,6 +477,10 @@ class FullyAsyncConfig(BaseConfig):
     clear_kv_cache_on_weight_sync: bool = False
     """Whether or not to clear the KV cache on weight sync. Defaults to False, which means KV cache from stale policies will be used during generation."""
 
+    @property
+    def skip_kv_cache_reset(self) -> bool:
+        return self.max_staleness_steps > 0 and not self.clear_kv_cache_on_weight_sync
+
 
 # ---------------------------------------------------------------------------
 # Sampling / Chat Template

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -474,12 +474,14 @@ class FullyAsyncConfig(BaseConfig):
     num_parallel_generation_workers: int = 768
     """Number of generation workers to spawn. Should be >= ``policy_mini_batch_size`` and
     <= ``policy_mini_batch_size * (max_staleness_steps + 1)``."""
-    clear_kv_cache_on_weight_sync: bool = False
-    """Whether or not to clear the KV cache on weight sync. Defaults to False, which means KV cache from stale policies will be used during generation."""
+    clear_kv_cache_on_weight_sync: bool = True
+    """Whether or not to clear the KV cache on weight sync. Defaults to True, matching synchronous RL.
+    Set to False for fully async training to reuse KV cache from stale policies during generation
+    (avoids recomputation at the cost of using slightly stale KV cache)."""
 
     @property
     def skip_kv_cache_reset(self) -> bool:
-        return self.max_staleness_steps > 0 and not self.clear_kv_cache_on_weight_sync
+        return not self.clear_kv_cache_on_weight_sync
 
 
 # ---------------------------------------------------------------------------

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -468,12 +468,14 @@ class FullyAsyncConfig(BaseConfig):
     """Knobs for fully async training.
     See https://docs.skyrl.ai/docs/tutorials/fully_async#step-2-config-knobs-to-tune-for-fully-async-training."""
 
-    max_staleness_steps: int = 4
+    max_staleness_steps: int = 0
     """Maximum off-policy steps allowed. If a trajectory group is scheduled at step *i* and trained at step *j*,
     then ``j - i <= max_staleness_steps``. Larger values increase throughput but also off-policy-ness."""
     num_parallel_generation_workers: int = 768
     """Number of generation workers to spawn. Should be >= ``policy_mini_batch_size`` and
     <= ``policy_mini_batch_size * (max_staleness_steps + 1)``."""
+    clear_kv_cache_on_weight_sync: bool = False
+    """Whether or not to clear the KV cache on weight sync. Defaults to False, which means KV cache from stale policies will be used during generation."""
 
 
 # ---------------------------------------------------------------------------

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -470,7 +470,7 @@ class FullyAsyncConfig(BaseConfig):
 
     max_staleness_steps: int = 0
     """Maximum off-policy steps allowed. If a trajectory group is scheduled at step *i* and trained at step *j*,
-    then ``j - i <= max_staleness_steps``. Larger values increase throughput but also off-policy-ness. Should be set > 1 for fully async training."""
+    then ``j - i <= max_staleness_steps``. Larger values increase throughput but also off-policy-ness. Should be set > 0 for fully async training."""
     num_parallel_generation_workers: int = 768
     """Number of generation workers to spawn. Should be >= ``policy_mini_batch_size`` and
     <= ``policy_mini_batch_size * (max_staleness_steps + 1)``."""


### PR DESCRIPTION
Previously, we always reset prefix cache prior to weight sync, even for fully async training:

https://github.com/NovaSky-AI/SkyRL/blob/649b16fb58ddcba6e2288368ae1e7f24b0fed211/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py#L1274

Adds a new flag `trainer.fully_async.clear_kv_cache_on_weight_sync` which defaults to `False`, meaning the default behavior during fully async training is to keep stale KV cache.

Also updates the default for `trainer.fully_async.max_staleness_steps` from `4` -> `0`, to be able to determine whether or not fully async training is enabled. All existing fully async scripts already manually set max_staleness_steps, and users should manually set this to a non zero value for all fully async scripts anyway.