### PR TITLE
UI/UX: Poor Error Handling UX in Async Dispatcher

### DIFF
--- a/skyrl-agent/skyrl_agent/dispatcher/async_utils.py
+++ b/skyrl-agent/skyrl_agent/dispatcher/async_utils.py
@@ -68,7 +68,11 @@ async def wait_all(iterable: Iterable[Coroutine], timeout: int = GENERAL_TIMEOUT
     if pending:
         for task in pending:
             task.cancel()
-        raise asyncio.TimeoutError()
+        pending_ids = [task.get_name() for task in pending]
+        raise asyncio.TimeoutError(
+            f"Timeout waiting for {len(pending)} pending task(s) out of {len(tasks)} total. "
+            f"Pending task IDs: {pending_ids}"
+        )
     results = []
     errors = []
     for task in tasks:


### PR DESCRIPTION
## Summary

UI/UX: Poor Error Handling UX in Async Dispatcher

## Problem

**Severity**: `Medium` | **File**: `skyrl-agent/skyrl_agent/dispatcher/async_utils.py:L53`

In `async_utils.py`, the `wait_all` function cancels pending tasks on timeout but uses a generic `asyncio.TimeoutError` without context about which tasks timed out or how many were pending. This provides poor UX for debugging distributed training failures.

## Solution

Include the number of pending tasks and their identifiers in the exception message. Consider creating a custom `TimeoutError` subclass with metadata about pending vs. completed tasks.

## Changes

- `skyrl-agent/skyrl_agent/dispatcher/async_utils.py` (modified)