### PR TITLE
[fully_async] fix DAPO postprocess_generator_output to accept metrics kwargs

### DIFF
--- a/examples/train/algorithms/dapo/main_dapo_fully_async.py
+++ b/examples/train/algorithms/dapo/main_dapo_fully_async.py
@@ -6,7 +6,7 @@ import sys
 
 import ray
 import torch
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from skyrl.train.fully_async_trainer import FullyAsyncRayPPOTrainer
 from skyrl.train.utils import initialize_ray, validate_cfg
@@ -20,7 +20,11 @@ from examples.train.algorithms.dapo.main_dapo import DAPOConfig
 class FullyAsyncDAPOTrainer(FullyAsyncRayPPOTrainer):
     @torch.no_grad()
     def postprocess_generator_output(
-        self, generator_output: GeneratorOutput, uids: List[str]
+        self,
+        generator_output: GeneratorOutput,
+        uids: List[str],
+        metrics_generator_output: Optional[GeneratorOutput] = None,
+        metrics_uids: Optional[List[str]] = None,
     ) -> Tuple[GeneratorOutput, List[str]]:
         """
         Overrides the postprocess_generator_output method to additionally apply DAPO specific soft overlong punishment to rewards.
@@ -30,9 +34,24 @@ class FullyAsyncDAPOTrainer(FullyAsyncRayPPOTrainer):
         NOTE(Charlie): this is different from DAPOTrainer.postprocess_generator_output because we have
         batched=false in fully async mode, so we need to handle both sequence-level rewards and per-token rewards.
         """
+        # Apply the penalty to the trained output, and also to the kept+dropped metrics view
+        # (a separate concatenation) so reward metrics reflect the penalized rewards.
+        self._apply_soft_overlong_punishment(generator_output)
+        if metrics_generator_output is not None:
+            self._apply_soft_overlong_punishment(metrics_generator_output)
+
+        # use base class impl for metrics and per-token reward conversion
+        return super().postprocess_generator_output(
+            generator_output, uids, metrics_generator_output=metrics_generator_output, metrics_uids=metrics_uids
+        )
+
+    def _apply_soft_overlong_punishment(self, generator_output: GeneratorOutput) -> None:
+        """Apply DAPO soft overlong punishment to ``generator_output["rewards"]`` in place.
+
+        Handles both sequence-level rewards (List[float]) and per-token rewards (List[List[float]]).
+        """
         overlong_buffer_len = self.cfg.trainer.algorithm.overlong_buffer_len
         overlong_buffer_penalty_factor = self.cfg.trainer.algorithm.overlong_buffer_penalty_factor
-        # modify rewards here
         response_ids = generator_output["response_ids"]
         rewards = generator_output["rewards"]
 
@@ -63,9 +82,6 @@ class FullyAsyncDAPOTrainer(FullyAsyncRayPPOTrainer):
                     rewards[i] = 0.0
 
         generator_output["rewards"] = rewards
-
-        # use base class impl for metrics and per-token reward conversion
-        return super().postprocess_generator_output(generator_output, uids)
 
 
 class FullyAsyncDAPOExp(BasePPOExp):

--- a/examples/train/algorithms/dapo/main_dapo_fully_async.py
+++ b/examples/train/algorithms/dapo/main_dapo_fully_async.py
@@ -71,8 +71,14 @@ class FullyAsyncDAPOTrainer(FullyAsyncRayPPOTrainer):
                 penalty = exceed_length / overlong_buffer_len * overlong_buffer_penalty_factor
 
                 if is_per_token:
-                    # Subtract penalty from the last token's reward
-                    rewards[i][-1] -= penalty
+                    # Subtract penalty from the last token's reward. Reassign the slot with a fresh
+                    # list instead of mutating in place: generator_output and metrics_generator_output
+                    # share the same inner reward-list objects (concatenate_generator_outputs only
+                    # copies the outer list), so an in-place mutation would penalize the shared list
+                    # twice -- once per call -- corrupting both the trained rewards and the metrics.
+                    penalized = list(rewards[i])
+                    penalized[-1] -= penalty
+                    rewards[i] = penalized
                 else:
                     rewards[i] -= penalty
             elif response_length > max_response_length:


### PR DESCRIPTION
## Summary

`FullyAsyncDAPOTrainer.postprocess_generator_output()` crashed with:

```
TypeError: FullyAsyncDAPOTrainer.postprocess_generator_output() got an unexpected keyword argument 'metrics_generator_output'
```

The base `postprocess_generator_output` (in `trainer.py`) gained `metrics_generator_output` / `metrics_uids` params in #1802 (`sample_full_batch`), and the fully-async caller (`fully_async_trainer.py`) now forwards them. The `FullyAsyncDAPOTrainer` override still had the old 2-arg signature.

## Changes

- Add `metrics_generator_output` / `metrics_uids` to the override signature and forward them to `super().postprocess_generator_output(...)`.
- Extract the soft-overlong penalty into `_apply_soft_overlong_punishment(...)` and apply it to **both** `generator_output` and `metrics_generator_output`. The metrics view is a separate kept+dropped concatenation, so without this the reward metrics would be computed over un-penalized rewards.

## Scope check

This was the only override that needed updating — the new kwargs are only passed by `FullyAsyncRayPPOTrainer.run()`. The other fully-async subclasses (`thunder_agent`, `harbor`, `fully_async/main_fully_async.py`) don't override the method, and the other DAPO overrides (`main_dapo`, `main_dapo_flashrl`, `main_tis_dapo`) only run through the synchronous trainer path, which doesn't pass the new kwargs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)