### PR TITLE
[fix] Include masked out batches in metrics calculation with `max_token_per_microbatch > 0`

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1027,6 +1027,9 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
                     "rollout_expert_indices": rollout_expert_indices if self.enable_router_replay else None,
                     # used with global sequence packing (None when token-based batching is active)
                     "sub_seq_lengths": experience.sub_seq_lengths,
+                    "is_padding_batch": (
+                        experience.metadata.get("is_padding_batch", False) if experience.metadata else False
+                    ),
                 }
             )
 
@@ -1092,7 +1095,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             # ...) are meaningless and would drag down the mean-reduced metrics. Summed
             # metrics (e.g. policy_loss) are unaffected since padding contributes 0, but
             # excluding them here keeps both reductions correct.
-            if m_batch["loss_mask"].sum().item() == 0:
+            if m_batch["is_padding_batch"]:
                 continue
             for k, v in metrics.items():
                 all_metrics[k].append(v)

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -273,9 +273,6 @@ class TokenBasedBatchIterator(BaseBatchIterator):
             data["rollout_expert_indices"] = torch.zeros(
                 (batch_size, *ref_tensor.shape[1:]), dtype=ref_tensor.dtype, device=device
             )
-        # add optional fields like rollout_logprobs as well
-        if self.data.get("rollout_logprobs") is not None:
-            data["rollout_logprobs"] = torch.zeros((batch_size, num_actions), device=device)
         data.metadata = {}
         if self.data.metadata:
             data.metadata.update(self.data.metadata)

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -273,7 +273,13 @@ class TokenBasedBatchIterator(BaseBatchIterator):
             data["rollout_expert_indices"] = torch.zeros(
                 (batch_size, *ref_tensor.shape[1:]), dtype=ref_tensor.dtype, device=device
             )
-        data.metadata = self.data.metadata
+        # add optional fields like rollout_logprobs as well
+        if self.data.get("rollout_logprobs") is not None:
+            data["rollout_logprobs"] = torch.zeros((batch_size, num_actions), device=device)
+        data.metadata = {}
+        if self.data.metadata:
+            data.metadata.update(self.data.metadata)
+        data.metadata["is_padding_batch"] = True
         return data
 
     def _sync_num_microbatches(self) -> int:


### PR DESCRIPTION
# What does this PR do?


After #1477 , we skip all micro batches where the `loss_mask` is zero while calculating batch metrics during `forward_backward`. The original rationale is that padding batches have loss masks that are all zeros. However, this also skips masked out trajectories from the metrics calculation. This is a regression from the previous metrics calculation behaviour.

 Further, this can also lead to subtle hangs: if a mini batch shard received by a DP rank has only masked out trajectories, then the `all_metrics` dict is empty because `loss_mask` is zero for all micro batches. This can lead to a NCCL timeout where the DP rank will exit metrics calculation early on : https://github.com/NovaSky-AI/SkyRL/blob/7495d61f85a476b77b666525d80d9f728dc961b5/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py#L1120-L1122 (dict is empty) 
 
 while other ranks wait for this DP rank to join in an all reduce. 