### PR TITLE
[chore][logging] Add trajectory and group completion metrics for async RL

### DIFF
--- a/docs/content/docs/configuration/config.mdx
+++ b/docs/content/docs/configuration/config.mdx
@@ -604,12 +604,18 @@ fully_async:
   max_staleness_steps: 4
   num_parallel_generation_workers: 768
   clear_kv_cache_on_weight_sync: true
+  simulate_training: false
+  simulate_training_step_seconds: 30.0
+  simulate_weight_sync_seconds: 0.0
 
 ```
 
 - `fully_async.max_staleness_steps`: Maximum off-policy steps allowed. If a trajectory group is scheduled at step *i* and trained at step *j*, then `j - i <= max_staleness_steps`. Larger values increase throughput but also off-policy-ness.
 - `fully_async.num_parallel_generation_workers`: Number of generation workers to spawn. Should be \>= `policy_mini_batch_size` and \<= `policy_mini_batch_size * (max_staleness_steps + 1)`.
 - `fully_async.clear_kv_cache_on_weight_sync`: Whether to clear the inference engine KV cache on each weight sync. Defaults to `true`, matching synchronous RL. Set to `false` for fully async training to reuse KV cache from stale policies during generation (avoids recomputation at the cost of using slightly stale KV cache).
+- `fully_async.simulate_training`: If `true`, run fully-async generation against a *simulated* trainer (`FullyAsyncTrainerSim`): no policy/critic/ref models are built and no weight broadcast happens. Each step consumes a mini-batch, sleeps for `simulate_training_step_seconds`, then issues pause/resume generation (as a real weight sync would) but skips the broadcast. Useful for benchmarking the generation/inference side (e.g. router load-balancing) on large models without paying for trainer GPUs. This is typically pointed at already-served endpoints via `external_proxy_url` / `external_server_urls`. See `examples/train/fully_async/main_fully_async_sim.py`. Requires `eval_interval`, `ckpt_interval`, and `hf_save_interval` all `<= 0`.
+- `fully_async.simulate_training_step_seconds`: Wall-clock seconds the simulated training step sleeps (stands in for fwd/bwd/optim). Only used when `simulate_training=true`. Defaults to `30.0`.
+- `fully_async.simulate_weight_sync_seconds`: Wall-clock seconds generation stays paused to stand in for the (skipped) weight broadcast. `0.0` means pause then immediately resume. Only used when `simulate_training=true`.
 
 ## Generator Configuration
 

--- a/examples/train_integrations/harbor/harbor_generator.py
+++ b/examples/train_integrations/harbor/harbor_generator.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import List, Optional
@@ -49,6 +50,9 @@ class HarborTrajectoryOutput:
     # One of: "complete", "context_length", "agent_timeout", "error". Used by
     # `build_step_wise_generator_output` to decide whether to skip the entire prompt group.
     stop_reason: str = "complete"
+    # End-to-end wall-clock time (seconds) to generate this trajectory. Optional: left as None if
+    # timing was not recorded.
+    e2e_time: Optional[float] = None
 
 
 def build_step_wise_generator_output(
@@ -92,6 +96,12 @@ def build_step_wise_generator_output(
     successful_trajectories: List[HarborTrajectoryOutput] = []
     response_ids_for_metrics: List[List[int]] = []
     rewards_for_metrics: List[float] = []
+    # One generation time per successful trajectory; used for completion-time metrics (avoids the
+    # duplicate per-step entries below inflating the stats).
+    trajectory_generation_times_per_prompt: List[Optional[float]] = []
+    # One generation time per emitted step, aligned 1:1 with the flattened per-step arrays above.
+    # Per trajectory we replicate its trajectory-level e2e_time across all of its steps.
+    out_trajectory_generation_times: List[Optional[float]] = []
     for traj in trajectory_outputs:
         tid = traj.trajectory_id
 
@@ -105,6 +115,7 @@ def build_step_wise_generator_output(
             is_last_step_list.append(True)
             out_trajectory_ids.append(tid)
             rollout_logprobs_list.append([0.0])
+            out_trajectory_generation_times.append(traj.e2e_time)
             continue
 
         # 2.2. For successful trajectories, emit one entry per step.
@@ -151,15 +162,29 @@ def build_step_wise_generator_output(
             is_last_step_list.append(is_last)
             out_trajectory_ids.append(tid)
             rollout_logprobs_list.append(lp)
+            # For trajectory completion per turn we just use the trajectory-level e2e time.
+            out_trajectory_generation_times.append(traj.e2e_time)
 
         # 2.5. For trajectory-level metrics, record the last turn's prompt IDs and response IDs which
         # contains the entire trajectory.
         response_ids_for_metrics.append(prompt_token_ids_per_turn[-1] + completion_token_ids_per_turn[-1])
         rewards_for_metrics.append(traj.reward)
+        trajectory_generation_times_per_prompt.append(traj.e2e_time)
 
     # 3. Aggregate trajectory-level metrics for logging.
+    # ``e2e_time`` is optional; if any trajectory did not record it, we omit the completion-time
+    # fields entirely rather than emit a partially-populated list.
+    # NOTE: metrics use the per-prompt times (not the per-step duplicates) to avoid skewing the stats.
+    if any(t is None for t in trajectory_generation_times_per_prompt):
+        trajectory_generation_times_per_prompt = None
+    if any(t is None for t in out_trajectory_generation_times):
+        out_trajectory_generation_times = None
     if successful_trajectories:
-        rollout_metrics = get_rollout_metrics(response_ids_for_metrics, rewards_for_metrics)
+        rollout_metrics = get_rollout_metrics(
+            response_ids_for_metrics,
+            rewards_for_metrics,
+            trajectory_completion_times=trajectory_generation_times_per_prompt,
+        )
         rollout_metrics["generate/trajectories_context_length_exceeded"] = sum(
             1 for t in successful_trajectories if t.stop_reason == "context_length"
         )
@@ -183,6 +208,8 @@ def build_step_wise_generator_output(
         rollout_logprobs=rollout_logprobs_list,
         trajectory_ids=out_trajectory_ids,
         is_last_step=is_last_step_list,
+        # Per-step times, aligned 1:1 with the flattened per-step arrays above.
+        trajectory_generation_times=out_trajectory_generation_times,
     )
 
 
@@ -304,6 +331,7 @@ class HarborGenerator(GeneratorInterface):
         """Run a single Harbor trial and return the rollout details plus a trajectory-level reward.
         Retries on unknown errors; context length errors train with reward=0; agent timeouts mask the trajectory.
         """
+        agent_loop_start_time = time.monotonic()
         reward = None
         results = None
         rollout_details = None
@@ -377,7 +405,12 @@ class HarborGenerator(GeneratorInterface):
             if stop_reason == "error":
                 error_message += f" Results: {results}"
             logger.warning(error_message)
-            return HarborTrajectoryOutput(trajectory_id=trajectory_id, rollout_details=None, stop_reason=stop_reason)
+            return HarborTrajectoryOutput(
+                trajectory_id=trajectory_id,
+                rollout_details=None,
+                stop_reason=stop_reason,
+                e2e_time=time.monotonic() - agent_loop_start_time,
+            )
         else:
             return HarborTrajectoryOutput(
                 trajectory_id=trajectory_id,
@@ -385,4 +418,5 @@ class HarborGenerator(GeneratorInterface):
                 reward=reward,
                 num_turns=num_turns,
                 stop_reason="context_length" if is_context_length_error else "complete",
+                e2e_time=time.monotonic() - agent_loop_start_time,
             )

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -887,6 +887,53 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 out[f"{suffix}/{k}"] = v
         return out
 
+    def _get_intra_group_completion_time_std_cv(
+        self, generated_output_output: GeneratedOutputGroup
+    ) -> Tuple[Optional[float], Optional[float]]:
+        traj_times = generated_output_output.generator_output.get("trajectory_generation_times")
+        group_std = None
+        group_cv = None
+        if traj_times and len(traj_times) > 1:
+            # For step wise training, each turn /step contributes one entry.
+            # Only take the metrics from the last step
+            is_last_step = generated_output_output.generator_output.get("is_last_step")
+            if is_last_step:
+                traj_times = [t for t, last in zip(traj_times, is_last_step) if last]
+            traj_times_arr = np.array(traj_times, dtype=np.float64)
+            # Population std of per-trajectory completion times within this group (seconds).
+            group_std = float(traj_times_arr.std())
+            # Coefficient of variation = std / mean. Guard against div-by-zero.
+            mean_traj_time = float(traj_times_arr.mean())
+            if mean_traj_time > 0:
+                group_cv = group_std / mean_traj_time
+        return group_std, group_cv
+
+    def _get_group_completion_metrics(
+        self,
+        group_completion_times: Optional[List[float]],
+        intra_group_stds: Optional[List[float]],
+        intra_group_cvs: Optional[List[float]],
+    ):
+        # Log per-group completion-time statistics for the groups consumed in this step. These
+        # surface generation load-balancing behavior (e.g. across vllm-router routing policies):
+        # tail group latency (p90/max) and how unevenly trajectories within a group finish
+        # (intra-group coefficient of variation).
+        metrics = {}
+        if group_completion_times:
+            group_times_arr = np.array(group_completion_times, dtype=np.float64)
+            metrics.update(
+                {
+                    "generate/group_completion_time_mean": float(group_times_arr.mean()),
+                    "generate/group_completion_time_p90": float(np.percentile(group_times_arr, 90)),
+                    "generate/group_completion_time_max": float(group_times_arr.max()),
+                }
+            )
+        if intra_group_stds:
+            metrics.update({"generate/intra_group_completion_time_std_mean": float(np.mean(intra_group_stds))})
+        if intra_group_cvs:
+            metrics.update({"generate/intra_group_completion_time_cv_mean": float(np.mean(intra_group_cvs))})
+        return metrics
+
     def convert_generation_group_mini_batch_to_training_input(
         self,
         cur_generation_group_mini_batch: List[GeneratedOutputGroup],
@@ -903,7 +950,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         stalenesses = []
         staleness_violation_count = 0
         # Per-group completion times (seconds) and the intra-group spread (std and coefficient of
-        # variation) of per-trajectory completion times, used to log generation load-balancing metrics.
+        # variation) of per-trajectory completion times. Helpful to understand tail latency
         group_completion_times: List[float] = []
         intra_group_stds: List[float] = []
         intra_group_cvs: List[float] = []
@@ -915,19 +962,12 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             # Collect per-group / per-trajectory completion-time stats for this group.
             if cur_generated_output_group.group_completion_time_s is not None:
                 group_completion_times.append(cur_generated_output_group.group_completion_time_s)
-            traj_times = cur_generated_output_group.generator_output.get("trajectory_generation_times")
-            if traj_times and len(traj_times) > 1:
-                is_last_step = cur_generated_output_group.generator_output.get("is_last_step")
-                if is_last_step:
-                    traj_times = [t for t, last in zip(traj_times, is_last_step) if last]
-                traj_times_arr = np.array(traj_times, dtype=np.float64)
-                # Population std of per-trajectory completion times within this group (seconds).
-                group_std = float(traj_times_arr.std())
-                intra_group_stds.append(group_std)
-                # Coefficient of variation = std / mean. Guard against div-by-zero.
-                mean_traj_time = float(traj_times_arr.mean())
-                if mean_traj_time > 0:
-                    intra_group_cvs.append(group_std / mean_traj_time)
+            intra_group_std, intra_group_cv = self._get_intra_group_completion_time_std_cv(cur_generated_output_group)
+            if intra_group_std is not None:
+                intra_group_stds.append(intra_group_std)
+            if intra_group_cv is not None:
+                intra_group_cvs.append(intra_group_cv)
+
             # NOTE(Charlie): for step-wise training each group can contain a variable number of entries
             # (n_samples_per_prompt * variable turns_per_trajectory), so the uid fanout is per-group.
             group_size = len(cur_generated_output_group.generator_output["response_ids"])
@@ -968,6 +1008,10 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         rollout_metrics_source = metrics_generator_output if metrics_generator_output is not None else generator_output
         self.all_metrics.update(rollout_metrics_source["rollout_metrics"])
 
+        group_completion_metrics = self._get_group_completion_metrics(
+            group_completion_times, intra_group_stds, intra_group_cvs
+        )
+
         if dropped_groups:
             # Also split generation metrics by kept vs dropped, plus reward metrics for the dropped
             # groups. (Kept reward metrics are uninformative -- pass@n ~1 -- and loss/avg_final_rewards
@@ -979,6 +1023,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             self.all_metrics.update(self._reprefix_metrics(dropped_generator_output["rollout_metrics"], "dropped"))
             dropped_uids = [g.uid for g in dropped_groups for _ in range(len(g.generator_output["response_ids"]))]
             dropped_reward = get_metrics_from_generator_output(dropped_generator_output, dropped_uids)
+
             n_samples_per_prompt = self.cfg.generator.n_samples_per_prompt
             self.all_metrics.update(
                 {
@@ -988,6 +1033,36 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 }
             )
             dropped_generator_output.pop("rollout_metrics", None)
+
+            # Per-group completion times and intra-group spread for dropped groups
+            dropped_group_completion_times = []
+            dropped_group_intra_group_stds = []
+            dropped_group_intra_group_cvs = []
+            for dropped_group in dropped_groups:
+                if dropped_group.group_completion_time_s is not None:
+                    dropped_group_completion_times.append(dropped_group.group_completion_time_s)
+                intra_group_std, intra_group_cv = self._get_intra_group_completion_time_std_cv(dropped_group)
+                if intra_group_std is not None:
+                    dropped_group_intra_group_stds.append(intra_group_std)
+                if intra_group_cv is not None:
+                    dropped_group_intra_group_cvs.append(intra_group_cv)
+
+            dropped_metrics = self._get_group_completion_metrics(
+                dropped_group_completion_times, dropped_group_intra_group_stds, dropped_group_intra_group_cvs
+            )
+
+            self.all_metrics.update(self._reprefix_metrics(group_completion_metrics, "kept"))
+            self.all_metrics.update(self._reprefix_metrics(dropped_metrics, "dropped"))
+
+            merged_group_completion_times = group_completion_times + dropped_group_completion_times
+            merged_intra_group_stds = intra_group_stds + dropped_group_intra_group_stds
+            merged_intra_group_cvs = intra_group_cvs + dropped_group_intra_group_cvs
+            # get merged metrics with kept + dropped groups
+            group_completion_metrics = self._get_group_completion_metrics(
+                merged_group_completion_times, merged_intra_group_stds, merged_intra_group_cvs
+            )
+
+        self.all_metrics.update(group_completion_metrics)
 
         generator_output.pop("rollout_metrics", None)
         if metrics_generator_output is not None:
@@ -1003,25 +1078,6 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 "async/staleness_violation_count": staleness_violation_count,
             }
         )
-
-
-        # Log per-group completion-time statistics for the groups consumed in this step. These
-        # surface generation load-balancing behavior (e.g. across vllm-router routing policies):
-        # tail group latency (p90/max) and how unevenly trajectories within a group finish
-        # (intra-group coefficient of variation).
-        if group_completion_times:
-            group_times_arr = np.array(group_completion_times, dtype=np.float64)
-            self.all_metrics.update(
-                {
-                    "async/group_completion_time_mean": float(group_times_arr.mean()),
-                    "async/group_completion_time_p90": float(np.percentile(group_times_arr, 90)),
-                    "async/group_completion_time_max": float(group_times_arr.max()),
-                }
-            )
-        if intra_group_stds:
-            self.all_metrics.update({"async/intra_group_completion_time_std_mean": float(np.mean(intra_group_stds))})
-        if intra_group_cvs:
-            self.all_metrics.update({"async/intra_group_completion_time_cv_mean": float(np.mean(intra_group_cvs))})
 
         # Per-token reward conversion (kept groups only) + reward metrics over the kept+dropped view.
         generator_output, uids = self.postprocess_generator_output(

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -15,10 +15,12 @@ import asyncio
 import inspect
 import os
 import sys
+import time
 import traceback
 from dataclasses import dataclass
 from typing import Iterable, List, Optional, Set, Tuple
 
+import numpy as np
 import torch
 from loguru import logger
 from torchdata.stateful_dataloader import StatefulDataLoader
@@ -57,11 +59,16 @@ class GeneratedOutputGroup:
 
         global_step_when_scheduled (int): The global step when the group was scheduled for generation,
             used for validating the staleness control.
+
+        group_completion_time_s (Optional[float]): Wall-clock time (seconds) for the whole group to
+            finish generation, i.e. the time for the slowest trajectory in the group to complete.
+            None if generation timing was not captured.
     """
 
     generator_output: GeneratorOutput
     uid: str
     global_step_when_scheduled: int
+    group_completion_time_s: Optional[float] = None
 
 
 @dataclass
@@ -826,6 +833,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 # 3. Generate one rollout group
                 global_step_at_start = self.global_step  # for staleness control
 
+                group_start_time = time.monotonic()
                 if "disable_tqdm" in inspect.signature(self.generator.generate).parameters:
                     # A workaround to disable tqdm for the SkyRLGymGenerator.generate method which will
                     # blast the console with each worker's progress bar.
@@ -834,6 +842,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                     )
                 else:
                     cur_generator_output: GeneratorOutput = await self.generator.generate(generator_input)
+                group_completion_time_s = time.monotonic() - group_start_time
 
                 # 4. Enqueue the completed group and mark accepted to free capacity slot.
                 try:
@@ -842,6 +851,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                             generator_output=cur_generator_output,
                             uid=uids[0],
                             global_step_when_scheduled=global_step_at_start,
+                            group_completion_time_s=group_completion_time_s,
                         )
                     )
                 except asyncio.QueueFull:
@@ -892,10 +902,29 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         uids = []
         stalenesses = []
         staleness_violation_count = 0
+        # Per-group completion times (seconds) and the intra-group spread (std and coefficient of
+        # variation) of per-trajectory completion times, used to log generation load-balancing metrics.
+        group_completion_times: List[float] = []
+        intra_group_stds: List[float] = []
+        intra_group_cvs: List[float] = []
         for cur_generated_output_group in cur_generation_group_mini_batch:
             cur_staleness = self.global_step - cur_generated_output_group.global_step_when_scheduled
             stalenesses.append(cur_staleness)
             generator_outputs.append(cur_generated_output_group.generator_output)
+
+            # Collect per-group / per-trajectory completion-time stats for this group.
+            if cur_generated_output_group.group_completion_time_s is not None:
+                group_completion_times.append(cur_generated_output_group.group_completion_time_s)
+            traj_times = cur_generated_output_group.generator_output.get("trajectory_generation_times")
+            if traj_times and len(traj_times) > 1:
+                traj_times_arr = np.array(traj_times, dtype=np.float64)
+                # Population std of per-trajectory completion times within this group (seconds).
+                group_std = float(traj_times_arr.std())
+                intra_group_stds.append(group_std)
+                # Coefficient of variation = std / mean. Guard against div-by-zero.
+                mean_traj_time = float(traj_times_arr.mean())
+                if mean_traj_time > 0:
+                    intra_group_cvs.append(group_std / mean_traj_time)
             # NOTE(Charlie): for step-wise training each group can contain a variable number of entries
             # (n_samples_per_prompt * variable turns_per_trajectory), so the uid fanout is per-group.
             group_size = len(cur_generated_output_group.generator_output["response_ids"])
@@ -971,6 +1000,25 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 "async/staleness_violation_count": staleness_violation_count,
             }
         )
+
+
+        # Log per-group completion-time statistics for the groups consumed in this step. These
+        # surface generation load-balancing behavior (e.g. across vllm-router routing policies):
+        # tail group latency (p90/max) and how unevenly trajectories within a group finish
+        # (intra-group coefficient of variation).
+        if group_completion_times:
+            group_times_arr = np.array(group_completion_times, dtype=np.float64)
+            self.all_metrics.update(
+                {
+                    "async/group_completion_time_mean": float(group_times_arr.mean()),
+                    "async/group_completion_time_p90": float(np.percentile(group_times_arr, 90)),
+                    "async/group_completion_time_max": float(group_times_arr.max()),
+                }
+            )
+        if intra_group_stds:
+            self.all_metrics.update({"async/intra_group_completion_time_std_mean": float(np.mean(intra_group_stds))})
+        if intra_group_cvs:
+            self.all_metrics.update({"async/intra_group_completion_time_cv_mean": float(np.mean(intra_group_cvs))})
 
         # Per-token reward conversion (kept groups only) + reward metrics over the kept+dropped view.
         generator_output, uids = self.postprocess_generator_output(

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -917,6 +917,9 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 group_completion_times.append(cur_generated_output_group.group_completion_time_s)
             traj_times = cur_generated_output_group.generator_output.get("trajectory_generation_times")
             if traj_times and len(traj_times) > 1:
+                is_last_step = cur_generated_output_group.generator_output.get("is_last_step")
+                if is_last_step:
+                    traj_times = [t for t, last in zip(traj_times, is_last_step) if last]
                 traj_times_arr = np.array(traj_times, dtype=np.float64)
                 # Population std of per-trajectory completion times within this group (seconds).
                 group_std = float(traj_times_arr.std())

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -20,7 +20,6 @@ import traceback
 from dataclasses import dataclass
 from typing import Iterable, List, Optional, Set, Tuple
 
-import numpy as np
 import torch
 from loguru import logger
 from torchdata.stateful_dataloader import StatefulDataLoader
@@ -42,6 +41,8 @@ from skyrl.train.utils import Timer
 from skyrl.train.utils.trainer_utils import (
     ResumeMode,
     build_dataloader,
+    get_group_completion_metrics,
+    get_intra_group_completion_time_std_cv,
     zero_variance_filter,
 )
 
@@ -887,53 +888,6 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 out[f"{suffix}/{k}"] = v
         return out
 
-    def _get_intra_group_completion_time_std_cv(
-        self, generated_output_group: GeneratedOutputGroup
-    ) -> Tuple[Optional[float], Optional[float]]:
-        traj_times = generated_output_group.generator_output.get("trajectory_generation_times")
-        group_std = None
-        group_cv = None
-        if traj_times and len(traj_times) > 1:
-            # For step wise training, each turn /step contributes one entry.
-            # Only take the metrics from the last step
-            is_last_step = generated_output_group.generator_output.get("is_last_step")
-            if is_last_step:
-                traj_times = [t for t, last in zip(traj_times, is_last_step) if last]
-            traj_times_arr = np.array(traj_times, dtype=np.float64)
-            # Population std of per-trajectory completion times within this group (seconds).
-            group_std = float(traj_times_arr.std())
-            # Coefficient of variation = std / mean. Guard against div-by-zero.
-            mean_traj_time = float(traj_times_arr.mean())
-            if mean_traj_time > 0:
-                group_cv = group_std / mean_traj_time
-        return group_std, group_cv
-
-    def _get_group_completion_metrics(
-        self,
-        group_completion_times: Optional[List[float]],
-        intra_group_stds: Optional[List[float]],
-        intra_group_cvs: Optional[List[float]],
-    ):
-        # Log per-group completion-time statistics for the groups consumed in this step. These
-        # surface generation load-balancing behavior (e.g. across vllm-router routing policies):
-        # tail group latency (p90/max) and how unevenly trajectories within a group finish
-        # (intra-group coefficient of variation).
-        metrics = {}
-        if group_completion_times:
-            group_times_arr = np.array(group_completion_times, dtype=np.float64)
-            metrics.update(
-                {
-                    "generate/group_completion_time_mean": float(group_times_arr.mean()),
-                    "generate/group_completion_time_p90": float(np.percentile(group_times_arr, 90)),
-                    "generate/group_completion_time_max": float(group_times_arr.max()),
-                }
-            )
-        if intra_group_stds:
-            metrics.update({"generate/intra_group_completion_time_std_mean": float(np.mean(intra_group_stds))})
-        if intra_group_cvs:
-            metrics.update({"generate/intra_group_completion_time_cv_mean": float(np.mean(intra_group_cvs))})
-        return metrics
-
     def convert_generation_group_mini_batch_to_training_input(
         self,
         cur_generation_group_mini_batch: List[GeneratedOutputGroup],
@@ -962,7 +916,9 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             # Collect per-group / per-trajectory completion-time stats for this group.
             if cur_generated_output_group.group_completion_time_s is not None:
                 group_completion_times.append(cur_generated_output_group.group_completion_time_s)
-            intra_group_std, intra_group_cv = self._get_intra_group_completion_time_std_cv(cur_generated_output_group)
+            intra_group_std, intra_group_cv = get_intra_group_completion_time_std_cv(
+                cur_generated_output_group.generator_output
+            )
             if intra_group_std is not None:
                 intra_group_stds.append(intra_group_std)
             if intra_group_cv is not None:
@@ -1008,7 +964,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         rollout_metrics_source = metrics_generator_output if metrics_generator_output is not None else generator_output
         self.all_metrics.update(rollout_metrics_source["rollout_metrics"])
 
-        group_completion_metrics = self._get_group_completion_metrics(
+        group_completion_metrics = get_group_completion_metrics(
             group_completion_times, intra_group_stds, intra_group_cvs
         )
 
@@ -1041,13 +997,13 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             for dropped_group in dropped_groups:
                 if dropped_group.group_completion_time_s is not None:
                     dropped_group_completion_times.append(dropped_group.group_completion_time_s)
-                intra_group_std, intra_group_cv = self._get_intra_group_completion_time_std_cv(dropped_group)
+                intra_group_std, intra_group_cv = get_intra_group_completion_time_std_cv(dropped_group.generator_output)
                 if intra_group_std is not None:
                     dropped_group_intra_group_stds.append(intra_group_std)
                 if intra_group_cv is not None:
                     dropped_group_intra_group_cvs.append(intra_group_cv)
 
-            dropped_metrics = self._get_group_completion_metrics(
+            dropped_metrics = get_group_completion_metrics(
                 dropped_group_completion_times, dropped_group_intra_group_stds, dropped_group_intra_group_cvs
             )
 
@@ -1058,7 +1014,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             merged_intra_group_stds = intra_group_stds + dropped_group_intra_group_stds
             merged_intra_group_cvs = intra_group_cvs + dropped_group_intra_group_cvs
             # get merged metrics with kept + dropped groups
-            group_completion_metrics = self._get_group_completion_metrics(
+            group_completion_metrics = get_group_completion_metrics(
                 merged_group_completion_times, merged_intra_group_stds, merged_intra_group_cvs
             )
 

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -888,15 +888,15 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         return out
 
     def _get_intra_group_completion_time_std_cv(
-        self, generated_output_output: GeneratedOutputGroup
+        self, generated_output_group: GeneratedOutputGroup
     ) -> Tuple[Optional[float], Optional[float]]:
-        traj_times = generated_output_output.generator_output.get("trajectory_generation_times")
+        traj_times = generated_output_group.generator_output.get("trajectory_generation_times")
         group_std = None
         group_cv = None
         if traj_times and len(traj_times) > 1:
             # For step wise training, each turn /step contributes one entry.
             # Only take the metrics from the last step
-            is_last_step = generated_output_output.generator_output.get("is_last_step")
+            is_last_step = generated_output_group.generator_output.get("is_last_step")
             if is_last_step:
                 traj_times = [t for t, last in zip(traj_times, is_last_step) if last]
             traj_times_arr = np.array(traj_times, dtype=np.float64)

--- a/skyrl/train/fully_async_trainer_sim.py
+++ b/skyrl/train/fully_async_trainer_sim.py
@@ -79,9 +79,15 @@ class FullyAsyncTrainerSim(FullyAsyncRayPPOTrainer):
         # _run_training). Everything else in train() that touches trainer models is config-gated,
         # so assert those are off — no models are built in sim mode, so they would otherwise crash.
         t = self.cfg.trainer
-        assert t.eval_interval <= 0, "FullyAsyncTrainerSim: set trainer.eval_interval=0 (no models to eval)."
-        assert t.ckpt_interval <= 0, "FullyAsyncTrainerSim: set trainer.ckpt_interval=-1 (no models to checkpoint)."
-        assert t.hf_save_interval <= 0, "FullyAsyncTrainerSim: set trainer.hf_save_interval=-1 (no models to save)."
+        assert (
+            t.eval_interval <= 0
+        ), "FullyAsyncTrainerSim: set trainer.eval_interval<=0 to disable (no models to eval)."
+        assert (
+            t.ckpt_interval <= 0
+        ), "FullyAsyncTrainerSim: set trainer.ckpt_interval<=0 to disable (no models to checkpoint)."
+        assert (
+            t.hf_save_interval <= 0
+        ), "FullyAsyncTrainerSim: set trainer.hf_save_interval<=0 to disable (no models to save)."
         assert not t.update_ref_every_epoch, "FullyAsyncTrainerSim: trainer.update_ref_every_epoch must be false."
         assert self.resume_mode == ResumeMode.NONE, "FullyAsyncTrainerSim: resumption is unsupported (no models)."
         self._step_sleep = float(fa.simulate_training_step_seconds)

--- a/skyrl/train/generators/base.py
+++ b/skyrl/train/generators/base.py
@@ -42,6 +42,10 @@ class GeneratorOutput(TypedDict):
     rollout_metrics: Optional[Dict[str, Any]]
     rollout_logprobs: Optional[List[List[float]]]
     trajectory_ids: Optional[List[TrajectoryID]]
+    # Wall-clock generation time (seconds) for each trajectory, with one entry per
+    # trajectory in the input batch (i.e. per ``agent_loop`` call). Used by the fully
+    # async trainer to compute per-group / intra-group completion-time metrics.
+    trajectory_generation_times: Optional[List[float]]
     rollout_expert_indices: Optional[List[List[List[List[int]]]]]  # [batch_size, seq_len, layer_num, topk]
     # Applicable only for step-wise training
     is_last_step: Optional[List[bool]]

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -7,6 +7,7 @@ For details, see https://docs.skyrl.ai/docs/tutorials/skyrl_gym_generator
 
 import asyncio
 import copy
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -55,6 +56,9 @@ class TrajectoryOutput:
     rollout_expert_indices: Optional[List[List[List[int]]]] = None
     pixel_values: Optional[torch.Tensor] = None
     image_grid_thw: Optional[torch.Tensor] = None
+    # End-to-end wall-clock time (seconds) to generate this trajectory. Optional: agent loops may
+    # leave this as None if they do not track timing.
+    e2e_time: Optional[float] = None
 
 
 @dataclass
@@ -62,6 +66,9 @@ class StepWiseOutput:
     """Output from a single agent_loop execution for step-wise training."""
 
     step_outputs: List[TrajectoryOutput]
+    # End-to-end wall-clock time (seconds) to generate this trajectory. Optional: agent loops may
+    # leave this as None if they do not track timing.
+    e2e_time: Optional[float] = None
 
 
 @dataclass
@@ -297,6 +304,20 @@ class SkyRLGymGenerator(GeneratorInterface):
             prompt_token_ids: List[int]
             rollout_logprobs: Optional[List[float]]
         """
+        agent_loop_start_time = time.monotonic()
+
+        # NOTE: `custom_chat_template` was mainly for getting accurate loss masks for thinking models.
+        # This is no longer needed now given that step wise training is supported
+        # TODO (sumanthrh): This path can be deprecated
+        retokenize_chat_history = self.use_conversation_multi_turn and self.custom_chat_template
+
+        # Create a new environment instance
+        env_extras["max_turns"] = self.max_turns  # TODO(shu): move this to config
+        env_extras = self._setup_env_extras(env_class, env_extras, sampling_params, trajectory_id)
+
+        env_config = getattr(self.skyrl_gym_cfg, env_class, dict())
+        env = skyrl_gym.make(env_class, env_config=env_config, extras=env_extras)
+
         session_id = (
             f"{trajectory_id.instance_id}_{trajectory_id.repetition_id}" if trajectory_id is not None else uuid4().hex
         )
@@ -579,6 +600,7 @@ class SkyRLGymGenerator(GeneratorInterface):
                 env_extras,
                 trajectory_id,
             )
+            agent_loop_output.e2e_time = time.monotonic() - agent_loop_start_time
             return agent_loop_output
 
         finally:
@@ -831,6 +853,12 @@ class SkyRLGymGenerator(GeneratorInterface):
             mininterval=5,
             disable=disable_tqdm,
         )
+        # Per-trajectory end-to-end generation times (one entry per prompt, preserving input order).
+        # ``e2e_time`` is optional for agent loops; if any trajectory did not record it, we omit the
+        # field entirely rather than emit a partially-populated list.
+        trajectory_generation_times = [getattr(output, "e2e_time", None) for output in all_outputs]
+        if any(t is None for t in trajectory_generation_times):
+            trajectory_generation_times = None
 
         if self.generator_cfg.step_wise_trajectories:
             responses = []
@@ -913,6 +941,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             "rollout_metrics": rollout_metrics,
             "rollout_logprobs": rollout_logprobs,
             "trajectory_ids": out_trajectory_ids,
+            "trajectory_generation_times": trajectory_generation_times,
             "rollout_expert_indices": rollout_expert_indices,
             "is_last_step": is_last_step,
             "env_metrics": env_metrics,

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -922,7 +922,14 @@ class SkyRLGymGenerator(GeneratorInterface):
         else:
             rollout_expert_indices = None
 
-        rollout_metrics = get_rollout_metrics(responses, rewards, env_metrics, env_classes, loss_masks)
+        rollout_metrics = get_rollout_metrics(
+            responses,
+            rewards,
+            env_metrics,
+            env_classes,
+            loss_masks,
+            trajectory_completion_times=trajectory_generation_times,
+        )
 
         if self.generator_cfg.zero_reward_on_non_stop:
             # set reward to 0 if the stop reason is not "stop"

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -306,18 +306,6 @@ class SkyRLGymGenerator(GeneratorInterface):
         """
         agent_loop_start_time = time.monotonic()
 
-        # NOTE: `custom_chat_template` was mainly for getting accurate loss masks for thinking models.
-        # This is no longer needed now given that step wise training is supported
-        # TODO (sumanthrh): This path can be deprecated
-        retokenize_chat_history = self.use_conversation_multi_turn and self.custom_chat_template
-
-        # Create a new environment instance
-        env_extras["max_turns"] = self.max_turns  # TODO(shu): move this to config
-        env_extras = self._setup_env_extras(env_class, env_extras, sampling_params, trajectory_id)
-
-        env_config = getattr(self.skyrl_gym_cfg, env_class, dict())
-        env = skyrl_gym.make(env_class, env_config=env_config, extras=env_extras)
-
         session_id = (
             f"{trajectory_id.instance_id}_{trajectory_id.repetition_id}" if trajectory_id is not None else uuid4().hex
         )
@@ -958,7 +946,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             "rollout_metrics": rollout_metrics,
             "rollout_logprobs": rollout_logprobs,
             "trajectory_ids": out_trajectory_ids,
-            # NOTE: for completion metrics, we output the completiontime
+            # NOTE: for completion metrics, we output the completion time
             "trajectory_generation_times": out_trajectory_generation_times,
             "rollout_expert_indices": rollout_expert_indices,
             "is_last_step": is_last_step,

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -856,9 +856,9 @@ class SkyRLGymGenerator(GeneratorInterface):
         # Per-trajectory end-to-end generation times (one entry per prompt, preserving input order).
         # ``e2e_time`` is optional for agent loops; if any trajectory did not record it, we omit the
         # field entirely rather than emit a partially-populated list.
-        trajectory_generation_times = [getattr(output, "e2e_time", None) for output in all_outputs]
-        if any(t is None for t in trajectory_generation_times):
-            trajectory_generation_times = None
+        trajectory_generation_times_per_prompt = [getattr(output, "e2e_time", None) for output in all_outputs]
+        if any(t is None for t in trajectory_generation_times_per_prompt):
+            trajectory_generation_times_per_prompt = None
 
         if self.generator_cfg.step_wise_trajectories:
             responses = []
@@ -870,6 +870,7 @@ class SkyRLGymGenerator(GeneratorInterface):
             is_last_step = []
             out_trajectory_ids = []
             out_env_classes = []
+            out_trajectory_generation_times = []
             for i, output in enumerate(all_outputs):
                 for j, step_output in enumerate(output.step_outputs):
                     responses.append(step_output.response_ids)
@@ -881,6 +882,11 @@ class SkyRLGymGenerator(GeneratorInterface):
                     is_last_step.append(j == len(output.step_outputs) - 1)
                     out_trajectory_ids.append(trajectory_ids[i])
                     out_env_classes.append(env_classes[i])
+                    # For trajectory completion per turn we just use the trajectory level e2e time
+                    out_trajectory_generation_times.append(getattr(output, "e2e_time", None))
+            # Keep aligned with the per-prompt None handling:
+            if not trajectory_generation_times_per_prompt:
+                out_trajectory_generation_times = None
             env_classes = out_env_classes
         else:
             responses = [output.response_ids for output in all_outputs]
@@ -891,6 +897,8 @@ class SkyRLGymGenerator(GeneratorInterface):
             env_metrics = [output.env_metrics for output in all_outputs]
             is_last_step = None
             out_trajectory_ids = None
+            # One time per trajectory, already aligned 1:1 with responses (None if not all recorded).
+            out_trajectory_generation_times = trajectory_generation_times_per_prompt
 
         has_vision_features = any(getattr(output, "pixel_values", None) is not None for output in all_outputs)
         pixel_values = (
@@ -928,7 +936,9 @@ class SkyRLGymGenerator(GeneratorInterface):
             env_metrics,
             env_classes,
             loss_masks,
-            trajectory_completion_times=trajectory_generation_times,
+            # NOTE: we only use trajectory completion times per prompt for
+            # metrics, to avoid duplicate entries with step-wise training
+            trajectory_completion_times=trajectory_generation_times_per_prompt,
         )
 
         if self.generator_cfg.zero_reward_on_non_stop:
@@ -948,7 +958,8 @@ class SkyRLGymGenerator(GeneratorInterface):
             "rollout_metrics": rollout_metrics,
             "rollout_logprobs": rollout_logprobs,
             "trajectory_ids": out_trajectory_ids,
-            "trajectory_generation_times": trajectory_generation_times,
+            # NOTE: for completion metrics, we output the completiontime
+            "trajectory_generation_times": out_trajectory_generation_times,
             "rollout_expert_indices": rollout_expert_indices,
             "is_last_step": is_last_step,
             "env_metrics": env_metrics,

--- a/skyrl/train/generators/skyrl_vlm_generator.py
+++ b/skyrl/train/generators/skyrl_vlm_generator.py
@@ -3,6 +3,7 @@ SkyRLVLMGymGenerator: VLM (vision-language model) multi-turn RL generator.
 """
 
 import copy
+import time
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple, TypedDict
 from uuid import uuid4
@@ -83,6 +84,7 @@ class SkyRLVLMGymGenerator(SkyRLGymGenerator):
         completion, error, or cancellation so session-aware routing policies can
         free the replica capacity held by the trajectory.
         """
+        agent_loop_start_time = time.monotonic()
         session_id = (
             f"{trajectory_id.instance_id}_{trajectory_id.repetition_id}" if trajectory_id is not None else uuid4().hex
         )
@@ -220,6 +222,7 @@ class SkyRLVLMGymGenerator(SkyRLGymGenerator):
                 env_metrics=env_metrics,
                 pixel_values=pixel_values,
                 image_grid_thw=image_grid_thw,
+                e2e_time=time.monotonic() - agent_loop_start_time,
             )
 
         finally:

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -281,7 +281,10 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput], step
 
     # Re-aggregate rollout metrics
     rollout_metrics = get_rollout_metrics(
-        result["response_ids"], result["rewards"], loss_masks=result.get("loss_masks")
+        result["response_ids"],
+        result["rewards"],
+        loss_masks=result.get("loss_masks"),
+        trajectory_completion_times=result.get("trajectory_generation_times"),
     )
 
     # Preserve generator-specific metrics from per-group rollout_metrics. get_rollout_metrics only
@@ -368,6 +371,7 @@ def get_rollout_metrics(
     env_metrics: Optional[List[Dict[str, Any]]] = None,
     env_classes: Optional[List[str]] = None,
     loss_masks: Optional[List[List[int]]] = None,
+    trajectory_completion_times: Optional[List[float]] = None,
 ):
     """
     Computes rollout metrics including token statistics and optional environment-specific metrics.
@@ -378,6 +382,8 @@ def get_rollout_metrics(
         env_metrics: Optional list of environment-specific metrics for each trajectory
         env_classes: Optional list of environment class names for each trajectory
         loss_masks: Optional list of per-token loss masks; used to compute assistant-only token counts
+        trajectory_completion_times: Optional per-trajectory end-to-end generation times (seconds);
+            used to compute aggregate trajectory completion-time stats (mean / p90 / max)
 
     Returns:
         Dictionary of aggregated metrics
@@ -430,6 +436,16 @@ def get_rollout_metrics(
                     "generate/tokens_per_turn_std": np.std(turn_token_counts_arr).item(),
                 }
             )
+
+    if trajectory_completion_times:
+        completion_times_arr = np.array(trajectory_completion_times, dtype=np.float64)
+        rollout_metrics.update(
+            {
+                "generate/trajectory_completion_time_mean": np.mean(completion_times_arr).item(),
+                "generate/trajectory_completion_time_p90": np.percentile(completion_times_arr, 90).item(),
+                "generate/trajectory_completion_time_max": np.max(completion_times_arr).item(),
+            }
+        )
 
     if env_metrics is not None and env_classes is not None:
         env_to_metrics = defaultdict(list)

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -258,12 +258,6 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput], step
         raise ValueError(
             "generator outputs are expected to all have null rollout_logprobs or all non-null, but received a mix"
         )
-    # ``trajectory_generation_times`` is a metrics-only field that each generator emits all-or-none
-    # per batch (None if any trajectory in the batch lacks a recorded time). A mix across batches is
-    # benign, but a partial flatten would misalign with ``is_last_step`` below -- so only concatenate
-    # when *every* batch recorded it, otherwise drop the metric to None (no crash, no misalignment).
-    all_have_traj_times = all(output.get("trajectory_generation_times") is not None for output in generator_outputs)
-
     first = generator_outputs[0]
     result: GeneratorOutput = {
         "prompt_token_ids": _flatten_field(generator_outputs, "prompt_token_ids"),
@@ -277,7 +271,9 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput], step
             _flatten_field(generator_outputs, "rollout_logprobs") if first.get("rollout_logprobs") is not None else None
         ),
         "trajectory_generation_times": (
-            _flatten_field(generator_outputs, "trajectory_generation_times") if all_have_traj_times else None
+            _flatten_field(generator_outputs, "trajectory_generation_times")
+            if first.get("trajectory_generation_times") is not None
+            else None
         ),
     }
 

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -258,6 +258,12 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput], step
         raise ValueError(
             "generator outputs are expected to all have null rollout_logprobs or all non-null, but received a mix"
         )
+    # ``trajectory_generation_times`` is a metrics-only field that each generator emits all-or-none
+    # per batch (None if any trajectory in the batch lacks a recorded time). A mix across batches is
+    # benign, but a partial flatten would misalign with ``is_last_step`` below -- so only concatenate
+    # when *every* batch recorded it, otherwise drop the metric to None (no crash, no misalignment).
+    all_have_traj_times = all(output.get("trajectory_generation_times") is not None for output in generator_outputs)
+
     first = generator_outputs[0]
     result: GeneratorOutput = {
         "prompt_token_ids": _flatten_field(generator_outputs, "prompt_token_ids"),
@@ -269,6 +275,9 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput], step
         ),
         "rollout_logprobs": (
             _flatten_field(generator_outputs, "rollout_logprobs") if first.get("rollout_logprobs") is not None else None
+        ),
+        "trajectory_generation_times": (
+            _flatten_field(generator_outputs, "trajectory_generation_times") if all_have_traj_times else None
         ),
     }
 

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -279,12 +279,19 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput], step
     for key in additional_keys:
         result[key] = _flatten_field(generator_outputs, key)
 
+    # With step-wise training, only use the trajectory generation time from the last step
+    trajectory_generation_times = result.get("trajectory_generation_times")
+    if step_wise and trajectory_generation_times and result.get("is_last_step"):
+        trajectory_generation_times = [
+            t for t, is_last_step in zip(trajectory_generation_times, result.get("is_last_step")) if is_last_step
+        ]
+
     # Re-aggregate rollout metrics
     rollout_metrics = get_rollout_metrics(
         result["response_ids"],
         result["rewards"],
         loss_masks=result.get("loss_masks"),
-        trajectory_completion_times=result.get("trajectory_generation_times"),
+        trajectory_completion_times=trajectory_generation_times,
     )
 
     # Preserve generator-specific metrics from per-group rollout_metrics. get_rollout_metrics only

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -339,6 +339,29 @@ def apply_overlong_filtering(
     ]
 
 
+def compute_turn_token_counts(loss_masks: List[List[int]]) -> List[int]:
+    """Compute per-turn assistant token counts across a batch of trajectories.
+
+    Each turn's generated tokens are the maximal runs of consecutive non-zero entries in the
+    loss mask; observation/non-assistant tokens are masked to 0 and thus separate turns. Returns
+    a flat list with one entry per turn (across all trajectories). Trajectories whose loss mask is
+    entirely zero (e.g. dropped by overlong filtering) contribute no turns.
+    """
+    turn_token_counts: List[int] = []
+    for mask in loss_masks:
+        if not mask:
+            continue
+        nz = (np.asarray(mask) != 0).astype(np.int8)
+        if nz.sum() == 0:
+            continue
+        # Pad with zeros on both ends so run starts/ends are detected via the first difference.
+        diffs = np.diff(np.concatenate(([0], nz, [0])))
+        starts = np.where(diffs == 1)[0]
+        ends = np.where(diffs == -1)[0]
+        turn_token_counts.extend((ends - starts).tolist())
+    return turn_token_counts
+
+
 def get_rollout_metrics(
     responses: List[List[int]],
     rewards: Union[List[float], List[List[float]]],
@@ -396,6 +419,17 @@ def get_rollout_metrics(
                 "generate/std_assistant_tokens": np.std(assistant_tokens_arr).item(),
             }
         )
+
+        # Per-turn token stats: run lengths of consecutive non-zero loss-mask entries (one run per turn).
+        turn_token_counts = compute_turn_token_counts(loss_masks)
+        if turn_token_counts:
+            turn_token_counts_arr = np.array(turn_token_counts)
+            rollout_metrics.update(
+                {
+                    "generate/tokens_per_turn_mean": np.mean(turn_token_counts_arr).item(),
+                    "generate/tokens_per_turn_std": np.std(turn_token_counts_arr).item(),
+                }
+            )
 
     if env_metrics is not None and env_classes is not None:
         env_to_metrics = defaultdict(list)

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -239,6 +239,63 @@ def calculate_per_dataset_metrics(
     return eval_metrics
 
 
+def get_intra_group_completion_time_std_cv(
+    generator_output: GeneratorOutput,
+) -> Tuple[Optional[float], Optional[float]]:
+    """Intra-group spread of per-trajectory completion times for a single group.
+
+    Returns ``(std, cv)`` where ``std`` is the population standard deviation (seconds) and ``cv``
+    is the coefficient of variation (``std / mean``). Both are ``None`` when the group recorded no
+    completion times or has fewer than two trajectories.
+    """
+    traj_times = generator_output.get("trajectory_generation_times")
+    group_std = None
+    group_cv = None
+    if traj_times and len(traj_times) > 1:
+        # For step wise training, each turn /step contributes one entry.
+        # Only take the metrics from the last step
+        is_last_step = generator_output.get("is_last_step")
+        if is_last_step:
+            traj_times = [t for t, last in zip(traj_times, is_last_step) if last]
+        traj_times_arr = np.array(traj_times, dtype=np.float64)
+        # Population std of per-trajectory completion times within this group (seconds).
+        group_std = float(traj_times_arr.std())
+        # Coefficient of variation = std / mean. Guard against div-by-zero.
+        mean_traj_time = float(traj_times_arr.mean())
+        if mean_traj_time > 0:
+            group_cv = group_std / mean_traj_time
+    return group_std, group_cv
+
+
+def get_group_completion_metrics(
+    group_completion_times: Optional[List[float]],
+    intra_group_stds: Optional[List[float]],
+    intra_group_cvs: Optional[List[float]],
+) -> Dict[str, float]:
+    """Per-group completion-time statistics for the groups consumed in a step.
+
+    These surface generation load-balancing behavior (e.g. across vllm-router routing policies):
+    tail group latency (p90/max) and how unevenly trajectories within a group finish (intra-group
+    coefficient of variation). Each input may be empty/None, in which case the corresponding metrics
+    are omitted.
+    """
+    metrics = {}
+    if group_completion_times:
+        group_times_arr = np.array(group_completion_times, dtype=np.float64)
+        metrics.update(
+            {
+                "generate/group_completion_time_mean": float(group_times_arr.mean()),
+                "generate/group_completion_time_p90": float(np.percentile(group_times_arr, 90)),
+                "generate/group_completion_time_max": float(group_times_arr.max()),
+            }
+        )
+    if intra_group_stds:
+        metrics.update({"generate/intra_group_completion_time_std_mean": float(np.mean(intra_group_stds))})
+    if intra_group_cvs:
+        metrics.update({"generate/intra_group_completion_time_cv_mean": float(np.mean(intra_group_cvs))})
+    return metrics
+
+
 def dump_per_dataset_eval_results(
     dump_dir_path: Path,
     tokenizer: AutoTokenizer,

--- a/tests/train/generators/test_generator_output_utils.py
+++ b/tests/train/generators/test_generator_output_utils.py
@@ -30,6 +30,7 @@ def test_generator_output_concatenation():
         "rollout_expert_indices",
         # optional but present in the signature
         "trajectory_ids",
+        "trajectory_generation_times",
         "is_last_step",
         "env_metrics",
         "pixel_values",
@@ -81,6 +82,9 @@ def test_generator_output_concatenation():
         "generate/min_assistant_tokens": 1,
         "generate/max_assistant_tokens": 3,
         "generate/std_assistant_tokens": np.std([2, 2, 3, 1]).item(),
+        # Each response is a single run of 1s, so per-turn counts match response lengths [2, 2, 3, 1].
+        "generate/tokens_per_turn_mean": 2.0,
+        "generate/tokens_per_turn_std": np.std([2, 2, 3, 1]).item(),
     }
     assert concatenated_output["rollout_metrics"].keys() == expected_rollout_metrics.keys()
     for key, value in expected_rollout_metrics.items():

--- a/tests/train/generators/test_generator_output_utils.py
+++ b/tests/train/generators/test_generator_output_utils.py
@@ -1,5 +1,5 @@
 """
-uv run --extra dev --isolated pytest tests/train/generators/test_generator_output_utils.py
+uv run --extra dev --extra skyrl-train --isolated pytest tests/train/generators/test_generator_output_utils.py
 """
 
 from unittest.mock import patch
@@ -90,6 +90,38 @@ def test_generator_output_concatenation():
     assert concatenated_output["rollout_metrics"].keys() == expected_rollout_metrics.keys()
     for key, value in expected_rollout_metrics.items():
         np.testing.assert_allclose(concatenated_output["rollout_metrics"][key], value)
+
+
+def test_concatenation_trajectory_generation_times():
+    """`trajectory_generation_times` is concatenated only when *every* output recorded it. If any
+    output is missing it (key absent or None), the metric is dropped to None -- a partial flatten
+    would otherwise misalign with `is_last_step` (see `concatenate_generator_outputs`)."""
+
+    def _base() -> dict:
+        return {
+            "prompt_token_ids": [[1, 2]],
+            "response_ids": [[1, 2]],
+            "rewards": [1.0],
+            "loss_masks": [[1, 1]],
+            "stop_reasons": ["stop"],
+            "rollout_logprobs": None,
+        }
+
+    with_times_1: GeneratorOutput = {**_base(), "trajectory_generation_times": [1.5]}
+    with_times_2: GeneratorOutput = {**_base(), "trajectory_generation_times": [2.5]}
+
+    # All outputs recorded times -> flattened in order.
+    out = concatenate_generator_outputs([with_times_1, with_times_2])
+    assert out["trajectory_generation_times"] == [1.5, 2.5]
+
+    # One output omits the key entirely -> drop to None (no crash, no misalignment).
+    out = concatenate_generator_outputs([with_times_1, _base()])
+    assert out["trajectory_generation_times"] is None
+
+    # One output explicitly None -> drop to None.
+    none_times: GeneratorOutput = {**_base(), "trajectory_generation_times": None}
+    out = concatenate_generator_outputs([with_times_1, none_times])
+    assert out["trajectory_generation_times"] is None
 
 
 def test_get_metrics_from_generator_output():

--- a/tests/train/generators/test_generator_output_utils.py
+++ b/tests/train/generators/test_generator_output_utils.py
@@ -92,38 +92,6 @@ def test_generator_output_concatenation():
         np.testing.assert_allclose(concatenated_output["rollout_metrics"][key], value)
 
 
-def test_concatenation_trajectory_generation_times():
-    """`trajectory_generation_times` is concatenated only when *every* output recorded it. If any
-    output is missing it (key absent or None), the metric is dropped to None -- a partial flatten
-    would otherwise misalign with `is_last_step` (see `concatenate_generator_outputs`)."""
-
-    def _base() -> dict:
-        return {
-            "prompt_token_ids": [[1, 2]],
-            "response_ids": [[1, 2]],
-            "rewards": [1.0],
-            "loss_masks": [[1, 1]],
-            "stop_reasons": ["stop"],
-            "rollout_logprobs": None,
-        }
-
-    with_times_1: GeneratorOutput = {**_base(), "trajectory_generation_times": [1.5]}
-    with_times_2: GeneratorOutput = {**_base(), "trajectory_generation_times": [2.5]}
-
-    # All outputs recorded times -> flattened in order.
-    out = concatenate_generator_outputs([with_times_1, with_times_2])
-    assert out["trajectory_generation_times"] == [1.5, 2.5]
-
-    # One output omits the key entirely -> drop to None (no crash, no misalignment).
-    out = concatenate_generator_outputs([with_times_1, _base()])
-    assert out["trajectory_generation_times"] is None
-
-    # One output explicitly None -> drop to None.
-    none_times: GeneratorOutput = {**_base(), "trajectory_generation_times": None}
-    out = concatenate_generator_outputs([with_times_1, none_times])
-    assert out["trajectory_generation_times"] is None
-
-
 def test_get_metrics_from_generator_output():
     # Per trajectory rewards, where rewards are List[float]
     generator_output: GeneratorOutput = {

--- a/tests/train/generators/test_generator_output_utils.py
+++ b/tests/train/generators/test_generator_output_utils.py
@@ -9,6 +9,7 @@ import pytest
 
 from skyrl.train.generators.base import GeneratorOutput, TrajectoryID
 from skyrl.train.generators.utils import (
+    compute_turn_token_counts,
     concatenate_generator_outputs,
     get_metrics_from_generator_output,
     merge_stepwise_output,
@@ -673,3 +674,35 @@ class TestMergeStepwiseOutput:
         cfg.generator.step_wise_trajectories = False
         with pytest.raises(ValueError, match="merge_stepwise_output.*requires.*step_wise_trajectories"):
             validate_cfg(cfg)
+
+
+def test_compute_turn_token_counts():
+    """`compute_turn_token_counts` returns one count per turn (maximal run of non-zero loss-mask
+    entries), flattened across trajectories. Observation/non-assistant tokens (0) split turns;
+    empty or all-zero masks contribute nothing."""
+    # Single turn: all assistant tokens.
+    assert compute_turn_token_counts([[1, 1, 1]]) == [3]
+
+    # Observation tokens (0) split assistant runs into separate turns.
+    assert compute_turn_token_counts([[1, 1, 0, 0, 1, 1, 1]]) == [2, 3]
+
+    # Leading/trailing zeros don't create or extend turns.
+    assert compute_turn_token_counts([[0, 0, 1, 1, 0]]) == [2]
+
+    # Isolated single non-zero tokens are length-1 turns.
+    assert compute_turn_token_counts([[0, 1, 0, 1, 0]]) == [1, 1]
+
+    # Multiple trajectories: flat list across all, preserving order.
+    assert compute_turn_token_counts([[1, 1], [1, 0, 1, 1]]) == [2, 1, 2]
+
+    # All-zero mask (e.g. dropped by overlong filtering) contributes no turns.
+    assert compute_turn_token_counts([[0, 0, 0]]) == []
+
+    # Empty mask is skipped.
+    assert compute_turn_token_counts([[]]) == []
+
+    # Empty batch.
+    assert compute_turn_token_counts([]) == []
+
+    # Mixed batch: only the trajectory with assistant tokens contributes.
+    assert compute_turn_token_counts([[], [0, 0], [1, 1, 1]]) == [3]

--- a/tests/train/generators/test_skyrl_gym_generator.py
+++ b/tests/train/generators/test_skyrl_gym_generator.py
@@ -1513,3 +1513,138 @@ async def test_step_wise_trajectories_basic_output_validation(mock_make, mock_to
     # Validate stop_reasons
     for i, stop_reason in enumerate(generator_output["stop_reasons"]):
         assert isinstance(stop_reason, str), f"stop_reasons[{i}] should be a string"
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_step_wise_trajectory_completion_time_metrics(mock_make, mock_tokenizer, mock_llm, mock_env_cfg):
+    """Step-wise training: completion-time metrics are computed from per-prompt times.
+
+    In step-wise mode the flattened output has one entry per turn, so a trajectory with N
+    turns contributes N steps. The per-trajectory ``e2e_time`` is replicated across that
+    trajectory's steps in ``trajectory_generation_times`` (so it stays aligned with
+    ``response_ids``), but the aggregate completion-time stats must be computed from the
+    per-prompt times (one per trajectory) to avoid the per-step duplicates skewing them.
+
+    This spies on ``get_rollout_metrics`` to capture the ``trajectory_completion_times`` it
+    actually receives.
+    """
+    import numpy as np
+
+    from skyrl.train.generators import utils as generator_utils
+    from skyrl.train.generators.base import TrajectoryID
+
+    mock_tokenizer.eos_token_id = 4
+
+    def apply_chat_template_side_effect(messages, **kwargs):
+        if kwargs.get("tokenize", True):
+            return [201, 202]
+        return "".join([m.get("content", "") for m in messages])
+
+    mock_tokenizer.apply_chat_template.side_effect = apply_chat_template_side_effect
+
+    async def llm_generate_side_effect(input_batch, model=None):
+        num = len(input_batch["prompt_token_ids"]) if "prompt_token_ids" in input_batch else len(input_batch["prompts"])
+        return {
+            "responses": ["step"] * num,
+            "stop_reasons": ["stop"] * num,
+            "response_logprobs": None,
+            "response_ids": [[10, 11, 12, mock_tokenizer.eos_token_id] for _ in range(num)],
+        }
+
+    mock_llm.generate = AsyncMock(side_effect=llm_generate_side_effect)
+
+    # Environment that runs for 2 steps before completing.
+    class MultiStepEnv(BaseTextEnv):
+        def __init__(self):
+            super().__init__()
+            self.turns = 0
+
+        def init(self, prompt):
+            return prompt, {}
+
+        def step(self, action):
+            self.turns += 1
+            if self.turns == 1:
+                return BaseTextEnvStepOutput(
+                    observations=[{"role": "user", "content": "obs1"}], reward=0.5, done=False, metadata={}
+                )
+            return BaseTextEnvStepOutput(observations=[], reward=1.0, done=True, metadata={})
+
+    mock_make.side_effect = lambda *args, **kwargs: MultiStepEnv()
+
+    cfg = GeneratorConfig()
+    cfg.sampling_params.max_generate_length = 50
+    cfg.sampling_params.logprobs = None
+    cfg.apply_overlong_filtering = False
+    cfg.max_input_length = 512
+    cfg.batched = False
+    cfg.max_turns = 10
+    cfg.zero_reward_on_non_stop = False
+    cfg.use_conversation_multi_turn = True
+    cfg.step_wise_trajectories = True
+    cfg.chat_template = ChatTemplateConfig(source="name", name_or_path=None)
+
+    generator = SkyRLGymGenerator(
+        generator_cfg=cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+    )
+    generator.base_conversation_token_ids = []
+
+    num_trajectories = 2
+    prompts = [[{"role": "user", "content": f"Q{i}?"}] for i in range(num_trajectories)]
+    env_extras = [{"test": f"value{i}"} for i in range(num_trajectories)]
+    trajectory_ids = [TrajectoryID(instance_id=f"uid{i}", repetition_id=0) for i in range(num_trajectories)]
+    input_batch: GeneratorInput = {
+        "prompts": prompts,
+        "env_extras": env_extras,
+        "env_classes": [mock_env_cfg.env_class for _ in prompts],
+        "trajectory_ids": trajectory_ids,
+    }
+
+    # Wrap the real metrics function so we can inspect what it was called with while still
+    # producing the real metrics in the output.
+    spy = MagicMock(side_effect=generator_utils.get_rollout_metrics)
+    with patch("skyrl.train.generators.skyrl_gym_generator.get_rollout_metrics", spy):
+        generator_output: GeneratorOutput = await generator.generate(input_batch)
+
+    # 2 trajectories x 2 steps each -> 4 flattened steps.
+    num_steps = num_trajectories * 2
+    assert len(generator_output["response_ids"]) == num_steps
+
+    # Metrics are computed from per-prompt times: one entry per trajectory, NOT one per step.
+    assert spy.call_count == 1
+    metrics_times = spy.call_args.kwargs["trajectory_completion_times"]
+    assert metrics_times is not None
+    assert len(metrics_times) == num_trajectories, (
+        f"completion times passed to metrics should be per-prompt (len {num_trajectories}), "
+        f"got len {len(metrics_times)} (per-step duplicates would skew the stats)"
+    )
+    assert all(t is not None and t >= 0.0 for t in metrics_times)
+
+    # The output field is per-step aligned with response_ids, with each trajectory's
+    # trajectory-level time replicated across its steps.
+    out_times = generator_output["trajectory_generation_times"]
+    assert out_times is not None
+    assert len(out_times) == num_steps
+    assert out_times[0] == out_times[1]  # trajectory 0's two steps share its e2e time
+    assert out_times[2] == out_times[3]  # trajectory 1's two steps share its e2e time
+    # The per-prompt times handed to metrics are exactly the distinct per-trajectory values.
+    assert metrics_times == [out_times[0], out_times[2]]
+
+    # Aggregate stats are present and computed over the per-prompt times.
+    rollout_metrics = generator_output["rollout_metrics"]
+    for key in (
+        "generate/trajectory_completion_time_mean",
+        "generate/trajectory_completion_time_p90",
+        "generate/trajectory_completion_time_max",
+    ):
+        assert key in rollout_metrics, f"missing metric {key}"
+    expected = np.array(metrics_times, dtype=np.float64)
+    assert rollout_metrics["generate/trajectory_completion_time_mean"] == pytest.approx(np.mean(expected).item())
+    assert rollout_metrics["generate/trajectory_completion_time_p90"] == pytest.approx(
+        np.percentile(expected, 90).item()
+    )
+    assert rollout_metrics["generate/trajectory_completion_time_max"] == pytest.approx(np.max(expected).item())


### PR DESCRIPTION
# What does this PR do?

Adds more generation metrics, especially useful for async RL

Adds the following metrics:
1. per turn token stats (average turn length, std dev)
2. trajectory completion times  (mean, p90, max)
3. group completion times (for async RL) - mean, p90 and max
4. intra-group trajectory completion time stddev and coefficient of variation

Note: technically group completion metrics can be added for sync Rl as well, but in terms of metrics group level doesn't add more signal in sync RL - with sync RL the synchronization is at the batch level while async RL the synchronization is at the group level. 


<img width="1037" height="454" alt="Screenshot 2026-06-18 at 11 40 09 AM" src="https://github.com/user-attachments/assets/1e47ab9f-32fd-4800-9240-cca75227c7b1" />


<img width="1041" height="457" alt="Screenshot 2026-06-18 at 11 40 18 AM" src="https://github.com/user-attachments/assets/8dd9df59-e59c-4973-bbd7-235b2a851e78" />


<img width="2070" height="930" alt="image" src="https://github.com/user-attachments/assets/6458c080-71cd-42c1-b4d9-ea1fc47cd1cb" />

Did a quick verification for single turn fully async RL

TODO
- [x] Verification for multi-turn RL