### PR TITLE
Add `reset_running_requests` to `reset_prefix_cache` call for async RL

### DIFF
--- a/examples/train/algorithms/dapo/run_dapo_qwen3_1.7b_aime_fully_async.sh
+++ b/examples/train/algorithms/dapo/run_dapo_qwen3_1.7b_aime_fully_async.sh
@@ -53,6 +53,7 @@ RUN_NAME=dapo_qwen3_1.7b_base-async-geoMask${GEO_MASK_LOW}_${GEO_MASK_HIGH}-bs${
 uv run --isolated --extra fsdp -m examples.train.algorithms.dapo.main_dapo_fully_async \
   data.train_data="['$TRAIN_FILE']" \
   data.val_data="['$TEST_FILE']" \
+  trainer.fully_async.enabled=true \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
   trainer.fully_async.clear_kv_cache_on_weight_sync=false \

--- a/examples/train/algorithms/dapo/run_dapo_qwen3_1.7b_aime_fully_async_onestep.sh
+++ b/examples/train/algorithms/dapo/run_dapo_qwen3_1.7b_aime_fully_async_onestep.sh
@@ -57,6 +57,7 @@ RUN_NAME=dapo_qwen3_1.7b_base-async-geoMask${GEO_MASK_LOW}_${GEO_MASK_HIGH}-bs${
 uv run --isolated --extra fsdp -m examples.train.algorithms.dapo.main_dapo_fully_async \
   data.train_data="['$TRAIN_FILE']" \
   data.val_data="['$TEST_FILE']" \
+  trainer.fully_async.enabled=true \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
   trainer.fully_async.clear_kv_cache_on_weight_sync=false \

--- a/examples/train/fully_async/fully_async_run_gsm8k.sh
+++ b/examples/train/fully_async/fully_async_run_gsm8k.sh
@@ -36,9 +36,9 @@ RUN_NAME=gsm8k-fully-async-qwen2.5_1.5B-geoMask${GEO_MASK_LOW}_${GEO_MASK_HIGH}-
 uv run --isolated --extra fsdp -m examples.train.fully_async.main_fully_async \
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.fully_async.enabled=true \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
-  trainer.fully_async.clear_kv_cache_on_weight_sync=false \
   trainer.algorithm.advantage_estimator="grpo" \
   trainer.algorithm.off_policy_correction.sequence_mask_metric=$SEQUENCE_MASK_METRIC \
   trainer.algorithm.off_policy_correction.geo_mask_high=$GEO_MASK_HIGH \
@@ -79,4 +79,5 @@ uv run --isolated --extra fsdp -m examples.train.fully_async.main_fully_async \
   trainer.resume_mode=latest \
   trainer.ckpt_path="$HOME/ckpts/${RUN_NAME}" \
   generator.inference_engine.enforce_eager=true \
+  trainer.fully_async.clear_kv_cache_on_weight_sync=true \
   $@

--- a/examples/train/fully_async/fully_async_run_gsm8k.sh
+++ b/examples/train/fully_async/fully_async_run_gsm8k.sh
@@ -79,6 +79,6 @@ uv run --isolated --extra fsdp -m examples.train.fully_async.main_fully_async \
   trainer.run_name=${RUN_NAME} \
   trainer.resume_mode=latest \
   trainer.ckpt_path="$HOME/ckpts/${RUN_NAME}" \
-  trainer.fully_async.clear_kv_cache_on_weight_sync=true \
+  trainer.fully_async.clear_kv_cache_on_weight_sync=false \
   generator.inference_engine.enforce_eager=$ENFORCE_EAGER \
   $@

--- a/examples/train/fully_async/fully_async_run_gsm8k_megatron_lora.sh
+++ b/examples/train/fully_async/fully_async_run_gsm8k_megatron_lora.sh
@@ -37,6 +37,7 @@ RUN_NAME=gsm8k-fully-async-qwen3-0.6B_lora_${LORA_RANK}_${LORA_ALPHA}
 uv run --isolated --extra megatron -m examples.train.fully_async.main_fully_async \
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.fully_async.enabled=true \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
   trainer.fully_async.clear_kv_cache_on_weight_sync=false \

--- a/examples/train/fully_async/sim_trainer/run_fully_async_sim_gsm8k_e2e.sh
+++ b/examples/train/fully_async/sim_trainer/run_fully_async_sim_gsm8k_e2e.sh
@@ -26,6 +26,7 @@ uv run --isolated --extra fsdp \
   -m examples.train.fully_async.main_fully_async_sim \
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.fully_async.enabled=true \
   trainer.fully_async.simulate_training=true \
   trainer.fully_async.simulate_training_step_seconds=$SIM_STEP_SECONDS \
   trainer.fully_async.simulate_weight_sync_seconds=$SIM_WEIGHT_SYNC_SECONDS \

--- a/examples/train/fully_async/sim_trainer/run_fully_async_sim_gsm8k_external.sh
+++ b/examples/train/fully_async/sim_trainer/run_fully_async_sim_gsm8k_external.sh
@@ -35,6 +35,7 @@ uv run --isolated --extra fsdp \
   -m examples.train.fully_async.main_fully_async_sim \
   data.train_data="['$DATA_DIR/train.parquet']" \
   data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.fully_async.enabled=true \
   trainer.fully_async.simulate_training=true \
   trainer.fully_async.simulate_training_step_seconds=$SIM_STEP_SECONDS \
   trainer.fully_async.simulate_weight_sync_seconds=$SIM_WEIGHT_SYNC_SECONDS \

--- a/examples/train/search/run_search_fully_async.sh
+++ b/examples/train/search/run_search_fully_async.sh
@@ -49,6 +49,7 @@ RUN_NAME=skyrl-search_4turns_maxgeneratelen_500-fully-async-geoMask${GEO_MASK_LO
 uv run --isolated --extra fsdp -m examples.train.fully_async.main_fully_async \
   data.train_data="['${DATA_DIR}/train.parquet']" \
   data.val_data="['${DATA_DIR}/validation.parquet']" \
+  trainer.fully_async.enabled=true \
   trainer.fully_async.max_staleness_steps=${MAX_STALENESS_STEPS} \
   trainer.fully_async.num_parallel_generation_workers=${NUM_PARALLEL_GENERATION_WORKERS} \
   trainer.fully_async.clear_kv_cache_on_weight_sync=false \

--- a/examples/train/thunder_agent/scripts/r2egym_32b/run_trainer.sh
+++ b/examples/train/thunder_agent/scripts/r2egym_32b/run_trainer.sh
@@ -289,6 +289,7 @@ fi
   trainer.algorithm.use_kl_loss="$USE_KL_LOSS" \
   trainer.algorithm.kl_loss_coef="$KL_LOSS_COEF" \
   trainer.algorithm.max_seq_len="$TRAIN_MAX_SEQ_LEN" \
+  trainer.fully_async.enabled=true \
   trainer.fully_async.max_staleness_steps="$FULL_MAX_STALENESS_STEPS" \
   trainer.fully_async.num_parallel_generation_workers="$NUM_PARALLEL_GENERATION_WORKERS" \
   trainer.fully_async.clear_kv_cache_on_weight_sync=false \

--- a/examples/train_integrations/harbor/run_codecontest_fully_async.sh
+++ b/examples/train_integrations/harbor/run_codecontest_fully_async.sh
@@ -82,6 +82,7 @@ uv run --isolated --extra fsdp --extra harbor -m examples.train_integrations.har
   trainer.export_path=$EXPORTS_DIR \
   trainer.ckpt_path=$CKPTS_DIR \
   trainer.log_path=$LOG_DIR \
+  trainer.fully_async.enabled=true \
   trainer.fully_async.max_staleness_steps=$MAX_STALENESS_STEPS \
   trainer.fully_async.num_parallel_generation_workers=$NUM_PARALLEL_GENERATION_WORKERS \
   trainer.fully_async.clear_kv_cache_on_weight_sync=false \

--- a/skyrl/backends/skyrl_train/inference_engines/base.py
+++ b/skyrl/backends/skyrl_train/inference_engines/base.py
@@ -172,7 +172,7 @@ class InferenceEngineInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def reset_prefix_cache(self):
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
         raise NotImplementedError
 
     @abstractmethod

--- a/skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py
+++ b/skyrl/backends/skyrl_train/inference_engines/inference_engine_client.py
@@ -360,8 +360,8 @@ class InferenceEngineClient(InferenceEngineInterface):
     async def finish_weight_update(self):
         return await self._run_on_all_engines("finish_weight_update")
 
-    async def reset_prefix_cache(self):
-        return await self._run_on_all_engines("reset_prefix_cache")
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
+        return await self._run_on_all_engines("reset_prefix_cache", reset_running_requests=reset_running_requests)
 
     async def teardown(self):
         return await self._run_on_all_engines("teardown")

--- a/skyrl/backends/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/ray_wrapped_inference_engine.py
@@ -78,8 +78,10 @@ class RayWrappedInferenceEngine(InferenceEngineInterface):
     async def teardown(self):
         return await self.inference_engine_actor.teardown.remote()
 
-    async def reset_prefix_cache(self):
-        return await self.inference_engine_actor.reset_prefix_cache.remote()
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
+        return await self.inference_engine_actor.reset_prefix_cache.remote(
+            reset_running_requests=reset_running_requests
+        )
 
     async def chat_completion(self, request_payload: Dict[str, Any]) -> Dict[str, Any]:
         return await self.inference_engine_actor.chat_completion.remote(request_payload)

--- a/skyrl/backends/skyrl_train/inference_engines/remote_inference_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/remote_inference_engine.py
@@ -266,14 +266,17 @@ class RemoteInferenceEngine(InferenceEngineInterface):
         return await self._weight_loader.load_weights(request)
 
     # TODO(tgriggs): Come up with a (more) elegant way to handle text or json responses, and test it and handle errors.
-    async def reset_prefix_cache(self):
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
         if self.engine_backend == "vllm":
             reset_prefix_cache_method = "reset_prefix_cache"
         else:
             raise ValueError(f"Invalid engine backend: {self.engine_backend}")
 
         async with aiohttp.ClientSession() as session:
-            resp = await session.post(f"{self.url}/{reset_prefix_cache_method}")
+            resp = await session.post(
+                f"{self.url}/{reset_prefix_cache_method}",
+                json={"reset_running_requests": reset_running_requests},
+            )
             text = await resp.text()
 
         # First try to parse it as JSON

--- a/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py
+++ b/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_engine.py
@@ -240,9 +240,9 @@ class BaseVLLMInferenceEngine(InferenceEngineInterface):
             return list(output_processor.external_req_ids.keys())
         return list(output_processor.request_states.keys())
 
-    def reset_prefix_cache(self):
+    def reset_prefix_cache(self, reset_running_requests: bool = False):
         """Reset the prefix cache. Subclasses override for async version."""
-        return self.llm.llm_engine.reset_prefix_cache()
+        return self.llm.llm_engine.reset_prefix_cache(reset_running_requests=reset_running_requests)
 
     async def pause_generation(self, clear_cache: bool = False) -> None:
         raise NotImplementedError("pause_generation is only supported for AsyncVLLMInferenceEngine.")
@@ -365,8 +365,10 @@ class VLLMInferenceEngine(BaseVLLMInferenceEngine):
     async def teardown(self):
         await self._teardown_weight_receiver()
 
-    async def reset_prefix_cache(self):
-        return await asyncio.to_thread(self.llm.llm_engine.reset_prefix_cache)
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
+        return await asyncio.to_thread(
+            self.llm.llm_engine.reset_prefix_cache, reset_running_requests=reset_running_requests
+        )
 
     async def _teardown_weight_receiver(self):
         engine = self._get_engine()
@@ -595,9 +597,9 @@ class AsyncVLLMInferenceEngine(BaseVLLMInferenceEngine):
     async def teardown(self):
         await self._teardown_weight_receiver()
 
-    async def reset_prefix_cache(self):
+    async def reset_prefix_cache(self, reset_running_requests: bool = False):
         engine = self._get_engine()
-        await engine.reset_prefix_cache()
+        await engine.reset_prefix_cache(reset_running_requests=reset_running_requests)
 
     async def _teardown_weight_receiver(self):
         engine = self._get_engine()

--- a/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_server.py
+++ b/skyrl/backends/skyrl_train/inference_engines/vllm/vllm_server.py
@@ -88,7 +88,12 @@ class VllmServer:
 
         @app.post("/reset_prefix_cache")
         async def _reset_prefix_cache(request: Request):
-            await engine.reset_prefix_cache()
+            try:
+                data = await request.json()
+            except Exception:
+                data = {}
+            reset_running_requests = data.get("reset_running_requests", False)
+            await engine.reset_prefix_cache(reset_running_requests=reset_running_requests)
             return {"status": "ok"}
 
         # NOTE (sumanthrh): We use the _skyrl suffix to differentiate this from the native /update_weights endpoint

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -375,8 +375,13 @@ class VLLMServerActor(ServerActorProtocol):
 
         @app.post("/reset_prefix_cache")
         async def _reset_prefix_cache(request: Request):
-            """Reset the prefix cache."""
-            await engine.reset_prefix_cache()
+            """Reset the prefix cache, optionally resetting in-flight requests too."""
+            try:
+                data = await request.json()
+            except Exception:
+                data = {}
+            reset_running_requests = data.get("reset_running_requests", False)
+            await engine.reset_prefix_cache(reset_running_requests=reset_running_requests)
             return {"status": "ok"}
 
         @app.post("/skyrl/v1/load_lora_adapter")

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -276,10 +276,12 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
         use_prefix_cache = inference_engine_cfg.enable_prefix_caching
         generator_dtype = str_to_torch_dtype(inference_engine_cfg.model_dtype)
         cache_reset_task = None
+
+        # Clear prefix cache for synchronous training or for async training if `clear_kv_cache_on_weight_sync` is set
         if (
             use_prefix_cache
             and torch.distributed.get_rank() == 0
-            and self.cfg.fully_async.clear_kv_cache_on_weight_sync
+            and (not self.cfg.fully_async.enabled or self.cfg.fully_async.clear_kv_cache_on_weight_sync)
         ):
             # clear prefix cache
             cache_reset_task = inference_engine_client.reset_prefix_cache(reset_running_requests=True)

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -282,7 +282,7 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
             and self.cfg.fully_async.clear_kv_cache_on_weight_sync
         ):
             # clear prefix cache
-            cache_reset_task = inference_engine_client.reset_prefix_cache()
+            cache_reset_task = inference_engine_client.reset_prefix_cache(reset_running_requests=True)
 
         torch.cuda.empty_cache()
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1275,10 +1275,12 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         use_prefix_cache = inference_engine_cfg.enable_prefix_caching
         generator_dtype = str_to_torch_dtype(inference_engine_cfg.model_dtype)
         cache_reset_task = None
+
+        # Clear prefix cache for synchronous training or for async training if `clear_kv_cache_on_weight_sync` is set
         if (
             use_prefix_cache
             and torch.distributed.get_rank() == 0
-            and self.cfg.fully_async.clear_kv_cache_on_weight_sync
+            and (not self.cfg.fully_async.enabled or self.cfg.fully_async.clear_kv_cache_on_weight_sync)
         ):
             # clear prefix cache
             cache_reset_task = inference_engine_client.reset_prefix_cache(reset_running_requests=True)

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1281,7 +1281,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             and self.cfg.fully_async.clear_kv_cache_on_weight_sync
         ):
             # clear prefix cache
-            cache_reset_task = inference_engine_client.reset_prefix_cache()
+            cache_reset_task = inference_engine_client.reset_prefix_cache(reset_running_requests=True)
 
         torch.cuda.empty_cache()
 

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -503,10 +503,11 @@ class FullyAsyncConfig(BaseConfig):
     Dropped groups are marked consumed (not regenerated on resume), so the per-epoch step count becomes
     an upper bound: if the epoch's prompts run out mid mini-batch, the partial batch is discarded and
     the epoch ends."""
-    clear_kv_cache_on_weight_sync: bool = True
-    """Whether or not to clear the KV cache on weight sync. Defaults to True, matching synchronous RL.
-    Set to False for fully async training to reuse KV cache from stale policies during generation
-    (avoids recomputation at the cost of using slightly stale KV cache)."""
+    clear_kv_cache_on_weight_sync: bool = False
+    """Whether or not to clear the KV cache on weight sync. Defaults to False.
+    If False, we reuse KV cache from stale policies during generation
+    (avoids recomputation at the cost of using slightly stale KV cache).
+    """
 
     # --- Trainer simulation (no real trainer components) ---
     simulate_training: bool = False

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -491,6 +491,8 @@ class FullyAsyncConfig(BaseConfig):
     """Knobs for fully async training.
     See https://docs.skyrl.ai/docs/tutorials/fully_async#step-2-config-knobs-to-tune-for-fully-async-training."""
 
+    enabled: bool = False
+    """Indicates whether fully async training is enabled"""
     max_staleness_steps: int = 4
     """Maximum off-policy steps allowed. If a trajectory group is scheduled at step *i* and trained at step *j*,
     then ``j - i <= max_staleness_steps``. Larger values increase throughput but also off-policy-ness."""

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -350,6 +350,9 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
 
         # Some async-specific validations
         assert (
+            self.cfg.trainer.fully_async.enabled
+        ), "trainer.fully_async.enabled must be True when using the fully async trainer."
+        assert (
             self.cfg.trainer.train_batch_size == self.cfg.trainer.policy_mini_batch_size
         ), "train_batch_size must equal policy_mini_batch_size for fully async training"
         assert (


### PR DESCRIPTION
# What does this PR do?

Adds `reset_running_requests` to `reset_prefix_cache` for async RL.

This unifies the behaviour of `reset_prefix_cache` for sync and async RL

Currently, we call `reset_prefix_cache` without any arguments [here](https://github.com/NovaSky-AI/SkyRL/blob/ffb3f95b7192e2682947b32dcf2efd41fb3f6a73/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py#L284-L285). In vLLM, this is finally passed to the scheduler in  the engine core process of each GPU worker:

https://github.com/vllm-project/vllm/blob/635c38338afe132f9555ebf4a7c8ac7dfb05b2a0/vllm/v1/core/sched/scheduler.py#L2154-L2190

if there are running requests, nothing is done, as can be seen in the KV Cache Block pool implementation [here](
https://github.com/vllm-project/vllm/blob/b529bfd6c51b252cee5741062ef140a34b43aad3/vllm/v1/core/block_pool.py#L470-L493). Thus, even if `clear_kv_cache_on_weight_sync` is set , stale KV cache is not cleared after a weight update with async RL right now, except at epoch boundaries. 

This PR adds `reset_running_requests` to clear kv cache for running requests. 

I did a quick test on the `fully_async_gsm8k.sh` script. 

With clear cache (purple), TTFT shoots up when there are running requests as expected.


<img width="538" height="424" alt="image" src="https://github.com/user-attachments/assets/aa96a425-e078-4f99-a52e-0bcec03ed395" />

<img width="540" height="420" alt="image" src="https://github.com/user-attachments/assets/a4928c09-25d5-4e68-b49c-176987878c92" />
