### PR TITLE
[chore] remove unnecessary `def run` overrides

### DIFF
--- a/examples/train/async/main_async.py
+++ b/examples/train/async/main_async.py
@@ -35,12 +35,6 @@ class AsyncPPOExp(BasePPOExp):
             colocate_pg=colocate_pg,
         )
 
-    def run(self):
-        trainer = self._setup_trainer()
-        # Start the async training loop
-        asyncio.run(trainer.train())
-
-
 @ray.remote(num_cpus=1)
 def skyrl_entrypoint(cfg: SkyRLTrainConfig):
     # make sure that the training loop is not run on the head node.

--- a/examples/train/async/main_async.py
+++ b/examples/train/async/main_async.py
@@ -35,6 +35,7 @@ class AsyncPPOExp(BasePPOExp):
             colocate_pg=colocate_pg,
         )
 
+
 @ray.remote(num_cpus=1)
 def skyrl_entrypoint(cfg: SkyRLTrainConfig):
     # make sure that the training loop is not run on the head node.

--- a/examples/train/fully_async/main_fully_async.py
+++ b/examples/train/fully_async/main_fully_async.py
@@ -10,7 +10,6 @@ from skyrl.train.fully_async_trainer import FullyAsyncRayPPOTrainer
 import asyncio
 from skyrl.train.utils import initialize_ray
 import ray
-from loguru import logger
 
 
 class FullyAsyncPPOExp(BasePPOExp):
@@ -35,6 +34,7 @@ class FullyAsyncPPOExp(BasePPOExp):
             generator=generator,
             colocate_pg=colocate_pg,
         )
+
 
 @ray.remote(num_cpus=1)
 def skyrl_entrypoint(cfg: SkyRLTrainConfig):

--- a/examples/train/fully_async/main_fully_async.py
+++ b/examples/train/fully_async/main_fully_async.py
@@ -10,6 +10,7 @@ from skyrl.train.fully_async_trainer import FullyAsyncRayPPOTrainer
 import asyncio
 from skyrl.train.utils import initialize_ray
 import ray
+from loguru import logger
 
 
 class FullyAsyncPPOExp(BasePPOExp):
@@ -34,12 +35,6 @@ class FullyAsyncPPOExp(BasePPOExp):
             generator=generator,
             colocate_pg=colocate_pg,
         )
-
-    def run(self):
-        trainer = self._setup_trainer()
-        # Start the async training loop
-        asyncio.run(trainer.train())
-
 
 @ray.remote(num_cpus=1)
 def skyrl_entrypoint(cfg: SkyRLTrainConfig):

--- a/examples/train/fully_async/main_fully_async_sim.py
+++ b/examples/train/fully_async/main_fully_async_sim.py
@@ -54,12 +54,6 @@ class FullyAsyncSimPPOExp(BasePPOExp):
             colocate_pg=colocate_pg,
         )
 
-    def run(self):
-        # _setup_trainer skips build_models() when fully_async.simulate_training=true.
-        trainer = self._setup_trainer()
-        asyncio.run(trainer.train())
-
-
 # max_retries=0: fail once loudly instead of looping, so the crash is easy to read.
 @ray.remote(num_cpus=1, max_retries=0)
 def skyrl_entrypoint(cfg: SkyRLTrainConfig):

--- a/examples/train/fully_async/main_fully_async_sim.py
+++ b/examples/train/fully_async/main_fully_async_sim.py
@@ -54,6 +54,7 @@ class FullyAsyncSimPPOExp(BasePPOExp):
             colocate_pg=colocate_pg,
         )
 
+
 # max_retries=0: fail once loudly instead of looping, so the crash is easy to read.
 @ray.remote(num_cpus=1, max_retries=0)
 def skyrl_entrypoint(cfg: SkyRLTrainConfig):

--- a/examples/train/thunder_agent/main_thunder_agent.py
+++ b/examples/train/thunder_agent/main_thunder_agent.py
@@ -49,10 +49,6 @@ class FullyAsyncThunderAgentExp(BasePPOExp):
             colocate_pg=colocate_pg,
         )
 
-    def run(self):
-        trainer = self._setup_trainer()
-        asyncio.run(trainer.train())
-
     def get_inference_client(self) -> InferenceEngineInterface:
         if _SKYRL_USE_NEW_INFERENCE:
             return self._get_new_inference_client()

--- a/examples/train_integrations/harbor/entrypoints/main_harbor_fully_async.py
+++ b/examples/train_integrations/harbor/entrypoints/main_harbor_fully_async.py
@@ -42,10 +42,6 @@ class HarborFullyAsyncExp(HarborExp):
             colocate_pg=colocate_pg,
         )
 
-    def run(self):
-        trainer = self._setup_trainer()
-        asyncio.run(trainer.train())
-
 
 @ray.remote(num_cpus=1)
 def skyrl_entrypoint(cfg):


### PR DESCRIPTION
Remove def run overrides in fully async trainers so that they all use the underlying try except logic used in `main_base.py` (https://github.com/NovaSky-AI/SkyRL/blob/719d1bf1d369494d638a1885251f5a9a7fc49b9e/skyrl/train/entrypoints/main_base.py#L413)



Original reason for different run was fixed in https://github.com/NovaSky-AI/SkyRL/pull/868 when we switched the sync trainer to use `async def` for train.