### PR TITLE
[algorithm] make zero-variance filter generic (tolerance + loss-mask aware + metric)

### DIFF
--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -449,6 +449,9 @@ class AlgorithmConfig(BaseConfig):
     grpo_norm_by_std: bool = True
     zero_variance_filter: bool = False
     """Loss-mask prompts with zero-variance rewards. Only applicable when rewards are response-level."""
+    zero_variance_filter_tol: float = 0.0
+    """Two rewards within this absolute tolerance count as equal when detecting zero-variance groups.
+    Only used when ``zero_variance_filter=True``. 0.0 = exact; set ~1e-6 for float (LLM-judge) rewards."""
     lambd: float = 1.0
     gamma: float = 1.0
     eps_clip_low: float = 0.2

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -969,7 +969,17 @@ class RayPPOTrainer:
             per_token_rewards = rewards
         else:
             if self.cfg.trainer.algorithm.zero_variance_filter:
-                kept_indices_set = set(zero_variance_filter(rewards, uids))
+                kept_indices_set = set(
+                    zero_variance_filter(
+                        rewards,
+                        uids,
+                        loss_masks=generator_output["loss_masks"],
+                        tol=self.cfg.trainer.algorithm.zero_variance_filter_tol,
+                    )
+                )
+                num_groups = len(set(uids))
+                num_kept_groups = len({uids[i] for i in kept_indices_set})
+                self.all_metrics["reward/num_zero_variance_filtered"] = num_groups - num_kept_groups
                 generator_output["loss_masks"] = [
                     [0] * len(mask) if i not in kept_indices_set else mask
                     for i, mask in enumerate(generator_output["loss_masks"])

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -597,7 +597,7 @@ def zero_variance_filter(
     Returns:
         List[int]
     """
-    is_live = [True] * len(rewards) if loss_masks is None else [sum(mask) > 0 for mask in loss_masks]
+    is_live = [True] * len(rewards) if loss_masks is None else [any(mask) for mask in loss_masks]
 
     # Group live rewards by UID.
     uid2live_rewards = defaultdict(list)

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -568,26 +568,49 @@ def filter_generator_output(output: GeneratorOutput, kept_indices: List[int]) ->
     return filtered
 
 
-def zero_variance_filter(rewards: List[float], uids: List[str]) -> List[int]:
+def zero_variance_filter(
+    rewards: List[float],
+    uids: List[str],
+    loss_masks: Optional[List[List[int]]] = None,
+    tol: float = 0.0,
+) -> List[int]:
     """
-    Given a list of trajectory level rewards and uids, return the indices of the trajectories with non-zero variance rewards.
+    Given a list of trajectory level rewards and uids, return the indices of the trajectories to keep.
+
+    A group (set of trajectories sharing a uid) is filtered out only when it has more than one
+    *live* trajectory and the spread of their rewards is within ``tol`` (i.e. no GRPO signal).
+    Groups with at most one live trajectory (singletons, or groups whose other trajectories were
+    already masked upstream) are always kept.
+
+    A trajectory is "live" if it has at least one unmasked token (``sum(loss_mask) > 0``). When
+    ``loss_masks`` is None, all trajectories are treated as live. Computing variance over live
+    trajectories only means trajectories masked upstream (e.g. failed or timed-out rollouts) do not
+    make a genuine zero-variance group look like it has variance.
 
     Args:
         rewards: List[float]
         uids: List[str]
+        loss_masks: Optional per-trajectory loss masks, used to determine which trajectories are live.
+        tol: Two rewards within this absolute tolerance count as equal. 0.0 reproduces exact
+            (``np.std > 0``) behavior; set a small value (e.g. 1e-6) for float (LLM-judge) rewards.
 
     Returns:
         List[int]
     """
-    # Group by UID and calculate standard deviation
-    uid2metric_vals = defaultdict(list)
-    for uid, reward in zip(uids, rewards):
-        uid2metric_vals[uid].append(reward)
+    is_live = [True] * len(rewards) if loss_masks is None else [sum(mask) > 0 for mask in loss_masks]
 
-    # Identify UIDs to keep: non-zero variance or singletons
-    kept_uids_set = {
-        uid for uid, metric_vals in uid2metric_vals.items() if np.std(metric_vals) > 0 or len(metric_vals) == 1
-    }
+    # Group live rewards by UID.
+    uid2live_rewards = defaultdict(list)
+    for uid, reward, live in zip(uids, rewards, is_live):
+        if live:
+            uid2live_rewards[uid].append(reward)
+
+    def _is_zero_variance(uid: str) -> bool:
+        vals = uid2live_rewards.get(uid, [])
+        return len(vals) > 1 and (max(vals) - min(vals)) <= tol
+
+    # Keep everything except groups with >1 live trajectory and no reward spread.
+    kept_uids_set = {uid for uid in set(uids) if not _is_zero_variance(uid)}
 
     # Return indices of trajectories with kept UIDs
     return [i for i, uid in enumerate(uids) if uid in kept_uids_set]

--- a/tests/train/test_trainer_utils.py
+++ b/tests/train/test_trainer_utils.py
@@ -689,6 +689,38 @@ def test_zero_variance_filter_singletons_kept():
     assert kept_indices == [0, 1, 2]
 
 
+def test_zero_variance_filter_tolerance():
+    """Near-equal float rewards are treated as zero-variance when within tol."""
+    rewards = [0.6667, 0.66670001, 1.0, 0.0]
+    uids = ["a", "a", "b", "b"]
+
+    # Exact (tol=0.0): uid "a" has a tiny spread > 0 -> kept.
+    assert zero_variance_filter(rewards, uids, tol=0.0) == [0, 1, 2, 3]
+    # With tol=1e-6, uid "a" collapses to zero-variance and is dropped; uid "b" still varies.
+    assert zero_variance_filter(rewards, uids, tol=1e-6) == [2, 3]
+
+
+def test_zero_variance_filter_ignores_masked_trajectories():
+    """Trajectories masked upstream are excluded from the within-group variance check."""
+    # Group "a": two live trajectories both reward 1.0, plus two masked (reward 0.0).
+    # Naively this looks like spread (1,1,0,0) -> variance, but the masked ones should be ignored,
+    # so the group is detected as zero-variance and dropped.
+    rewards = [1.0, 1.0, 0.0, 0.0]
+    uids = ["a", "a", "a", "a"]
+    loss_masks = [[1, 1], [1, 1], [0, 0], [0, 0]]
+
+    assert zero_variance_filter(rewards, uids, loss_masks=loss_masks) == []
+
+
+def test_zero_variance_filter_single_live_trajectory_kept():
+    """A group with only one live trajectory (others masked) is kept as a singleton."""
+    rewards = [1.0, 0.0]
+    uids = ["a", "a"]
+    loss_masks = [[1, 1], [0, 0]]
+
+    assert zero_variance_filter(rewards, uids, loss_masks=loss_masks) == [0, 1]
+
+
 def test_validate_generator_output_valid_case():
     """Test validate_generator_output with valid case."""
     input_batch = GeneratorInput(


### PR DESCRIPTION
## Summary

Make the trainer's generic `zero_variance_filter` a strict superset of bespoke per-generator zero-variance filters so those can be removed and the logic lives in one place.

- **Loss-mask aware:** within-group variance is now computed over *live* trajectories only (`sum(loss_mask) > 0`). Trajectories masked upstream (e.g. failed / timed-out rollouts) no longer make a genuine zero-variance group look like it has reward spread.
- **Tolerance:** new `algorithm.zero_variance_filter_tol` (default `0.0`, exact / unchanged) so near-equal float rewards from LLM-judge rubrics (e.g. `0.6667`) count as zero-variance. Set `~1e-6` for float rewards.
- **Metric:** emits `reward/num_zero_variance_filtered` via `postprocess_generator_output`, so it flows for both the sync and fully-async trainers.

A group is filtered only when it has more than one live trajectory with reward spread within `tol`; singletons (and groups whose other trajectories were masked upstream) are always kept. `tol=0.0` + no `loss_masks` reproduces the previous `np.std > 0` behavior exactly.

This is phase 1 of generalizing zero-variance filtering; a follow-up adds active drop+refill (`sample_full_batch`) for the fully-async trainer.

## Test plan

- New unit tests in `tests/train/test_trainer_utils.py`: tolerance, loss-mask awareness, single-live-trajectory; existing three still pass (backward compatible).
- `tests/train/test_generator_postprocess.py` passes.
- ruff + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
