### PR TITLE
[algorithm] add rollout KL loss + fix padding-microbatch field drops

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -28,6 +28,7 @@ from skyrl.backends.skyrl_train.utils.ppo_utils import (
     compute_approx_kl,
 )
 from skyrl.backends.skyrl_train.utils.replay_utils import (
+    clear_router_replay,
     setup_per_microbatch_replay_backward,
     setup_per_microbatch_replay_forward,
 )
@@ -189,6 +190,14 @@ class MegatronModelWrapper:
                     model_config=get_model_config(model),
                     remove_microbatch_padding=self.remove_microbatch_padding,
                 )
+            elif getattr(get_model_config(model), "moe_enable_routing_replay", False):
+                # This microbatch carries no replay indices (e.g. a token-batching padding
+                # microbatch, which is appended last and built without rollout_expert_indices).
+                # Clear any stale REPLAY_FORWARD action left by the previous microbatch: otherwise
+                # RouterReplay.get_replay_topk() gathers the previous microbatch's (mis-sized)
+                # target_topk_idx against this microbatch's scores, raising mid-collective inside the
+                # distributed forward_backward and aborting all ranks with no traceback.
+                clear_router_replay()
 
             sequences = batch["sequences"]
             attention_mask = batch["attention_mask"].to(bool)
@@ -458,6 +467,26 @@ class MegatronModelWrapper:
                 kl_loss = torch.tensor(0.0, device=logits.device)
             kl_loss_term = kl_loss * loss_config.kl_loss_coef
 
+            # rollout KL loss: soft trust region penalizing the train<->rollout logprob drift.
+            # Unlike the binary DPPO/clip masks (which only act on tokens that cross a threshold),
+            # this penalizes the train-rollout gap on every token, so it directly counteracts the
+            # growing off-policy gap in async training. prime-rl uses the squared log importance
+            # ratio (log_probs - rollout_logprobs)**2; "k2" gives that up to a 1/2 factor.
+            if loss_config.use_rollout_kl_loss:
+                assert (
+                    rollout_action_logprobs is not None
+                ), "use_rollout_kl_loss=True requires rollout_logprobs (e.g. fully async training)"
+                rollout_kl_loss = compute_approx_kl(
+                    action_log_probs,
+                    rollout_action_logprobs,
+                    loss_mask=loss_mask,
+                    kl_estimator_type=loss_config.rollout_kl_estimator_type,
+                )
+                rollout_kl_loss = masked_mean(rollout_kl_loss, loss_mask, dim=-1).mean()
+            else:
+                rollout_kl_loss = torch.tensor(0.0, device=logits.device)
+            rollout_kl_loss_term = rollout_kl_loss * loss_config.rollout_kl_loss_coef
+
             # Policy losses are pre-scaled to achieve the correct loss_reduction
             # when summing across the entire minibatch (see `apply_loss_reduction_to_advantages_minibatch`).
             # Megatron divides loss by num_microbatches
@@ -480,7 +509,7 @@ class MegatronModelWrapper:
             kl_entropy_microbatch_scale = num_microbatches / max(1, num_real_microbatches)
             loss = (
                 policy_loss * grad_sum_correction_factor
-                + (kl_loss_term - entropy_loss_term) * kl_entropy_microbatch_scale
+                + (kl_loss_term + rollout_kl_loss_term - entropy_loss_term) * kl_entropy_microbatch_scale
             )
             unscaled_loss = loss / grad_sum_correction_factor
 
@@ -509,6 +538,7 @@ class MegatronModelWrapper:
                 "policy_loss": policy_loss.detach().item(),
                 "policy_entropy": entropy.detach().item(),
                 "policy_kl": kl_loss.detach().item(),
+                "rollout_kl": rollout_kl_loss.detach().item(),
                 "loss_fn_outputs": loss_fn_outputs,
             }
             for k, v in loss_metrics.items():
@@ -530,6 +560,14 @@ class MegatronModelWrapper:
                     model_config=get_model_config(model),
                     remove_microbatch_padding=self.remove_microbatch_padding,
                 )
+            elif getattr(get_model_config(model), "moe_enable_routing_replay", False):
+                # This microbatch carries no replay indices (e.g. a token-batching padding
+                # microbatch, which is appended last and built without rollout_expert_indices).
+                # Clear any stale REPLAY_FORWARD action left by the previous microbatch: otherwise
+                # RouterReplay.get_replay_topk() gathers the previous microbatch's (mis-sized)
+                # target_topk_idx against this microbatch's scores, raising mid-collective inside the
+                # distributed forward_backward and aborting all ranks with no traceback.
+                clear_router_replay()
 
             sequences = batch["sequences"]
             attention_mask = batch["attention_mask"].to(bool)

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -959,6 +959,26 @@ class PolicyWorkerBase(Worker):
                 kl_loss = torch.tensor(0.0)
             kl_loss_term = kl_loss * self.cfg.algorithm.kl_loss_coef
 
+            # rollout KL loss: soft trust region penalizing the train<->rollout logprob drift.
+            # Unlike the binary DPPO/clip masks (which only act on tokens that cross a threshold),
+            # this penalizes the train-rollout gap on every token, so it directly counteracts the
+            # growing off-policy gap in async training. prime-rl uses the squared log importance
+            # ratio (log_probs - rollout_logprobs)**2; "k2" gives that up to a 1/2 factor.
+            if self.cfg.algorithm.use_rollout_kl_loss:
+                assert (
+                    rollout_action_logprobs is not None
+                ), "use_rollout_kl_loss=True requires rollout_logprobs (e.g. fully async training)"
+                rollout_kl_loss = compute_approx_kl(
+                    action_log_probs,
+                    rollout_action_logprobs,
+                    loss_mask=loss_mask,
+                    kl_estimator_type=self.cfg.algorithm.rollout_kl_estimator_type,
+                )
+                rollout_kl_loss = masked_mean(rollout_kl_loss, loss_mask, dim=-1).mean()
+            else:
+                rollout_kl_loss = torch.tensor(0.0)
+            rollout_kl_loss_term = rollout_kl_loss * self.cfg.algorithm.rollout_kl_loss_coef
+
             # DP all-reduce averages gradients, but policy losses are pre-scaled sums
             # (see `apply_loss_reduction_to_advantages_minibatch`), so we multiply by
             # dp_size to recover the correct sum reduction across workers.
@@ -966,7 +986,10 @@ class PolicyWorkerBase(Worker):
 
             # NOTE: The KL and entropy loss terms are not pre-scaled,
             # so we just average them across microbatches and DP workers.
-            loss = policy_loss * grad_sum_correction_factor + (kl_loss_term - entropy_loss_term) * microbatch_weight
+            loss = (
+                policy_loss * grad_sum_correction_factor
+                + (kl_loss_term + rollout_kl_loss_term - entropy_loss_term) * microbatch_weight
+            )
             unscaled_loss = loss / grad_sum_correction_factor
             self.strategy.backward(loss, self.model, self.optimizer)
 
@@ -1002,6 +1025,8 @@ class PolicyWorkerBase(Worker):
                 status["loss_metrics/" + k] = v
             if self.cfg.algorithm.use_kl_loss:
                 status["policy_kl"] = kl_loss.item()
+            if self.cfg.algorithm.use_rollout_kl_loss:
+                status["rollout_kl"] = rollout_kl_loss.item()
 
         return status
 

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -250,20 +250,27 @@ class TokenBasedBatchIterator(BaseBatchIterator):
         attention_mask = torch.zeros((batch_size, seq_len), dtype=int, device=device)
         attention_mask[:, 0] = 1
 
-        data = TrainingInputBatch(
-            {
-                "sequences": torch.randint(0, 100, (batch_size, seq_len), device=device),
-                "attention_mask": attention_mask,
-                "action_log_probs": 0.4 * torch.ones((batch_size, num_actions), device=device),
-                "base_action_log_probs": 0.3 * torch.ones((batch_size, num_actions), device=device),
-                "values": 0.5 * torch.ones((batch_size, num_actions), device=device),
-                "returns": 0.5 * torch.ones((batch_size, num_actions), device=device),
-                "advantages": 0.6 * torch.ones((batch_size, num_actions), device=device),
-                # Loss mask is all zeros so padding samples don't contribute to the loss.
-                "loss_mask": torch.zeros((batch_size, num_actions), dtype=int, device=device),
-                "response_mask": torch.ones((batch_size, num_actions), dtype=int, device=device),
-            }
-        )
+        padding_data = {
+            "sequences": torch.randint(0, 100, (batch_size, seq_len), device=device),
+            "attention_mask": attention_mask,
+            "action_log_probs": 0.4 * torch.ones((batch_size, num_actions), device=device),
+            "base_action_log_probs": 0.3 * torch.ones((batch_size, num_actions), device=device),
+            "values": 0.5 * torch.ones((batch_size, num_actions), device=device),
+            "returns": 0.5 * torch.ones((batch_size, num_actions), device=device),
+            "advantages": 0.6 * torch.ones((batch_size, num_actions), device=device),
+            # Loss mask is all zeros so padding samples don't contribute to the loss.
+            "loss_mask": torch.zeros((batch_size, num_actions), dtype=int, device=device),
+            "response_mask": torch.ones((batch_size, num_actions), dtype=int, device=device),
+        }
+        # Mirror optional fields present on the real data so padding microbatches carry the same
+        # keys (loss_mask=0 keeps their values irrelevant). A loss function that requires a field to
+        # be present -- e.g. rollout_logprobs for off_policy_correction / use_rollout_kl_loss -- would
+        # otherwise hit a None on padding microbatches and raise. Inside the distributed
+        # forward_backward that raise desyncs the collective and aborts all ranks with no traceback.
+        if self.data.get("rollout_logprobs") is not None:
+            padding_data["rollout_logprobs"] = torch.zeros((batch_size, num_actions), device=device)
+
+        data = TrainingInputBatch(padding_data)
         data.metadata = self.data.metadata
         return data
 

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -432,6 +432,16 @@ class AlgorithmConfig(BaseConfig):
     use_kl_loss: bool = True
     """Apply KL loss in the policy model. Mutually exclusive with ``use_kl_in_reward``."""
     kl_loss_coef: float = 0.001
+    use_rollout_kl_loss: bool = False
+    """Penalize the train<->rollout logprob drift (the "mismatch"/off-policy gap) with a KL term
+    against the rollout (behavior) policy, in addition to the policy loss. Requires the generator
+    to provide ``rollout_logprobs`` (e.g. fully async training). Composes with any ``policy_loss_type``
+    and is independent of ``use_kl_loss`` (which is KL vs the frozen reference model)."""
+    rollout_kl_loss_coef: float = 0.0
+    """Coefficient for the rollout KL loss. Only used when ``use_rollout_kl_loss=True``."""
+    rollout_kl_estimator_type: str = "k2"
+    """KL estimator for the rollout KL loss. Default ``"k2"`` gives ``0.5 * (log_probs - rollout_logprobs)**2``,
+    i.e. the squared log importance ratio (up to the 1/2 factor absorbed by ``rollout_kl_loss_coef``)."""
     use_entropy_loss: bool = False
     entropy_loss_coef: float = 0.01
     temperature: Optional[float] = None

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -813,10 +813,19 @@ class RayPPOTrainer:
         off_policy_correction = self.cfg.trainer.algorithm.off_policy_correction
         tis_ratio_type = off_policy_correction.tis_ratio_type
         sequence_mask_metric = off_policy_correction.sequence_mask_metric
-        if tis_ratio_type is not None or sequence_mask_metric is not None:
-            assert (
-                rollout_logprobs_tensor is not None
-            ), "expected non-null rollout logprobs tensor when off_policy_correction is enabled"
+        # Fail fast on the driver (with a clear traceback) if rollout logprobs are required but missing.
+        # Deferring this to the per-rank loss function instead raises mid-collective inside the distributed
+        # forward_backward, which desyncs NCCL and surfaces as a silent multi-rank abort with no traceback.
+        needs_rollout_logprobs = (
+            tis_ratio_type is not None
+            or sequence_mask_metric is not None
+            or self.cfg.trainer.algorithm.use_rollout_kl_loss
+        )
+        if needs_rollout_logprobs:
+            assert rollout_logprobs_tensor is not None, (
+                "expected non-null rollout logprobs tensor when off_policy_correction or use_rollout_kl_loss "
+                "is enabled. Ensure `generator.sampling_params.logprobs` is set so the generator returns them."
+            )
             assert rollout_logprobs_tensor.shape == loss_masks_tensor.shape, "Logprobs should look like responses"
 
         # 3. Create training input batch.

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -376,6 +376,16 @@ def validate_cfg(cfg: SkyRLTrainConfig):
                 "`trainer.algorithm.off_policy_correction` doesn't support clip_cov or kl_cov policy loss types"
             )
 
+    # Rollout KL loss penalizes the train<->rollout logprob gap, so it also needs the generator
+    # to return rollout logprobs. Auto-enable logprobs (mirroring off_policy_correction above) so the
+    # feature does not fail deep inside the training step with a None rollout_logprobs tensor.
+    if cfg.trainer.algorithm.use_rollout_kl_loss and cfg.generator.sampling_params.logprobs is None:
+        logger.warning(
+            "`generator.sampling_params.logprobs` is `None` but `use_rollout_kl_loss` is enabled."
+            " Setting `logprobs` to `1`."
+        )
+        cfg.generator.sampling_params.logprobs = 1
+
     if cfg.trainer.policy.model.lora.rank > 0:
         # LoRA enabled: generator backend must be vllm, training backend must be fsdp or megatron
         assert cfg.generator.inference_engine.backend == "vllm", "LoRA enabled requires vLLM backend"

--- a/tests/backends/skyrl_train/test_token_based_batching_utils.py
+++ b/tests/backends/skyrl_train/test_token_based_batching_utils.py
@@ -199,6 +199,24 @@ class TestTokenBasedBatchIterator:
         # Padding rows must not contribute to the loss.
         assert padding["loss_mask"].sum().item() == 0
 
+    def test_padding_microbatch_carries_rollout_logprobs(self):
+        """When the real data has rollout_logprobs, padding microbatches must carry the key too.
+        Otherwise a loss requiring it (off_policy_correction / use_rollout_kl_loss) hits a None on
+        padding microbatches and raises inside the distributed forward_backward -- which desyncs the
+        collective and aborts all ranks with no traceback. Regression test for that drop."""
+        batch = self._make_batch([10, 10, 5, 5], num_actions=4)
+        batch["rollout_logprobs"] = 0.2 * torch.ones((4, 4), device="cpu")
+        iterator = TokenBasedBatchIterator(batch, max_tokens_per_microbatch=15)
+
+        padding = iterator._create_padding_microbatch()
+        assert padding.get("rollout_logprobs") is not None
+        assert padding["rollout_logprobs"].shape == (padding["loss_mask"].shape[0], 4)
+
+        # And it must NOT be fabricated when the real data lacks it.
+        batch_no_lp = self._make_batch([10, 10, 5, 5], num_actions=4)
+        iterator_no_lp = TokenBasedBatchIterator(batch_no_lp, max_tokens_per_microbatch=15)
+        assert iterator_no_lp._create_padding_microbatch().get("rollout_logprobs") is None
+
     def test_multimodal_tensorlist_microbatching(self):
         """Token-based microbatching must gather TensorList fields (multi-modal pixel_values /
         image_grid_thw) via the same index gather used for regular tensors."""


### PR DESCRIPTION
## Summary

Adds an optional **rollout KL loss**: a soft trust region that penalizes the train↔rollout logprob drift (the off-policy "mismatch" gap) on *every* token, in addition to the policy loss. Unlike the binary DPPO/clip masks — which only act on tokens crossing a threshold — it constrains the *aggregate* gap, which is the lever that controls drift in fully-async training. Motivated by growing logprob diff observed with DPPO. Follows prime-rl, which uses the squared log importance ratio `(log_probs - rollout_logprobs)**2`; the `"k2"` estimator gives that up to a 1/2 factor folded into the coefficient.

This composes with any `policy_loss_type` and is independent of `use_kl_loss` (which is KL vs the frozen reference model — this is KL vs the rollout/behavior policy).

## Feature

- `AlgorithmConfig`: `use_rollout_kl_loss` (default `False`), `rollout_kl_loss_coef` (default `0.0`), `rollout_kl_estimator_type` (default `"k2"`).
- FSDP (`worker.py`) and Megatron (`megatron_model_wrapper.py`) loss paths compute the term against `rollout_logprobs`, mirroring the existing `use_kl_loss` term, and report a `rollout_kl` metric.
- `validate_cfg` auto-enables `generator.sampling_params.logprobs`, mirroring the existing `off_policy_correction` behavior.

Usage:
```
trainer.algorithm.use_rollout_kl_loss=true
trainer.algorithm.rollout_kl_loss_coef=<tune, e.g. 1e-3 .. 1.0>
```

## Bug fixes (included)

While validating the feature, two latent bugs surfaced. Both manifest as **traceback-less multi-rank aborts**: an exception raised inside the distributed `forward_backward` desyncs NCCL and kills all ranks with no Python traceback (in sync training the same path raises a clean `RayTaskError`).

1. **`_create_padding_microbatch` dropped optional per-token fields.** Token-based batching appends fully-padding microbatches built from a hardcoded key set, so `rollout_logprobs` was absent on them → the loss saw `None` and raised. Now mirrors `rollout_logprobs` when the real data has it (`loss_mask=0` keeps the value irrelevant). Regression test added.

2. **The same drop left router-replay state stale on padding microbatches for MoE models.** `RouterReplay` stays in `REPLAY_FORWARD` with the previous microbatch's target indices, so `get_replay_topk()` gathers mis-sized indices against the padding microbatch's scores and raises. Both `forward_step` closures now clear the replay action on padding microbatches (gated on `moe_enable_routing_replay`).

3. `trainer.convert_to_training_input` now **fails fast on the driver** (clear traceback) when `rollout_logprobs` are required but missing, instead of deferring to the per-rank loss inside the collective.

## Testing

- `tests/backends/skyrl_train/test_token_based_batching_utils.py` — added `test_padding_microbatch_carries_rollout_logprobs` (both directions). Full file passes (17/17) via `uv run --isolated --extra dev --extra fsdp pytest`.
- The Megatron loss-combination and MoE router-replay paths are GPU-only; the router-replay fix is reasoned from the megatron-core `RouterReplay` source, not yet validated on an MoE run. **Recommend a smoke test on the 30B-A3B recipe** (token batching + `moe_enable_routing_replay=true`) past the first uneven-DP step before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
