### PR TITLE
[fix] Memory-map dataset per SFT tokenize worker to avoid cache stampede

### DIFF
--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -80,14 +80,13 @@ from skyrl.utils.tok import get_tokenizer
 def _tokenize_chat_slice_worker(args):
     """Worker function for parallel chat-format tokenization with slice-based loading.
 
-    Each worker loads the full dataset (HF caches it locally after the parent's
-    first call) and tokenizes only its assigned index range.
+    Each worker memory-maps the parent's on-disk arrow dataset and tokenizes
+    only its assigned index range.
 
     Must be top-level for pickling with spawn.
     """
     (
-        dataset_name,
-        dataset_split,
+        arrow_path,
         start_idx,
         end_idx,
         tokenizer_path,
@@ -108,9 +107,9 @@ def _tokenize_chat_slice_worker(args):
 
     train_on_what = TrainOnWhat(train_on_what_str)
 
-    # Reload the dataset using the original split string and slice by index.
-    # The parent has already loaded once so this hits the HF cache.
-    dataset = load_dataset(dataset_name, split=dataset_split)
+    # ``load_from_disk`` mmaps the parent's arrow files, so each worker reads only
+    # its ``[start_idx, end_idx)`` rows instead of re-decoding the full source.
+    dataset = Dataset.load_from_disk(arrow_path)
     dataset_slice = dataset.select(range(start_idx, end_idx))
 
     # Tokenize and filter inline
@@ -134,12 +133,12 @@ def _tokenize_chat_slice_worker(args):
 def _tokenize_alpaca_slice_worker(args):
     """Worker function for parallel Alpaca-format tokenization with slice-based loading.
 
-    Each worker loads the full dataset (HF caches it locally after the parent's
-    first call) and tokenizes only its assigned index range.
+    Each worker memory-maps the parent's on-disk arrow dataset and tokenizes
+    only its assigned index range.
 
     Must be top-level for pickling with spawn.
     """
-    dataset_name, dataset_split, start_idx, end_idx, tokenizer_path, max_length = args
+    arrow_path, start_idx, end_idx, tokenizer_path, max_length = args
 
     # Worker loads tokenizer from cached path
     tokenizer = AutoTokenizer.from_pretrained(
@@ -149,8 +148,9 @@ def _tokenize_alpaca_slice_worker(args):
         local_files_only=True,
     )
 
-    # Reload the dataset using the original split string and slice by index.
-    dataset = load_dataset(dataset_name, split=dataset_split)
+    # mmap the parent's arrow files and slice by index (see
+    # ``_tokenize_chat_slice_worker``).
+    dataset = Dataset.load_from_disk(arrow_path)
     dataset_slice = dataset.select(range(start_idx, end_idx))
 
     # Tokenize and filter inline
@@ -977,13 +977,20 @@ class SFTTrainer:
         # Parallel tokenization path with slice-based loading
         logger.info(f"Tokenizing dataset with {num_workers} workers (slice-based loading)...")
 
-        # Cache tokenizer to temp dir for fast worker loading
-        tokenizer_cache_dir = tempfile.mkdtemp(prefix="skyrl_tokenizer_")
+        # Both temp dirs are created inside the ``try`` so the ``finally`` cleans
+        # them up even if creation or ``save_to_disk`` fails partway.
+        tokenizer_cache_dir = ""
+        dataset_arrow_dir = ""
         try:
+            tokenizer_cache_dir = tempfile.mkdtemp(prefix="skyrl_tokenizer_")
+            # Materialize once to a temp arrow dir; workers mmap it via
+            # ``load_from_disk`` instead of each re-decoding the source, keeping total
+            # read I/O at ~1x rather than ~num_workers x.
+            dataset_arrow_dir = tempfile.mkdtemp(prefix="skyrl_sft_arrow_")
             self.tokenizer.save_pretrained(tokenizer_cache_dir)
+            dataset.save_to_disk(dataset_arrow_dir)
 
-            # Slice the already-loaded dataset; the original split string is
-            # forwarded to workers verbatim so HF parses it (no local regex).
+            # Slice the already-materialized dataset by absolute row index.
             dataset_size = len(dataset)
             chunk_size = max(1, dataset_size // num_workers)
 
@@ -1007,8 +1014,7 @@ class SFTTrainer:
                     system_key = self.sft_cfg.system_key if self.sft_cfg.system_key in columns else None
                     worker_args.append(
                         (
-                            dataset_name,
-                            dataset_split,
+                            dataset_arrow_dir,
                             worker_start,
                             worker_end,
                             tokenizer_cache_dir,
@@ -1022,8 +1028,7 @@ class SFTTrainer:
                 elif "instruction" in columns and "output" in columns:
                     worker_args.append(
                         (
-                            dataset_name,
-                            dataset_split,
+                            dataset_arrow_dir,
                             worker_start,
                             worker_end,
                             tokenizer_cache_dir,
@@ -1066,10 +1071,11 @@ class SFTTrainer:
             return tokenized
 
         finally:
-            # Cleanup temp tokenizer cache
+            # Cleanup temp tokenizer cache and materialized arrow dataset
             import shutil
 
             shutil.rmtree(tokenizer_cache_dir, ignore_errors=True)
+            shutil.rmtree(dataset_arrow_dir, ignore_errors=True)
 
     def load_dataset(self) -> list:
         """Load and tokenize the training dataset."""

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -921,3 +921,99 @@ def test_load_and_tokenize_cache_hit_skips_retokenization(tokenizer, tmp_path, m
         assert a["attention_mask"] == b["attention_mask"]
         assert a["num_actions"] == b["num_actions"]
         assert a["loss_mask"] == b["loss_mask"]
+
+
+# ---------------------------------------------------------------------------
+# Slice workers read from the parent's on-disk arrow dataset: each ``select``s
+# only its ``[start, end)`` range. These tests pin that workers honor their
+# bounds and tile ``[0, n)`` with no gaps or overlaps.
+# ---------------------------------------------------------------------------
+
+
+def _save_chat_dataset_to_disk(arrow_dir, n):
+    """Write an n-row chat dataset to ``arrow_dir`` via ``save_to_disk``."""
+    from datasets import Dataset
+
+    rows = [
+        {
+            "messages": [
+                {"role": "user", "content": f"Q{i}: what is {i} + {i}?"},
+                {"role": "assistant", "content": f"{2 * i}"},
+            ]
+        }
+        for i in range(n)
+    ]
+    Dataset.from_list(rows).save_to_disk(arrow_dir)
+
+
+def _chat_worker_args(arrow_dir, start, end, tokenizer_dir):
+    return (
+        arrow_dir,
+        start,
+        end,
+        tokenizer_dir,
+        1024,
+        "messages",
+        TrainOnWhat.LAST_ASSISTANT_MESSAGE.value,
+        None,
+        None,
+    )
+
+
+def test_chat_slice_worker_reads_only_its_range(tokenizer, tmp_path):
+    """``_tokenize_chat_slice_worker`` tokenizes exactly the rows in ``[start, end)``."""
+    from skyrl.train.sft_trainer import _tokenize_chat_slice_worker
+
+    arrow_dir = str(tmp_path / "arrow")
+    _save_chat_dataset_to_disk(arrow_dir, 10)
+    tokenizer_dir = str(tmp_path / "tok")
+    tokenizer.save_pretrained(tokenizer_dir)
+
+    out = _tokenize_chat_slice_worker(_chat_worker_args(arrow_dir, 3, 7, tokenizer_dir))
+    assert len(out) == 4
+
+
+def test_chat_slice_workers_tile_the_dataset(tokenizer, tmp_path):
+    """Disjoint ``[start, end)`` slices reconstruct the full dataset -- the
+    invariant the parent relies on when partitioning rows across workers."""
+    from skyrl.train.sft_trainer import _tokenize_chat_slice_worker
+
+    n, num_workers = 10, 3
+    arrow_dir = str(tmp_path / "arrow")
+    _save_chat_dataset_to_disk(arrow_dir, n)
+    tokenizer_dir = str(tmp_path / "tok")
+    tokenizer.save_pretrained(tokenizer_dir)
+
+    # Whole-dataset reference.
+    reference = _tokenize_chat_slice_worker(_chat_worker_args(arrow_dir, 0, n, tokenizer_dir))
+
+    # Same boundaries the parent computes.
+    chunk = max(1, n // num_workers)
+    tiled = []
+    for i in range(num_workers):
+        start = i * chunk
+        end = n if i == num_workers - 1 else min((i + 1) * chunk, n)
+        if start >= end:
+            continue
+        tiled.extend(_tokenize_chat_slice_worker(_chat_worker_args(arrow_dir, start, end, tokenizer_dir)))
+
+    assert len(tiled) == len(reference) == n
+    for a, b in zip(tiled, reference):
+        assert a["input_ids"] == b["input_ids"]
+        assert a["loss_mask"] == b["loss_mask"]
+
+
+def test_alpaca_slice_worker_reads_only_its_range(tokenizer, tmp_path):
+    """``_tokenize_alpaca_slice_worker`` tokenizes exactly the rows in ``[start, end)``."""
+    from datasets import Dataset
+
+    from skyrl.train.sft_trainer import _tokenize_alpaca_slice_worker
+
+    arrow_dir = str(tmp_path / "arrow")
+    rows = [{"instruction": f"instr {i}", "input": "", "output": f"out {i}"} for i in range(10)]
+    Dataset.from_list(rows).save_to_disk(arrow_dir)
+    tokenizer_dir = str(tmp_path / "tok")
+    tokenizer.save_pretrained(tokenizer_dir)
+
+    out = _tokenize_alpaca_slice_worker((arrow_dir, 2, 8, tokenizer_dir, 1024))
+    assert len(out) == 6


### PR DESCRIPTION
## Why

The parallel SFT tokenization path spawns N workers, and each worker calls `load_dataset(dataset_name, split).select(range(start, end))`. `select(range)` only slices *after* the dataset is decoded, so every worker decodes the **entire** source into the HF arrow cache before taking its slice -- an O(num_workers x full_dataset) read.

On a cold networked filesystem (e.g. FSx Lustre) the N workers also stampede the shared HF cache-builder lock. We observed runs where workers contend on that lock and fail to make progress on large datasets.

## What changed

The parent already loads the dataset once. It now also `save_to_disk`s that materialized dataset to a single temp arrow directory. Workers `Dataset.load_from_disk(arrow_dir)` -- which memory-maps the arrow files rather than re-decoding the source -- and `select` only their `[start, end)` rows.

- Total read I/O is ~1x the dataset instead of ~Nx.
- No shared HF cache-builder lock contention between workers.
- Works for all input types (HF Hub, JSON, parquet, local directory) because the data is uniform on-disk arrow by the time workers run.
- The temp arrow dir is cleaned up alongside the existing temp tokenizer dir.

## Tests

Adds unit tests in `tests/train/test_sft_tokenization.py`:

- a worker tokenizes exactly the rows in its `[start, end)` range,
- disjoint worker slices tile the dataset with no gaps/overlaps and reconstruct the full tokenized output,
- the Alpaca-format worker path honors its slice bounds.