### PR TITLE
feat: Arctic RL training backend integration

### DIFF
--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -116,19 +116,6 @@ uv pip install flash-attn-3 --index-url https://download.pytorch.org/whl/cu128
 
 Skip and set `trainer.arctic_rl.attn_implementation=flash_attention_2` if you don't want FA3.
 
-## What you get vs. SkyRL FSDP2
-
-For the deep dive on where the numbers come from — split attention, Forest Cascade, Arctic Speculator — read the [ZoRRo blog post](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/). The headline:
-
-| Optimization | Speedup on Arctic-Text2SQL-R2 (Qwen3-32B, 32 × H200) |
-| --- | --- |
-| ZoRRo training (split attention) | 6× actor update, 5× log-prob |
-| Forest Cascade + Arctic spec-dec | 1.7× rollout generation |
-| End-to-end RL iteration | **3.5×** (5 days → 1.5 days) |
-| Max context window | **3.2×** (20 K → 64 K) |
-
-This integration exposes the same stack to SkyRL users.
-
 ## File layout
 
 ```

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -36,9 +36,12 @@ uv run -m skyrl.train.entrypoints.main_base \
     trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
     trainer.arctic_rl.use_zorro=true \
     trainer.arctic_rl.use_arctic_inference=true \
+    trainer.arctic_rl.speculative_model=<hf-id-or-path> \
     trainer.arctic_rl.zero_stage=2 \
     <... your existing recipe overrides ...>
 ```
+
+The integration translates each typed `arctic_rl.*` knob into the matching arctic-platform / vLLM payload — no raw `vllm_config` blocks required for FCA, speculative decoding, or the multi-replica FlashInfer workaround.
 
 `trainer.override_entrypoint` tells `main_base` to dispatch into the Arctic entrypoint after Hydra parsing. No `PYTHONPATH` setup, no edits to `main_base.py`.
 
@@ -47,7 +50,9 @@ uv run -m skyrl.train.entrypoints.main_base \
 | Knob | Default | Purpose |
 | --- | --- | --- |
 | `use_zorro` | `false` | Enable ZoRRo split-attention + prompt dedup in the trainer. |
-| `use_arctic_inference` | `false` | Enable Forest Cascade Attention + Arctic spec-dec in the rollout. |
+| `use_arctic_inference` | `false` | Enable Forest Cascade Attention in the rollout (auto-injects the multi-replica `fuse_allreduce_rms` workaround when needed). |
+| `speculative_model` | `None` | HF id / local path of an Arctic draft head. Set this to turn on Arctic speculative decoding — no raw `vllm_config` needed. |
+| `num_speculative_tokens` | `3` | Draft tokens per target-model step (only when `speculative_model` is set). |
 | `use_liger` | `false` | Liger fused kernels in the policy fwd/bwd. |
 | `zero_stage` | `0` | DeepSpeed ZeRO (use `2` for ~1B, `3` for ≥7B; required for bf16 + fp32 grad). |
 | `offload_optimizer` | `false` | CPU offload optimizer state (`zero_stage≥2`). |
@@ -56,29 +61,27 @@ uv run -m skyrl.train.entrypoints.main_base \
 | `attn_implementation` | `flash_attention_2` | `flash_attention_2` or `flash_attention_3` (Hopper, optional wheel). |
 | `cuda_ipc_weight_sync` | `false` | Zero-copy IPC weight sync (colocate-only). |
 | `vllm_max_num_seqs` | `256` | vLLM batching cap. |
-| `vllm_config` | `None` | Raw `vllm.AsyncEngineArgs` overrides (see below). |
+| `vllm_config` | `None` | Escape hatch for raw `vllm.AsyncEngineArgs` keys not covered above (see below). |
 
 ### Escape hatch — `trainer.arctic_rl.vllm_config`
 
-The simple case (`use_zorro=true use_arctic_inference=true`) is enough for most users — cudagraph mode, attention pass selection, KV-cache settings, weight-sync wiring are all handled inside arctic-platform + arctic-inference. You shouldn't need to think about vLLM flags.
-
-For knobs that aren't yet exposed as typed `trainer.arctic_rl.*` fields — currently Forest Cascade Attention configs, Arctic speculative decoding, and one multi-replica fused-allreduce workaround — `vllm_config` is a dict forwarded verbatim to `vllm.AsyncEngineArgs` via `arctic-platform`'s `ArcticRLClientConfig.vllm_config` (public main, unmodified):
+The simple case is fully typed:
 
 ```bash
-trainer.arctic_rl.vllm_config="{
-    forest_cascade_attn_configs: '{}',
-    speculative_config: {method: arctic, model: <hf-id>, num_speculative_tokens: 3},
-    compilation_config: {pass_config: {fuse_allreduce_rms: false}},
-}"
+trainer.arctic_rl.use_zorro=true \
+trainer.arctic_rl.use_arctic_inference=true \
+trainer.arctic_rl.speculative_model=<hf-id-or-path>     # optional spec-dec
 ```
 
-Why each of those three appears here today, and why we expect them to disappear:
+That alone gives you ZoRRo (training-side), FCA (rollout), the multi-replica FlashInfer workaround, and Arctic speculative decoding — the integration translates each typed flag into the matching `vllm.AsyncEngineArgs` keys for you.
 
-- **`forest_cascade_attn_configs`** — should be implied by `use_arctic_inference=true`. Will be folded into the high-level knob in a follow-up.
-- **`speculative_config`** — should be a typed `trainer.arctic_rl.speculative_model` field. arctic-platform's `arctic_inference_config` schema already has slots for this; we'll wire SkyRL to it once the public-main schema reconciles.
-- **`compilation_config.pass_config.fuse_allreduce_rms: false`** — arctic-inference's `use_fca=True` default is `true`, which collides with FlashInfer workspace allocation on multi-replica/multi-node setups (per-process IPC port collision). The right fix is inside arctic-inference (auto-disable when `world_size > tp_size`); this `vllm_config` override is the interim workaround on multi-node runs.
+`vllm_config` is the escape hatch for vLLM knobs the typed fields don't yet cover — e.g. a non-default `cudagraph_mode`, a custom `compilation_config` pass, or any future vLLM field arctic-inference doesn't model. The dict is forwarded verbatim to `vllm.AsyncEngineArgs` via arctic-platform's `ArcticRLClientConfig.vllm_config` (public main, unmodified), and **user keys win on conflict** with the auto-injected defaults:
 
-In short: `vllm_config` exists for the long tail; it shouldn't be in the critical path of getting the speedup.
+```bash
+trainer.arctic_rl.vllm_config="{compilation_config: {cudagraph_mode: FULL}}"
+```
+
+You should not need this in the happy path. If you reach for it, the typed-knob layer probably should grow a new field — file a follow-up.
 
 ## Architecture
 

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -2,7 +2,7 @@
 
 **Bring [ZoRRo](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/)'s 3.5× RL speedup to any SkyRL recipe with a single CLI flag.**
 
-[ZoRRo (Zero Redundancy Rollouts)](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/) is Snowflake AI Research's RL acceleration stack — prompt-deduplicated split attention for training, Forest Cascade Attention for inference, and Arctic speculative decoding for generation. On Arctic-Text2SQL-R2 (Qwen3-32B, 32 × H200), it delivers **3.5× faster end-to-end training**, **6× faster actor update**, **5× faster log-prob**, **1.7× faster rollout generation**, and **3.2× longer context**.
+[ZoRRo (Zero Redundancy Rollouts)](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/) is Snowflake AI Research's RL acceleration stack — prompt-deduplicated split attention for training, Forest Cascade Attention for inference, and Arctic speculative decoding for generation. On Arctic-Text2SQL-R2 it delivers **3.5× faster end-to-end training**, **6× faster actor update**, **5× faster log-prob**, **1.7× faster rollout generation**, and **3.2× longer context**.
 
 This integration routes SkyRL's GRPO loop through the open-source [Arctic RL](https://github.com/Snowflake-AI-Research/Arctic-Platform) server — the same backend that produced those numbers — so you get all of ZoRRo's optimizations on your existing recipes, untouched.
 

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -41,6 +41,7 @@ Any stock SkyRL recipe becomes an Arctic RL recipe by appending **one flag** and
 
 ```bash
 FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+FLASH_ATTN3_WHL="https://download.pytorch.org/whl/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
 
 uv run --isolated --extra skyrl-train \
     --with arctic-platform \
@@ -48,8 +49,10 @@ uv run --isolated --extra skyrl-train \
     --with liger-kernel \
     --with 'transformers==4.57.6' \
     --with "flash-attn@${FLASH_ATTN_WHL}" \
+    --with "flash-attn-3@${FLASH_ATTN3_WHL}" \
     -- python -m skyrl.train.entrypoints.main_base \
         trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+        trainer.arctic_rl.attn_implementation=flash_attention_3 \
         <... your existing recipe overrides ...>
 ```
 
@@ -73,7 +76,7 @@ Defaults assume you came here to use Arctic RL; opt **out** of optimizations exp
 | `offload_optimizer` | `false` | CPU offload optimizer state (`zero_stage≥2`). |
 | `offload_param` | `false` | CPU offload ZeRO-3 param shards. |
 | `colocate` | `false` | Share GPUs between training and sampling. |
-| `attn_implementation` | `flash_attention_2` | `flash_attention_2` or `flash_attention_3` (Hopper, optional wheel). |
+| `attn_implementation` | `flash_attention_3` (BIRD) / `flash_attention_2` (GSM8K) | FA3 is the default on the BIRD launchers (Hopper-targeted, matches the 2.38× recipe). Use FA2 on A100/L40S. The FA3 wheel ships in the launcher's `--with` chain. |
 | `cuda_ipc_weight_sync` | `false` | Zero-copy IPC weight sync (colocate-only). |
 | `vllm_max_num_seqs` | `256` | vLLM batching cap. |
 | `vllm_config` | `None` | Escape hatch for raw `vllm.AsyncEngineArgs` keys not covered above (see below). |
@@ -129,10 +132,12 @@ GPU layout follows standard SkyRL knobs:
 - Sampling: `generator.inference_engine.num_engines * tensor_parallel_size`
 - Log-prob: `trainer.arctic_rl.log_prob_gpus` (0 = colocate with sampling)
 
-Optional FA3 on Hopper (recommended for the largest speedups):
+**FlashAttention 3** is the default on the BIRD recipes (Hopper-targeted — this is the attention backend that produced the 2.38× speedup). The launchers ship the FA3 wheel from PyTorch's cu128 index as one of the `--with` overrides, so no extra install step is needed; just run the launcher on H100/H200 and `ATTN_IMPL=flash_attention_3` kicks in. On A100/L40S, set `ATTN_IMPL=flash_attention_2` before invoking the launcher.
+
+For your own launcher, add this `--with` line to ship FA3:
 
 ```bash
-uv pip install flash-attn-3 --index-url https://download.pytorch.org/whl/cu128
+--with "flash-attn-3@https://download.pytorch.org/whl/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
 ```
 
 
@@ -167,8 +172,7 @@ uv run --isolated --extra skyrl-train ray start --head --port=6379 --num-gpus=8
 # on each worker:
 #   uv run --isolated --extra skyrl-train ray start --address=<head>:6379 --num-gpus=8
 
-# 3. (Hopper) FA3 wheel
-uv pip install flash-attn-3 --index-url https://download.pytorch.org/whl/cu128
+# 3. (FA3 ships in the launcher's --with chain — no extra install step on Hopper.)
 
 # 4. BIRD data — raw download + preprocess (a one-command HF bundle is on the roadmap)
 mkdir -p /data/bird && cd /data/bird

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -8,23 +8,21 @@ This integration routes SkyRL's GRPO loop through the open-source [Arctic RL](ht
 
 ## Install
 
-Arctic RL's deps (`arctic-platform`, `arctic-inference[vllm]`, `liger-kernel`) are **not** SkyRL extras — `arctic-inference[vllm]` pins `vllm<=0.18`, which conflicts with SkyRL's `vllm==0.23.0` pin in `fsdp` / `megatron`. Install them on top of a stock SkyRL venv:
-
 ```bash
 git clone https://github.com/NovaSky-AI/SkyRL.git && cd SkyRL
-uv sync
-uv pip install arctic-platform 'arctic-inference[vllm]' liger-kernel
-uv pip install --upgrade 'transformers>=4.57,<5'   # vllm 0.18 pin
 ```
 
-The launchers below call `python -m skyrl.train.entrypoints.main_base` against the active venv, so the install above is one-time. (Alternatively use `uv run --with arctic-platform --with 'arctic-inference[vllm]' --with liger-kernel python -m ...` for an ephemeral run.)
+That's it. No `uv sync --extra`, no `uv pip install`. Every launcher in `examples/` uses `uv run --isolated --extra skyrl-train --with arctic-platform --with 'arctic-inference[vllm]' --with liger-kernel --with 'transformers==4.57.6' --with flash-attn@<wheel>` — the same pattern as `examples/train/flash_rl` and `examples/train_integrations/harbor`. uv resolves the env on first launch (~5 min, cached after) and SkyRL's uv+Ray plugin replicates the exact invocation on every worker.
+
+Why the `--with` overrides: `arctic-inference[vllm]` pulls vLLM 0.18, which requires `transformers<5` and a torch-2.10 ABI flash-attn wheel. SkyRL's `pyproject.toml` pins `transformers>=5.6.1` and ships a torch-2.11 flash-attn (both needed by the fsdp/megatron backends). `--isolated` + `--with` overrides resolve to vLLM 0.18's stack for this run only, leaving the project `.venv` untouched.
 
 ## 30-second smoke test (GSM8K, 4 GPUs)
 
 ```bash
-uv run ray start --head --num-gpus=4
 bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
 ```
+
+(Single-node — the launcher's `python -m skyrl.train.entrypoints.main_base` auto-starts a local Ray cluster.)
 
 Auto-downloads `Qwen/Qwen3-0.6B`, auto-preps GSM8K parquets. First reward signal lands in ~3 min from a cold start. On a clean public-mains run we see:
 
@@ -39,12 +37,20 @@ sync_weights steady state: <0.1s
 
 ## Drop into your own recipe
 
-Any stock SkyRL recipe becomes an Arctic RL recipe by appending **one flag**:
+Any stock SkyRL recipe becomes an Arctic RL recipe by appending **one flag** and running through the same `uv run --isolated` driver the launchers use:
 
 ```bash
-uv run -m skyrl.train.entrypoints.main_base \
-    trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
-    <... your existing recipe overrides ...>
+FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+
+uv run --isolated --extra skyrl-train \
+    --with arctic-platform \
+    --with 'arctic-inference[vllm]' \
+    --with liger-kernel \
+    --with 'transformers==4.57.6' \
+    --with "flash-attn@${FLASH_ATTN_WHL}" \
+    -- python -m skyrl.train.entrypoints.main_base \
+        trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+        <... your existing recipe overrides ...>
 ```
 
 That's it. ZoRRo (training-side dedup + memory-chunked logits), Forest Cascade Attention (rollout), Liger fused kernels, and the multi-replica FlashInfer workaround are all **on by default**. Add `trainer.arctic_rl.speculative_model=<hf-id-or-path>` to also turn on Arctic speculative decoding.
@@ -106,13 +112,17 @@ The integration pins `comm_protocol="ray"` — the SkyRL driver and Arctic serve
 
 ## Multi-node and FA3
 
+Same `ray start` pattern as every other SkyRL recipe — `uv run --isolated --extra skyrl-train ray start ...` on each node:
+
 ```bash
 # Head node:
-uv run ray start --head --port=6379 --num-gpus=8
-# Each worker (same SkyRL checkout, same env):
-uv run ray start --address=<HEAD_IP>:6379 --num-gpus=8
-uv run ray status   # confirms total GPUs
+uv run --isolated --extra skyrl-train ray start --head --port=6379 --num-gpus=8
+# Each worker (same SkyRL checkout):
+uv run --isolated --extra skyrl-train ray start --address=<HEAD_IP>:6379 --num-gpus=8
+uv run --isolated --extra skyrl-train ray status   # confirms total GPUs
 ```
+
+The launcher's `uv run --isolated --extra skyrl-train --with arctic-platform ...` invocation is replicated on every Ray worker via the uv+Ray `py_executable` integration, so workers automatically get the same arctic stack.
 
 GPU layout follows standard SkyRL knobs:
 - Training: `trainer.placement.policy_num_gpus_per_node * policy_num_nodes`
@@ -149,16 +159,13 @@ integrations/arctic_rl/
 `examples/run_bird_grpo_32b_32gpu.sh` reproduces the 32B Text2SQL setup from the [ZoRRo blog](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/). End-to-end from a clean machine:
 
 ```bash
-# 1. Clone + install
+# 1. Clone (first launcher invocation resolves the env in ~5 min, cached after)
 git clone https://github.com/NovaSky-AI/SkyRL.git && cd SkyRL
-uv sync
-uv pip install arctic-platform 'arctic-inference[vllm]' liger-kernel
-uv pip install --upgrade 'transformers>=4.57,<5'   # vllm 0.18 pin
 
 # 2. Ray up (4-node example; repeat on each worker)
-uv run ray start --head --port=6379 --num-gpus=8
+uv run --isolated --extra skyrl-train ray start --head --port=6379 --num-gpus=8
 # on each worker:
-#   uv run ray start --address=<head>:6379 --num-gpus=8
+#   uv run --isolated --extra skyrl-train ray start --address=<head>:6379 --num-gpus=8
 
 # 3. (Hopper) FA3 wheel
 uv pip install flash-attn-3 --index-url https://download.pytorch.org/whl/cu128

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -1,16 +1,13 @@
 # Arctic RL Integration for SkyRL
 
-Routes SkyRL's GRPO training loop through the Arctic RL server — **all GPU operations** (training, generation, log-probs, weight sync) happen on the server. The SkyRL client is CPU-only.
-
-## Architecture
+Routes SkyRL's GRPO training loop through the [Arctic RL](https://github.com/Snowflake-AI-Research/Arctic-Platform) server — **all GPU operations** (training, generation, log-probs, weight sync) run on the server. The SkyRL client is CPU-only and orchestrates over HTTP.
 
 ```
 SkyRL Client (CPU-only, ray num_gpus=0)
   - Data loading, reward scoring (skyrl-gym)
-  - Orchestration: generate → score → train
+  - Orchestration: generate -> score -> train
   - HTTP calls to Arctic RL server
         |
-        | HTTP (torch-serialized batches)
         v
 Arctic RL Server (own Ray cluster, all GPUs)
   - DeepSpeed Workers: forward/backward, GRPO loss, optimizer step
@@ -18,212 +15,183 @@ Arctic RL Server (own Ray cluster, all GPUs)
   - NCCL weight sync between training and inference
 ```
 
-## Validated Results
+## Quick Start (GSM8K, 4 GPUs, single node)
 
-### Arctic RL Server Backend (this integration)
-
-**Setup**: Qwen2.5-1.5B-Instruct, 4 DeepSpeed training GPUs + 2 ArcticInference (vLLM) sampling GPUs + 1 log-prob GPU (7x H200), GRPO with 5 samples/prompt.
-
-| Step | GSM8K Eval (pass@1) | Training Reward |
-|------|-------------------|-----------------|
-| 0 (base) | 7.8% | — |
-| 5 | 33% | 0.22 |
-| 10 | 63% | 0.60 |
-| 30 | 70% | 0.65 |
-| 45 | 73% | 0.81 |
-| 75 | **75.4%** | 0.82 |
-
-### SkyRL Default (FSDP2 baseline)
-
-| Model | GSM8K Accuracy (1,319 test) |
-|---|---|
-| Base (Qwen2.5-1.5B-Instruct) | 7.43% |
-| Trained (step 59) | **79.00%** |
-
-## Quick Start
-
-### Prerequisites
-
-- Linux x86_64, NVIDIA GPU with CUDA 12.8 driver (Hopper recommended).
-- [`uv`](https://docs.astral.sh/uv/) installed
-  (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+The fastest way to verify a clean install: GSM8K trains end-to-end on 4 GPUs with no manual data prep. Auto-downloads `Qwen/Qwen3-0.6B` from HuggingFace and writes GSM8K parquets on first launch.
 
 ### 1. Clone and install
 
 ```bash
-git clone https://github.com/Snowflake-AI-Research/SkyRL.git
+git clone https://github.com/NovaSky-AI/SkyRL.git
 cd SkyRL
 uv sync --extra arctic-rl
-```
-
-The `arctic-rl` extra pulls in `arctic-platform` and `arctic-inference[vllm]`
-from their public `main` branches; vLLM and torch arrive transitively via
-`arctic-inference[vllm]`, SkyRL training core via `skyrl[skyrl-train]`. No
-manual installs of arctic-platform / arctic-inference / vLLM / torch needed.
-
-Add `--extra fsdp` *only* if you also want to run the SkyRL native FSDP
-backend side-by-side (the two extras pin different vLLM versions, so
-`arctic-rl` alone is preferred for pure Arctic runs).
-
-SkyRL's base `transformers` pin (`>=5.0.0,<=5.3.0`, for the megatron
-backend) conflicts with vLLM 0.18 + arctic-platform, so after `uv sync`
-force the older line:
-
-```bash
 uv pip install --upgrade 'transformers>=4.57,<5'
 ```
 
-### 2. Start a Ray cluster
+The `arctic-rl` extra pulls `arctic-platform`, `arctic-inference[vllm]`, and `liger-kernel` from their public `main` branches; vLLM and torch arrive transitively via `arctic-inference[vllm]`. The `transformers` line is a one-time pin: SkyRL's base extra requires `>=5.0`, but vLLM 0.18 (what arctic-inference targets) requires `<5`.
 
-Single-node (8 GPUs):
+### 2. Start Ray
 
 ```bash
-uv run ray start --head --num-gpus=8
+uv run ray start --head --num-gpus=4
+uv run ray status   # should show 4/4 GPUs
 ```
 
-Multi-node (e.g. 4 × 8 H200):
+### 3. Run
+
+```bash
+bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
+```
+
+That's it. The recipe auto-preps GSM8K parquets to `$HOME/data/gsm8k/` and starts training. Pass `LOGGER=wandb WANDB_API_KEY=...` to log to W&B; the default `LOGGER=console` runs with no credentials.
+
+#### What to expect
+
+On 4 H200 GPUs (1 inference engine, 2 training, 1 log-prob), at default batch sizes (`train_batch_size=256`, `n_samples_per_prompt=4`):
+
+| Phase | Wall clock |
+| --- | --- |
+| Cold eval (6 iters) | ~2 min |
+| Step 1 (cold) | ~56s (generate + train + sync) |
+| `sync_weights` (steady state) | <0.1s |
+| `train_critic_and_policy` | ~12s |
+
+Reward signal at the first four steps from a clean run on locked public-main `arctic-platform` + `arctic-inference`:
+
+```
+step 0  avg_final_rewards: 0.229
+step 1  avg_final_rewards: 0.247
+step 2  avg_final_rewards: 0.280
+step 3  avg_final_rewards: 0.337   loss=0.104  grad_norm=0.22
+```
+
+## Enabling Arctic RL on Your Own Recipe
+
+Any stock SkyRL recipe becomes an Arctic RL recipe by appending a single override:
+
+```bash
+uv run -m skyrl.train.entrypoints.main_base \
+    trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+    trainer.arctic_rl.zero_stage=2 \
+    <... your existing recipe overrides ...>
+```
+
+`trainer.override_entrypoint` tells `skyrl.train.entrypoints.main_base` to dispatch into `integrations/arctic_rl/entrypoint.py:main()` after Hydra parsing. No changes to `main_base.py` required; no `PYTHONPATH` setup either — `integrations/` is a PEP-420 namespace package, reachable from the SkyRL repo root.
+
+### Arctic-specific knobs
+
+All under `trainer.arctic_rl.*`. Defaults are filled in by `integrations/arctic_rl/config.py` if unset.
+
+| Knob | Default | Purpose |
+| --- | --- | --- |
+| `zero_stage` | `0` | DeepSpeed ZeRO stage. Use `2` for ~1B params, `3` for ≥7B. ZeRO ≥ 1 is required for bf16 + fp32 grad accumulation. |
+| `offload_optimizer` | `false` | Offload optimizer state to CPU (needs `zero_stage>=2`). |
+| `offload_param` | `false` | Offload ZeRO-3 param shards to CPU (needs `zero_stage>=3`). |
+| `colocate` | `false` | Share GPUs between training and sampling. |
+| `log_prob_gpus` | `0` | Dedicated log-prob GPUs (0 = colocate with sampling vLLM). |
+| `use_zorro` | `false` | Enable Snowflake's ZoRRo trainer (chunked / fused GRPO loss). |
+| `use_liger` | `false` | Enable Liger fused kernels in the policy fwd/bwd. |
+| `attn_implementation` | `flash_attention_2` | `flash_attention_2` or `flash_attention_3` (Hopper, needs FA3 wheel). |
+| `use_arctic_inference` | `false` | Use Arctic's vLLM wrapper (required for FCA / Arctic spec-dec). |
+| `cuda_ipc_weight_sync` | `false` | Zero-copy IPC weight sync (colocate-only). |
+| `vllm_enforce_eager` | `false` | Disable vLLM cudagraph compilation. |
+| `vllm_max_num_seqs` | `256` | vLLM batching cap. |
+| `vllm_config` | `None` | Raw `vllm.AsyncEngineArgs` overrides — see below. |
+
+### Raw vLLM overrides via `vllm_config`
+
+Performance knobs that the high-level schema doesn't model go through `trainer.arctic_rl.vllm_config`. The dict is merged on top of the integration's vLLM defaults and forwarded verbatim to `vllm.AsyncEngineArgs`:
+
+```bash
+trainer.arctic_rl.vllm_config="{
+    compilation_config: {
+        cudagraph_mode: PIECEWISE,
+        pass_config: {fuse_allreduce_rms: false},
+    },
+    speculative_config: {
+        method: arctic,
+        model: <hf-id-or-local-path>,
+        num_speculative_tokens: 3,
+    },
+    forest_cascade_attn_configs: '{}',
+}"
+```
+
+This routes through `arctic-platform`'s public-main `ArcticRLClientConfig.vllm_config` field, which forwards every key into vLLM — typed fields land on `ModelConfig`, unknown keys land in `extra_engine_kwargs`. Use this for things like:
+
+- `compilation_config` — pin `cudagraph_mode` or disable a specific compile pass (`fuse_allreduce_rms` collides with multi-replica/node FlashInfer; turn it off when you see `Flashinfer workspace must be initialized` asserts).
+- `speculative_config` — point at an Arctic draft head for inference-time spec-decoding.
+- `forest_cascade_attn_configs` — enable Arctic's FCA attention pass (`"{}"` uses defaults).
+
+OmegaConf parses flow-style YAML, so leave a space after every `:` and quote string values that contain colons.
+
+## Multi-node setup
+
+The integration is identical for multi-node — only the Ray bringup changes.
 
 ```bash
 # On the head node:
 uv run ray start --head --port=6379 --num-gpus=8
 
-# On each worker node (same SkyRL checkout + same env installed):
+# On each worker node (same SkyRL checkout, same env):
 uv run ray start --address=<HEAD_IP>:6379 --num-gpus=8
 
 # Confirm:
-uv run ray status   # should show 32/32 GPUs across 4 nodes
+uv run ray status
 ```
 
-### 3. (Hopper only) Install FlashAttention-3
+GPU layout is derived from standard SkyRL knobs and `trainer.arctic_rl.*`:
 
-The 32B BIRD recipe targets `flash_attention_3` for the 2× speedup vs FSDP.
-PyTorch publishes [official FA3 wheels](https://dev-discuss.pytorch.org/t/flash-attention-3-wheels/3322)
-ABI-stable for any Python ≥ 3.9, torch ≥ 2.9. Pick the index matching your
-CUDA build:
+- Training GPUs: `trainer.placement.policy_num_gpus_per_node * trainer.placement.policy_num_nodes`
+- Sampling GPUs: `generator.inference_engine.num_engines * generator.inference_engine.tensor_parallel_size`
+- Log-prob GPUs: `trainer.arctic_rl.log_prob_gpus` (0 = colocate with sampling)
+
+When `trainer.arctic_rl.colocate=true`, training and sampling share the same GPU set; otherwise the two sets must be disjoint.
+
+### (Optional) FlashAttention-3 on Hopper
+
+The 8B / 32B recipes target `flash_attention_3` for best throughput. PyTorch publishes [official FA3 wheels](https://dev-discuss.pytorch.org/t/flash-attention-3-wheels/3322), ABI-stable for any Python ≥ 3.9, torch ≥ 2.9:
 
 ```bash
 uv pip install flash-attn-3 --index-url https://download.pytorch.org/whl/cu128
 ```
 
-(`cu126`, `cu130` indices also available.) Skip this if you're on FA2 — set
-`ATTN_IMPL=flash_attention_2` when launching.
+(`cu126` / `cu130` indices also available.) If you don't install FA3, set `trainer.arctic_rl.attn_implementation=flash_attention_2` on the launcher.
 
-### 4. Prepare data
+## BIRD-SQL recipes
 
-Models auto-download to `$HF_HOME` on first use (Qwen3 weights are public,
-no HF auth required). GSM8K parquets auto-prep on first launch via SkyRL's
-bundled `gsm8k_dataset.py`.
+`integrations/arctic_rl/examples/run_bird_grpo_*` ships 8B and 32B BIRD-SQL recipes. These currently require manual BIRD data prep (raw download + `integrations/arctic_rl/envs/preprocess_bird.py`); a one-command HuggingFace-hosted parquet bundle is on the roadmap. See the launcher source for the current path.
 
-For BIRD-SQL, run the bundled preprocessor against your raw BIRD SQLite
-dump (downloadable from <https://bird-bench.github.io/>):
-
-```bash
-python integrations/arctic_rl/envs/preprocess_bird.py \
-    --bird_dir   /path/to/raw/bird \
-    --output_dir $HOME/data/bird \
-    --max_tokens 16384 \
-    --tokenizer  Qwen/Qwen3-1.7B
-```
-
-This writes `train.parquet` and `val.parquet` to `$DATA_DIR` in the
-verl-compatible format the launcher expects (`--help` for the full set of
-flags, including Spider / GretelAI sources).
-
-### 5. Run
-
-Use with any stock SkyRL recipe — append a single CLI flag:
-
-```bash
-uv run -m skyrl.train.entrypoints.main_base \
-    trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
-    <... your existing recipe overrides ...>
-```
-
-Arctic-specific knobs go under `trainer.arctic_rl.*` (e.g.
-`trainer.arctic_rl.colocate=true`, `trainer.arctic_rl.zero_stage=3`); the
-entrypoint auto-fills sensible defaults if you set none.
-
-Or invoke one of the provided launchers:
-
-```bash
-# GSM8K, 4 H200s (single node):
-DATA_DIR=$HOME/data/gsm8k LOGGER=console \
-    bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
-
-# BIRD-SQL, Qwen3-32B, 32 H200s (4 nodes):
-DATA_DIR=$HOME/data/bird HF_HOME=$HOME/.cache/huggingface LOGGER=console \
-    bash integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
-```
-
-Launchers default to `LOGGER=wandb` (parity with the original recipes); pass
-`LOGGER=console` for no-credentials smoke runs. When `LOGGER=wandb`, set
-`WANDB_API_KEY` in your environment.
-
-## Configuration
-
-### GPU Allocation
-
-GPU layout is derived from standard SkyRL knobs:
-- Training GPUs: `trainer.placement.policy_num_gpus_per_node * trainer.placement.policy_num_nodes`
-- Sampling GPUs: `generator.inference_engine.num_engines * generator.inference_engine.tensor_parallel_size`
-- Log-prob GPUs: `trainer.arctic_rl.log_prob_gpus` (default: 0 — log-probs colocate with sampling vLLM)
-- Colocation between training and sampling: `trainer.arctic_rl.colocate` (default: false)
-
-### Key Training Parameters
-
-The launch script passes these to SkyRL via Hydra overrides:
-
-| Parameter | Value | Notes |
-|-----------|-------|-------|
-| `trainer.train_batch_size` | 256 | Prompts per step |
-| `trainer.policy_mini_batch_size` | 2 | Prompts per mini-batch |
-| `generator.n_samples_per_prompt` | 5 | Completions per prompt |
-| `trainer.policy.optimizer_config.lr` | 1e-6 | Learning rate |
-| `trainer.epochs` | 20 | Training epochs |
-| `trainer.eval_interval` | 5 | Eval every N steps |
-
-DeepSpeed config is set automatically:
-- `gradient_accumulation_steps` = `train_batch_size * n_samples / (policy_mini_batch_size * n_samples)` = 128
-- `gradient_clipping` = 1.0
-- `optimizer` = AdamW with lr from config
-
-## File Structure
+## File structure
 
 ```
 integrations/arctic_rl/                # importable as integrations.arctic_rl
 ├── README.md
-├── __init__.py                       # exports ArcticPPOTrainer, ArcticGenerator
-├── trainer.py                        # ArcticPPOTrainer: routes training to server
-├── generator.py                      # ArcticGenerator: routes generation to server vLLM
-├── config.py                         # ArcticRLTrainerConfig + build_rl_config
-├── entrypoint.py                     # dispatched here from main_base
+├── __init__.py                        # exports ArcticPPOTrainer, ArcticGenerator
+├── trainer.py                         # ArcticPPOTrainer: routes training to server
+├── generator.py                       # ArcticGenerator: routes generation to server vLLM
+├── config.py                          # ArcticRLTrainerConfig + build_rl_config
+├── entrypoint.py                      # dispatched here from main_base
 ├── envs/
-│   ├── bird.py                       # skyrl-gym BIRD SQL env
-│   ├── bird_reward.py                # vendored V6b SQL reward fn (verl PR #6 parity)
-│   └── preprocess_bird.py            # vendored BIRD parquet preprocessor
+│   ├── bird.py                        # skyrl-gym BIRD SQL env
+│   ├── bird_reward.py                 # vendored verl PR #6 SQL reward fn
+│   └── preprocess_bird.py             # raw BIRD -> verl parquets
 └── examples/
-    └── run_*.sh                      # launchers (call main_base with override_entrypoint)
+    ├── run_gsm8k_grpo_4gpu.sh         # 4-GPU GSM8K smoke / reference recipe
+    └── run_bird_grpo_*.sh             # BIRD-SQL recipes (require manual data prep)
 ```
 
-`integrations/` is a PEP 420 namespace package (no `__init__.py`); the
-`arctic_rl` package below it is reachable as `integrations.arctic_rl` from
-the SkyRL repo root with no `PYTHONPATH` setup. It is distinct from the
-upstream `arctic_training` PyPI package's `arctic_training.arctic_rl`
-sub-namespace — both coexist at import time without collision.
+## How it works
 
-## How It Works
+1. **`arctic_rl.entrypoint`** spawns the Arctic RL server as a subprocess with a clean environment (stripped `CUDA_VISIBLE_DEVICES` and `RAY_*` vars so the server gets its own GPU access), then hands control to SkyRL's trainer.
 
-1. **`arctic_rl.entrypoint`** creates an `ArcticRLClient` which spawns the server as a subprocess with a clean environment (stripped `CUDA_VISIBLE_DEVICES` and `RAY_*` vars so the server gets its own GPU access)
-
-2. **`ArcticPPOTrainer`** overrides the standard SkyRL training loop:
+2. **`ArcticPPOTrainer`** replaces three steps of SkyRL's training loop:
    - `fwd_logprobs_values_reward` → no-op (server computes old log-probs internally)
    - `compute_advantages_and_returns` → no-op (server computes GRPO advantages from rewards)
-   - `train_critic_and_policy` → sends batches to server via HTTP, server runs GRPO loss + backward
+   - `train_critic_and_policy` → ships batches to the server over HTTP; server runs GRPO loss + backward + step
 
-3. **`ArcticGenerator`** routes generation to server vLLM and scores completions via `skyrl-gym`
+3. **`ArcticGenerator`** routes generation to server vLLM and scores completions client-side via `skyrl-gym`.
 
-4. **Server-side `grpo_loss`** (in `processors.py`) is self-contained:
-   - Computes per-token log-probs with causal shift
-   - Derives old log-probs by detaching (correct for `update_epochs_per_batch=1`)
-   - Computes group-relative advantages from per-sequence rewards
-   - Applies PPO clipped surrogate (eps_clip=0.2)
+4. **Server-side GRPO loss** is self-contained: per-token log-probs with causal shift, old log-probs by detaching (correct for `update_epochs_per_batch=1`), group-relative advantages from per-sequence rewards, PPO clipped surrogate.
+
+The SkyRL ↔ Arctic RL protocol is minimal: server takes `(sequences, rewards, loss_mask)`, returns updated weights for NCCL sync. All reward scoring and data orchestration live on the SkyRL side, all GPU compute lives on the Arctic side.

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -58,20 +58,27 @@ uv run -m skyrl.train.entrypoints.main_base \
 | `vllm_max_num_seqs` | `256` | vLLM batching cap. |
 | `vllm_config` | `None` | Raw `vllm.AsyncEngineArgs` overrides (see below). |
 
-### Raw vLLM overrides — `trainer.arctic_rl.vllm_config`
+### Escape hatch — `trainer.arctic_rl.vllm_config`
 
-For anything the high-level schema doesn't model — `compilation_config`, `speculative_config`, Forest Cascade Attention configs — pass a dict that's forwarded verbatim to vLLM:
+The simple case (`use_zorro=true use_arctic_inference=true`) is enough for most users — cudagraph mode, attention pass selection, KV-cache settings, weight-sync wiring are all handled inside arctic-platform + arctic-inference. You shouldn't need to think about vLLM flags.
+
+For knobs that aren't yet exposed as typed `trainer.arctic_rl.*` fields — currently Forest Cascade Attention configs, Arctic speculative decoding, and one multi-replica fused-allreduce workaround — `vllm_config` is a dict forwarded verbatim to `vllm.AsyncEngineArgs` via `arctic-platform`'s `ArcticRLClientConfig.vllm_config` (public main, unmodified):
 
 ```bash
 trainer.arctic_rl.vllm_config="{
-    compilation_config: {cudagraph_mode: PIECEWISE,
-                         pass_config: {fuse_allreduce_rms: false}},
-    speculative_config: {method: arctic, model: <hf-id>, num_speculative_tokens: 3},
     forest_cascade_attn_configs: '{}',
+    speculative_config: {method: arctic, model: <hf-id>, num_speculative_tokens: 3},
+    compilation_config: {pass_config: {fuse_allreduce_rms: false}},
 }"
 ```
 
-This routes through `arctic-platform`'s `ArcticRLClientConfig.vllm_config` (public main, unmodified) — typed keys land on `ModelConfig`, unknown keys land in `extra_engine_kwargs`. No patches to arctic-platform or arctic-inference required.
+Why each of those three appears here today, and why we expect them to disappear:
+
+- **`forest_cascade_attn_configs`** — should be implied by `use_arctic_inference=true`. Will be folded into the high-level knob in a follow-up.
+- **`speculative_config`** — should be a typed `trainer.arctic_rl.speculative_model` field. arctic-platform's `arctic_inference_config` schema already has slots for this; we'll wire SkyRL to it once the public-main schema reconciles.
+- **`compilation_config.pass_config.fuse_allreduce_rms: false`** — arctic-inference's `use_fca=True` default is `true`, which collides with FlashInfer workspace allocation on multi-replica/multi-node setups (per-process IPC port collision). The right fix is inside arctic-inference (auto-disable when `world_size > tp_size`); this `vllm_config` override is the interim workaround on multi-node runs.
+
+In short: `vllm_config` exists for the long tail; it shouldn't be in the critical path of getting the speedup.
 
 ## Architecture
 
@@ -134,6 +141,43 @@ integrations/arctic_rl/
     └── run_bird_grpo_*.sh      (BIRD recipes — manual data prep today)
 ```
 
-## BIRD-SQL recipes
+## BIRD-SQL: 32B Qwen3 on 32 × H200
 
-`examples/run_bird_grpo_8b_32gpu.sh` and `run_bird_grpo_32b_32gpu.sh` reproduce the 32B Arctic-Text2SQL-R2 setup. They currently require manual BIRD raw-data download + `python integrations/arctic_rl/envs/preprocess_bird.py`; a single-command HuggingFace-hosted parquet bundle is on the roadmap. See the launcher source for the current path.
+`examples/run_bird_grpo_32b_32gpu.sh` reproduces the 32B Arctic-Text2SQL-R2 setup from the [ZoRRo blog](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/). End-to-end from a clean machine:
+
+```bash
+# 1. Clone + install
+git clone https://github.com/Snowflake-AI-Research/SkyRL.git && cd SkyRL
+uv sync --extra arctic-rl
+uv pip install --upgrade 'transformers>=4.57,<5'   # vllm 0.18 pin
+
+# 2. Ray up (4-node example; repeat on each worker)
+uv run ray start --head --port=6379 --num-gpus=8
+# on each worker:
+#   uv run ray start --address=<head>:6379 --num-gpus=8
+
+# 3. (Hopper) FA3 wheel
+uv pip install flash-attn-3 --index-url https://download.pytorch.org/whl/cu128
+
+# 4. BIRD data — raw download + preprocess (a one-command HF bundle is on the roadmap)
+mkdir -p /data/bird && cd /data/bird
+wget https://bird-bench.oss-cn-beijing.aliyuncs.com/train.zip && unzip train.zip
+wget https://bird-bench.oss-cn-beijing.aliyuncs.com/dev.zip   && unzip dev.zip
+cd -
+python integrations/arctic_rl/envs/preprocess_bird.py \
+    --bird_dir   /data/bird \
+    --output_dir $HOME/data/bird \
+    --max_tokens 32768 \
+    --tokenizer  Qwen/Qwen3-1.7B
+
+# 5. Run
+DATA_DIR=$HOME/data/bird WANDB_API_KEY=<key> \
+    bash integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
+```
+
+Notes:
+
+- BIRD raw data is gated behind <https://bird-bench.github.io>; the `wget` URLs above are the public mirrors arctic-platform's txt2sql README uses.
+- `--max_tokens 32768` matches the recipe's `trainer.max_prompt_length=32768`. Drop this lower only if you also lower the recipe's prompt length.
+- `preprocess_bird.py` writes verl-format parquets whose `extra_info.db_path` is absolute. The SQLite files at those paths must be readable on every node at training time — either a shared filesystem, or mirror `/data/bird/` to each worker.
+- An 8B variant `run_bird_grpo_8b_32gpu.sh` ships for quick smoke tests on the same cluster.

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -6,12 +6,22 @@
 
 This integration routes SkyRL's GRPO loop through the open-source [Arctic RL](https://github.com/Snowflake-AI-Research/Arctic-Platform) server — the same backend that produced those numbers — so you get all of ZoRRo's optimizations on your existing recipes, untouched.
 
-## 30-second smoke test (GSM8K, 4 GPUs)
+## Install
+
+Arctic RL's deps (`arctic-platform`, `arctic-inference[vllm]`, `liger-kernel`) are **not** SkyRL extras — `arctic-inference[vllm]` pins `vllm<=0.18`, which conflicts with SkyRL's `vllm==0.23.0` pin in `fsdp` / `megatron`. Install them on top of a stock SkyRL venv:
 
 ```bash
 git clone https://github.com/NovaSky-AI/SkyRL.git && cd SkyRL
-uv sync --extra arctic-rl
+uv sync
+uv pip install arctic-platform 'arctic-inference[vllm]' liger-kernel
 uv pip install --upgrade 'transformers>=4.57,<5'   # vllm 0.18 pin
+```
+
+The launchers below call `python -m skyrl.train.entrypoints.main_base` against the active venv, so the install above is one-time. (Alternatively use `uv run --with arctic-platform --with 'arctic-inference[vllm]' --with liger-kernel python -m ...` for an ephemeral run.)
+
+## 30-second smoke test (GSM8K, 4 GPUs)
+
+```bash
 uv run ray start --head --num-gpus=4
 bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
 ```
@@ -140,8 +150,9 @@ integrations/arctic_rl/
 
 ```bash
 # 1. Clone + install
-git clone https://github.com/Snowflake-AI-Research/SkyRL.git && cd SkyRL
-uv sync --extra arctic-rl
+git clone https://github.com/NovaSky-AI/SkyRL.git && cd SkyRL
+uv sync
+uv pip install arctic-platform 'arctic-inference[vllm]' liger-kernel
 uv pip install --upgrade 'transformers>=4.57,<5'   # vllm 0.18 pin
 
 # 2. Ray up (4-node example; repeat on each worker)

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -1,203 +1,152 @@
 # Arctic RL Integration for SkyRL
 
-Routes SkyRL's GRPO training loop through [Arctic RL](https://github.com/Snowflake-AI-Research/Arctic-Platform) — **all GPU operations** (training, generation, log-probs, weight sync) run on Arctic's Ray actors. The SkyRL driver process holds 0 GPUs and orchestrates via Ray actor calls.
+**Bring [ZoRRo](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/)'s 3.5× RL speedup to any SkyRL recipe with a single CLI flag.**
 
-```
-                       Single Ray cluster
- +----------------------------------------------------------------+
- |                                                                |
- |   SkyRL driver (num_gpus=0)        Arctic RL Ray actors        |
- |   - Data loading                   - ArcticRLRayServerState    |
- |   - skyrl-gym reward scoring       - DeepSpeedWorker (xN)      |
- |   - generate -> score -> train     - InferenceWorker (xM)      |
- |                                      = ArcticInference vLLM    |
- |          |                                  ^                  |
- |          +---- ray.get(actor.x.remote()) ---+                  |
- |                                                                |
- |   NCCL weight sync runs directly between DeepSpeedWorker       |
- |   and InferenceWorker GPUs (no driver involvement).            |
- +----------------------------------------------------------------+
-```
+[ZoRRo (Zero Redundancy Rollouts)](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/) is Snowflake AI Research's RL acceleration stack — prompt-deduplicated split attention for training, Forest Cascade Attention for inference, and Arctic speculative decoding for generation. On Arctic-Text2SQL-R2 (Qwen3-32B, 32 × H200), it delivers **3.5× faster end-to-end training**, **6× faster actor update**, **5× faster log-prob**, **1.7× faster rollout generation**, and **3.2× longer context**.
 
-`arctic-platform` supports both Ray and HTTP transports (`comm_protocol="ray"` vs `"http"`); the HTTP path is for remote dss-platform deployments. This integration pins `comm_protocol="ray"` so the SkyRL driver and the Arctic server actors live in the same Ray cluster and talk via in-cluster actor calls — no HTTP server, no separate process group.
+This integration routes SkyRL's GRPO loop through the open-source [Arctic RL](https://github.com/Snowflake-AI-Research/Arctic-Platform) server — the same backend that produced those numbers — so you get all of ZoRRo's optimizations on your existing recipes, untouched.
 
-## Quick Start (GSM8K, 4 GPUs, single node)
-
-The fastest way to verify a clean install: GSM8K trains end-to-end on 4 GPUs with no manual data prep. Auto-downloads `Qwen/Qwen3-0.6B` from HuggingFace and writes GSM8K parquets on first launch.
-
-### 1. Clone and install
+## 30-second smoke test (GSM8K, 4 GPUs)
 
 ```bash
-git clone https://github.com/NovaSky-AI/SkyRL.git
-cd SkyRL
+git clone https://github.com/NovaSky-AI/SkyRL.git && cd SkyRL
 uv sync --extra arctic-rl
-uv pip install --upgrade 'transformers>=4.57,<5'
-```
-
-The `arctic-rl` extra pulls `arctic-platform`, `arctic-inference[vllm]`, and `liger-kernel` from their public `main` branches; vLLM and torch arrive transitively via `arctic-inference[vllm]`. The `transformers` line is a one-time pin: SkyRL's base extra requires `>=5.0`, but vLLM 0.18 (what arctic-inference targets) requires `<5`.
-
-### 2. Start Ray
-
-```bash
+uv pip install --upgrade 'transformers>=4.57,<5'   # vllm 0.18 pin
 uv run ray start --head --num-gpus=4
-uv run ray status   # should show 4/4 GPUs
-```
-
-### 3. Run
-
-```bash
 bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
 ```
 
-That's it. The recipe auto-preps GSM8K parquets to `$HOME/data/gsm8k/` and starts training. Pass `LOGGER=wandb WANDB_API_KEY=...` to log to W&B; the default `LOGGER=console` runs with no credentials.
-
-#### What to expect
-
-On 4 H200 GPUs (1 inference engine, 2 training, 1 log-prob), at default batch sizes (`train_batch_size=256`, `n_samples_per_prompt=4`):
-
-| Phase | Wall clock |
-| --- | --- |
-| Cold eval (6 iters) | ~2 min |
-| Step 1 (cold) | ~56s (generate + train + sync) |
-| `sync_weights` (steady state) | <0.1s |
-| `train_critic_and_policy` | ~12s |
-
-Reward signal at the first four steps from a clean run on locked public-main `arctic-platform` + `arctic-inference`:
+Auto-downloads `Qwen/Qwen3-0.6B`, auto-preps GSM8K parquets. First reward signal lands in ~3 min from a cold start. On a clean public-mains run we see:
 
 ```
 step 0  avg_final_rewards: 0.229
 step 1  avg_final_rewards: 0.247
 step 2  avg_final_rewards: 0.280
-step 3  avg_final_rewards: 0.337   loss=0.104  grad_norm=0.22
+step 3  avg_final_rewards: 0.337    loss=0.104  grad_norm=0.22
+step 1 wall clock: 56s  (generate + train + sync_weights)
+sync_weights steady state: <0.1s
 ```
 
-## Enabling Arctic RL on Your Own Recipe
+## Drop into your own recipe
 
-Any stock SkyRL recipe becomes an Arctic RL recipe by appending a single override:
+Any stock SkyRL recipe becomes an Arctic RL recipe by appending one flag:
 
 ```bash
 uv run -m skyrl.train.entrypoints.main_base \
     trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+    trainer.arctic_rl.use_zorro=true \
+    trainer.arctic_rl.use_arctic_inference=true \
     trainer.arctic_rl.zero_stage=2 \
     <... your existing recipe overrides ...>
 ```
 
-`trainer.override_entrypoint` tells `skyrl.train.entrypoints.main_base` to dispatch into `integrations/arctic_rl/entrypoint.py:main()` after Hydra parsing. No changes to `main_base.py` required; no `PYTHONPATH` setup either — `integrations/` is a PEP-420 namespace package, reachable from the SkyRL repo root.
+`trainer.override_entrypoint` tells `main_base` to dispatch into the Arctic entrypoint after Hydra parsing. No `PYTHONPATH` setup, no edits to `main_base.py`.
 
-### Arctic-specific knobs
-
-All under `trainer.arctic_rl.*`. Defaults are filled in by `integrations/arctic_rl/config.py` if unset.
+### `trainer.arctic_rl.*` knobs
 
 | Knob | Default | Purpose |
 | --- | --- | --- |
-| `zero_stage` | `0` | DeepSpeed ZeRO stage. Use `2` for ~1B params, `3` for ≥7B. ZeRO ≥ 1 is required for bf16 + fp32 grad accumulation. |
-| `offload_optimizer` | `false` | Offload optimizer state to CPU (needs `zero_stage>=2`). |
-| `offload_param` | `false` | Offload ZeRO-3 param shards to CPU (needs `zero_stage>=3`). |
+| `use_zorro` | `false` | Enable ZoRRo split-attention + prompt dedup in the trainer. |
+| `use_arctic_inference` | `false` | Enable Forest Cascade Attention + Arctic spec-dec in the rollout. |
+| `use_liger` | `false` | Liger fused kernels in the policy fwd/bwd. |
+| `zero_stage` | `0` | DeepSpeed ZeRO (use `2` for ~1B, `3` for ≥7B; required for bf16 + fp32 grad). |
+| `offload_optimizer` | `false` | CPU offload optimizer state (`zero_stage≥2`). |
+| `offload_param` | `false` | CPU offload ZeRO-3 param shards. |
 | `colocate` | `false` | Share GPUs between training and sampling. |
-| `log_prob_gpus` | `0` | Dedicated log-prob GPUs (0 = colocate with sampling vLLM). |
-| `use_zorro` | `false` | Enable Snowflake's ZoRRo trainer (chunked / fused GRPO loss). |
-| `use_liger` | `false` | Enable Liger fused kernels in the policy fwd/bwd. |
-| `attn_implementation` | `flash_attention_2` | `flash_attention_2` or `flash_attention_3` (Hopper, needs FA3 wheel). |
-| `use_arctic_inference` | `false` | Use Arctic's vLLM wrapper (required for FCA / Arctic spec-dec). |
+| `attn_implementation` | `flash_attention_2` | `flash_attention_2` or `flash_attention_3` (Hopper, optional wheel). |
 | `cuda_ipc_weight_sync` | `false` | Zero-copy IPC weight sync (colocate-only). |
-| `vllm_enforce_eager` | `false` | Disable vLLM cudagraph compilation. |
 | `vllm_max_num_seqs` | `256` | vLLM batching cap. |
-| `vllm_config` | `None` | Raw `vllm.AsyncEngineArgs` overrides — see below. |
+| `vllm_config` | `None` | Raw `vllm.AsyncEngineArgs` overrides (see below). |
 
-### Raw vLLM overrides via `vllm_config`
+### Raw vLLM overrides — `trainer.arctic_rl.vllm_config`
 
-Performance knobs that the high-level schema doesn't model go through `trainer.arctic_rl.vllm_config`. The dict is merged on top of the integration's vLLM defaults and forwarded verbatim to `vllm.AsyncEngineArgs`:
+For anything the high-level schema doesn't model — `compilation_config`, `speculative_config`, Forest Cascade Attention configs — pass a dict that's forwarded verbatim to vLLM:
 
 ```bash
 trainer.arctic_rl.vllm_config="{
-    compilation_config: {
-        cudagraph_mode: PIECEWISE,
-        pass_config: {fuse_allreduce_rms: false},
-    },
-    speculative_config: {
-        method: arctic,
-        model: <hf-id-or-local-path>,
-        num_speculative_tokens: 3,
-    },
+    compilation_config: {cudagraph_mode: PIECEWISE,
+                         pass_config: {fuse_allreduce_rms: false}},
+    speculative_config: {method: arctic, model: <hf-id>, num_speculative_tokens: 3},
     forest_cascade_attn_configs: '{}',
 }"
 ```
 
-This routes through `arctic-platform`'s public-main `ArcticRLClientConfig.vllm_config` field, which forwards every key into vLLM — typed fields land on `ModelConfig`, unknown keys land in `extra_engine_kwargs`. Use this for things like:
+This routes through `arctic-platform`'s `ArcticRLClientConfig.vllm_config` (public main, unmodified) — typed keys land on `ModelConfig`, unknown keys land in `extra_engine_kwargs`. No patches to arctic-platform or arctic-inference required.
 
-- `compilation_config` — pin `cudagraph_mode` or disable a specific compile pass (`fuse_allreduce_rms` collides with multi-replica/node FlashInfer; turn it off when you see `Flashinfer workspace must be initialized` asserts).
-- `speculative_config` — point at an Arctic draft head for inference-time spec-decoding.
-- `forest_cascade_attn_configs` — enable Arctic's FCA attention pass (`"{}"` uses defaults).
+## Architecture
 
-OmegaConf parses flow-style YAML, so leave a space after every `:` and quote string values that contain colons.
-
-## Multi-node setup
-
-The integration is identical for multi-node — only the Ray bringup changes.
-
-```bash
-# On the head node:
-uv run ray start --head --port=6379 --num-gpus=8
-
-# On each worker node (same SkyRL checkout, same env):
-uv run ray start --address=<HEAD_IP>:6379 --num-gpus=8
-
-# Confirm:
-uv run ray status
+```
+                 Single Ray cluster (no HTTP, no subprocess)
+ +----------------------------------------------------------------+
+ |  SkyRL driver (num_gpus=0)        Arctic RL Ray actors         |
+ |  - Data loading                   - ArcticRLRayServerState     |
+ |  - skyrl-gym reward scoring       - DeepSpeedWorker (xN)       |
+ |  - generate -> score -> train     - InferenceWorker (xM)       |
+ |                                     = ArcticInference vLLM     |
+ |         |                                  ^                   |
+ |         +---- ray.get(actor.x.remote()) ---+                   |
+ |                                                                |
+ |  NCCL weight sync runs GPU-to-GPU between DeepSpeedWorker and  |
+ |  InferenceWorker (driver never sees weights).                  |
+ +----------------------------------------------------------------+
 ```
 
-GPU layout is derived from standard SkyRL knobs and `trainer.arctic_rl.*`:
+The integration pins `comm_protocol="ray"` — the SkyRL driver and Arctic server actors share one Ray cluster. arctic-platform's HTTP transport is for remote dss-platform deployments and isn't used here.
 
-- Training GPUs: `trainer.placement.policy_num_gpus_per_node * trainer.placement.policy_num_nodes`
-- Sampling GPUs: `generator.inference_engine.num_engines * generator.inference_engine.tensor_parallel_size`
-- Log-prob GPUs: `trainer.arctic_rl.log_prob_gpus` (0 = colocate with sampling)
+## Multi-node and FA3
 
-When `trainer.arctic_rl.colocate=true`, training and sampling share the same GPU set; otherwise the two sets must be disjoint.
+```bash
+# Head node:
+uv run ray start --head --port=6379 --num-gpus=8
+# Each worker (same SkyRL checkout, same env):
+uv run ray start --address=<HEAD_IP>:6379 --num-gpus=8
+uv run ray status   # confirms total GPUs
+```
 
-### (Optional) FlashAttention-3 on Hopper
+GPU layout follows standard SkyRL knobs:
+- Training: `trainer.placement.policy_num_gpus_per_node * policy_num_nodes`
+- Sampling: `generator.inference_engine.num_engines * tensor_parallel_size`
+- Log-prob: `trainer.arctic_rl.log_prob_gpus` (0 = colocate with sampling)
 
-The 8B / 32B recipes target `flash_attention_3` for best throughput. PyTorch publishes [official FA3 wheels](https://dev-discuss.pytorch.org/t/flash-attention-3-wheels/3322), ABI-stable for any Python ≥ 3.9, torch ≥ 2.9:
+Optional FA3 on Hopper (recommended for the largest speedups):
 
 ```bash
 uv pip install flash-attn-3 --index-url https://download.pytorch.org/whl/cu128
 ```
 
-(`cu126` / `cu130` indices also available.) If you don't install FA3, set `trainer.arctic_rl.attn_implementation=flash_attention_2` on the launcher.
+Skip and set `trainer.arctic_rl.attn_implementation=flash_attention_2` if you don't want FA3.
+
+## What you get vs. SkyRL FSDP2
+
+For the deep dive on where the numbers come from — split attention, Forest Cascade, Arctic Speculator — read the [ZoRRo blog post](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/). The headline:
+
+| Optimization | Speedup on Arctic-Text2SQL-R2 (Qwen3-32B, 32 × H200) |
+| --- | --- |
+| ZoRRo training (split attention) | 6× actor update, 5× log-prob |
+| Forest Cascade + Arctic spec-dec | 1.7× rollout generation |
+| End-to-end RL iteration | **3.5×** (5 days → 1.5 days) |
+| Max context window | **3.2×** (20 K → 64 K) |
+
+This integration exposes the same stack to SkyRL users.
+
+## File layout
+
+```
+integrations/arctic_rl/
+├── README.md
+├── trainer.py         ArcticPPOTrainer — routes training to Arctic server actors
+├── generator.py       ArcticGenerator — routes generation to vLLM, scores via skyrl-gym
+├── config.py          ArcticRLTrainerConfig + build_rl_config
+├── entrypoint.py      Dispatched from main_base via trainer.override_entrypoint
+├── envs/
+│   ├── bird.py
+│   ├── bird_reward.py
+│   └── preprocess_bird.py
+└── examples/
+    ├── run_gsm8k_grpo_4gpu.sh
+    └── run_bird_grpo_*.sh      (BIRD recipes — manual data prep today)
+```
 
 ## BIRD-SQL recipes
 
-`integrations/arctic_rl/examples/run_bird_grpo_*` ships 8B and 32B BIRD-SQL recipes. These currently require manual BIRD data prep (raw download + `integrations/arctic_rl/envs/preprocess_bird.py`); a one-command HuggingFace-hosted parquet bundle is on the roadmap. See the launcher source for the current path.
-
-## File structure
-
-```
-integrations/arctic_rl/                # importable as integrations.arctic_rl
-├── README.md
-├── __init__.py                        # exports ArcticPPOTrainer, ArcticGenerator
-├── trainer.py                         # ArcticPPOTrainer: routes training to server
-├── generator.py                       # ArcticGenerator: routes generation to server vLLM
-├── config.py                          # ArcticRLTrainerConfig + build_rl_config
-├── entrypoint.py                      # dispatched here from main_base
-├── envs/
-│   ├── bird.py                        # skyrl-gym BIRD SQL env
-│   ├── bird_reward.py                 # vendored verl PR #6 SQL reward fn
-│   └── preprocess_bird.py             # raw BIRD -> verl parquets
-└── examples/
-    ├── run_gsm8k_grpo_4gpu.sh         # 4-GPU GSM8K smoke / reference recipe
-    └── run_bird_grpo_*.sh             # BIRD-SQL recipes (require manual data prep)
-```
-
-## How it works
-
-1. **`arctic_rl.entrypoint.main`** pre-initializes the Arctic RL Ray actors on the driver (one `ArcticRLRayServerState` actor that owns `DeepSpeedWorker` and `InferenceWorker` child actors), grabs their handles via `pre_client.get_server_state()`, then launches the SkyRL trainer as another Ray task in the same cluster, passing the actor handles in as `server_state`. The trainer reattaches via `create_arctic_rl_client(reconnect_cfg, server_state)` so it talks to the same actors the driver started.
-
-2. **`ArcticPPOTrainer`** replaces three steps of SkyRL's training loop:
-   - `fwd_logprobs_values_reward` → no-op (server actors compute old log-probs internally)
-   - `compute_advantages_and_returns` → no-op (server actors compute GRPO advantages from rewards)
-   - `train_critic_and_policy` → ships batches to the server actors via `ray.get(actor.train.remote(...))`; the actors run GRPO loss + backward + step
-
-3. **`ArcticGenerator`** routes generation to the `InferenceWorker` (vLLM) actors and scores completions client-side via `skyrl-gym`.
-
-4. **Server-side GRPO loss** is self-contained: per-token log-probs with causal shift, old log-probs by detaching (correct for `update_epochs_per_batch=1`), group-relative advantages from per-sequence rewards, PPO clipped surrogate.
-
-The SkyRL ↔ Arctic RL protocol is minimal: server actors take `(sequences, rewards, loss_mask)` and return updated weights via NCCL sync directly to the `InferenceWorker` GPUs (the driver never sees the weights). All reward scoring and data orchestration live on the SkyRL side, all GPU compute lives on the Arctic actors.
+`examples/run_bird_grpo_8b_32gpu.sh` and `run_bird_grpo_32b_32gpu.sh` reproduce the 32B Arctic-Text2SQL-R2 setup. They currently require manual BIRD raw-data download + `python integrations/arctic_rl/envs/preprocess_bird.py`; a single-command HuggingFace-hosted parquet bundle is on the roadmap. See the launcher source for the current path.

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -1,97 +1,116 @@
 # Arctic RL Integration for SkyRL
 
-**Bring [ZoRRo](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/)'s 3.5× RL speedup to any SkyRL recipe with a single CLI flag.**
-
-[ZoRRo (Zero Redundancy Rollouts)](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/) is Snowflake AI Research's RL acceleration stack — prompt-deduplicated split attention for training, Forest Cascade Attention for inference, and Arctic speculative decoding for generation. On Arctic-Text2SQL-R2 it delivers **3.5× faster end-to-end training**, **6× faster actor update**, **5× faster log-prob**, **1.7× faster rollout generation**, and **3.2× longer context**.
-
-This integration routes SkyRL's GRPO loop through the open-source [Arctic RL](https://github.com/Snowflake-AI-Research/Arctic-Platform) server — the same backend that produced those numbers — so you get all of ZoRRo's optimizations on your existing recipes, untouched.
+Routes SkyRL's GRPO loop through the [Arctic RL](https://github.com/Snowflake-AI-Research/Arctic-Platform) server. Adds the ZoRRo / Forest Cascade Attention / Arctic speculative-decoding stack ([ZoRRo blog](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/)) under SkyRL's existing trainer / Hydra / Ray plumbing.
 
 ## Install
+
+Clone SkyRL:
 
 ```bash
 git clone https://github.com/NovaSky-AI/SkyRL.git && cd SkyRL
 ```
 
-That's it. No `uv sync --extra`, no `uv pip install`. Every launcher in `examples/` uses `uv run --isolated --extra skyrl-train --with arctic-platform --with 'arctic-inference[vllm]' --with liger-kernel --with 'transformers==4.57.6' --with flash-attn@<wheel>` — the same pattern as `examples/train/flash_rl` and `examples/train_integrations/harbor`. uv resolves the env on first launch (~5 min, cached after) and SkyRL's uv+Ray plugin replicates the exact invocation on every worker.
+There is no `uv sync` step. Each launcher in `integrations/arctic_rl/examples/` invokes:
 
-Why the `--with` overrides: `arctic-inference[vllm]` pulls vLLM 0.18, which requires `transformers<5` and a torch-2.10 ABI flash-attn wheel. SkyRL's `pyproject.toml` pins `transformers>=5.6.1` and ships a torch-2.11 flash-attn (both needed by the fsdp/megatron backends). `--isolated` + `--with` overrides resolve to vLLM 0.18's stack for this run only, leaving the project `.venv` untouched.
+```
+uv run --isolated --extra skyrl-train \
+    --with arctic-platform \
+    --with 'arctic-inference[vllm]' \
+    --with liger-kernel \
+    --with 'transformers==4.57.6' \
+    --with "flash-attn@<torch-2.10 cu128 wheel URL>" \
+    --with "flash-attn-3@<cu128 wheel URL>" \
+    -- python -m ...
+```
 
-## 30-second smoke test (GSM8K, 4 GPUs)
+What each flag does:
+
+- `--isolated` — resolves a fresh env from scratch instead of using SkyRL's lockfile. Required because `tool.uv.sources` in `pyproject.toml` pins vLLM to the cu129 index (vLLM 0.23 only), but `arctic-inference[vllm]` needs vLLM 0.18.
+- `--extra skyrl-train` — pulls SkyRL's training deps (`ray`, `deepspeed`, `hydra-core`, …).
+- `--with arctic-platform`, `--with 'arctic-inference[vllm]'`, `--with liger-kernel` — the three Arctic packages.
+- `--with 'transformers==4.57.6'` — vLLM 0.18 needs transformers `<5`; pinned exact (not `<5`) because Ray's worker-spawn shell parses `<5` as a redirect from fd 5. Same reason `examples/train/flash_rl` exact-pins `transformers==4.53.3`.
+- `--with "flash-attn@<URL>"` — overrides the torch-2.11 flash-attn wheel that `tool.uv.sources` selects, replacing it with a torch-2.10 ABI wheel that matches vLLM 0.18's torch pin.
+- `--with "flash-attn-3@<URL>"` — FA3 wheel from PyTorch's cu128 index (`cp39-abi3`). Default attention backend on the BIRD recipes; this is what produced the 2.38× number on H200.
+
+Ray workers replay the same `uv run --isolated --with ...` via the [uv+Ray `py_executable`](https://www.anyscale.com/blog/uv-ray-pain-free-python-dependencies-in-clusters) integration, so the Arctic stack lands on every worker without a separate install.
+
+First launch resolves and downloads the wheels (~5 min). Subsequent launches hit the uv cache.
+
+## Smoke test — GSM8K, 4 GPUs
 
 ```bash
 bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
 ```
 
-(Single-node — the launcher's `python -m skyrl.train.entrypoints.main_base` auto-starts a local Ray cluster.)
+Downloads `Qwen/Qwen3-0.6B`, preps GSM8K parquets, starts a local Ray cluster. First reward in ~3 min from a cold uv cache.
 
-Auto-downloads `Qwen/Qwen3-0.6B`, auto-preps GSM8K parquets. First reward signal lands in ~3 min from a cold start. On a clean public-mains run we see:
+Recent run (public mains, 4 GPUs):
 
 ```
 step 0  avg_final_rewards: 0.229
 step 1  avg_final_rewards: 0.247
 step 2  avg_final_rewards: 0.280
 step 3  avg_final_rewards: 0.337    loss=0.104  grad_norm=0.22
-step 1 wall clock: 56s  (generate + train + sync_weights)
 sync_weights steady state: <0.1s
 ```
 
-## Drop into your own recipe
+## Use Arctic RL in a recipe
 
-Any stock SkyRL recipe becomes an Arctic RL recipe by appending **one flag** and running through the same `uv run --isolated` driver the launchers use:
+Add one flag to the SkyRL `main_base` invocation:
+
+```
+trainer.override_entrypoint=integrations.arctic_rl.entrypoint
+```
+
+This dispatches into `integrations/arctic_rl/entrypoint.py` after Hydra parsing. ZoRRo, FCA, Liger, and the multi-replica FlashInfer workaround are on by default; opt out via the `trainer.arctic_rl.*` knobs below.
+
+Wrapped in the launcher driver:
 
 ```bash
 FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
 FLASH_ATTN3_WHL="https://download.pytorch.org/whl/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
 
 uv run --isolated --extra skyrl-train \
-    --with arctic-platform \
-    --with 'arctic-inference[vllm]' \
-    --with liger-kernel \
+    --with arctic-platform --with 'arctic-inference[vllm]' --with liger-kernel \
     --with 'transformers==4.57.6' \
     --with "flash-attn@${FLASH_ATTN_WHL}" \
     --with "flash-attn-3@${FLASH_ATTN3_WHL}" \
     -- python -m skyrl.train.entrypoints.main_base \
         trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
         trainer.arctic_rl.attn_implementation=flash_attention_3 \
-        <... your existing recipe overrides ...>
+        <existing recipe overrides>
 ```
 
-That's it. ZoRRo (training-side dedup + memory-chunked logits), Forest Cascade Attention (rollout), Liger fused kernels, and the multi-replica FlashInfer workaround are all **on by default**. Add `trainer.arctic_rl.speculative_model=<hf-id-or-path>` to also turn on Arctic speculative decoding.
-
-`trainer.override_entrypoint` tells `main_base` to dispatch into the Arctic entrypoint after Hydra parsing. No `PYTHONPATH` setup, no edits to `main_base.py`.
+Add `trainer.arctic_rl.speculative_model=<hf-id-or-path>` to enable Arctic speculative decoding.
 
 ### `trainer.arctic_rl.*` knobs
 
-Defaults assume you came here to use Arctic RL; opt **out** of optimizations explicitly if you need a baseline comparison.
-
-| Knob | Default | Purpose |
+| Knob | Default | Effect |
 | --- | --- | --- |
-| `use_arctic_inference` | **`true`** | Forest Cascade Attention in the rollout (auto-injects the multi-replica `fuse_allreduce_rms` workaround when needed). |
-| `use_zorro` | **`true`** | ZoRRo split-attention + prompt dedup in the trainer. |
-| `logits_optimization` | **`"memory"`** | Chunked logits compute on the server (ZoRRo only). |
-| `use_liger` | **`true`** | Liger fused MLP/RMSNorm kernels. |
-| `speculative_model` | `None` | HF id / local path of an Arctic draft head — set this to enable Arctic speculative decoding. |
-| `num_speculative_tokens` | `3` | Draft tokens per target-model step (only when `speculative_model` is set). |
-| `zero_stage` | `0` | DeepSpeed ZeRO (use `2` for ~1B, `3` for ≥7B; required for bf16 + fp32 grad). |
-| `offload_optimizer` | `false` | CPU offload optimizer state (`zero_stage≥2`). |
-| `offload_param` | `false` | CPU offload ZeRO-3 param shards. |
+| `use_arctic_inference` | `true` | Forest Cascade Attention in the rollout; auto-injects the multi-replica `fuse_allreduce_rms` workaround when `num_engines > 1`. |
+| `use_zorro` | `true` | ZoRRo split-attention + prompt dedup on the trainer side. |
+| `logits_optimization` | `"memory"` | Chunked logits compute on the server (ZoRRo only). |
+| `use_liger` | `true` | Liger fused MLP/RMSNorm kernels. |
+| `speculative_model` | `None` | HF id or local path of an Arctic draft head. Enables Arctic speculative decoding when set. |
+| `num_speculative_tokens` | `3` | Draft tokens per target-model step. Only used when `speculative_model` is set. |
+| `zero_stage` | `0` | DeepSpeed ZeRO stage. `2` for ~1B models, `3` for ≥7B. Required to be ≥1 for bf16 model + fp32 grad. |
+| `offload_optimizer` | `false` | CPU offload optimizer state. Needs `zero_stage ≥ 2`. |
+| `offload_param` | `false` | CPU offload ZeRO-3 parameter shards. |
 | `colocate` | `false` | Share GPUs between training and sampling. |
-| `attn_implementation` | `flash_attention_3` (BIRD) / `flash_attention_2` (GSM8K) | FA3 is the default on the BIRD launchers (Hopper-targeted, matches the 2.38× recipe). Use FA2 on A100/L40S. The FA3 wheel ships in the launcher's `--with` chain. |
-| `cuda_ipc_weight_sync` | `false` | Zero-copy IPC weight sync (colocate-only). |
+| `attn_implementation` | `flash_attention_3` on BIRD launchers, `flash_attention_2` on GSM8K | Set to `flash_attention_2` on A100 / L40S. |
+| `cuda_ipc_weight_sync` | `false` | Zero-copy IPC weight sync. Requires `colocate=true`. |
 | `vllm_max_num_seqs` | `256` | vLLM batching cap. |
-| `vllm_config` | `None` | Escape hatch for raw `vllm.AsyncEngineArgs` keys not covered above (see below). |
+| `vllm_config` | `None` | Raw `vllm.AsyncEngineArgs` dict, forwarded verbatim. See below. |
 
-### Escape hatch — `trainer.arctic_rl.vllm_config`
+### `trainer.arctic_rl.vllm_config`
 
-The integration translates `arctic_rl.*` knobs into the corresponding `vllm.AsyncEngineArgs` keys for you — FCA, the multi-replica FlashInfer workaround, and Arctic speculative decoding are all auto-injected when their typed flag is on.
-
-`vllm_config` is the escape hatch for vLLM knobs the typed fields don't yet cover — e.g. a non-default `cudagraph_mode`, a custom `compilation_config` pass, or any future vLLM field arctic-inference doesn't model. The dict is forwarded verbatim to `vllm.AsyncEngineArgs` via arctic-platform's `ArcticRLClientConfig.vllm_config` (public main, unmodified), and **user keys win on conflict** with the auto-injected defaults:
+`trainer.arctic_rl.*` covers the vLLM knobs Arctic RL needs. `vllm_config` is for raw vLLM fields the typed knobs don't model:
 
 ```bash
 trainer.arctic_rl.vllm_config="{compilation_config: {cudagraph_mode: FULL}}"
 ```
 
-You should not need this in the happy path. If you reach for it, the typed-knob layer probably should grow a new field — file a follow-up.
+The dict is shallow-merged after auto-injected defaults, so user keys win on conflict.
 
 ## Architecture
 
@@ -111,35 +130,27 @@ You should not need this in the happy path. If you reach for it, the typed-knob 
  +----------------------------------------------------------------+
 ```
 
-The integration pins `comm_protocol="ray"` — the SkyRL driver and Arctic server actors share one Ray cluster. arctic-platform's HTTP transport is for remote dss-platform deployments and isn't used here.
+`comm_protocol="ray"` is pinned in the integration. arctic-platform's HTTP transport is for remote dss-platform deployments and is not used here.
 
-## Multi-node and FA3
+## Multi-node
 
-Same `ray start` pattern as every other SkyRL recipe — `uv run --isolated --extra skyrl-train ray start ...` on each node:
+`ray start` on each node, same pattern as every other SkyRL recipe:
 
 ```bash
-# Head node:
+# Head node
 uv run --isolated --extra skyrl-train ray start --head --port=6379 --num-gpus=8
-# Each worker (same SkyRL checkout):
+
+# Each worker
 uv run --isolated --extra skyrl-train ray start --address=<HEAD_IP>:6379 --num-gpus=8
-uv run --isolated --extra skyrl-train ray status   # confirms total GPUs
+
+uv run --isolated --extra skyrl-train ray status
 ```
 
-The launcher's `uv run --isolated --extra skyrl-train --with arctic-platform ...` invocation is replicated on every Ray worker via the uv+Ray `py_executable` integration, so workers automatically get the same arctic stack.
+GPU layout:
 
-GPU layout follows standard SkyRL knobs:
 - Training: `trainer.placement.policy_num_gpus_per_node * policy_num_nodes`
 - Sampling: `generator.inference_engine.num_engines * tensor_parallel_size`
-- Log-prob: `trainer.arctic_rl.log_prob_gpus` (0 = colocate with sampling)
-
-**FlashAttention 3** is the default on the BIRD recipes (Hopper-targeted — this is the attention backend that produced the 2.38× speedup). The launchers ship the FA3 wheel from PyTorch's cu128 index as one of the `--with` overrides, so no extra install step is needed; just run the launcher on H100/H200 and `ATTN_IMPL=flash_attention_3` kicks in. On A100/L40S, set `ATTN_IMPL=flash_attention_2` before invoking the launcher.
-
-For your own launcher, add this `--with` line to ship FA3:
-
-```bash
---with "flash-attn-3@https://download.pytorch.org/whl/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
-```
-
+- Log-prob: `trainer.arctic_rl.log_prob_gpus` (`0` colocates with sampling)
 
 ## File layout
 
@@ -161,20 +172,18 @@ integrations/arctic_rl/
 
 ## BIRD-SQL: 32B Qwen3 on 32 × H200
 
-`examples/run_bird_grpo_32b_32gpu.sh` reproduces the 32B Text2SQL setup from the [ZoRRo blog](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/). End-to-end from a clean machine:
+`examples/run_bird_grpo_32b_32gpu.sh` runs the 32B Text2SQL setup from the [ZoRRo blog](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/).
 
 ```bash
-# 1. Clone (first launcher invocation resolves the env in ~5 min, cached after)
+# 1. Clone
 git clone https://github.com/NovaSky-AI/SkyRL.git && cd SkyRL
 
-# 2. Ray up (4-node example; repeat on each worker)
+# 2. Ray cluster (4-node example; repeat on each worker)
 uv run --isolated --extra skyrl-train ray start --head --port=6379 --num-gpus=8
-# on each worker:
+# worker:
 #   uv run --isolated --extra skyrl-train ray start --address=<head>:6379 --num-gpus=8
 
-# 3. (FA3 ships in the launcher's --with chain — no extra install step on Hopper.)
-
-# 4. BIRD data — raw download + preprocess (a one-command HF bundle is on the roadmap)
+# 3. BIRD raw data + preprocess
 mkdir -p /data/bird && cd /data/bird
 wget https://bird-bench.oss-cn-beijing.aliyuncs.com/train.zip && unzip train.zip
 wget https://bird-bench.oss-cn-beijing.aliyuncs.com/dev.zip   && unzip dev.zip
@@ -185,14 +194,14 @@ python integrations/arctic_rl/envs/preprocess_bird.py \
     --max_tokens 32768 \
     --tokenizer  Qwen/Qwen3-1.7B
 
-# 5. Run
+# 4. Launch
 DATA_DIR=$HOME/data/bird WANDB_API_KEY=<key> \
     bash integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
 ```
 
 Notes:
 
-- BIRD raw data is gated behind <https://bird-bench.github.io>; the `wget` URLs above are the public mirrors arctic-platform's txt2sql README uses.
-- `--max_tokens 32768` matches the recipe's `trainer.max_prompt_length=32768`. Drop this lower only if you also lower the recipe's prompt length.
-- `preprocess_bird.py` writes verl-format parquets whose `extra_info.db_path` is absolute. The SQLite files at those paths must be readable on every node at training time — either a shared filesystem, or mirror `/data/bird/` to each worker.
-- An 8B variant `run_bird_grpo_8b_32gpu.sh` ships for quick smoke tests on the same cluster.
+- BIRD raw data is gated behind <https://bird-bench.github.io>; the `wget` URLs above are the mirrors arctic-platform's txt2sql README uses.
+- `--max_tokens 32768` matches the recipe's `trainer.max_prompt_length=32768`.
+- `preprocess_bird.py` emits verl-format parquets with absolute `extra_info.db_path`. The SQLite files at those paths must be readable on every Ray node — shared filesystem, or mirror `/data/bird/` to each worker.
+- `run_bird_grpo_8b_32gpu.sh` ships an 8B variant on the same cluster shape for faster iteration.

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -1,0 +1,229 @@
+# Arctic RL Integration for SkyRL
+
+Routes SkyRL's GRPO training loop through the Arctic RL server — **all GPU operations** (training, generation, log-probs, weight sync) happen on the server. The SkyRL client is CPU-only.
+
+## Architecture
+
+```
+SkyRL Client (CPU-only, ray num_gpus=0)
+  - Data loading, reward scoring (skyrl-gym)
+  - Orchestration: generate → score → train
+  - HTTP calls to Arctic RL server
+        |
+        | HTTP (torch-serialized batches)
+        v
+Arctic RL Server (own Ray cluster, all GPUs)
+  - DeepSpeed Workers: forward/backward, GRPO loss, optimizer step
+  - ArcticInference (vLLM) Replicas: generation, log-probs
+  - NCCL weight sync between training and inference
+```
+
+## Validated Results
+
+### Arctic RL Server Backend (this integration)
+
+**Setup**: Qwen2.5-1.5B-Instruct, 4 DeepSpeed training GPUs + 2 ArcticInference (vLLM) sampling GPUs + 1 log-prob GPU (7x H200), GRPO with 5 samples/prompt.
+
+| Step | GSM8K Eval (pass@1) | Training Reward |
+|------|-------------------|-----------------|
+| 0 (base) | 7.8% | — |
+| 5 | 33% | 0.22 |
+| 10 | 63% | 0.60 |
+| 30 | 70% | 0.65 |
+| 45 | 73% | 0.81 |
+| 75 | **75.4%** | 0.82 |
+
+### SkyRL Default (FSDP2 baseline)
+
+| Model | GSM8K Accuracy (1,319 test) |
+|---|---|
+| Base (Qwen2.5-1.5B-Instruct) | 7.43% |
+| Trained (step 59) | **79.00%** |
+
+## Quick Start
+
+### Prerequisites
+
+- Linux x86_64, NVIDIA GPU with CUDA 12.8 driver (Hopper recommended).
+- [`uv`](https://docs.astral.sh/uv/) installed
+  (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/Snowflake-AI-Research/SkyRL.git
+cd SkyRL
+uv sync --extra arctic-rl
+```
+
+The `arctic-rl` extra pulls in `arctic-platform` and `arctic-inference[vllm]`
+from their public `main` branches; vLLM and torch arrive transitively via
+`arctic-inference[vllm]`, SkyRL training core via `skyrl[skyrl-train]`. No
+manual installs of arctic-platform / arctic-inference / vLLM / torch needed.
+
+Add `--extra fsdp` *only* if you also want to run the SkyRL native FSDP
+backend side-by-side (the two extras pin different vLLM versions, so
+`arctic-rl` alone is preferred for pure Arctic runs).
+
+SkyRL's base `transformers` pin (`>=5.0.0,<=5.3.0`, for the megatron
+backend) conflicts with vLLM 0.18 + arctic-platform, so after `uv sync`
+force the older line:
+
+```bash
+uv pip install --upgrade 'transformers>=4.57,<5'
+```
+
+### 2. Start a Ray cluster
+
+Single-node (8 GPUs):
+
+```bash
+uv run ray start --head --num-gpus=8
+```
+
+Multi-node (e.g. 4 × 8 H200):
+
+```bash
+# On the head node:
+uv run ray start --head --port=6379 --num-gpus=8
+
+# On each worker node (same SkyRL checkout + same env installed):
+uv run ray start --address=<HEAD_IP>:6379 --num-gpus=8
+
+# Confirm:
+uv run ray status   # should show 32/32 GPUs across 4 nodes
+```
+
+### 3. (Hopper only) Install FlashAttention-3
+
+The 32B BIRD recipe targets `flash_attention_3` for the 2× speedup vs FSDP.
+PyTorch publishes [official FA3 wheels](https://dev-discuss.pytorch.org/t/flash-attention-3-wheels/3322)
+ABI-stable for any Python ≥ 3.9, torch ≥ 2.9. Pick the index matching your
+CUDA build:
+
+```bash
+uv pip install flash-attn-3 --index-url https://download.pytorch.org/whl/cu128
+```
+
+(`cu126`, `cu130` indices also available.) Skip this if you're on FA2 — set
+`ATTN_IMPL=flash_attention_2` when launching.
+
+### 4. Prepare data
+
+Models auto-download to `$HF_HOME` on first use (Qwen3 weights are public,
+no HF auth required). GSM8K parquets auto-prep on first launch via SkyRL's
+bundled `gsm8k_dataset.py`.
+
+For BIRD-SQL, run the bundled preprocessor against your raw BIRD SQLite
+dump (downloadable from <https://bird-bench.github.io/>):
+
+```bash
+python integrations/arctic_rl/envs/preprocess_bird.py \
+    --bird_dir   /path/to/raw/bird \
+    --output_dir $HOME/data/bird \
+    --max_tokens 16384 \
+    --tokenizer  Qwen/Qwen3-1.7B
+```
+
+This writes `train.parquet` and `val.parquet` to `$DATA_DIR` in the
+verl-compatible format the launcher expects (`--help` for the full set of
+flags, including Spider / GretelAI sources).
+
+### 5. Run
+
+Use with any stock SkyRL recipe — append a single CLI flag:
+
+```bash
+uv run -m skyrl.train.entrypoints.main_base \
+    trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+    <... your existing recipe overrides ...>
+```
+
+Arctic-specific knobs go under `trainer.arctic_rl.*` (e.g.
+`trainer.arctic_rl.colocate=true`, `trainer.arctic_rl.zero_stage=3`); the
+entrypoint auto-fills sensible defaults if you set none.
+
+Or invoke one of the provided launchers:
+
+```bash
+# GSM8K, 4 H200s (single node):
+DATA_DIR=$HOME/data/gsm8k LOGGER=console \
+    bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
+
+# BIRD-SQL, Qwen3-32B, 32 H200s (4 nodes):
+DATA_DIR=$HOME/data/bird HF_HOME=$HOME/.cache/huggingface LOGGER=console \
+    bash integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
+```
+
+Launchers default to `LOGGER=wandb` (parity with the original recipes); pass
+`LOGGER=console` for no-credentials smoke runs. When `LOGGER=wandb`, set
+`WANDB_API_KEY` in your environment.
+
+## Configuration
+
+### GPU Allocation
+
+GPU layout is derived from standard SkyRL knobs:
+- Training GPUs: `trainer.placement.policy_num_gpus_per_node * trainer.placement.policy_num_nodes`
+- Sampling GPUs: `generator.inference_engine.num_engines * generator.inference_engine.tensor_parallel_size`
+- Log-prob GPUs: `trainer.arctic_rl.log_prob_gpus` (default: 0 — log-probs colocate with sampling vLLM)
+- Colocation between training and sampling: `trainer.arctic_rl.colocate` (default: false)
+
+### Key Training Parameters
+
+The launch script passes these to SkyRL via Hydra overrides:
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `trainer.train_batch_size` | 256 | Prompts per step |
+| `trainer.policy_mini_batch_size` | 2 | Prompts per mini-batch |
+| `generator.n_samples_per_prompt` | 5 | Completions per prompt |
+| `trainer.policy.optimizer_config.lr` | 1e-6 | Learning rate |
+| `trainer.epochs` | 20 | Training epochs |
+| `trainer.eval_interval` | 5 | Eval every N steps |
+
+DeepSpeed config is set automatically:
+- `gradient_accumulation_steps` = `train_batch_size * n_samples / (policy_mini_batch_size * n_samples)` = 128
+- `gradient_clipping` = 1.0
+- `optimizer` = AdamW with lr from config
+
+## File Structure
+
+```
+integrations/arctic_rl/                # importable as integrations.arctic_rl
+├── README.md
+├── __init__.py                       # exports ArcticPPOTrainer, ArcticGenerator
+├── trainer.py                        # ArcticPPOTrainer: routes training to server
+├── generator.py                      # ArcticGenerator: routes generation to server vLLM
+├── config.py                         # ArcticRLTrainerConfig + build_rl_config
+├── entrypoint.py                     # dispatched here from main_base
+├── envs/
+│   ├── bird.py                       # skyrl-gym BIRD SQL env
+│   ├── bird_reward.py                # vendored V6b SQL reward fn (verl PR #6 parity)
+│   └── preprocess_bird.py            # vendored BIRD parquet preprocessor
+└── examples/
+    └── run_*.sh                      # launchers (call main_base with override_entrypoint)
+```
+
+`integrations/` is a PEP 420 namespace package (no `__init__.py`); the
+`arctic_rl` package below it is reachable as `integrations.arctic_rl` from
+the SkyRL repo root with no `PYTHONPATH` setup. It is distinct from the
+upstream `arctic_training` PyPI package's `arctic_training.arctic_rl`
+sub-namespace — both coexist at import time without collision.
+
+## How It Works
+
+1. **`arctic_rl.entrypoint`** creates an `ArcticRLClient` which spawns the server as a subprocess with a clean environment (stripped `CUDA_VISIBLE_DEVICES` and `RAY_*` vars so the server gets its own GPU access)
+
+2. **`ArcticPPOTrainer`** overrides the standard SkyRL training loop:
+   - `fwd_logprobs_values_reward` → no-op (server computes old log-probs internally)
+   - `compute_advantages_and_returns` → no-op (server computes GRPO advantages from rewards)
+   - `train_critic_and_policy` → sends batches to server via HTTP, server runs GRPO loss + backward
+
+3. **`ArcticGenerator`** routes generation to server vLLM and scores completions via `skyrl-gym`
+
+4. **Server-side `grpo_loss`** (in `processors.py`) is self-contained:
+   - Computes per-token log-probs with causal shift
+   - Derives old log-probs by detaching (correct for `update_epochs_per_batch=1`)
+   - Computes group-relative advantages from per-sequence rewards
+   - Applies PPO clipped surrogate (eps_clip=0.2)

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -29,31 +29,30 @@ sync_weights steady state: <0.1s
 
 ## Drop into your own recipe
 
-Any stock SkyRL recipe becomes an Arctic RL recipe by appending one flag:
+Any stock SkyRL recipe becomes an Arctic RL recipe by appending **one flag**:
 
 ```bash
 uv run -m skyrl.train.entrypoints.main_base \
     trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
-    trainer.arctic_rl.use_zorro=true \
-    trainer.arctic_rl.use_arctic_inference=true \
-    trainer.arctic_rl.speculative_model=<hf-id-or-path> \
-    trainer.arctic_rl.zero_stage=2 \
     <... your existing recipe overrides ...>
 ```
 
-The integration translates each typed `arctic_rl.*` knob into the matching arctic-platform / vLLM payload — no raw `vllm_config` blocks required for FCA, speculative decoding, or the multi-replica FlashInfer workaround.
+That's it. ZoRRo (training-side dedup + memory-chunked logits), Forest Cascade Attention (rollout), Liger fused kernels, and the multi-replica FlashInfer workaround are all **on by default**. Add `trainer.arctic_rl.speculative_model=<hf-id-or-path>` to also turn on Arctic speculative decoding.
 
 `trainer.override_entrypoint` tells `main_base` to dispatch into the Arctic entrypoint after Hydra parsing. No `PYTHONPATH` setup, no edits to `main_base.py`.
 
 ### `trainer.arctic_rl.*` knobs
 
+Defaults assume you came here to use Arctic RL; opt **out** of optimizations explicitly if you need a baseline comparison.
+
 | Knob | Default | Purpose |
 | --- | --- | --- |
-| `use_zorro` | `false` | Enable ZoRRo split-attention + prompt dedup in the trainer. |
-| `use_arctic_inference` | `false` | Enable Forest Cascade Attention in the rollout (auto-injects the multi-replica `fuse_allreduce_rms` workaround when needed). |
-| `speculative_model` | `None` | HF id / local path of an Arctic draft head. Set this to turn on Arctic speculative decoding — no raw `vllm_config` needed. |
+| `use_arctic_inference` | **`true`** | Forest Cascade Attention in the rollout (auto-injects the multi-replica `fuse_allreduce_rms` workaround when needed). |
+| `use_zorro` | **`true`** | ZoRRo split-attention + prompt dedup in the trainer. |
+| `logits_optimization` | **`"memory"`** | Chunked logits compute on the server (ZoRRo only). |
+| `use_liger` | **`true`** | Liger fused MLP/RMSNorm kernels. |
+| `speculative_model` | `None` | HF id / local path of an Arctic draft head — set this to enable Arctic speculative decoding. |
 | `num_speculative_tokens` | `3` | Draft tokens per target-model step (only when `speculative_model` is set). |
-| `use_liger` | `false` | Liger fused kernels in the policy fwd/bwd. |
 | `zero_stage` | `0` | DeepSpeed ZeRO (use `2` for ~1B, `3` for ≥7B; required for bf16 + fp32 grad). |
 | `offload_optimizer` | `false` | CPU offload optimizer state (`zero_stage≥2`). |
 | `offload_param` | `false` | CPU offload ZeRO-3 param shards. |
@@ -65,15 +64,7 @@ The integration translates each typed `arctic_rl.*` knob into the matching arcti
 
 ### Escape hatch — `trainer.arctic_rl.vllm_config`
 
-The simple case is fully typed:
-
-```bash
-trainer.arctic_rl.use_zorro=true \
-trainer.arctic_rl.use_arctic_inference=true \
-trainer.arctic_rl.speculative_model=<hf-id-or-path>     # optional spec-dec
-```
-
-That alone gives you ZoRRo (training-side), FCA (rollout), the multi-replica FlashInfer workaround, and Arctic speculative decoding — the integration translates each typed flag into the matching `vllm.AsyncEngineArgs` keys for you.
+The integration translates `arctic_rl.*` knobs into the corresponding `vllm.AsyncEngineArgs` keys for you — FCA, the multi-replica FlashInfer workaround, and Arctic speculative decoding are all auto-injected when their typed flag is on.
 
 `vllm_config` is the escape hatch for vLLM knobs the typed fields don't yet cover — e.g. a non-default `cudagraph_mode`, a custom `compilation_config` pass, or any future vLLM field arctic-inference doesn't model. The dict is forwarded verbatim to `vllm.AsyncEngineArgs` via arctic-platform's `ArcticRLClientConfig.vllm_config` (public main, unmodified), and **user keys win on conflict** with the auto-injected defaults:
 

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -143,7 +143,7 @@ integrations/arctic_rl/
 
 ## BIRD-SQL: 32B Qwen3 on 32 × H200
 
-`examples/run_bird_grpo_32b_32gpu.sh` reproduces the 32B Arctic-Text2SQL-R2 setup from the [ZoRRo blog](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/). End-to-end from a clean machine:
+`examples/run_bird_grpo_32b_32gpu.sh` reproduces the 32B Text2SQL setup from the [ZoRRo blog](https://www.snowflake.com/en/blog/engineering/zorro-enterprise-rl-training/). End-to-end from a clean machine:
 
 ```bash
 # 1. Clone + install

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -1,19 +1,25 @@
 # Arctic RL Integration for SkyRL
 
-Routes SkyRL's GRPO training loop through the [Arctic RL](https://github.com/Snowflake-AI-Research/Arctic-Platform) server — **all GPU operations** (training, generation, log-probs, weight sync) run on the server. The SkyRL client is CPU-only and orchestrates over HTTP.
+Routes SkyRL's GRPO training loop through [Arctic RL](https://github.com/Snowflake-AI-Research/Arctic-Platform) — **all GPU operations** (training, generation, log-probs, weight sync) run on Arctic's Ray actors. The SkyRL driver process holds 0 GPUs and orchestrates via Ray actor calls.
 
 ```
-SkyRL Client (CPU-only, ray num_gpus=0)
-  - Data loading, reward scoring (skyrl-gym)
-  - Orchestration: generate -> score -> train
-  - HTTP calls to Arctic RL server
-        |
-        v
-Arctic RL Server (own Ray cluster, all GPUs)
-  - DeepSpeed Workers: forward/backward, GRPO loss, optimizer step
-  - ArcticInference (vLLM) Replicas: generation, log-probs
-  - NCCL weight sync between training and inference
+                       Single Ray cluster
+ +----------------------------------------------------------------+
+ |                                                                |
+ |   SkyRL driver (num_gpus=0)        Arctic RL Ray actors        |
+ |   - Data loading                   - ArcticRLRayServerState    |
+ |   - skyrl-gym reward scoring       - DeepSpeedWorker (xN)      |
+ |   - generate -> score -> train     - InferenceWorker (xM)      |
+ |                                      = ArcticInference vLLM    |
+ |          |                                  ^                  |
+ |          +---- ray.get(actor.x.remote()) ---+                  |
+ |                                                                |
+ |   NCCL weight sync runs directly between DeepSpeedWorker       |
+ |   and InferenceWorker GPUs (no driver involvement).            |
+ +----------------------------------------------------------------+
 ```
+
+`arctic-platform` supports both Ray and HTTP transports (`comm_protocol="ray"` vs `"http"`); the HTTP path is for remote dss-platform deployments. This integration pins `comm_protocol="ray"` so the SkyRL driver and the Arctic server actors live in the same Ray cluster and talk via in-cluster actor calls — no HTTP server, no separate process group.
 
 ## Quick Start (GSM8K, 4 GPUs, single node)
 
@@ -183,15 +189,15 @@ integrations/arctic_rl/                # importable as integrations.arctic_rl
 
 ## How it works
 
-1. **`arctic_rl.entrypoint`** spawns the Arctic RL server as a subprocess with a clean environment (stripped `CUDA_VISIBLE_DEVICES` and `RAY_*` vars so the server gets its own GPU access), then hands control to SkyRL's trainer.
+1. **`arctic_rl.entrypoint.main`** pre-initializes the Arctic RL Ray actors on the driver (one `ArcticRLRayServerState` actor that owns `DeepSpeedWorker` and `InferenceWorker` child actors), grabs their handles via `pre_client.get_server_state()`, then launches the SkyRL trainer as another Ray task in the same cluster, passing the actor handles in as `server_state`. The trainer reattaches via `create_arctic_rl_client(reconnect_cfg, server_state)` so it talks to the same actors the driver started.
 
 2. **`ArcticPPOTrainer`** replaces three steps of SkyRL's training loop:
-   - `fwd_logprobs_values_reward` → no-op (server computes old log-probs internally)
-   - `compute_advantages_and_returns` → no-op (server computes GRPO advantages from rewards)
-   - `train_critic_and_policy` → ships batches to the server over HTTP; server runs GRPO loss + backward + step
+   - `fwd_logprobs_values_reward` → no-op (server actors compute old log-probs internally)
+   - `compute_advantages_and_returns` → no-op (server actors compute GRPO advantages from rewards)
+   - `train_critic_and_policy` → ships batches to the server actors via `ray.get(actor.train.remote(...))`; the actors run GRPO loss + backward + step
 
-3. **`ArcticGenerator`** routes generation to server vLLM and scores completions client-side via `skyrl-gym`.
+3. **`ArcticGenerator`** routes generation to the `InferenceWorker` (vLLM) actors and scores completions client-side via `skyrl-gym`.
 
 4. **Server-side GRPO loss** is self-contained: per-token log-probs with causal shift, old log-probs by detaching (correct for `update_epochs_per_batch=1`), group-relative advantages from per-sequence rewards, PPO clipped surrogate.
 
-The SkyRL ↔ Arctic RL protocol is minimal: server takes `(sequences, rewards, loss_mask)`, returns updated weights for NCCL sync. All reward scoring and data orchestration live on the SkyRL side, all GPU compute lives on the Arctic side.
+The SkyRL ↔ Arctic RL protocol is minimal: server actors take `(sequences, rewards, loss_mask)` and return updated weights via NCCL sync directly to the `InferenceWorker` GPUs (the driver never sees the weights). All reward scoring and data orchestration live on the SkyRL side, all GPU compute lives on the Arctic actors.

--- a/integrations/arctic_rl/README.md
+++ b/integrations/arctic_rl/README.md
@@ -121,7 +121,6 @@ Optional FA3 on Hopper (recommended for the largest speedups):
 uv pip install flash-attn-3 --index-url https://download.pytorch.org/whl/cu128
 ```
 
-Skip and set `trainer.arctic_rl.attn_implementation=flash_attention_2` if you don't want FA3.
 
 ## File layout
 

--- a/integrations/arctic_rl/__init__.py
+++ b/integrations/arctic_rl/__init__.py
@@ -10,8 +10,8 @@ Provides ``ArcticPPOTrainer`` and ``ArcticGenerator`` that route all GPU work
 to an Arctic RL server; depends on ``arctic_platform.rl`` for the client.
 """
 
-from .trainer import ArcticPPOTrainer
-from .generator import ArcticGenerator
 from . import envs as _envs  # noqa: F401  side-effect: register `bird` env
+from .generator import ArcticGenerator
+from .trainer import ArcticPPOTrainer
 
 __all__ = ["ArcticPPOTrainer", "ArcticGenerator"]

--- a/integrations/arctic_rl/__init__.py
+++ b/integrations/arctic_rl/__init__.py
@@ -1,0 +1,17 @@
+"""Arctic RL integration for SkyRL.
+
+Lives at ``integrations/arctic_rl/`` (PEP 420 namespace under ``integrations/``);
+not pip-installed. Invoked via core dispatch::
+
+    python -m skyrl.train.entrypoints.main_base \\
+        trainer.override_entrypoint=integrations.arctic_rl.entrypoint <flags>
+
+Provides ``ArcticPPOTrainer`` and ``ArcticGenerator`` that route all GPU work
+to an Arctic RL server; depends on ``arctic_platform.rl`` for the client.
+"""
+
+from .trainer import ArcticPPOTrainer
+from .generator import ArcticGenerator
+from . import envs as _envs  # noqa: F401  side-effect: register `bird` env
+
+__all__ = ["ArcticPPOTrainer", "ArcticGenerator"]

--- a/integrations/arctic_rl/config.py
+++ b/integrations/arctic_rl/config.py
@@ -66,8 +66,9 @@ class ArcticRLTrainerConfig(BaseConfig):
     """Enable Liger fused MLP/RMSNorm kernels on the training engine.
 
     Defaults to ``True`` — Liger is a pure fused-kernel speedup with no
-    behavioral effect. ``liger-kernel`` ships with the ``arctic-rl`` extra
-    so it is always available. Server reads from ``ds_worker_config.use_liger``
+    behavioral effect. ``liger-kernel`` is one of the three packages
+    installed alongside SkyRL (see ``integrations/arctic_rl/README.md``).
+    Server reads from ``ds_worker_config.use_liger``
     (``arctic_platform/rl/deepspeed_worker.py:155``).
     """
     attn_implementation: str = "flash_attention_2"
@@ -206,8 +207,8 @@ class ArcticRLTrainerConfig(BaseConfig):
     rollout vLLM engine; ``ARCTIC_INFERENCE_ENABLED=1`` is set on every
     sampling Ray worker. Matches verl's ``rollout.name=arctic`` converged
     path; typical 2-3x rollout speedup on long-context prompts. Requires
-    ``arctic_inference`` to be installed (ships with the ``arctic-rl``
-    extra).
+    ``arctic-inference[vllm]`` to be installed (see
+    ``integrations/arctic_rl/README.md`` for the install command).
     """
     speculative_model: Optional[str] = None
     """HF id or local path of an Arctic draft-head checkpoint. When set

--- a/integrations/arctic_rl/config.py
+++ b/integrations/arctic_rl/config.py
@@ -193,39 +193,52 @@ class ArcticRLTrainerConfig(BaseConfig):
     converged path; typical 2-3x rollout speedup on long-context prompts.
     Requires ``arctic_inference`` to be installed.
     """
+    speculative_model: Optional[str] = None
+    """HF id or local path of an Arctic draft-head checkpoint. When set
+    (and ``use_arctic_inference=True``), the integration auto-injects::
+
+        speculative_config: {
+            method: arctic,
+            model: <speculative_model>,
+            num_speculative_tokens: <num_speculative_tokens>,
+        }
+
+    into the rollout vLLM engine. Leave ``None`` to disable speculative
+    decoding. End users normally set just this field — no raw
+    ``vllm_config`` block needed.
+    """
+    num_speculative_tokens: int = 3
+    """Number of draft tokens proposed per target-model step. Only used
+    when ``speculative_model`` is set.
+    """
     arctic_inference_config: Optional[dict] = None
     """Optional ArcticInference high-level schema (e.g. ``zorro_inference:
     {enable: true}``, ``speculative_decoding: {model: ...}``). Forwarded
     as-is to ``ArcticRLClientConfig.arctic_inference_config``, where
     arctic-platform's ``parse_arctic_inference_rollout`` translates the
     recognised keys (``use_fca``, ``spec_model``) into ``ModelConfig``
-    fields. Unknown keys are dropped by that helper -- pass raw vLLM
-    kwargs (e.g. ``compilation_config``, ``speculative_config``,
-    ``forest_cascade_attn_configs``) via ``vllm_config`` below instead.
+    fields. Most users should leave this ``None`` and use the typed
+    ``speculative_model`` / ``use_arctic_inference`` knobs above — the
+    integration injects the matching raw vLLM kwargs automatically.
     """
     vllm_config: Optional[dict] = None
-    """Optional raw ``vllm.AsyncEngineArgs`` overrides for the sampling +
-    log-prob engines. Merged on top of the integration's built-in defaults
-    (TP, ``max_num_seqs``, etc.), user keys win on conflict. Mirrors
-    arctic-platform's own ``ArcticRLClientConfig.vllm_config`` field name
-    and semantics: every key is forwarded into vLLM (those matching
-    ``ModelConfig`` fields become typed fields, the rest land in
-    ``extra_engine_kwargs``).
+    """Escape hatch for raw ``vllm.AsyncEngineArgs`` keys that aren't yet
+    exposed as typed ``trainer.arctic_rl.*`` fields.
 
-    Use this for performance knobs the high-level
-    ``arctic_inference_config`` schema doesn't model, e.g.::
+    Merged on top of the integration's defaults (TP, ``max_num_seqs``,
+    auto-injected FCA / speculative_config / ``fuse_allreduce_rms``
+    workaround); **user keys win on conflict**. Mirrors arctic-platform's
+    own ``ArcticRLClientConfig.vllm_config`` field name and semantics:
+    every key is forwarded to vLLM (those matching ``ModelConfig`` fields
+    become typed fields, the rest land in ``extra_engine_kwargs``).
+
+    The simple case never needs this — ``use_arctic_inference=true`` and
+    ``speculative_model=<id>`` cover FCA + Arctic spec-dec automatically.
+    Reach for ``vllm_config`` only when you need an inference-engine knob
+    the typed fields don't cover, e.g.::
 
         trainer.arctic_rl.vllm_config={
-            compilation_config: {
-                cudagraph_mode: PIECEWISE,
-                pass_config: {fuse_allreduce_rms: false},
-            },
-            speculative_config: {
-                method: arctic,
-                model: "<path-or-hf-id>",
-                num_speculative_tokens: 3,
-            },
-            forest_cascade_attn_configs: "{}",
+            compilation_config: {cudagraph_mode: FULL},
         }
     """
 
@@ -369,11 +382,49 @@ def build_rl_config(cfg: SkyRLTrainConfig) -> ArcticRLClientConfig:
     if arl.vllm_max_num_batched_tokens is not None:
         vllm_cfg["max_num_batched_tokens"] = int(arl.vllm_max_num_batched_tokens)
 
+    # ------------------------------------------------------------------
+    # Auto-inject Arctic Inference vLLM kwargs from typed top-level knobs.
+    # The intent: keep the user's recipe free of raw ``vllm_config`` blocks
+    # for the common Arctic flows. User-supplied ``arl.vllm_config`` is
+    # still merged on top below and wins on conflict.
+    # ------------------------------------------------------------------
+    num_engines = int(cfg.generator.inference_engine.num_engines)
+
+    if arl.use_arctic_inference:
+        # FCA is the headline Arctic Inference optimization; enable it
+        # whenever the user opts into Arctic Inference. ``"{}"`` =
+        # arctic-inference defaults.
+        vllm_cfg.setdefault("forest_cascade_attn_configs", "{}")
+
+        # Multi-replica FlashInfer workaround. arctic-inference's
+        # ``use_fca=True`` default also enables ``fuse_allreduce_rms``,
+        # which collides with per-process FlashInfer IPC port allocation
+        # when ``world_size > tp_size`` (multiple replicas per node).
+        # Symptom: ``AssertionError: Flashinfer workspace must be
+        # initialized when using flashinfer``. Auto-disable for the
+        # multi-replica topology; single-replica keeps the fused path.
+        # Long-term fix belongs inside arctic-inference; this is the
+        # interim workaround so end users never have to know.
+        if num_engines > 1:
+            comp_cfg = vllm_cfg.setdefault("compilation_config", {})
+            pass_cfg = comp_cfg.setdefault("pass_config", {})
+            pass_cfg.setdefault("fuse_allreduce_rms", False)
+
+    # Arctic speculative decoding: opt-in via a single typed flag.
+    if arl.speculative_model:
+        vllm_cfg.setdefault(
+            "speculative_config",
+            {
+                "method": "arctic",
+                "model": str(arl.speculative_model),
+                "num_speculative_tokens": int(arl.num_speculative_tokens),
+            },
+        )
+
     # Layer user-supplied raw vLLM kwargs on top of the integration's
-    # defaults. arctic-platform forwards this dict to vLLM verbatim (any
-    # key not on ``ModelConfig`` lands in ``extra_engine_kwargs``), so this
-    # is where performance knobs like ``compilation_config``,
-    # ``speculative_config``, and ``forest_cascade_attn_configs`` belong.
+    # defaults + auto-injected Arctic kwargs. arctic-platform forwards
+    # this dict to vLLM verbatim (any key not on ``ModelConfig`` lands in
+    # ``extra_engine_kwargs``); user keys win on conflict.
     if arl.vllm_config is not None:
         user_vllm = OmegaConf.to_container(
             OmegaConf.create(arl.vllm_config),

--- a/integrations/arctic_rl/config.py
+++ b/integrations/arctic_rl/config.py
@@ -194,9 +194,39 @@ class ArcticRLTrainerConfig(BaseConfig):
     Requires ``arctic_inference`` to be installed.
     """
     arctic_inference_config: Optional[dict] = None
-    """Optional per-key overrides for ArcticInference (e.g. speculative
-    decoding model). When None and ``use_arctic_inference=True``, sends
-    an empty dict (= enable with defaults).
+    """Optional ArcticInference high-level schema (e.g. ``zorro_inference:
+    {enable: true}``, ``speculative_decoding: {model: ...}``). Forwarded
+    as-is to ``ArcticRLClientConfig.arctic_inference_config``, where
+    arctic-platform's ``parse_arctic_inference_rollout`` translates the
+    recognised keys (``use_fca``, ``spec_model``) into ``ModelConfig``
+    fields. Unknown keys are dropped by that helper -- pass raw vLLM
+    kwargs (e.g. ``compilation_config``, ``speculative_config``,
+    ``forest_cascade_attn_configs``) via ``vllm_config`` below instead.
+    """
+    vllm_config: Optional[dict] = None
+    """Optional raw ``vllm.AsyncEngineArgs`` overrides for the sampling +
+    log-prob engines. Merged on top of the integration's built-in defaults
+    (TP, ``max_num_seqs``, etc.), user keys win on conflict. Mirrors
+    arctic-platform's own ``ArcticRLClientConfig.vllm_config`` field name
+    and semantics: every key is forwarded into vLLM (those matching
+    ``ModelConfig`` fields become typed fields, the rest land in
+    ``extra_engine_kwargs``).
+
+    Use this for performance knobs the high-level
+    ``arctic_inference_config`` schema doesn't model, e.g.::
+
+        trainer.arctic_rl.vllm_config={
+            compilation_config: {
+                cudagraph_mode: PIECEWISE,
+                pass_config: {fuse_allreduce_rms: false},
+            },
+            speculative_config: {
+                method: arctic,
+                model: "<path-or-hf-id>",
+                num_speculative_tokens: 3,
+            },
+            forest_cascade_attn_configs: "{}",
+        }
     """
 
     host: str = "localhost"
@@ -345,6 +375,22 @@ def build_rl_config(cfg: SkyRLTrainConfig) -> ArcticRLClientConfig:
     }
     if arl.vllm_max_num_batched_tokens is not None:
         vllm_cfg["max_num_batched_tokens"] = int(arl.vllm_max_num_batched_tokens)
+
+    # Layer user-supplied raw vLLM kwargs on top of the integration's
+    # defaults. arctic-platform forwards this dict to vLLM verbatim (any
+    # key not on ``ModelConfig`` lands in ``extra_engine_kwargs``), so this
+    # is where performance knobs like ``compilation_config``,
+    # ``speculative_config``, and ``forest_cascade_attn_configs`` belong.
+    if arl.vllm_config is not None:
+        user_vllm = OmegaConf.to_container(
+            OmegaConf.create(arl.vllm_config), resolve=True,
+        )
+        if not isinstance(user_vllm, dict):
+            raise TypeError(
+                f"trainer.arctic_rl.vllm_config must be a dict, got "
+                f"{type(user_vllm).__name__}"
+            )
+        vllm_cfg.update(user_vllm)
 
     # -- DeepSpeed engine config (training) ---------------------------------
     # Mirrors ``_create_ds_config`` in verl's arctic_rl.py. ``sequence_parallel_size``

--- a/integrations/arctic_rl/config.py
+++ b/integrations/arctic_rl/config.py
@@ -12,14 +12,14 @@ lazily dispatches here. All shared knobs (GPU counts, vLLM settings, colocation)
 are derived from existing SkyRL config fields by ``build_rl_config``.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from arctic_platform.rl import ArcticRLClientConfig
 from omegaconf import OmegaConf
+
 from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.config.config import BaseConfig, TrainerConfig, make_config
-
 
 # ---------------------------------------------------------------------------
 # Arctic RL backend configuration
@@ -279,10 +279,7 @@ def build_rl_config(cfg: SkyRLTrainConfig) -> ArcticRLClientConfig:
         )
 
     # -- Derived from existing SkyRL configs ---------------------------------
-    training_gpus = (
-        cfg.trainer.placement.policy_num_gpus_per_node
-        * cfg.trainer.placement.policy_num_nodes
-    )
+    training_gpus = cfg.trainer.placement.policy_num_gpus_per_node * cfg.trainer.placement.policy_num_nodes
     # Arctic-Platform's `sampling_gpus` is the TOTAL sampling-side GPU count,
     # not the replica count (replicas = sampling_gpus // tp_size); SkyRL's
     # `num_engines` is the replica count, so multiply by `tp_size`.
@@ -302,7 +299,6 @@ def build_rl_config(cfg: SkyRLTrainConfig) -> ArcticRLClientConfig:
 
     n_samples = cfg.generator.n_samples_per_prompt
     mini_batch_size = cfg.trainer.policy_mini_batch_size * n_samples
-    train_batch_size_global = cfg.trainer.train_batch_size * n_samples
 
     max_prompt = int(cfg.trainer.max_prompt_length)
     max_resp = int(cfg.generator.sampling_params.max_generate_length)
@@ -337,8 +333,7 @@ def build_rl_config(cfg: SkyRLTrainConfig) -> ArcticRLClientConfig:
     # so the effective DP world is ``training_gpus // ulysses_sp``.
     ulysses_sp = max(1, int(arl.ulysses_sequence_parallel_size))
     assert training_gpus % ulysses_sp == 0, (
-        f"training_gpus ({training_gpus}) must be divisible by "
-        f"ulysses_sequence_parallel_size ({ulysses_sp})"
+        f"training_gpus ({training_gpus}) must be divisible by " f"ulysses_sequence_parallel_size ({ulysses_sp})"
     )
     dp_world = max(1, training_gpus // ulysses_sp)
     mini_per_dp = max(1, mini_batch_size // dp_world)
@@ -350,9 +345,7 @@ def build_rl_config(cfg: SkyRLTrainConfig) -> ArcticRLClientConfig:
         f"n_samples_per_prompt={n_samples}, use_zorro={arl.use_zorro}"
     )
     grad_accum_steps = max(1, mini_per_dp // train_micro_batch_size_per_gpu)
-    assert (
-        mini_batch_size == train_micro_batch_size_per_gpu * grad_accum_steps * dp_world
-    ), (
+    assert mini_batch_size == train_micro_batch_size_per_gpu * grad_accum_steps * dp_world, (
         f"DeepSpeed batch assertion would fail: train_batch_size={mini_batch_size} "
         f"!= micro={train_micro_batch_size_per_gpu} * grad_accum={grad_accum_steps} "
         f"* dp_world={dp_world} (= {train_micro_batch_size_per_gpu * grad_accum_steps * dp_world})"
@@ -383,13 +376,11 @@ def build_rl_config(cfg: SkyRLTrainConfig) -> ArcticRLClientConfig:
     # ``speculative_config``, and ``forest_cascade_attn_configs`` belong.
     if arl.vllm_config is not None:
         user_vllm = OmegaConf.to_container(
-            OmegaConf.create(arl.vllm_config), resolve=True,
+            OmegaConf.create(arl.vllm_config),
+            resolve=True,
         )
         if not isinstance(user_vllm, dict):
-            raise TypeError(
-                f"trainer.arctic_rl.vllm_config must be a dict, got "
-                f"{type(user_vllm).__name__}"
-            )
+            raise TypeError(f"trainer.arctic_rl.vllm_config must be a dict, got " f"{type(user_vllm).__name__}")
         vllm_cfg.update(user_vllm)
 
     # -- DeepSpeed engine config (training) ---------------------------------
@@ -464,9 +455,7 @@ def build_rl_config(cfg: SkyRLTrainConfig) -> ArcticRLClientConfig:
             temperature=float(getattr(cfg.generator.sampling_params, "temperature", 1.0) or 1.0),
             use_unpad=True,
             logits_optimization=arl.logits_optimization,
-            logits_optimization_peak_mem_size_in_gib=float(
-                arl.logits_optimization_peak_mem_size_in_gib
-            ),
+            logits_optimization_peak_mem_size_in_gib=float(arl.logits_optimization_peak_mem_size_in_gib),
             logits_compute_from_fp32_inputs=bool(arl.logits_compute_from_fp32_inputs),
             logits_compute_in_fp32=bool(arl.logits_compute_in_fp32),
         )
@@ -531,11 +520,14 @@ def build_rl_config(cfg: SkyRLTrainConfig) -> ArcticRLClientConfig:
         # ``OmegaConf.create(x)`` round-trip normalizes both plain ``dict``
         # and ``DictConfig`` inputs, matching the ``OmegaConf.to_container``
         # idiom used in ``arctic-verl/verl/workers/remote_client/arctic_rl.py``.
-        arctic_inference_config=OmegaConf.to_container(
-            OmegaConf.create(arl.arctic_inference_config), resolve=True,
-        )
-        if arl.use_arctic_inference and arl.arctic_inference_config is not None
-        else None,
+        arctic_inference_config=(
+            OmegaConf.to_container(
+                OmegaConf.create(arl.arctic_inference_config),
+                resolve=True,
+            )
+            if arl.use_arctic_inference and arl.arctic_inference_config is not None
+            else None
+        ),
         full_determinism=bool(arl.determinism_full),
         seed=int(arl.determinism_seed),
         startup_timeout=arl.startup_timeout,

--- a/integrations/arctic_rl/config.py
+++ b/integrations/arctic_rl/config.py
@@ -1,0 +1,497 @@
+"""Arctic RL configuration types.
+
+Defines:
+- ``ArcticRLTrainerConfig``: backend-specific knobs (colocate, zero_stage, ...)
+- ``ArcticTrainerConfig``: extends core ``TrainerConfig`` with ``arctic_rl`` field
+- ``ArcticSkyRLConfig``: top-level config used by the integration's entrypoint
+- ``build_rl_config(cfg)``: translates ``SkyRLTrainConfig`` → ``ArcticRLClientConfig``
+
+These live in the integration to keep core SkyRL integration-agnostic — core only
+knows about a generic ``trainer.override_entrypoint: Optional[str]`` field that
+lazily dispatches here. All shared knobs (GPU counts, vLLM settings, colocation)
+are derived from existing SkyRL config fields by ``build_rl_config``.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+from arctic_platform.rl import ArcticRLClientConfig
+from omegaconf import OmegaConf
+from skyrl.train.config import SkyRLTrainConfig
+from skyrl.train.config.config import BaseConfig, TrainerConfig, make_config
+
+
+# ---------------------------------------------------------------------------
+# Arctic RL backend configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ArcticRLTrainerConfig(BaseConfig):
+    """Arctic RL (DeepSpeed) backend settings.
+
+    Mirrors the surface area of verl's
+    ``arctic-verl/verl/workers/remote_client/arctic_rl.py``
+    (``ArcticRLClientWrapper``). Each field corresponds 1:1 to a knob that
+    the verl xid2pl9f BIRD-1.7B converged-reference run sets in its
+    ``launch_1.7b_newshape.sh``; defaults pick safe non-Arctic values so
+    flipping ``trainer.arctic_rl={}`` alone is sufficient for a smoke
+    test.
+    """
+
+    colocate: bool = False
+    """Share GPUs between training and inference on the ARL server.
+
+    Distinct from ``trainer.placement.colocate_all`` which controls Ray placement
+    groups.  ARL colocation is server-side GPU sharing — ``colocate_all`` must
+    stay ``false`` when using the ARL backend.
+    """
+    use_zorro: bool = False
+    """Enable ZoRRO (prompt deduplication) on the training server."""
+    zero_stage: int = 0
+    """DeepSpeed ZeRO stage (0, 2, or 3)."""
+    log_prob_gpus: int = 0
+    """Number of GPUs for log-prob computation (0 = skip separate log-prob)."""
+    offload_optimizer: bool = False
+    """Offload optimizer state to CPU when ``zero_stage >= 2``."""
+
+    # -- Model / kernel knobs (verl: actor_rollout_ref.model.*) -------------
+    use_liger: bool = False
+    """Enable Liger fused MLP/RMSNorm kernels on the training engine.
+
+    Server reads from ``ds_worker_config.use_liger``
+    (``arctic_platform/rl/deepspeed_worker.py:155``). Requires
+    ``liger_kernel`` to be installed.
+    """
+    attn_implementation: str = "flash_attention_2"
+    """HF attention implementation passed to ``Qwen3ForCausalLM.from_pretrained``.
+
+    Server reads from ``ds_worker_config.attn_implementation``
+    (``arctic_platform/rl/deepspeed_worker.py:147``). verl's converged
+    reference uses ``flash_attention_3`` (requires the ``flash_attn_3``
+    wheel) for O(N) attention memory on long sequences.
+    """
+    enable_gradient_checkpointing: bool = True
+    """Activation checkpointing on the training engine.
+
+    Server reads from ``ds_worker_config.enable_gradient_checkpointing``
+    (``arctic_platform/rl/deepspeed_worker.py:202``); defaults to True so
+    long sequences fit in colocated mode.
+    """
+    ulysses_sequence_parallel_size: int = 1
+    """Ulysses sequence-parallel degree (DeepSpeed ``sequence_parallel_size``).
+
+    Splits a single sequence's compute across this many GPUs, cutting
+    per-GPU activation memory at the same factor. verl's converged
+    reference uses 2.
+    """
+
+    # -- Logits / loss memory knobs (verl: arctic_rl.train.logits.*) --------
+    logits_optimization: Optional[str] = None
+    """``"memory"`` enables chunked logits compute on the server (ZoRRO
+    only). None = full materialization. verl converged reference: "memory".
+    Maps to ``ppo_trainer.yaml: arctic_rl.train.logits.optimization``.
+    """
+    logits_optimization_peak_mem_size_in_gib: float = 4.0
+    """Per-chunk peak memory budget for the chunked-logits path. Matches
+    verl ``ppo_trainer.yaml: arctic_rl.train.logits.optimization_peak_mem_size_in_gib``
+    default (4). Smaller -> more, smaller chunks -> lower peak memory but
+    more compute overhead.
+    """
+    logits_compute_from_fp32_inputs: bool = False
+    """Cast hidden states to fp32 before the LM head (ZoRRO logits path).
+    Maps to ``arctic_rl.train.logits.compute_from_fp32_inputs``.
+    """
+    logits_compute_in_fp32: bool = False
+    """Run the LM-head matmul itself in fp32 (ZoRRO logits path).
+    Maps to ``arctic_rl.train.logits.compute_in_fp32``.
+    """
+
+    # -- Determinism (verl: arctic_rl.train.determinism.*) -----------------
+    determinism_full: bool = False
+    """Enable ``transformers.enable_full_determinism`` on the server.
+    Maps to ``arctic_rl.train.determinism.full``.
+    """
+    determinism_seed: int = 42
+    """Seed used when ``determinism_full=True``. Maps to
+    ``arctic_rl.train.determinism.seed``.
+    """
+
+    # -- Weight sync (verl: arctic_rl.cuda_ipc_weight_sync) ----------------
+    cuda_ipc_weight_sync: bool = False
+    """Use CUDA-IPC zero-copy weight sync (colocate-only). Avoids the
+    extra GPU buffer that the NCCL/CPU paths need; verl converged
+    reference enables it.
+    """
+    low_memory_weight_sync: bool = False
+    """Stream one param at a time during CUDA-IPC sync (more round-trips,
+    bounded peak extra GPU memory). Matches verl
+    ``arctic_rl.low_memory_weight_sync`` default (False).
+    """
+
+    # -- DeepSpeed config knobs not exposed elsewhere (verl: arctic_rl.train.deepspeed.*)
+    offload_param: bool = False
+    """Offload ZeRO-3 parameter shards to CPU when ``zero_stage >= 2``.
+    verl ``arctic_rl.train.deepspeed.zero_optimization.offload_param.device``
+    default is ``"none"`` (off); xid2pl9f also leaves it off.
+    """
+    torch_autocast_enabled: bool = False
+    """Enable DeepSpeed ``torch_autocast`` on the training engine. verl
+    default and xid2pl9f: False (relies on the bf16 path).
+    """
+    torch_autocast_dtype: Optional[str] = None
+    """``"bfloat16"`` etc; only consumed when ``torch_autocast_enabled=True``."""
+
+    # -- Comms (verl: arctic_rl.comms.*) -----------------------------------
+    drop_position_ids: bool = True
+    """Drop position_ids from the wire payload and rebuild them server-side
+    from attention_mask. verl default: True; only set False for models that
+    need non-arange position_ids (mrope / 3D rope).
+    """
+
+    # -- LR scheduler (verl: actor.optim.*) ---------------------------------
+    lr_warmup_ratio: float = 0.0
+    """Linear warmup fraction of the total training horizon. verl uses 0.05."""
+    lr_scheduler_type: str = "constant"
+    """Server-side LR scheduler. "constant" matches verl's default."""
+    optimizer_betas: Tuple[float, float] = (0.9, 0.999)
+    """AdamW betas. verl converged reference uses (0.9, 0.95)."""
+
+    # -- vLLM knobs not exposed in SkyRL's generator config -----------------
+    vllm_max_num_seqs: int = 256
+    """vLLM ``max_num_seqs``. verl converged reference: 256."""
+    vllm_enforce_eager: bool = True
+    """Disable vLLM CUDA graph capture. verl converged reference: False
+    (graphs on; uses more memory but is faster). Default True is safer in
+    colocated mode.
+    """
+    vllm_enable_chunked_prefill: bool = True
+    """Chunked prefill (lower KV memory peak)."""
+    vllm_enable_prefix_caching: bool = True
+    """vLLM ``enable_prefix_caching``. Verl converged reference: True.
+    Big win for long-context bird prompts since the schema prefix is
+    shared across all 16 rollouts of every prompt.
+    """
+    vllm_max_model_len: Optional[int] = None
+    """vLLM ``max_model_len``; if None, derived from
+    ``max_prompt_length + max_generate_length``.
+    """
+    vllm_max_num_batched_tokens: Optional[int] = None
+    """vLLM ``max_num_batched_tokens`` (prefill batch capacity).
+    Verl converged reference: 40960 (= ``ROLLOUT_MAX_BATCHED``).
+    Higher = more parallel prefill at the cost of GPU memory.
+    None = leave vLLM's default (typically 8192, which throttles
+    long-prompt prefill on bird).
+    """
+
+    # -- ArcticInference (FCA / fast-continuous-attention; verl: rollout.name=arctic)
+    use_arctic_inference: bool = False
+    """Enable Arctic Inference (FCA + custom kernels) for the vLLM
+    sampling engine. Passes ``arctic_inference_config={}`` to
+    ``ArcticRLClientConfig`` which sets ``ARCTIC_INFERENCE_ENABLED=1``
+    on the sampling Ray workers. Matches verl's ``rollout.name=arctic``
+    converged path; typical 2-3x rollout speedup on long-context prompts.
+    Requires ``arctic_inference`` to be installed.
+    """
+    arctic_inference_config: Optional[dict] = None
+    """Optional per-key overrides for ArcticInference (e.g. speculative
+    decoding model). When None and ``use_arctic_inference=True``, sends
+    an empty dict (= enable with defaults).
+    """
+
+    host: str = "localhost"
+    """Server host for HTTP comm protocol; ignored for Ray."""
+    port: int = 7000
+    """Server port for HTTP comm protocol; ignored for Ray."""
+    startup_timeout: float = 300.0
+    """Seconds to wait for server jobs to come up."""
+    server_logs: bool = False
+    """Forward server logs to stdout for debugging."""
+
+
+@dataclass
+class ArcticTrainerConfig(TrainerConfig):
+    """``TrainerConfig`` extended with the Arctic RL field. Used when
+    ``trainer.override_entrypoint=integrations.arctic_rl.entrypoint`` is set."""
+
+    arctic_rl: Optional[ArcticRLTrainerConfig] = None
+    """Arctic RL backend settings. ``None`` falls back to defaults."""
+
+
+# Top-level config for arctic_rl recipes; parsed by the integration's entrypoint
+# after core dispatch (``trainer.override_entrypoint=integrations.arctic_rl.entrypoint``).
+ArcticSkyRLConfig = make_config(trainer_cls=ArcticTrainerConfig)
+
+
+# ---------------------------------------------------------------------------
+# Translation: SkyRLTrainConfig → ArcticRLClientConfig
+# ---------------------------------------------------------------------------
+
+
+def build_rl_config(cfg: SkyRLTrainConfig) -> ArcticRLClientConfig:
+    """Build ``ArcticRLClientConfig`` from ``SkyRLTrainConfig``.
+
+    Mirrors ``arctic-verl/verl/workers/remote_client/arctic_rl.py``
+    (``ArcticRLClientWrapper._initialize_client``,
+    ``_create_ds_config``, ``_create_ds_worker_config``) so the SkyRL
+    bridge sends the Arctic server the same payload shape as the
+    verl xid2pl9f BIRD-1.7B converged-reference run.
+
+    Raises ``ValueError`` if ``cfg.trainer.arctic_rl`` is not set.
+    """
+    arl = cfg.trainer.arctic_rl
+    if arl is None:
+        raise ValueError(
+            "trainer.arctic_rl must be set when using the Arctic RL entrypoint. "
+            "Add 'trainer.arctic_rl={}' to your config overrides to enable it "
+            "with defaults, or set individual fields like "
+            "'trainer.arctic_rl.zero_stage=2'."
+        )
+
+    # -- Derived from existing SkyRL configs ---------------------------------
+    training_gpus = (
+        cfg.trainer.placement.policy_num_gpus_per_node
+        * cfg.trainer.placement.policy_num_nodes
+    )
+    # Arctic-Platform's `sampling_gpus` is the TOTAL sampling-side GPU count,
+    # not the replica count (replicas = sampling_gpus // tp_size); SkyRL's
+    # `num_engines` is the replica count, so multiply by `tp_size`.
+    tp_size = cfg.generator.inference_engine.tensor_parallel_size
+    sampling_gpus = cfg.generator.inference_engine.num_engines * tp_size
+    colocate = arl.colocate
+    vllm_gpu_mem = cfg.generator.inference_engine.gpu_memory_utilization
+
+    # -- From ARL-specific config --------------------------------------------
+    opt = cfg.trainer.policy.optimizer_config
+    lr = opt.lr
+    weight_decay = float(getattr(opt, "weight_decay", 0.0) or 0.0)
+    eps = float(getattr(opt, "eps", 1e-8))
+    grad_clip = float(opt.max_grad_norm) if opt.max_grad_norm else 0.0
+    betas_from_cfg = getattr(opt, "betas", None)
+    betas = tuple(betas_from_cfg) if betas_from_cfg else tuple(arl.optimizer_betas)
+
+    n_samples = cfg.generator.n_samples_per_prompt
+    mini_batch_size = cfg.trainer.policy_mini_batch_size * n_samples
+    train_batch_size_global = cfg.trainer.train_batch_size * n_samples
+
+    max_prompt = int(cfg.trainer.max_prompt_length)
+    max_resp = int(cfg.generator.sampling_params.max_generate_length)
+    max_length = max_prompt + max_resp
+
+    # DeepSpeed micro-batch sizing — mirrors verl's
+    # `actor.ppo_micro_batch_size_per_gpu` convention
+    # (`verl/workers/remote_client/arctic_rl.py:_create_ds_config`). Each
+    # fwd / fwd+bwd RPC ships one per-GPU mini-batch shard; the server then
+    # splits it into `gradient_accumulation_steps` micro-batches inside
+    # DeepSpeed.
+    #
+    # Default depends on ZoRRO:
+    #   * ZoRRO off: 1 sample / micro-batch (verl's long-seq GRPO default;
+    #     safe under ZeRO-3 + vLLM colocation).
+    #   * ZoRRO on:  n_samples_per_prompt — each micro-batch must contain
+    #     a full prompt-group (1 prompt + n_samples responses) so the
+    #     dedup + bin-pack in `arctic_platform/rl/zorro_train/seqlen_balancing.py
+    #     ::create_prompt_groups` can run. With micro-batch < n_samples,
+    #     only one rollout's worth of prompt is present; the server-side
+    #     `unpadded_tensor_1d_response_to_padded_tensor_2d_full` then
+    #     emits a tensor of the wrong shape and the run dies with a
+    #     `RuntimeError: shape mismatch: value tensor of shape [T_resp]
+    #     cannot be broadcast to indexing result of shape [B*R]`.
+    train_micro_batch_size_per_gpu = n_samples if arl.use_zorro else 1
+    # DeepSpeed `_batch_assertion` requires:
+    #   train_batch_size == micro_batch * grad_accum * world_size
+    # When ``sequence_parallel_size > 1`` DeepSpeed sets
+    #   world_size = dist.get_world_size() / sequence_parallel_size
+    # (see ``deepspeed/runtime/config.py``: "if 'sequence_parallel_size' in
+    # config: self.world_size = dist.get_world_size() / config[...]"),
+    # so the effective DP world is ``training_gpus // ulysses_sp``.
+    ulysses_sp = max(1, int(arl.ulysses_sequence_parallel_size))
+    assert training_gpus % ulysses_sp == 0, (
+        f"training_gpus ({training_gpus}) must be divisible by "
+        f"ulysses_sequence_parallel_size ({ulysses_sp})"
+    )
+    dp_world = max(1, training_gpus // ulysses_sp)
+    mini_per_dp = max(1, mini_batch_size // dp_world)
+    assert mini_per_dp % train_micro_batch_size_per_gpu == 0, (
+        f"per-DP-rank mini-batch ({mini_per_dp}) must be divisible by "
+        f"train_micro_batch_size_per_gpu ({train_micro_batch_size_per_gpu}); "
+        f"got mini_batch_size={mini_batch_size}, training_gpus={training_gpus}, "
+        f"ulysses_sp={ulysses_sp}, dp_world={dp_world}, "
+        f"n_samples_per_prompt={n_samples}, use_zorro={arl.use_zorro}"
+    )
+    grad_accum_steps = max(1, mini_per_dp // train_micro_batch_size_per_gpu)
+    assert (
+        mini_batch_size == train_micro_batch_size_per_gpu * grad_accum_steps * dp_world
+    ), (
+        f"DeepSpeed batch assertion would fail: train_batch_size={mini_batch_size} "
+        f"!= micro={train_micro_batch_size_per_gpu} * grad_accum={grad_accum_steps} "
+        f"* dp_world={dp_world} (= {train_micro_batch_size_per_gpu * grad_accum_steps * dp_world})"
+    )
+
+    # -- vLLM config ---------------------------------------------------------
+    # Always populate (not just colocated) so server gets the same shape
+    # verl sends to Arctic. Mirrors ``arctic_rl.py:vllm_config`` block.
+    # ``max_num_batched_tokens`` and ``enable_prefix_caching`` are not
+    # native ModelConfig fields -- they're passed through to vLLM via
+    # ``extra_engine_kwargs`` (see arctic_platform/rl/ray_server.py:121).
+    vllm_cfg: dict = {
+        "tensor_parallel_size": tp_size,
+        "gpu_memory_utilization": vllm_gpu_mem,
+        "max_model_len": int(arl.vllm_max_model_len) if arl.vllm_max_model_len else max_length,
+        "max_num_seqs": int(arl.vllm_max_num_seqs),
+        "enforce_eager": bool(arl.vllm_enforce_eager),
+        "enable_chunked_prefill": bool(arl.vllm_enable_chunked_prefill),
+        "enable_prefix_caching": bool(arl.vllm_enable_prefix_caching),
+    }
+    if arl.vllm_max_num_batched_tokens is not None:
+        vllm_cfg["max_num_batched_tokens"] = int(arl.vllm_max_num_batched_tokens)
+
+    # -- DeepSpeed engine config (training) ---------------------------------
+    # Mirrors ``_create_ds_config`` in verl's arctic_rl.py. ``sequence_parallel_size``
+    # = ulysses degree (per-sequence compute split across this many GPUs);
+    # 1 = disabled.
+    # ``train_batch_size`` here is the per-optimizer-step global batch
+    # (DeepSpeed's view: micro * grad_accum * dp_world). With
+    # ``update_epochs_per_batch=1`` and ``policy_mini_batch == train_batch``
+    # in the launcher this equals the global training batch.
+    ds_config: dict = {
+        "train_micro_batch_size_per_gpu": train_micro_batch_size_per_gpu,
+        "train_batch_size": mini_batch_size,
+        "gradient_accumulation_steps": grad_accum_steps,
+        "sequence_parallel_size": ulysses_sp,
+        "bf16": {"enabled": True},
+        "gradient_clipping": grad_clip,
+        "optimizer": {
+            "type": "AdamW",
+            "params": {
+                "lr": lr,
+                "betas": list(betas),
+                "eps": eps,
+                "weight_decay": weight_decay,
+            },
+        },
+    }
+
+    zero_cfg: dict = {"stage": int(arl.zero_stage)}
+    if arl.zero_stage >= 2 and arl.offload_optimizer:
+        zero_cfg["offload_optimizer"] = {"device": "cpu", "pin_memory": True}
+    else:
+        # Explicit "none" mirrors verl xid2pl9f's
+        # arctic_rl.train.deepspeed.zero_optimization.offload_optimizer.device.
+        zero_cfg["offload_optimizer"] = {"device": "none"}
+    if arl.zero_stage >= 3 and arl.offload_param:
+        zero_cfg["offload_param"] = {"device": "cpu", "pin_memory": True}
+    else:
+        zero_cfg["offload_param"] = {"device": "none"}
+    ds_config["zero_optimization"] = zero_cfg
+
+    # torch_autocast: verl xid2pl9f leaves disabled, but expose the knob.
+    if arl.torch_autocast_enabled:
+        autocast_cfg: dict = {"enabled": True}
+        if arl.torch_autocast_dtype:
+            autocast_cfg["dtype"] = str(arl.torch_autocast_dtype)
+        ds_config["torch_autocast"] = autocast_cfg
+    # Determinism handled at the ArcticRLClientConfig top level below
+    # (NOT in ds_config — Arctic's server reads full_determinism/seed
+    # from job_config, not the DeepSpeed config).
+
+    # -- DeepSpeed worker config (per-process; model + kernel + ZoRRO) ------
+    # Mirrors ``_create_ds_worker_config`` in verl's arctic_rl.py. These
+    # are read by ``arctic_platform/rl/deepspeed_worker.py`` at engine
+    # build time -- NOT per-call. Without ``attn_implementation`` and
+    # ``use_liger`` here the Qwen3 forward defaults to eager attention
+    # (O(N^2) memory) and unfused MLP, which OOMs in colocated mode.
+    ds_worker_config: dict = {
+        "use_liger": bool(arl.use_liger),
+        "enable_gradient_checkpointing": bool(arl.enable_gradient_checkpointing),
+        "attn_implementation": str(arl.attn_implementation),
+    }
+    if arl.use_zorro:
+        # ZoRRO budget: ``max_token_len`` must be >= max_prompt +
+        # n_samples * max_response (see _ArcticDispatch._max_token_len_per_gpu
+        # for the full reasoning).
+        ds_worker_config.update(
+            zorro_train_enable=True,
+            response_len=max_resp,
+            max_token_len=int(max_prompt + n_samples * max_resp),
+            rollout_n=int(n_samples),
+            temperature=float(getattr(cfg.generator.sampling_params, "temperature", 1.0) or 1.0),
+            use_unpad=True,
+            logits_optimization=arl.logits_optimization,
+            logits_optimization_peak_mem_size_in_gib=float(
+                arl.logits_optimization_peak_mem_size_in_gib
+            ),
+            logits_compute_from_fp32_inputs=bool(arl.logits_compute_from_fp32_inputs),
+            logits_compute_in_fp32=bool(arl.logits_compute_in_fp32),
+        )
+
+    # -- Top-level training_config (LR schedule, model meta, etc.) ----------
+    # Mirrors ``training_config`` arg in verl's _initialize_client.
+    # ``training_horizon`` is the number of optimizer steps over which the
+    # LR scheduler interpolates (warmup + decay); for SkyRL we approximate
+    # it as ``epochs * (rows / train_batch_size)`` -- the same
+    # ``trainer.epochs * data_size / train_batch_size`` quantity SkyRL uses
+    # internally for its scheduler. Falls back to a generous default so the
+    # constant-LR path (verl's reference) is robust.
+    training_horizon = int(getattr(cfg.trainer, "total_training_steps", 0) or 0)
+    if training_horizon <= 0:
+        # ``constant`` scheduler ignores horizon; non-constant schedulers
+        # will get a default 1k horizon (caller can override via
+        # cfg.trainer.total_training_steps).
+        training_horizon = 1000
+
+    optimizer_config: dict = {
+        "lr": lr,
+        "weight_decay": weight_decay,
+        "betas": list(betas),
+    }
+    if grad_clip > 0:
+        optimizer_config["gradient_clipping"] = grad_clip
+
+    lr_scheduler_config: dict = {
+        "type": str(arl.lr_scheduler_type),
+        "warmup_ratio": float(arl.lr_warmup_ratio),
+    }
+
+    training_config: dict = {
+        "training_horizon": training_horizon,
+        "optimizer": optimizer_config,
+        "lr_scheduler": lr_scheduler_config,
+        "max_length": max_length,
+        "model_config": None,
+        "attn_implementation": str(arl.attn_implementation),
+    }
+
+    return ArcticRLClientConfig(
+        model_name=cfg.trainer.policy.model.path,
+        backend="local",
+        # arctic_platform.rl defaults comm_protocol to "http"; preserve the
+        # public-branch behavior (in-process Ray actor) by setting it explicitly.
+        # Host/port are auto-derived from comm_protocol (None for ray).
+        comm_protocol="ray",
+        checkpoint_path=cfg.trainer.ckpt_path,
+        training_gpus=training_gpus,
+        sampling_gpus=sampling_gpus,
+        log_prob_gpus=arl.log_prob_gpus,
+        log_prob_engine="deepspeed" if arl.log_prob_gpus > 0 else "vllm",
+        colocate=colocate,
+        vllm_config=vllm_cfg,
+        ds_config=ds_config,
+        ds_worker_config=ds_worker_config,
+        training_config=training_config,
+        # Deep-convert OmegaConf containers to plain Python so that vLLM's
+        # ``AsyncEngineArgs.__post_init__`` recognizes nested overrides
+        # (``compilation_config``, ``speculative_config``, ...). The
+        # ``OmegaConf.create(x)`` round-trip normalizes both plain ``dict``
+        # and ``DictConfig`` inputs, matching the ``OmegaConf.to_container``
+        # idiom used in ``arctic-verl/verl/workers/remote_client/arctic_rl.py``.
+        arctic_inference_config=OmegaConf.to_container(
+            OmegaConf.create(arl.arctic_inference_config), resolve=True,
+        )
+        if arl.use_arctic_inference and arl.arctic_inference_config is not None
+        else None,
+        full_determinism=bool(arl.determinism_full),
+        seed=int(arl.determinism_seed),
+        startup_timeout=arl.startup_timeout,
+        server_logs=arl.server_logs,
+    )

--- a/integrations/arctic_rl/config.py
+++ b/integrations/arctic_rl/config.py
@@ -46,8 +46,14 @@ class ArcticRLTrainerConfig(BaseConfig):
     groups.  ARL colocation is server-side GPU sharing — ``colocate_all`` must
     stay ``false`` when using the ARL backend.
     """
-    use_zorro: bool = False
-    """Enable ZoRRO (prompt deduplication) on the training server."""
+    use_zorro: bool = True
+    """Enable ZoRRO (prompt deduplication) on the training server.
+
+    Defaults to ``True`` — ZoRRo is the trainer-side speedup that motivates
+    using the Arctic RL integration in the first place. Disable explicitly
+    (``trainer.arctic_rl.use_zorro=false``) if you need vanilla GRPO for a
+    baseline comparison.
+    """
     zero_stage: int = 0
     """DeepSpeed ZeRO stage (0, 2, or 3)."""
     log_prob_gpus: int = 0
@@ -56,12 +62,13 @@ class ArcticRLTrainerConfig(BaseConfig):
     """Offload optimizer state to CPU when ``zero_stage >= 2``."""
 
     # -- Model / kernel knobs (verl: actor_rollout_ref.model.*) -------------
-    use_liger: bool = False
+    use_liger: bool = True
     """Enable Liger fused MLP/RMSNorm kernels on the training engine.
 
-    Server reads from ``ds_worker_config.use_liger``
-    (``arctic_platform/rl/deepspeed_worker.py:155``). Requires
-    ``liger_kernel`` to be installed.
+    Defaults to ``True`` — Liger is a pure fused-kernel speedup with no
+    behavioral effect. ``liger-kernel`` ships with the ``arctic-rl`` extra
+    so it is always available. Server reads from ``ds_worker_config.use_liger``
+    (``arctic_platform/rl/deepspeed_worker.py:155``).
     """
     attn_implementation: str = "flash_attention_2"
     """HF attention implementation passed to ``Qwen3ForCausalLM.from_pretrained``.
@@ -87,10 +94,12 @@ class ArcticRLTrainerConfig(BaseConfig):
     """
 
     # -- Logits / loss memory knobs (verl: arctic_rl.train.logits.*) --------
-    logits_optimization: Optional[str] = None
+    logits_optimization: Optional[str] = "memory"
     """``"memory"`` enables chunked logits compute on the server (ZoRRO
-    only). None = full materialization. verl converged reference: "memory".
-    Maps to ``ppo_trainer.yaml: arctic_rl.train.logits.optimization``.
+    only); ``None`` = full materialization. Defaults to ``"memory"`` to
+    match the ``use_zorro=True`` default — without it, ZoRRo materializes
+    the full B*R logits tensor and OOMs on long-context recipes. Maps to
+    ``ppo_trainer.yaml: arctic_rl.train.logits.optimization``.
     """
     logits_optimization_peak_mem_size_in_gib: float = 4.0
     """Per-chunk peak memory budget for the chunked-logits path. Matches
@@ -185,13 +194,20 @@ class ArcticRLTrainerConfig(BaseConfig):
     """
 
     # -- ArcticInference (FCA / fast-continuous-attention; verl: rollout.name=arctic)
-    use_arctic_inference: bool = False
+    use_arctic_inference: bool = True
     """Enable Arctic Inference (FCA + custom kernels) for the vLLM
-    sampling engine. Passes ``arctic_inference_config={}`` to
-    ``ArcticRLClientConfig`` which sets ``ARCTIC_INFERENCE_ENABLED=1``
-    on the sampling Ray workers. Matches verl's ``rollout.name=arctic``
-    converged path; typical 2-3x rollout speedup on long-context prompts.
-    Requires ``arctic_inference`` to be installed.
+    sampling engine.
+
+    Defaults to ``True`` — if you're using the ``integrations.arctic_rl``
+    entrypoint at all, Arctic Inference is the rollout-side speedup you
+    came here for. Setting this auto-injects
+    ``forest_cascade_attn_configs="{}"`` (and the multi-replica
+    ``fuse_allreduce_rms`` workaround when ``num_engines > 1``) into the
+    rollout vLLM engine; ``ARCTIC_INFERENCE_ENABLED=1`` is set on every
+    sampling Ray worker. Matches verl's ``rollout.name=arctic`` converged
+    path; typical 2-3x rollout speedup on long-context prompts. Requires
+    ``arctic_inference`` to be installed (ships with the ``arctic-rl``
+    extra).
     """
     speculative_model: Optional[str] = None
     """HF id or local path of an Arctic draft-head checkpoint. When set

--- a/integrations/arctic_rl/entrypoint.py
+++ b/integrations/arctic_rl/entrypoint.py
@@ -12,9 +12,9 @@ import sys
 from typing import Any, Optional
 
 import ray
+from arctic_platform.rl import ArcticRLClientConfig, create_arctic_rl_client
 from loguru import logger
 
-from arctic_platform.rl import ArcticRLClientConfig, create_arctic_rl_client
 from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.entrypoints.main_base import BasePPOExp
 from skyrl.train.utils import validate_cfg
@@ -64,8 +64,9 @@ class ArcticRLExp(BasePPOExp):
             sampling_params=cfg.generator.sampling_params,
         )
 
-    def get_trainer(self, cfg, tracker, tokenizer, train_dataset, eval_dataset,
-                    inference_engine_client, generator, colocate_pg):
+    def get_trainer(
+        self, cfg, tracker, tokenizer, train_dataset, eval_dataset, inference_engine_client, generator, colocate_pg
+    ):
         return ArcticPPOTrainer(
             cfg=cfg,
             tracker=tracker,
@@ -88,6 +89,7 @@ class ArcticRLExp(BasePPOExp):
         cfg_colocate = bool(getattr(arl_cfg, "colocate", False)) if arl_cfg else False
 
         from .trainer import _ArcticInferenceEngineStub
+
         ie_stub = _ArcticInferenceEngineStub(client=self.arctic_client, colocate=cfg_colocate)
 
         tracker = self.get_tracker()
@@ -127,10 +129,11 @@ def main() -> None:
     empty ``ArcticRLTrainerConfig()`` (=Arctic with default settings) so the
     user only needs the one ``override_entrypoint`` flag to opt into Arctic.
     """
-    from .config import ArcticRLTrainerConfig, ArcticSkyRLConfig
     # Register Arctic-RL-shipped envs (bird / bird_sql) with skyrl-gym before
     # any code path tries to ``make()`` them. Side-effect import.
     from . import envs  # noqa: F401
+    from .config import ArcticRLTrainerConfig, ArcticSkyRLConfig
+
     # Strip the dispatch flag itself: it was consumed by main_base.py's peek-
     # ahead and is not a real ArcticTrainerConfig field, so a strict parse
     # would reject it.
@@ -148,15 +151,14 @@ def main() -> None:
     # client also owns an in-process server actor state that the reconnecting
     # worker needs (http: None). Policy flags read from `cfg` (see
     # _ArcticDispatch.__init__).
-    server_state = (
-        pre_client.get_server_state() if rl_config.comm_protocol == "ray" else None
-    )
+    server_state = pre_client.get_server_state() if rl_config.comm_protocol == "ray" else None
     logger.info(
         f"ArcticRL jobs ready — training={pre_client.training_job_id}, "
         f"sample={pre_client.sampling_job_id}, log_prob={pre_client.log_prob_job_id}"
     )
 
     from skyrl.train.utils.utils import prepare_runtime_environment
+
     env_vars = prepare_runtime_environment(cfg)
     # Forward ARCTIC_* env vars to Ray workers — moved here from core utils per
     # reviewer feedback (core stays integration-agnostic).
@@ -167,9 +169,7 @@ def main() -> None:
     env_vars.update({k: v for k, v in os.environ.items() if k.startswith("WANDB_")})
     # Forward the SkyRL repo root on Ray workers' PYTHONPATH so they can import
     # ``integrations.arctic_rl.*`` when deserializing the skyrl_entrypoint task.
-    _repo_root = os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    )
+    _repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     _existing_pp = env_vars.get("PYTHONPATH") or os.environ.get("PYTHONPATH", "")
     env_vars["PYTHONPATH"] = _repo_root + (os.pathsep + _existing_pp if _existing_pp else "")
     runtime_env = {"env_vars": env_vars}
@@ -179,7 +179,9 @@ def main() -> None:
     ray.init(num_gpus=0, runtime_env=runtime_env, ignore_reinit_error=True)
     ray.get(
         skyrl_entrypoint.options(runtime_env=runtime_env).remote(
-            cfg, reconnect_config=reconnect_cfg, server_state=server_state,
+            cfg,
+            reconnect_config=reconnect_cfg,
+            server_state=server_state,
         )
     )
 

--- a/integrations/arctic_rl/entrypoint.py
+++ b/integrations/arctic_rl/entrypoint.py
@@ -1,0 +1,181 @@
+"""Arctic RL entrypoint. Launches an ``ArcticRLClient`` (GPU work runs on the
+Arctic server) and wires it into SkyRL's trainer/generator.
+
+Invoked via ``trainer.override_entrypoint=integrations.arctic_rl.entrypoint``
+on the ``skyrl.train.entrypoints.main_base`` command line. ARL-specific knobs
+live under ``trainer.arctic_rl`` (see ``ArcticRLTrainerConfig`` in
+``.config``).
+"""
+
+import os
+import sys
+from typing import Any, Optional
+
+import ray
+from loguru import logger
+
+from arctic_platform.rl import ArcticRLClientConfig, create_arctic_rl_client
+from skyrl.train.config import SkyRLTrainConfig
+from skyrl.train.entrypoints.main_base import BasePPOExp
+from skyrl.train.utils import validate_cfg
+
+from . import ArcticGenerator, ArcticPPOTrainer
+from .config import build_rl_config
+
+
+class ArcticRLExp(BasePPOExp):
+
+    def __init__(
+        self,
+        cfg: SkyRLTrainConfig,
+        reconnect_config: Optional[ArcticRLClientConfig] = None,
+        server_state: Optional[Any] = None,
+    ):
+        n_samples = cfg.generator.n_samples_per_prompt
+        mini_batch_size = cfg.trainer.policy_mini_batch_size * n_samples
+        train_batch_size = cfg.trainer.train_batch_size * n_samples
+        grad_accum_steps = max(1, train_batch_size // mini_batch_size)
+        lr = cfg.trainer.policy.optimizer_config.lr
+
+        # arctic_platform.rl.create_arctic_rl_client takes an optional
+        # server_state used by the ray-protocol client to reattach to an
+        # already-initialized server actor (driver pre-init pattern, see main()).
+        if reconnect_config is not None:
+            self.arctic_client = create_arctic_rl_client(reconnect_config, server_state)
+        else:
+            self.arctic_client = create_arctic_rl_client(build_rl_config(cfg), server_state)
+
+        logger.info(
+            f"DeepSpeed config: lr={lr}, grad_accum_steps={grad_accum_steps}, "
+            f"mini_batch={mini_batch_size}, train_batch={train_batch_size}"
+        )
+        logger.info(
+            f"ArcticRLClient ready — "
+            f"training_job={self.arctic_client.training_job_id}, "
+            f"sample_job={self.arctic_client.sampling_job_id}, "
+            f"log_prob_job={self.arctic_client.log_prob_job_id}"
+        )
+        super().__init__(cfg)
+
+    def get_generator(self, cfg, tokenizer, inference_engine_client):
+        return ArcticGenerator(
+            arctic_client=self.arctic_client,
+            tokenizer=tokenizer,
+            sampling_params=cfg.generator.sampling_params,
+        )
+
+    def get_trainer(self, cfg, tracker, tokenizer, train_dataset, eval_dataset,
+                    inference_engine_client, generator, colocate_pg):
+        return ArcticPPOTrainer(
+            cfg=cfg,
+            tracker=tracker,
+            tokenizer=tokenizer,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            inference_engine_client=inference_engine_client,
+            generator=generator,
+            colocate_pg=colocate_pg,
+            arctic_client=self.arctic_client,
+        )
+
+    def _setup_trainer(self):
+        logger.info("Setting up ArcticRL trainer (GPU work delegated to on-prem server)")
+        os.makedirs(self.cfg.trainer.export_path, exist_ok=True)
+        os.makedirs(self.cfg.trainer.ckpt_path, exist_ok=True)
+
+        # `colocate` from cfg, not client.config (see _ArcticDispatch.__init__).
+        arl_cfg = getattr(self.cfg.trainer, "arctic_rl", None)
+        cfg_colocate = bool(getattr(arl_cfg, "colocate", False)) if arl_cfg else False
+
+        from .trainer import _ArcticInferenceEngineStub
+        ie_stub = _ArcticInferenceEngineStub(client=self.arctic_client, colocate=cfg_colocate)
+
+        tracker = self.get_tracker()
+        generator = self.get_generator(self.cfg, self.tokenizer, None)
+        trainer = self.get_trainer(
+            cfg=self.cfg,
+            tracker=tracker,
+            tokenizer=self.tokenizer,
+            train_dataset=self.train_dataset,
+            eval_dataset=self.eval_dataset,
+            inference_engine_client=ie_stub,
+            generator=generator,
+            colocate_pg=self.colocate_pg,
+        )
+        trainer.build_models()
+        if cfg_colocate:
+            trainer.colocate_all = True
+        return trainer
+
+
+@ray.remote(num_cpus=1)
+def skyrl_entrypoint(
+    cfg: SkyRLTrainConfig,
+    reconnect_config: Optional[ArcticRLClientConfig] = None,
+    server_state: Optional[Any] = None,
+):
+    exp = ArcticRLExp(cfg, reconnect_config=reconnect_config, server_state=server_state)
+    exp.run()
+
+
+def main() -> None:
+    """Arctic RL entrypoint. Dispatched here by ``main_base`` when
+    ``trainer.override_entrypoint=integrations.arctic_rl.entrypoint`` is set on
+    the CLI. Parses with ``ArcticSkyRLConfig`` (core config + ``trainer.arctic_rl``).
+
+    If the user didn't pass ``trainer.arctic_rl=`` overrides, defaults to an
+    empty ``ArcticRLTrainerConfig()`` (=Arctic with default settings) so the
+    user only needs the one ``override_entrypoint`` flag to opt into Arctic.
+    """
+    from .config import ArcticRLTrainerConfig, ArcticSkyRLConfig
+    cfg = ArcticSkyRLConfig.from_cli_overrides(sys.argv[1:])
+    if cfg.trainer.arctic_rl is None:
+        cfg.trainer.arctic_rl = ArcticRLTrainerConfig()
+    validate_cfg(cfg)
+
+    rl_config = build_rl_config(cfg)
+    logger.info("Pre-initializing ArcticRL jobs (before ray.init)…")
+    pre_client = create_arctic_rl_client(rl_config)
+    reconnect_cfg = pre_client.reconnect_config()
+    # reconnect_cfg is a minimal schema (no policy flags); for ray comm the
+    # client also owns an in-process server actor state that the reconnecting
+    # worker needs (http: None). Policy flags read from `cfg` (see
+    # _ArcticDispatch.__init__).
+    server_state = (
+        pre_client.get_server_state() if rl_config.comm_protocol == "ray" else None
+    )
+    logger.info(
+        f"ArcticRL jobs ready — training={pre_client.training_job_id}, "
+        f"sample={pre_client.sampling_job_id}, log_prob={pre_client.log_prob_job_id}"
+    )
+
+    from skyrl.train.utils.utils import prepare_runtime_environment
+    env_vars = prepare_runtime_environment(cfg)
+    # Forward ARCTIC_* env vars to Ray workers — moved here from core utils per
+    # reviewer feedback (core stays integration-agnostic).
+    env_vars.update({k: v for k, v in os.environ.items() if k.startswith("ARCTIC_")})
+    # Forward all WANDB_* env vars to Ray workers so wandb can authenticate
+    # (skyrl's default propagation only forwards WANDB_API_KEY, which is
+    # insufficient when WANDB_BASE_URL points to a non-default endpoint).
+    env_vars.update({k: v for k, v in os.environ.items() if k.startswith("WANDB_")})
+    # Forward the SkyRL repo root on Ray workers' PYTHONPATH so they can import
+    # ``integrations.arctic_rl.*`` when deserializing the skyrl_entrypoint task.
+    _repo_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    _existing_pp = env_vars.get("PYTHONPATH") or os.environ.get("PYTHONPATH", "")
+    env_vars["PYTHONPATH"] = _repo_root + (os.pathsep + _existing_pp if _existing_pp else "")
+    runtime_env = {"env_vars": env_vars}
+    # create_arctic_rl_client(ray) above started a Ray cluster; reuse it via
+    # ignore_reinit_error and pass runtime_env at TASK granularity (init's
+    # runtime_env is ignored on the second call to an already-initialized cluster).
+    ray.init(num_gpus=0, runtime_env=runtime_env, ignore_reinit_error=True)
+    ray.get(
+        skyrl_entrypoint.options(runtime_env=runtime_env).remote(
+            cfg, reconnect_config=reconnect_cfg, server_state=server_state,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/arctic_rl/entrypoint.py
+++ b/integrations/arctic_rl/entrypoint.py
@@ -128,7 +128,14 @@ def main() -> None:
     user only needs the one ``override_entrypoint`` flag to opt into Arctic.
     """
     from .config import ArcticRLTrainerConfig, ArcticSkyRLConfig
-    cfg = ArcticSkyRLConfig.from_cli_overrides(sys.argv[1:])
+    # Register Arctic-RL-shipped envs (bird / bird_sql) with skyrl-gym before
+    # any code path tries to ``make()`` them. Side-effect import.
+    from . import envs  # noqa: F401
+    # Strip the dispatch flag itself: it was consumed by main_base.py's peek-
+    # ahead and is not a real ArcticTrainerConfig field, so a strict parse
+    # would reject it.
+    argv = [a for a in sys.argv[1:] if not a.startswith("trainer.override_entrypoint=")]
+    cfg = ArcticSkyRLConfig.from_cli_overrides(argv)
     if cfg.trainer.arctic_rl is None:
         cfg.trainer.arctic_rl = ArcticRLTrainerConfig()
     validate_cfg(cfg)

--- a/integrations/arctic_rl/envs/__init__.py
+++ b/integrations/arctic_rl/envs/__init__.py
@@ -1,0 +1,15 @@
+"""Registers Arctic-RL-shipped envs with skyrl-gym at integration-import time.
+
+Uses ``__name__`` for the entry_point so registration works under any import
+path (e.g. ``integrations.arctic_rl.envs`` from core dispatch, or ``arctic_rl.envs``
+when the integration dir is on PYTHONPATH).
+"""
+
+from skyrl_gym.envs.registration import register
+
+register(
+    id="bird",
+    entry_point=f"{__name__}.bird:BirdEnv",
+)
+
+__all__ = []

--- a/integrations/arctic_rl/envs/__init__.py
+++ b/integrations/arctic_rl/envs/__init__.py
@@ -3,13 +3,17 @@
 Uses ``__name__`` for the entry_point so registration works under any import
 path (e.g. ``integrations.arctic_rl.envs`` from core dispatch, or ``arctic_rl.envs``
 when the integration dir is on PYTHONPATH).
+
+Both ``bird`` and ``bird_sql`` resolve to the same env: launcher recipes pass
+``environment.env_class=bird`` for evals, while preprocessed BIRD parquets
+have ``env_class="bird_sql"`` baked per-row (this is the verl PR #6 schema).
+Registering both names keeps either source-of-truth working without a parquet
+rewrite.
 """
 
 from skyrl_gym.envs.registration import register
 
-register(
-    id="bird",
-    entry_point=f"{__name__}.bird:BirdEnv",
-)
+for _id in ("bird", "bird_sql"):
+    register(id=_id, entry_point=f"{__name__}.bird:BirdEnv")
 
 __all__ = []

--- a/integrations/arctic_rl/envs/bird.py
+++ b/integrations/arctic_rl/envs/bird.py
@@ -31,8 +31,9 @@ verl-format parquet — no schema rewriting needed):
 
 from typing import Any, Dict
 
-from .bird_reward import compute_score
 from skyrl_gym.envs.base_text_env import BaseTextEnv, BaseTextEnvStepOutput
+
+from .bird_reward import compute_score
 
 
 class BirdEnv(BaseTextEnv):

--- a/integrations/arctic_rl/envs/bird.py
+++ b/integrations/arctic_rl/envs/bird.py
@@ -1,0 +1,87 @@
+r"""BIRD SQL env for skyrl-gym, mirroring the verl PR #6 reward contract.
+
+Single-turn env: the model emits a response containing one SQL query inside a
+``<think>...</think>`` block followed by a ```` ```sql ... ``` ```` block (the
+arctic_text_to_sql_r1 format). We hand the full response and the gold SQL +
+per-sample SQLite path to ``.bird_reward.compute_score`` — the *same*
+reward function the validated verl PR #6 run used — and surface its ``score``
+field as the GRPO reward.
+
+The reward function is vendored at
+``integrations/arctic_rl/envs/bird_reward.py`` so the integration doesn't
+depend on a private Arctic-Platform recipe branch.
+
+Why a SkyRL-side env at all?  The Arctic RL server is reward-agnostic; reward
+scoring runs client-side via skyrl-gym (see ``ArcticGenerator.generate``).
+This keeps the protocol simple (server takes (sequences, rewards, loss_mask))
+and lets us reuse verl PR #6's reward function unmodified.
+
+Required ``extras`` (forwarded automatically by ``PromptDataset`` from the
+verl-format parquet — no schema rewriting needed):
+
+  - ``reward_model.ground_truth`` : gold SQL string
+  - ``extra_info.db_path``        : absolute path to the SQLite DB file
+  - ``extra_info``                : passed through to ``compute_score``
+                                    as the ``extra_info`` arg (it needs
+                                    ``db_path`` and optionally
+                                    ``alternative_answers``).
+  - ``data_source``               : passed through (used by some reward fns
+                                    for routing; benign for BIRD).
+"""
+
+from typing import Any, Dict
+
+from .bird_reward import compute_score
+from skyrl_gym.envs.base_text_env import BaseTextEnv, BaseTextEnvStepOutput
+
+
+class BirdEnv(BaseTextEnv):
+    """Single-turn BIRD SQL env using the verl PR #6 reward fn verbatim."""
+
+    def __init__(self, env_config: Any = None, extras: Dict[str, Any] = {}):
+        super().__init__()
+
+        # ``reward_model`` is the verl-canonical name; some SkyRL envs use
+        # ``reward_spec``. Accept either to stay compatible across schemas.
+        reward_block = extras.get("reward_model") or extras.get("reward_spec") or {}
+        ground_truth = reward_block.get("ground_truth")
+        if ground_truth is None:
+            raise ValueError(
+                "BirdEnv requires `reward_model.ground_truth` (or "
+                "`reward_spec.ground_truth`) in env_extras — gold SQL is "
+                "missing from this prompt's parquet row."
+            )
+        self.ground_truth: str = ground_truth
+
+        extra_info = extras.get("extra_info") or {}
+        if "db_path" not in extra_info:
+            raise ValueError(
+                "BirdEnv requires `extra_info.db_path` in env_extras — the "
+                "per-sample SQLite path is missing. Re-run preprocess_bird.py "
+                "to regenerate the parquet with `db_path` populated."
+            )
+        self.extra_info: Dict[str, Any] = dict(extra_info)
+        # ``data_source`` lets reward fns route across SQL dialects; default to
+        # "bird" since this env is BIRD-specific.
+        self.data_source: str = extras.get("data_source", "bird")
+
+    def _get_reward(self, response: str) -> float:
+        result = compute_score(
+            data_source=self.data_source,
+            solution_str=response,
+            ground_truth=self.ground_truth,
+            extra_info=self.extra_info,
+        )
+        return float(result["score"])
+
+    def step(self, action: str) -> BaseTextEnvStepOutput:
+        # Single-turn: one model response -> one reward -> done.
+        # The reward function reads <think>...</think> and ```sql ...``` blocks
+        # itself, so we hand it the raw action without parsing.
+        reward = self._get_reward(action)
+        return BaseTextEnvStepOutput(
+            observations=[],
+            reward=reward,
+            done=True,
+            metadata={},
+        )

--- a/integrations/arctic_rl/envs/bird_reward.py
+++ b/integrations/arctic_rl/envs/bird_reward.py
@@ -1,0 +1,299 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+SQL reward function for BIRD RL training, adapted from SnowflakeDialectSQLRewardManagerV6b.
+
+Uses SQLite execution instead of Snowflake. Compatible with verl's
+custom_reward_function mechanism via compute_score().
+
+Vendored from
+``arctic_platform.rl.projects.txt2sql.bird_reward`` so this integration is
+self-contained and doesn't require the Arctic-Platform private RL recipe
+checkout. Bit-for-bit identical to the upstream reward function the verl
+PR #6 benchmark uses; keep them in sync.
+
+Reward scheme (matching V6b non-semantic-model behavior):
+    1.0  - Predicted SQL produces the same result set as gold SQL
+    0.1  - Predicted SQL executes successfully but produces wrong results,
+           OR SQL was extracted successfully (format bonus)
+    0.0  - No SQL extracted, SQL fails to execute, or timeout
+"""
+
+import json
+import re
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+SQL_TIMEOUT = 30
+DEFAULT_LIMIT_NUMBER = 5000
+FORMAT_REWARD_BONUS = 0.1
+
+
+# ---------------------------------------------------------------------------
+# SQL extraction (mirrors V6b's extract_solution / _extract_sql_omnisql)
+# ---------------------------------------------------------------------------
+
+
+def _extract_sql_omnisql(message: str) -> str:
+    """Extract SQL from ```sql ... ``` markdown blocks (last valid block)."""
+    pattern = r"```sql\s*(.*?)\s*```"
+    sql_blocks = re.findall(pattern, message, re.DOTALL)
+    for block in reversed(sql_blocks):
+        if len(block.strip()) > 6:
+            return block.strip()
+    return ""
+
+
+def _extract_sql_generic_block(message: str) -> str:
+    """Extract SQL from generic ``` ... ``` blocks containing SELECT."""
+    blocks = re.findall(r"```\s*(.*?)\s*```", message, re.DOTALL)
+    for block in reversed(blocks):
+        if "SELECT" in block.upper() and len(block.strip()) > 6:
+            return block.strip()
+    return ""
+
+
+def _extract_sql_analyst(message: str) -> str:
+    """Extract SQL from ```json { "sql": "..." } ``` blocks."""
+    block = re.search(r"```\s*json(.*?)```", message, re.DOTALL)
+    if block is None:
+        return ""
+    json_str = block.group(1)
+    idx_left = json_str.rfind("{")
+    idx_right = json_str.find("}")
+    if idx_left == -1 or idx_right == -1:
+        return ""
+    json_str = json_str[idx_left : idx_right + 1]
+    try:
+        return json.loads(json_str.replace("\\n", "\n").replace("\\'", "'"), strict=False).get("sql", "")
+    except Exception:
+        return ""
+
+
+def _extract_sql_raw_select(message: str) -> str:
+    """Fallback: extract a raw SELECT statement."""
+    match = re.search(r"(SELECT\s+.+?)(?:\n\n|$)", message, re.DOTALL | re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return ""
+
+
+def extract_sql(response: str) -> str:
+    """Extract SQL from model response, following V6b's extraction pipeline.
+
+    1. Split on </think> to isolate the answer portion
+    2. Try ```sql blocks
+    3. Try generic ``` blocks with SELECT
+    4. Try ```json blocks with {"sql": ...}
+    5. Fallback to raw SELECT statement
+    """
+    if "</think>" in response:
+        answer_part = response.split("</think>", 1)[1]
+    else:
+        answer_part = response
+
+    sql = _extract_sql_omnisql(answer_part)
+    if sql:
+        return sql
+
+    sql = _extract_sql_generic_block(answer_part)
+    if sql:
+        return sql
+
+    sql = _extract_sql_analyst(answer_part)
+    if sql:
+        return sql
+
+    return _extract_sql_raw_select(answer_part)
+
+
+# ---------------------------------------------------------------------------
+# Format validation (mirrors V6b's validate_response_structure)
+# ---------------------------------------------------------------------------
+
+
+def validate_response_format(response: str) -> bool:
+    """Check that the response has exactly one <think>...</think> pair, properly nested."""
+    start_positions = [m.start() for m in re.finditer(r"<think>", response)]
+    end_positions = [m.start() for m in re.finditer(r"</think>", response)]
+
+    if len(start_positions) != 1 or len(end_positions) != 1:
+        return False
+    return start_positions[0] < end_positions[0]
+
+
+# ---------------------------------------------------------------------------
+# LIMIT addition (mirrors V6b's _add_limit_to_query)
+# ---------------------------------------------------------------------------
+
+
+def _add_limit_to_query(query: str, limit: int = DEFAULT_LIMIT_NUMBER) -> str:
+    """Add LIMIT clause if the query doesn't already have one."""
+    if not query:
+        return query
+    upper = query.upper()
+    if "LIMIT " in upper or "LIMIT\n" in upper or "LIMIT\t" in upper:
+        return query
+    return query.rstrip().rstrip(";").rstrip() + f" LIMIT {limit};"
+
+
+# ---------------------------------------------------------------------------
+# SQLite execution and comparison
+# ---------------------------------------------------------------------------
+
+
+def _execute_sql(db_path: str, sql: str, timeout: float = SQL_TIMEOUT) -> frozenset | Exception:
+    """Execute SQL against a SQLite database and return result as frozenset of row tuples."""
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
+        deadline = __import__("time").monotonic() + timeout
+
+        def _check_cancel():
+            if __import__("time").monotonic() > deadline:
+                return 1
+            return 0
+
+        conn.set_progress_handler(_check_cancel, 1000)
+        cursor = conn.cursor()
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+        conn.close()
+        return frozenset(rows)
+    except sqlite3.OperationalError as e:
+        if "interrupt" in str(e).lower():
+            return TimeoutError(f"SQL execution exceeded {timeout}s")
+        return e
+    except Exception as e:
+        return e
+
+
+def _execute_with_timeout(db_path: str, sql: str, timeout: float = SQL_TIMEOUT) -> frozenset | Exception:
+    """Execute SQL with a timeout using a thread pool.
+
+    Uses shutdown(wait=False) to avoid blocking if the SQLite thread is stuck.
+    The SQLite progress handler provides cooperative cancellation.
+    """
+    executor = ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(_execute_sql, db_path, sql, timeout)
+    try:
+        return future.result(timeout=timeout + 2)
+    except FuturesTimeoutError:
+        return TimeoutError(f"SQL execution exceeded {timeout}s")
+    except Exception as e:
+        return e
+    finally:
+        executor.shutdown(wait=False)
+
+
+def _compare_results(
+    db_path: str,
+    pred_sql: str,
+    gold_sqls: list[str],
+    timeout: float = SQL_TIMEOUT,
+) -> tuple[float, bool]:
+    """Execute and compare predicted SQL against all gold SQLs.
+
+    Returns (reward, execution_success) matching V6b's non-semantic-model logic:
+        - 1.0 if pred result == any gold result (frozenset match)
+        - 0.1 if pred executes but doesn't match any gold
+        - 0.0 if pred fails to execute
+
+    Caches gold results within this call to avoid re-execution.
+    """
+    pred_sql_limited = _add_limit_to_query(pred_sql)
+    pred_result = _execute_with_timeout(db_path, pred_sql_limited, timeout)
+
+    if isinstance(pred_result, Exception):
+        return 0.0, False
+
+    gold_cache: dict[str, frozenset | Exception] = {}
+    scores = []
+    for gold_sql in gold_sqls:
+        if gold_sql not in gold_cache:
+            gold_sql_limited = _add_limit_to_query(gold_sql)
+            gold_cache[gold_sql] = _execute_with_timeout(db_path, gold_sql_limited, timeout)
+        gold_result = gold_cache[gold_sql]
+
+        if isinstance(gold_result, Exception):
+            scores.append(0.0)
+            continue
+
+        if pred_result == gold_result:
+            scores.append(1.0)
+        else:
+            scores.append(0.1)
+
+    return (max(scores) if scores else 0.0), True
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def compute_score(data_source, solution_str, ground_truth, extra_info=None, **kwargs):
+    """Compute reward score for SQL generation (verl custom_reward_function interface).
+
+    Mirrors SnowflakeDialectSQLRewardManagerV6b logic with SQLite execution:
+    1. Extract SQL from model response
+    2. Validate response format (<think> tags)
+    3. Execute predicted and gold SQL against SQLite
+    4. Compare results (frozenset match)
+    5. Apply format bonus
+
+    Args:
+        data_source: Dataset identifier (e.g. "bird")
+        solution_str: Full model response text (decoded)
+        ground_truth: Gold SQL query string
+        extra_info: Dict with at minimum {"db_path": "/path/to/db.sqlite"}.
+                    Optionally {"alternative_answers": [...]} for multiple gold SQLs.
+
+    Returns:
+        dict with "score" (float), "format_correct" (float), "execution_success" (float)
+    """
+    if extra_info is None:
+        return {"score": 0.0, "format_correct": 0.0, "execution_success": 0.0}
+
+    db_path = extra_info.get("db_path", "")
+    if not db_path:
+        return {"score": 0.0, "format_correct": 0.0, "execution_success": 0.0}
+
+    pred_sql = extract_sql(solution_str)
+    format_correct = float(bool(pred_sql) and validate_response_format(solution_str))
+
+    if not pred_sql:
+        return {"score": 0.0, "format_correct": 0.0, "execution_success": 0.0}
+
+    alternative_answers = extra_info.get("alternative_answers")
+    if alternative_answers and len(alternative_answers) > 0:
+        gold_sqls = [str(s).strip() for s in alternative_answers if s and str(s).strip()]
+    else:
+        gold_sqls = [ground_truth] if ground_truth else []
+
+    if not gold_sqls:
+        return {"score": 0.0, "format_correct": format_correct, "execution_success": 0.0}
+
+    reward, execution_success = _compare_results(db_path, pred_sql, gold_sqls)
+
+    if format_correct:
+        reward = max(reward, FORMAT_REWARD_BONUS)
+
+    return {
+        "score": reward,
+        "format_correct": format_correct,
+        "execution_success": float(execution_success),
+    }

--- a/integrations/arctic_rl/envs/preprocess_bird.py
+++ b/integrations/arctic_rl/envs/preprocess_bird.py
@@ -1,0 +1,748 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Preprocess SQL RL training data to verl-compatible parquet format.
+
+Supports three data sources:
+  - BIRD     (default): reads from raw BIRD JSON + SQLite databases
+  - Spider:  reads from raw Spider JSON + SQLite databases
+  - GretelAI: reads from original parquet, builds per-sample SQLite databases
+
+Produces prompts in the arctic_text_to_sql_r1 format and applies a Qwen3
+token-length filter (default 16,384 tokens) to drop the long-tail BIRD DBs
+(e.g. works_cycles, movie_3) whose full SQLite DDL exceeds 100K tokens and
+won't fit in context.
+
+Usage:
+    # BIRD only with default 16K-token cap (recommended for long-prompt RL):
+    python preprocess_bird.py
+
+    # Different token cap or tokenizer:
+    python preprocess_bird.py --max_tokens 8192 --tokenizer Qwen/Qwen3-1.7B
+
+    # All three sources:
+    python preprocess_bird.py --sources bird spider gretelai
+
+
+This script is vendored from
+``arctic_platform.rl.projects.txt2sql.preprocess_bird`` so the BIRD pipeline
+in this integration is self-contained and doesn't require the
+Arctic-Platform private RL recipe checkout. Keep the upstream copy as the
+source of truth — re-sync if it changes.
+"""
+
+import argparse
+import csv
+import os
+import re
+import sqlite3
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# R1 prompt template (arctic_text_to_sql_r1)
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = (
+    "You are a data science expert. Below, you are provided with a database schema "
+    "and a natural language question. Your task is to understand the schema and generate "
+    "a valid SQL query to answer the question."
+)
+
+INSTRUCT_INFO = """
+Please provide a detailed chain-of-thought reasoning process and include your thought process within `<think>` tags. Your final answer should be enclosed within `<answer>` tags.
+
+Ensure that your SQL query follows the correct syntax and is formatted as follows:
+
+```sql
+-- Your SQL query here
+```
+
+Example format:
+<think> Step-by-step reasoning, including self-reflection and corrections if necessary. [Limited by 4K tokens] </think>
+<answer> Summary of the thought process leading to the final SQL query. [Limited by 1K tokens]
+
+```sql
+Correct SQL query here
+```
+</answer>""".strip()
+
+
+def build_r1_messages(schema_ddl: str, question: str, engine: str = "SQLite") -> list[dict]:
+    """Build prompt messages matching the arctic_text_to_sql_r1 format."""
+    user_content = f"""
+Database Engine:
+{engine}
+
+Database Schema:
+{schema_ddl}
+This schema describes the database's structure, including tables, columns, primary keys, foreign keys, and any relevant relationships or constraints.
+
+Question:
+{question}
+
+Instructions:
+- Make sure you only output the information that is asked in the question. If the question asks for a specific column, make sure to only include that column in the SELECT clause, nothing more.
+- The generated query should return all of the information asked in the question without any missing or extra information.
+- Before generating the final SQL query, please think through the steps of how to write the query.
+
+Output Format:
+{INSTRUCT_INFO}
+    """.strip()
+
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Schema DDL extraction from SQLite databases
+# ---------------------------------------------------------------------------
+
+
+def _flatten_inline(s: str) -> str:
+    """Collapse whitespace so the value fits on a single comment line. No length cap."""
+    return " ".join(s.split())
+
+
+def _short_value(v, max_len: int = 60) -> str:
+    """Render a single cell for the sample-rows table; trim only very long values."""
+    s = str(v) if isinstance(v, (int, float)) else repr(v)
+    return s[: max_len - 3] + "..." if len(s) > max_len else s
+
+
+_FK_RE = re.compile(
+    r"FOREIGN\s+KEY\s*\(\s*([^)]+?)\s*\)\s*REFERENCES\s+" r"[\"'`]?([A-Za-z_][\w]*)[\"'`]?\s*(?:\(\s*([^)]+?)\s*\))?",
+    re.IGNORECASE,
+)
+
+
+def _extract_fks(create_sql: str) -> list[str]:
+    """Extract FK relationships from a CREATE TABLE block, formatted compactly."""
+    fks = []
+    for m in _FK_RE.finditer(create_sql):
+        local_cols = m.group(1).replace('"', "").replace("`", "").replace("'", "").strip()
+        ref_table = m.group(2)
+        ref_cols = m.group(3) or ""
+        ref_cols = ref_cols.replace('"', "").replace("`", "").replace("'", "").strip()
+        if ref_cols:
+            fks.append(f"{local_cols} -> {ref_table}.{ref_cols}")
+        else:
+            fks.append(f"{local_cols} -> {ref_table}")
+    # Also handle inline column-level "REFERENCES" syntax (no FOREIGN KEY clause).
+    # Skip lines that already declare a FOREIGN KEY (handled above), PRIMARY KEY, etc.
+    for line in create_sql.split("\n"):
+        s = line.strip()
+        if not s:
+            continue
+        first = s.split()[0].upper()
+        if first in {"FOREIGN", "PRIMARY", "UNIQUE", "CONSTRAINT", "CHECK", "CREATE", ")", "("}:
+            continue
+        m = re.search(
+            r"^\s*[\"\'`]?([A-Za-z_][\w]*)[\"\'`]?\s+[^,]*?\bREFERENCES\s+"
+            r"[\"\'`]?([A-Za-z_][\w]*)[\"\'`]?(?:\s*\(\s*([^)]+?)\s*\))?",
+            line,
+            re.IGNORECASE,
+        )
+        if m:
+            local_col = m.group(1)
+            ref_table = m.group(2)
+            ref_cols = (m.group(3) or "").replace('"', "").replace("`", "").replace("'", "").strip()
+            if ref_cols:
+                fks.append(f"{local_col} -> {ref_table}.{ref_cols}")
+            else:
+                fks.append(f"{local_col} -> {ref_table}")
+    # Dedup while preserving order.
+    seen = set()
+    uniq = []
+    for fk in fks:
+        if fk not in seen:
+            seen.add(fk)
+            uniq.append(fk)
+    return uniq
+
+
+def load_db_descriptions(db_dir: str) -> dict:
+    """Load BIRD's database_description/*.csv as {(table_lower, col_lower): {...}}.
+
+    BIRD ships per-table CSVs with column-level semantic descriptions and value
+    semantics. Returns an empty dict if the folder is missing.
+    """
+    desc_dir = os.path.join(db_dir, "database_description")
+    out: dict = {}
+    if not os.path.isdir(desc_dir):
+        return out
+
+    for fname in os.listdir(desc_dir):
+        if not fname.endswith(".csv"):
+            continue
+        table = fname[:-4]
+        path = os.path.join(desc_dir, fname)
+        # utf-8-sig strips a leading BOM (BIRD CSVs sometimes have one).
+        rows = None
+        for enc in ("utf-8-sig", "latin-1"):
+            try:
+                with open(path, encoding=enc) as f:
+                    rows = list(csv.DictReader(f))
+                break
+            except UnicodeDecodeError:
+                continue
+        if not rows:
+            continue
+        for row in rows:
+            col = (row.get("original_column_name") or "").strip()
+            if not col:
+                continue
+            out[(table.lower(), col.lower())] = {
+                "name": (row.get("column_name") or "").strip(),
+                "desc": (row.get("column_description") or "").strip(),
+                "val_desc": (row.get("value_description") or "").strip(),
+            }
+    return out
+
+
+def get_schema_ddl(
+    db_path: str,
+    num_examples: int = 5,
+    descriptions: dict | None = None,
+    sample_rows: int = 3,
+    include_fk_summary: bool = True,
+) -> str:
+    """Read schema DDL from a SQLite database, enriched with sample values.
+
+    Augmentations applied (all reuse the single ``SELECT ... LIMIT`` per table —
+    no extra DB scans):
+
+    - Sample-rows block per table (markdown-style pipe table) using the same
+      rows fetched for per-column examples.
+    - Foreign-key summary line at the top of each table block.
+    - Inline ``-- example: ... | name: ... | desc: ... | values: ...`` comment
+      on each column line. ``name``, ``desc``, and ``values`` come from
+      ``descriptions``; descriptions are NOT length-truncated (whitespace is
+      collapsed so they stay one line).
+    """
+    descriptions = descriptions or {}
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT name, sql FROM sqlite_master WHERE type='table' ORDER BY name")
+    tables = cursor.fetchall()
+
+    ddl_parts = []
+    rows_to_fetch = max(num_examples, sample_rows, 1)
+
+    for table_name, create_sql in tables:
+        if not create_sql:
+            continue
+
+        col_examples: dict = {}
+        col_names: list = []
+        rows_for_table: list = []
+        try:
+            cursor.execute(f'SELECT * FROM "{table_name}" LIMIT {rows_to_fetch}')
+            rows_for_table = cursor.fetchall()
+            col_names = [desc[0] for desc in cursor.description]
+            if num_examples > 0:
+                for col_idx, col_name in enumerate(col_names):
+                    vals = [row[col_idx] for row in rows_for_table[:num_examples] if row[col_idx] is not None]
+                    if vals:
+                        col_examples[col_name] = vals
+        except sqlite3.Error:
+            pass
+
+        # Top-of-block header: FK summary + sample rows.
+        header_lines: list = []
+        if include_fk_summary:
+            fks = _extract_fks(create_sql)
+            if fks:
+                header_lines.append(f"-- Foreign keys: {'; '.join(fks)}")
+        if sample_rows > 0 and rows_for_table and col_names:
+            header_lines.append(f'-- Sample rows from "{table_name}":')
+            header_lines.append("-- | " + " | ".join(col_names) + " |")
+            for row in rows_for_table[:sample_rows]:
+                header_lines.append("-- | " + " | ".join(_short_value(v) for v in row) + " |")
+
+        enriched_lines: list = list(header_lines)
+        for line in create_sql.split("\n"):
+            stripped = line.strip().rstrip(",")
+            if stripped and not stripped.startswith("CREATE") and not stripped.startswith(")"):
+                col_token = stripped.split()[0].strip('"').strip("'").strip("`")
+                annots = []
+                if col_token in col_examples:
+                    annots.append(f"example: {col_examples[col_token]!r}")
+                desc_key = (table_name.lower(), col_token.lower())
+                if desc_key in descriptions:
+                    d = descriptions[desc_key]
+                    name = d.get("name", "")
+                    if name and name.lower() != col_token.lower():
+                        annots.append(f"name: {_flatten_inline(name)}")
+                    if d["desc"]:
+                        annots.append(f"desc: {_flatten_inline(d['desc'])}")
+                    if d["val_desc"]:
+                        annots.append(f"values: {_flatten_inline(d['val_desc'])}")
+                if annots:
+                    comment = " -- " + " | ".join(annots)
+                    if line.rstrip().endswith(","):
+                        line = line.rstrip()[:-1] + comment + ","
+                    else:
+                        line = line.rstrip() + comment
+            enriched_lines.append(line)
+        ddl_parts.append("\n".join(enriched_lines))
+
+    conn.close()
+    return "\n\n".join(ddl_parts)
+
+
+# ---------------------------------------------------------------------------
+# BIRD processing
+# ---------------------------------------------------------------------------
+
+
+def process_bird(
+    bird_dir: str,
+    split: str,
+    num_examples: int = 5,
+    use_descriptions: bool = True,
+    sample_rows: int = 3,
+    include_fk_summary: bool = True,
+) -> list[dict]:
+    """Process BIRD dataset from raw JSON + SQLite databases."""
+    import json
+
+    if split == "train":
+        json_file = os.path.join(bird_dir, "train", "train.json")
+        db_base = os.path.join(bird_dir, "train", "train_databases")
+    else:
+        json_file = os.path.join(bird_dir, "dev", "dev.json")
+        db_base = os.path.join(bird_dir, "dev", "dev_databases")
+
+    with open(json_file) as f:
+        data = json.load(f)
+
+    print(f"  BIRD {split}: {len(data)} raw samples from {json_file}")
+
+    schema_cache = {}
+    records = []
+
+    for idx, item in enumerate(data):
+        db_id = item["db_id"]
+        question = item["question"]
+        evidence = item.get("evidence", "")
+        gold_sql = item["SQL"]
+
+        db_path = os.path.join(db_base, db_id, f"{db_id}.sqlite")
+        if not os.path.exists(db_path):
+            continue
+
+        if db_id not in schema_cache:
+            try:
+                db_dir = os.path.join(db_base, db_id)
+                descs = load_db_descriptions(db_dir) if use_descriptions else {}
+                schema_cache[db_id] = get_schema_ddl(
+                    db_path,
+                    num_examples=num_examples,
+                    descriptions=descs,
+                    sample_rows=sample_rows,
+                    include_fk_summary=include_fk_summary,
+                )
+            except Exception as e:
+                print(f"    Warning: failed to read schema for {db_id}: {e}")
+                continue
+
+        if evidence and evidence.strip():
+            full_question = f"{question}\n\nEvidence:\n{evidence}"
+        else:
+            full_question = question
+
+        records.append(
+            {
+                "data_source": "bird",
+                "prompt": build_r1_messages(schema_cache[db_id], full_question),
+                "ability": "sql",
+                "reward_model": {"style": "rule", "ground_truth": gold_sql},
+                "extra_info": {
+                    "split": split,
+                    "index": idx,
+                    "db_id": db_id,
+                    "db_path": db_path,
+                    "question": question,
+                },
+            }
+        )
+
+    print(f"    -> {len(records)} samples")
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Spider processing
+# ---------------------------------------------------------------------------
+
+
+def process_spider(spider_dir: str) -> list[dict]:
+    """Process Spider dataset from raw JSON + SQLite databases."""
+    import json
+
+    db_base = os.path.join(spider_dir, "database")
+    records = []
+
+    for json_name in ["train_spider.json", "train_others.json"]:
+        json_file = os.path.join(spider_dir, json_name)
+        if not os.path.exists(json_file):
+            print(f"    Warning: {json_file} not found, skipping")
+            continue
+
+        with open(json_file) as f:
+            data = json.load(f)
+        print(f"  Spider {json_name}: {len(data)} raw samples")
+
+        schema_cache = {}
+        for idx, item in enumerate(data):
+            db_id = item["db_id"]
+            question = item["question"]
+            gold_sql = item["query"]
+
+            db_path = os.path.join(db_base, db_id, f"{db_id}.sqlite")
+            if not os.path.exists(db_path):
+                continue
+
+            if db_id not in schema_cache:
+                try:
+                    schema_cache[db_id] = get_schema_ddl(db_path, num_examples=3)
+                except Exception:
+                    continue
+
+            records.append(
+                {
+                    "data_source": "spider",
+                    "prompt": build_r1_messages(schema_cache[db_id], question),
+                    "ability": "sql",
+                    "reward_model": {"style": "rule", "ground_truth": gold_sql},
+                    "extra_info": {
+                        "split": "train",
+                        "index": idx,
+                        "db_id": db_id,
+                        "db_path": db_path,
+                        "question": question,
+                    },
+                }
+            )
+
+    print(f"    -> {len(records)} samples total")
+    return records
+
+
+# ---------------------------------------------------------------------------
+# GretelAI processing
+# ---------------------------------------------------------------------------
+
+
+def _create_gretelai_db(sql_context: str, db_path: str) -> bool:
+    """Create a SQLite database from GretelAI's sql_context (CREATE+INSERT statements)."""
+    try:
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        conn.executescript(sql_context)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+def process_gretelai(
+    gretelai_parquet: str,
+    r1_parquet: str,
+    gretelai_db_dir: str,
+) -> list[dict]:
+    """Process GretelAI using R1 parquet for cleaned gold SQLs + original parquet for sql_context.
+
+    Creates per-sample SQLite databases from sql_context for reward execution.
+    """
+    r1_df = pd.read_parquet(r1_parquet)
+    r1_gretel = r1_df[r1_df["data_source"] == "gretelai"].copy()
+    r1_gretel["db_id_int"] = r1_gretel["db_id"].astype(int)
+
+    orig_df = pd.read_parquet(gretelai_parquet)
+    orig_lookup = orig_df.set_index("id")
+
+    print(f"  GretelAI: {len(r1_gretel)} samples from R1 parquet")
+
+    os.makedirs(gretelai_db_dir, exist_ok=True)
+    records = []
+    skipped = 0
+
+    for _, row in r1_gretel.iterrows():
+        sample_id = row["db_id_int"]
+
+        if sample_id not in orig_lookup.index:
+            skipped += 1
+            continue
+
+        orig_row = orig_lookup.loc[sample_id]
+        sql_context = orig_row["sql_context"]
+        domain = orig_row["domain"]
+
+        db_path = os.path.join(gretelai_db_dir, f"{sample_id}.sqlite")
+        if not os.path.exists(db_path):
+            if not _create_gretelai_db(sql_context, db_path):
+                skipped += 1
+                continue
+
+        schema_ddl = row["omnisql_schema"]
+        question = row["question"]
+        gold_sql = row["ground_truth"]
+
+        records.append(
+            {
+                "data_source": "gretelai",
+                "prompt": build_r1_messages(schema_ddl, question),
+                "ability": "sql",
+                "reward_model": {"style": "rule", "ground_truth": gold_sql},
+                "extra_info": {
+                    "split": "train",
+                    "index": int(row["extra_info"].get("index", 0)),
+                    "db_id": str(sample_id),
+                    "db_path": db_path,
+                    "question": question,
+                    "domain": domain,
+                },
+            }
+        )
+
+    print(f"    -> {len(records)} samples, {skipped} skipped")
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Token-length filtering
+# ---------------------------------------------------------------------------
+
+
+def filter_by_token_length(
+    records: list[dict],
+    tokenizer_name: str,
+    max_tokens: int,
+    batch_size: int = 64,
+) -> list[dict]:
+    """Drop records whose tokenized prompt exceeds ``max_tokens``."""
+    if max_tokens is None or max_tokens <= 0 or not records:
+        return records
+
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=True)
+
+    texts = ["".join(m.get("content", "") for m in r["prompt"]) for r in records]
+
+    kept, dropped_per_source = [], {}
+    lens = []
+    for i in range(0, len(texts), batch_size):
+        enc = tok(texts[i : i + batch_size], add_special_tokens=False)
+        for j, ids in enumerate(enc["input_ids"]):
+            n = len(ids)
+            lens.append(n)
+            rec = records[i + j]
+            if n <= max_tokens:
+                kept.append(rec)
+            else:
+                dropped_per_source[rec["data_source"]] = dropped_per_source.get(rec["data_source"], 0) + 1
+
+    n_total = len(records)
+    n_kept = len(kept)
+    print(
+        f"  Token filter (<= {max_tokens} tokens, {tokenizer_name}): "
+        f"{n_kept}/{n_total} kept ({n_total - n_kept} dropped)"
+    )
+    if dropped_per_source:
+        for src, cnt in sorted(dropped_per_source.items()):
+            print(f"    dropped {cnt} from {src}")
+    if lens:
+        import numpy as np
+
+        arr = np.array(lens)
+        print(
+            f"  Pre-filter token stats: median={int(np.median(arr))} "
+            f"p90={int(np.percentile(arr, 90))} "
+            f"p99={int(np.percentile(arr, 99))} max={int(arr.max())}"
+        )
+    return kept
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+DEFAULT_PATHS = {
+    "bird_dir": "/data/ruofan/bird_wiki_original",
+    "spider_dir": "/data/ruofan/spider_data",
+    "gretelai_parquet": "/data/ruofan/gretelai/synthetic_text_to_sql_train.snappy.parquet",
+    "r1_parquet": (
+        "/code/users/lukasz/process/snowflake_v1/merged_train_model_type-qwen_coder-sft_maxtoken-8192_maxtime-10_len-16459.parquet"
+    ),
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Preprocess SQL data for verl RL training")
+    parser.add_argument("--output_dir", type=str, default=None)
+    parser.add_argument(
+        "--sources",
+        nargs="+",
+        default=["bird"],
+        choices=["bird", "spider", "gretelai"],
+        help="Data sources to include (default: bird only)",
+    )
+    parser.add_argument("--bird_dir", type=str, default=DEFAULT_PATHS["bird_dir"])
+    parser.add_argument("--spider_dir", type=str, default=DEFAULT_PATHS["spider_dir"])
+    parser.add_argument("--gretelai_parquet", type=str, default=DEFAULT_PATHS["gretelai_parquet"])
+    parser.add_argument("--r1_parquet", type=str, default=DEFAULT_PATHS["r1_parquet"])
+    parser.add_argument(
+        "--max_tokens",
+        type=int,
+        default=32768,
+        help=(
+            "Drop training samples whose prompt exceeds this many tokens. "
+            "Set to 0 to disable filtering. Default: 32768. "
+            "(BIRD's outlier DBs `works_cycles` and `movie_3` sit at >80K "
+            "tokens with full augmentation, so 32K is the natural break.)"
+        ),
+    )
+    parser.add_argument(
+        "--tokenizer",
+        type=str,
+        default="Qwen/Qwen3-1.7B",
+        help="HF tokenizer used for the token-length filter. Default: Qwen/Qwen3-1.7B.",
+    )
+    parser.add_argument(
+        "--num_examples",
+        type=int,
+        default=10,
+        help=(
+            "Sample rows per column to include inline as `-- example: [...]`. "
+            "Higher values produce longer prompts. Default: 10."
+        ),
+    )
+    parser.add_argument(
+        "--sample_rows",
+        type=int,
+        default=10,
+        help=(
+            "Full sample rows shown as a markdown table at the top of each "
+            "CREATE TABLE block. Reuses the rows fetched for `--num_examples` "
+            "(no extra DB queries). Set to 0 to disable. Default: 10."
+        ),
+    )
+    parser.add_argument(
+        "--no_descriptions",
+        action="store_true",
+        help="Disable BIRD `database_description/*.csv` schema enrichment (column descriptions and value semantics).",
+    )
+    parser.add_argument(
+        "--no_fk_summary",
+        action="store_true",
+        help="Disable the `-- Foreign keys: ...` summary line at the top of each CREATE TABLE block.",
+    )
+    args = parser.parse_args()
+
+    if args.output_dir is None:
+        args.output_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
+
+    print(f"Sources: {args.sources}")
+    print(f"Output:  {args.output_dir}")
+    print()
+
+    # --- Training data ---
+    train_records = []
+
+    if "bird" in args.sources:
+        print("Processing BIRD (train)...")
+        train_records.extend(
+            process_bird(
+                args.bird_dir,
+                "train",
+                num_examples=args.num_examples,
+                use_descriptions=not args.no_descriptions,
+                sample_rows=args.sample_rows,
+                include_fk_summary=not args.no_fk_summary,
+            )
+        )
+
+    if "spider" in args.sources:
+        print("Processing Spider...")
+        train_records.extend(process_spider(args.spider_dir))
+
+    if "gretelai" in args.sources:
+        print("Processing GretelAI...")
+        gretelai_db_dir = os.path.join(args.output_dir, "gretelai_dbs")
+        train_records.extend(
+            process_gretelai(
+                args.gretelai_parquet,
+                args.r1_parquet,
+                gretelai_db_dir,
+            )
+        )
+
+    if train_records and args.max_tokens and args.max_tokens > 0:
+        print("\nFiltering train by token length...")
+        train_records = filter_by_token_length(
+            train_records,
+            args.tokenizer,
+            args.max_tokens,
+        )
+
+    if train_records:
+        train_path = os.path.join(args.output_dir, "train.parquet")
+        os.makedirs(args.output_dir, exist_ok=True)
+        import datasets as hf_datasets
+
+        hf_datasets.Dataset.from_list(train_records).to_parquet(train_path)
+        print(f"\nTrain: {len(train_records)} samples -> {train_path}")
+
+        from collections import Counter
+
+        source_counts = Counter(r["data_source"] for r in train_records)
+        for src, cnt in source_counts.most_common():
+            print(f"  {src}: {cnt}")
+
+    # --- Validation data (BIRD dev only) ---
+    # Dev is intentionally kept *clean* — minimal schema augmentation, matching
+    # how the model would be evaluated on raw BIRD. No `database_description`
+    # CSV enrichment, no per-table sample-rows block, no FK-summary line, just
+    # 3 inline example values per column.  This avoids leaking auxiliary
+    # context into the validation prompts that might inflate eval signal.
+    if "bird" in args.sources:
+        print("\nProcessing BIRD (dev) for validation (clean / no augmentation)...")
+        val_records = process_bird(
+            args.bird_dir,
+            "dev",
+            num_examples=3,
+            use_descriptions=False,
+            sample_rows=0,
+            include_fk_summary=False,
+        )
+        if val_records:
+            val_path = os.path.join(args.output_dir, "val.parquet")
+            import datasets as hf_datasets
+
+            hf_datasets.Dataset.from_list(val_records).to_parquet(val_path)
+            print(f"Val: {len(val_records)} samples -> {val_path}")
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/arctic_rl/examples/fsdp_bird_entry.py
+++ b/integrations/arctic_rl/examples/fsdp_bird_entry.py
@@ -1,0 +1,56 @@
+"""FSDP-native SkyRL entrypoint that registers the ``bird`` env on driver +
+Ray workers. Stock ``main_base`` doesn't import the integration, so this shim
+side-effect-imports ``integrations.arctic_rl.envs`` on the driver and arranges
+for Ray workers to do the same. No core SkyRL changes.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_REPO_ROOT = _HERE.parents[3]
+sys.path.insert(0, str(_REPO_ROOT))
+import integrations.arctic_rl.envs  # noqa: F401,E402  register `bird` on driver
+
+import ray  # noqa: E402
+import skyrl.train.entrypoints.main_base as _mb  # noqa: E402
+import skyrl.train.utils.utils as _skyrl_utils  # noqa: E402
+
+_repo_root_str = str(_REPO_ROOT)
+
+_original_prepare = _skyrl_utils.prepare_runtime_environment
+
+
+def _patched_prepare(cfg):
+    env_vars = _original_prepare(cfg)
+    existing_pp = env_vars.get("PYTHONPATH", os.environ.get("PYTHONPATH", ""))
+    if _repo_root_str not in existing_pp.split(":"):
+        env_vars["PYTHONPATH"] = (
+            _repo_root_str + (":" + existing_pp if existing_pp else "")
+        )
+    if "SKYRL_USE_LIGER" in os.environ:
+        env_vars["SKYRL_USE_LIGER"] = os.environ["SKYRL_USE_LIGER"]
+    return env_vars
+
+
+_skyrl_utils.prepare_runtime_environment = _patched_prepare
+
+
+@ray.remote(num_cpus=1)
+def _skyrl_entrypoint_with_bird(cfg):
+    import sys as _sys
+
+    if _repo_root_str not in _sys.path:
+        _sys.path.insert(0, _repo_root_str)
+    import integrations.arctic_rl.envs  # noqa: F401  register `bird` on worker
+
+    exp = _mb.BasePPOExp(cfg)
+    exp.run()
+
+
+_mb.skyrl_entrypoint = _skyrl_entrypoint_with_bird
+
+
+if __name__ == "__main__":
+    _mb.main()

--- a/integrations/arctic_rl/examples/fsdp_bird_entry.py
+++ b/integrations/arctic_rl/examples/fsdp_bird_entry.py
@@ -11,9 +11,9 @@ from pathlib import Path
 _HERE = Path(__file__).resolve()
 _REPO_ROOT = _HERE.parents[3]
 sys.path.insert(0, str(_REPO_ROOT))
-import integrations.arctic_rl.envs  # noqa: F401,E402  register `bird` on driver
-
 import ray  # noqa: E402
+
+import integrations.arctic_rl.envs  # noqa: F401,E402  register `bird` on driver
 import skyrl.train.entrypoints.main_base as _mb  # noqa: E402
 import skyrl.train.utils.utils as _skyrl_utils  # noqa: E402
 
@@ -26,9 +26,7 @@ def _patched_prepare(cfg):
     env_vars = _original_prepare(cfg)
     existing_pp = env_vars.get("PYTHONPATH", os.environ.get("PYTHONPATH", ""))
     if _repo_root_str not in existing_pp.split(":"):
-        env_vars["PYTHONPATH"] = (
-            _repo_root_str + (":" + existing_pp if existing_pp else "")
-        )
+        env_vars["PYTHONPATH"] = _repo_root_str + (":" + existing_pp if existing_pp else "")
     if "SKYRL_USE_LIGER" in os.environ:
         env_vars["SKYRL_USE_LIGER"] = os.environ["SKYRL_USE_LIGER"]
     return env_vars
@@ -43,7 +41,6 @@ def _skyrl_entrypoint_with_bird(cfg):
 
     if _repo_root_str not in _sys.path:
         _sys.path.insert(0, _repo_root_str)
-    import integrations.arctic_rl.envs  # noqa: F401  register `bird` on worker
 
     exp = _mb.BasePPOExp(cfg)
     exp.run()

--- a/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
@@ -113,23 +113,13 @@ cd "${SKYRL_DIR}"
     trainer.arctic_rl.colocate=true \
     trainer.arctic_rl.zero_stage=3 \
     trainer.arctic_rl.offload_optimizer=true \
-    trainer.arctic_rl.offload_param=false \
-    trainer.arctic_rl.log_prob_gpus=0 \
-    trainer.arctic_rl.use_zorro=true \
-    trainer.arctic_rl.use_liger=true \
     trainer.arctic_rl.attn_implementation=${ATTN_IMPL} \
-    trainer.arctic_rl.enable_gradient_checkpointing=true \
-    trainer.arctic_rl.ulysses_sequence_parallel_size=1 \
-    trainer.arctic_rl.logits_optimization=memory \
     trainer.arctic_rl.cuda_ipc_weight_sync=true \
     trainer.arctic_rl.low_memory_weight_sync=true \
     trainer.arctic_rl.lr_warmup_ratio=0.05 \
     'trainer.arctic_rl.optimizer_betas=[0.9,0.95]' \
     trainer.arctic_rl.vllm_enforce_eager=false \
-    trainer.arctic_rl.vllm_enable_prefix_caching=true \
     trainer.arctic_rl.vllm_max_num_batched_tokens=40960 \
-    trainer.arctic_rl.vllm_max_num_seqs=256 \
-    trainer.arctic_rl.use_arctic_inference=true \
     trainer.arctic_rl.server_logs=true \
     trainer.arctic_rl.startup_timeout=1800 \
     "${ARCTIC_SPEC_OVERRIDE[@]}" \

--- a/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
@@ -13,17 +13,21 @@ SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
 DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
 
 # Driver (same shape as flash_rl/harbor; see run_gsm8k_grpo_4gpu.sh for details).
+# FA3 (cp39-abi3 wheel from PyTorch's cu128 index) ships alongside FA2 — this
+# is the recipe that produced the 2.38x BIRD-SQL speedup on H200.
 FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+FLASH_ATTN3_WHL="https://download.pytorch.org/whl/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
 DRIVER=(uv run --isolated --extra skyrl-train
     --with arctic-platform
     --with 'arctic-inference[vllm]'
     --with liger-kernel
     --with 'transformers==4.57.6'
     --with "flash-attn@${FLASH_ATTN_WHL}"
+    --with "flash-attn-3@${FLASH_ATTN3_WHL}"
     -- python)
-# FlashAttention impl: flash_attention_2 (broadly available) or flash_attention_3
-# (Hopper-only, build from source from Dao-AILab/flash-attention hopper subdir).
-ATTN_IMPL=${ATTN_IMPL:-flash_attention_2}
+# FlashAttention impl: flash_attention_3 (Hopper, default — the recipe that
+# produced the 2.38x speedup) or flash_attention_2 (broadly available, A100/L40S).
+ATTN_IMPL=${ATTN_IMPL:-flash_attention_3}
 
 export PYTHONUNBUFFERED=1
 export HYDRA_FULL_ERROR=1

--- a/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# SkyRL + Arctic RL backend: Qwen3-32B BIRD-SQL GRPO — 4 nodes / 32 H200s.
+#
+# Topology: NUM_NODES=4, GPUS_PER_NODE=8 (DP=32). vLLM TP=4, num_engines=8.
+# train_batch=128 prompts x n_samples=16 = 2048 trajectories/step.
+# Sibling: run_bird_grpo_32b_32gpu_fsdp.sh (same recipe, SkyRL FSDP-native).
+#
+# Prereq: 4-node ray cluster up; `ray status` shows 32/32 GPU.
+
+set -euxo pipefail
+
+SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
+DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
+PYBIN=${PYBIN:-python}
+# FlashAttention impl: flash_attention_2 (broadly available) or flash_attention_3
+# (Hopper-only, build from source from Dao-AILab/flash-attention hopper subdir).
+ATTN_IMPL=${ATTN_IMPL:-flash_attention_2}
+
+export PYTHONUNBUFFERED=1
+export HYDRA_FULL_ERROR=1
+export RAY_DEDUP_LOGS=0
+export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+# Default to ONLINE (auto-download missing models). Set OFFLINE=1 to disable
+# (e.g. on isolated clusters where the model is pre-staged in HF_HOME).
+export HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-0}"
+export TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-0}"
+export TORCH_COMPILE_DISABLE=1
+export VLLM_DISABLE_COMPILE_CACHE=1
+# Disable torch.inductor's on-disk cache too. Without this, a prior run that
+# baked in `flashinfer_trtllm_fused_allreduce_norm` (when fuse_allreduce_rms
+# was on) reuses that compiled graph and asserts during warm-up:
+#   AssertionError: Flashinfer workspace must be initialized when using flashinfer
+# VLLM_DISABLE_COMPILE_CACHE only covers vLLM's own cache, not inductor's.
+export TORCHINDUCTOR_FORCE_DISABLE_CACHES=1
+export VLLM_CACHE_ROOT="${VLLM_CACHE_ROOT:-$HOME/.cache/vllm}"
+export VLLM_LOGGING_LEVEL=INFO
+export VLLM_ATTENTION_BACKEND="${VLLM_ATTENTION_BACKEND:-FLASH_ATTN}"
+export ARCTIC_CUDA_IPC_LOW_MEM=0
+# 32B + tie_word_embeddings is False, but keep the bypass on — it's a no-op
+# when names match and a safety net if upstream Qwen3 adds new tied buffers.
+export ARCTIC_WEIGHT_SYNC_STRICT_NAMES=0
+# verl 32B recipe ships this; helps with the 32B optimizer-state CPU offload churn.
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# WandB — set WANDB_API_KEY in your environment to enable logging; override
+# WANDB_PROJECT to write to a different project.
+export WANDB_API_KEY="${WANDB_API_KEY:-}"
+export WANDB_PROJECT="${WANDB_PROJECT:-skyrl_arctic_rl}"
+export WANDB_DISABLE_CODE=True
+
+# Model: pass the HF id by default — transformers/vLLM auto-download to
+# HF_HOME on first use. If you've pre-staged the snapshot (multi-node
+# shared cache), set MODEL=<absolute snapshot path> to skip the hub lookup.
+MODEL="${MODEL:-Qwen/Qwen3-32B}"
+echo "MODEL=${MODEL}"
+
+RUN_TS=$(date -u +%Y%m%dT%H%M%SZ)
+EXPERIMENT_NAME=skyrl_bird_grpo_Qwen3-32B_arctic_zorro_4node_${RUN_TS}
+# CHECKPOINT_DIR should be on a shared filesystem visible to all nodes
+# (head writes weight-sync tensor, all nodes mmap-read it).
+CHECKPOINT_DIR=${CHECKPOINT_DIR:-${HOME}/skyrl-runs/ckpts/${EXPERIMENT_NAME}}
+mkdir -p "${CHECKPOINT_DIR}"
+
+# BIRD-SQL parquets are bring-your-own (no public prep script).
+if [[ ! -f "${DATA_DIR}/train.parquet" || ! -f "${DATA_DIR}/val.parquet" ]]; then
+    echo "ERROR: BIRD-SQL parquets not found at ${DATA_DIR}/{train,val}.parquet"
+    echo "       Stage your own BIRD-SQL train/val parquets and set DATA_DIR."
+    exit 1
+fi
+
+NUM_NODES=4
+GPUS_PER_NODE=8
+NUM_GPUS=$((NUM_NODES * GPUS_PER_NODE))   # = 32
+
+# Global batch: 128 prompts x 16 samples = 2048 trajectories. With DP=32 and
+# ulysses_sp=1: per-DP mini=64, ZoRRo micro=16 (n_samples), grad_accum=4.
+TRAIN_BSZ=128
+MINI_BSZ=128
+N_SAMPLES=16
+
+LR=2e-6
+PROMPT_LEN=32768
+RESPONSE_LEN=4096
+
+# vLLM sampling TP — verl recipe uses TP=4 (Qwen3-32B doesn't fit per-GPU at
+# bf16 + 0.5 mem_util headroom on H200). 32 GPUs / TP=4 -> 8 engine replicas.
+TP_SIZE=4
+NUM_ENGINES=$((NUM_GPUS / TP_SIZE))
+
+# Inference knobs forwarded to ArcticAsyncEngineArgs via
+# trainer.arctic_rl.arctic_inference_config (raw passthrough):
+#   FCA: forest_cascade_attn_configs={} + cudagraph_mode=PIECEWISE.
+#   pass_config.fuse_allreduce_rms=false: with 8 replicas x TP=4 colocated
+#        2-per-node, the two co-located replicas race for FlashInfer's
+#        per-process AllReduce IPC port; the loser gets EADDRINUSE, the
+#        pass marks itself disabled, but the already-emitted graph nodes
+#        still call into the workspace -> assert during CUDA-graph warmup
+#        (`Flashinfer workspace must be initialized when using flashinfer`).
+#        Disabling the fuse pass avoids the contested port entirely.
+#        Tunji's verl recipe doesn't trip this because it co-locates one
+#        sampling replica per node.
+#   Spec-dec: speculative_config={method: arctic, model: <path>, ...}.
+#
+# These nested dicts are routed to vLLM by integrations.arctic_rl.config,
+# which round-trips them through OmegaConf.to_container so AsyncEngineArgs
+# sees plain dicts (the nested-override hook uses `isinstance(_, dict)`,
+# which is False for omegaconf.DictConfig and silently drops the value).
+# Same idiom as arctic-verl/verl/workers/remote_client/arctic_rl.py.
+#
+# KNOWN ISSUE (open, see follow-up): the OmegaConf round-trip alone is
+# *not* sufficient end-to-end in this checkout — the nested
+# compilation_config is still being dropped somewhere between
+# ArcticRLClientConfig and AsyncEngineArgs.__post_init__ (vLLM resolves
+# cudagraph_mode=FULL_AND_PIECEWISE and fuse_allreduce_rms=True at engine
+# init, even with this override set). Until that plumbing is traced and
+# fixed end-to-end, we pin optimization_level=1 below — that hard-codes
+# fuse_allreduce_rms=false inside vLLM, which empirically reproduced the
+# Jun 24 (skyrl_v1) 2x speedup baseline and is what unblocks TP>1 + Hopper
+# from the FlashInfer-workspace assertion.
+#
+# Flow-style dict values need a space after every `:` — OmegaConf.from_cli
+# runs yaml.load on each rhs (Hydra's CLI parser is more lenient).
+USE_FCA=${USE_FCA:-True}
+SPEC_MODEL=${SPEC_MODEL:-/data-fast/qwen3-32b-bird-4096-3head}
+NUM_SPEC_TOKENS=${NUM_SPEC_TOKENS:-3}
+
+AI_CFG_PARTS=()
+if [[ "${USE_FCA}" == "True" ]]; then
+    AI_CFG_PARTS+=('forest_cascade_attn_configs: "{}"')
+    AI_CFG_PARTS+=('optimization_level: 1')
+    AI_CFG_PARTS+=('compilation_config: {cudagraph_mode: PIECEWISE, pass_config: {fuse_allreduce_rms: false}}')
+fi
+if [[ -n "${SPEC_MODEL}" && -d "${SPEC_MODEL}" ]]; then
+    AI_CFG_PARTS+=("speculative_config: {method: arctic, model: ${SPEC_MODEL}, num_speculative_tokens: ${NUM_SPEC_TOKENS}}")
+fi
+
+AI_CFG_OVERRIDE=()
+if (( ${#AI_CFG_PARTS[@]} > 0 )); then
+    IFS=, AI_CFG_BODY="${AI_CFG_PARTS[*]}" ; unset IFS
+    AI_CFG_OVERRIDE+=("trainer.arctic_rl.arctic_inference_config={${AI_CFG_BODY}}")
+fi
+
+cd "${SKYRL_DIR}"
+
+"${PYBIN}" -m skyrl.train.entrypoints.main_base \
+    trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+    trainer.arctic_rl.colocate=true \
+    trainer.arctic_rl.zero_stage=3 \
+    trainer.arctic_rl.offload_optimizer=true \
+    trainer.arctic_rl.offload_param=false \
+    trainer.arctic_rl.log_prob_gpus=0 \
+    trainer.arctic_rl.use_zorro=true \
+    trainer.arctic_rl.use_liger=true \
+    trainer.arctic_rl.attn_implementation=${ATTN_IMPL} \
+    trainer.arctic_rl.enable_gradient_checkpointing=true \
+    trainer.arctic_rl.ulysses_sequence_parallel_size=1 \
+    trainer.arctic_rl.logits_optimization=memory \
+    trainer.arctic_rl.cuda_ipc_weight_sync=true \
+    trainer.arctic_rl.low_memory_weight_sync=true \
+    trainer.arctic_rl.lr_warmup_ratio=0.05 \
+    'trainer.arctic_rl.optimizer_betas=[0.9,0.95]' \
+    trainer.arctic_rl.vllm_enforce_eager=false \
+    trainer.arctic_rl.vllm_enable_prefix_caching=true \
+    trainer.arctic_rl.vllm_max_num_batched_tokens=40960 \
+    trainer.arctic_rl.vllm_max_num_seqs=256 \
+    trainer.arctic_rl.use_arctic_inference=true \
+    trainer.arctic_rl.server_logs=true \
+    trainer.arctic_rl.startup_timeout=1800 \
+    "${AI_CFG_OVERRIDE[@]}" \
+    data.train_data="['${DATA_DIR}/train.parquet']" \
+    data.val_data="['${DATA_DIR}/val.parquet']" \
+    trainer.algorithm.advantage_estimator=grpo \
+    trainer.policy.model.path="${MODEL}" \
+    trainer.placement.colocate_all=false \
+    trainer.placement.policy_num_gpus_per_node=${GPUS_PER_NODE} \
+    trainer.placement.policy_num_nodes=${NUM_NODES} \
+    generator.inference_engine.num_engines=${NUM_ENGINES} \
+    generator.inference_engine.tensor_parallel_size=${TP_SIZE} \
+    generator.inference_engine.backend=vllm \
+    generator.inference_engine.run_engines_locally=true \
+    generator.inference_engine.gpu_memory_utilization=0.5 \
+    generator.inference_engine.async_engine=true \
+    generator.batched=true \
+    trainer.epochs=1 \
+    trainer.eval_batch_size=32 \
+    trainer.eval_before_train=false \
+    trainer.eval_interval=100 \
+    trainer.update_epochs_per_batch=1 \
+    trainer.train_batch_size=${TRAIN_BSZ} \
+    trainer.policy_mini_batch_size=${MINI_BSZ} \
+    trainer.max_prompt_length=${PROMPT_LEN} \
+    generator.sampling_params.max_generate_length=${RESPONSE_LEN} \
+    generator.sampling_params.temperature=1.0 \
+    generator.sampling_params.top_p=1.0 \
+    generator.eval_sampling_params.max_generate_length=${RESPONSE_LEN} \
+    generator.eval_sampling_params.temperature=0.0 \
+    generator.eval_sampling_params.top_p=1.0 \
+    generator.eval_sampling_params.top_k=-1 \
+    generator.eval_n_samples_per_prompt=1 \
+    trainer.policy.optimizer_config.lr=${LR} \
+    trainer.policy.optimizer_config.max_grad_norm=1.0 \
+    trainer.algorithm.use_kl_loss=false \
+    trainer.algorithm.use_kl_in_reward=false \
+    environment.env_class=bird \
+    generator.n_samples_per_prompt=${N_SAMPLES} \
+    trainer.logger=${LOGGER:-wandb} \
+    trainer.project_name="${WANDB_PROJECT}" \
+    trainer.run_name="${EXPERIMENT_NAME}" \
+    trainer.resume_mode=null \
+    trainer.log_path="${CHECKPOINT_DIR}/logs" \
+    trainer.ckpt_path="${CHECKPOINT_DIR}/ckpt" \
+    trainer.ckpt_interval=-1 \
+    "$@"

--- a/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
@@ -87,49 +87,47 @@ RESPONSE_LEN=4096
 TP_SIZE=4
 NUM_ENGINES=$((NUM_GPUS / TP_SIZE))
 
-# Inference knobs forwarded to ArcticAsyncEngineArgs via
-# trainer.arctic_rl.arctic_inference_config (raw passthrough):
-#   FCA: forest_cascade_attn_configs={} + cudagraph_mode=PIECEWISE.
-#   pass_config.fuse_allreduce_rms=false: with 8 replicas x TP=4 colocated
-#        2-per-node, the two co-located replicas race for FlashInfer's
-#        per-process AllReduce IPC port; the loser gets EADDRINUSE, the
-#        pass marks itself disabled, but the already-emitted graph nodes
-#        still call into the workspace -> assert during CUDA-graph warmup
-#        (`Flashinfer workspace must be initialized when using flashinfer`).
-#        Disabling the fuse pass avoids the contested port entirely.
-#   Spec-dec: speculative_config={method: arctic, model: <path>, ...}.
-#   optimization_level=1: belt-and-suspenders alongside the explicit
-#        compilation_config override -- vLLM's O1 also hard-codes
-#        fuse_allreduce_rms=false + cudagraph_mode=PIECEWISE, so even if
-#        a future vLLM version changes O2's defaults the recipe stays
-#        pinned to a known-good configuration.
+# Inference-engine performance knobs, forwarded raw to vLLM via
+# trainer.arctic_rl.vllm_config:
 #
-# These nested dicts are routed to vLLM by integrations.arctic_rl.config,
-# which round-trips them through OmegaConf.to_container so AsyncEngineArgs
-# sees plain dicts (the nested-override hook uses `isinstance(_, dict)`,
-# which is False for omegaconf.DictConfig and silently drops the value).
-# Same idiom as arctic-verl/verl/workers/remote_client/arctic_rl.py.
+#   * FCA (forest cascade attention): enabled by setting
+#     ``forest_cascade_attn_configs`` (anything arctic-inference
+#     recognises; "{}" = defaults).
+#
+#   * Arctic speculative decoding: ``speculative_config`` with
+#     ``method=arctic`` + a draft head + 3 spec tokens.
+#
+#   * ``compilation_config``: pin ``cudagraph_mode=PIECEWISE`` and
+#     ``pass_config.fuse_allreduce_rms=false``. The fuse_allreduce_rms
+#     override dodges the FlashInfer-workspace assert that fires when
+#     >1 vLLM replica per node tries to use the fused-allreduce compile
+#     pass simultaneously (per-process IPC port collision).
+#
+# We route via ``vllm_config`` (NOT ``arctic_inference_config``) because
+# arctic-platform's ``build_model_config`` forwards ``vllm_config``
+# verbatim to vLLM, whereas ``arctic_inference_config`` is filtered by
+# ``parse_arctic_inference_rollout`` which only knows the high-level
+# ``use_fca`` / ``spec_model`` schema and drops everything else.
 #
 # Flow-style dict values need a space after every `:` — OmegaConf.from_cli
-# runs yaml.load on each rhs (Hydra's CLI parser is more lenient).
+# runs yaml.load on each rhs.
 USE_FCA=${USE_FCA:-True}
-SPEC_MODEL=${SPEC_MODEL:-/data-fast/qwen3-32b-bird-4096-3head}
+SPEC_MODEL=${SPEC_MODEL:-}
 NUM_SPEC_TOKENS=${NUM_SPEC_TOKENS:-3}
 
-AI_CFG_PARTS=()
+VLLM_CFG_PARTS=()
 if [[ "${USE_FCA}" == "True" ]]; then
-    AI_CFG_PARTS+=('forest_cascade_attn_configs: "{}"')
-    AI_CFG_PARTS+=('optimization_level: 1')
-    AI_CFG_PARTS+=('compilation_config: {cudagraph_mode: PIECEWISE, pass_config: {fuse_allreduce_rms: false}}')
+    VLLM_CFG_PARTS+=('forest_cascade_attn_configs: "{}"')
+    VLLM_CFG_PARTS+=('compilation_config: {cudagraph_mode: PIECEWISE, pass_config: {fuse_allreduce_rms: false}}')
 fi
 if [[ -n "${SPEC_MODEL}" && -d "${SPEC_MODEL}" ]]; then
-    AI_CFG_PARTS+=("speculative_config: {method: arctic, model: ${SPEC_MODEL}, num_speculative_tokens: ${NUM_SPEC_TOKENS}}")
+    VLLM_CFG_PARTS+=("speculative_config: {method: arctic, model: ${SPEC_MODEL}, num_speculative_tokens: ${NUM_SPEC_TOKENS}}")
 fi
 
-AI_CFG_OVERRIDE=()
-if (( ${#AI_CFG_PARTS[@]} > 0 )); then
-    IFS=, AI_CFG_BODY="${AI_CFG_PARTS[*]}" ; unset IFS
-    AI_CFG_OVERRIDE+=("trainer.arctic_rl.arctic_inference_config={${AI_CFG_BODY}}")
+VLLM_CFG_OVERRIDE=()
+if (( ${#VLLM_CFG_PARTS[@]} > 0 )); then
+    IFS=, VLLM_CFG_BODY="${VLLM_CFG_PARTS[*]}" ; unset IFS
+    VLLM_CFG_OVERRIDE+=("trainer.arctic_rl.vllm_config={${VLLM_CFG_BODY}}")
 fi
 
 cd "${SKYRL_DIR}"
@@ -158,7 +156,7 @@ cd "${SKYRL_DIR}"
     trainer.arctic_rl.use_arctic_inference=true \
     trainer.arctic_rl.server_logs=true \
     trainer.arctic_rl.startup_timeout=1800 \
-    "${AI_CFG_OVERRIDE[@]}" \
+    "${VLLM_CFG_OVERRIDE[@]}" \
     data.train_data="['${DATA_DIR}/train.parquet']" \
     data.val_data="['${DATA_DIR}/val.parquet']" \
     trainer.algorithm.advantage_estimator=grpo \

--- a/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
@@ -11,7 +11,16 @@ set -euxo pipefail
 
 SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
 DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
-PYBIN=${PYBIN:-python}
+
+# Driver (same shape as flash_rl/harbor; see run_gsm8k_grpo_4gpu.sh for details).
+FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+DRIVER=(uv run --isolated --extra skyrl-train
+    --with arctic-platform
+    --with 'arctic-inference[vllm]'
+    --with liger-kernel
+    --with 'transformers==4.57.6'
+    --with "flash-attn@${FLASH_ATTN_WHL}"
+    -- python)
 # FlashAttention impl: flash_attention_2 (broadly available) or flash_attention_3
 # (Hopper-only, build from source from Dao-AILab/flash-attention hopper subdir).
 ATTN_IMPL=${ATTN_IMPL:-flash_attention_2}
@@ -108,7 +117,7 @@ fi
 
 cd "${SKYRL_DIR}"
 
-"${PYBIN}" -m skyrl.train.entrypoints.main_base \
+"${DRIVER[@]}" -m skyrl.train.entrypoints.main_base \
     trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
     trainer.arctic_rl.colocate=true \
     trainer.arctic_rl.zero_stage=3 \

--- a/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
@@ -97,26 +97,18 @@ NUM_ENGINES=$((NUM_GPUS / TP_SIZE))
 #        still call into the workspace -> assert during CUDA-graph warmup
 #        (`Flashinfer workspace must be initialized when using flashinfer`).
 #        Disabling the fuse pass avoids the contested port entirely.
-#        Tunji's verl recipe doesn't trip this because it co-locates one
-#        sampling replica per node.
 #   Spec-dec: speculative_config={method: arctic, model: <path>, ...}.
+#   optimization_level=1: belt-and-suspenders alongside the explicit
+#        compilation_config override -- vLLM's O1 also hard-codes
+#        fuse_allreduce_rms=false + cudagraph_mode=PIECEWISE, so even if
+#        a future vLLM version changes O2's defaults the recipe stays
+#        pinned to a known-good configuration.
 #
 # These nested dicts are routed to vLLM by integrations.arctic_rl.config,
 # which round-trips them through OmegaConf.to_container so AsyncEngineArgs
 # sees plain dicts (the nested-override hook uses `isinstance(_, dict)`,
 # which is False for omegaconf.DictConfig and silently drops the value).
 # Same idiom as arctic-verl/verl/workers/remote_client/arctic_rl.py.
-#
-# KNOWN ISSUE (open, see follow-up): the OmegaConf round-trip alone is
-# *not* sufficient end-to-end in this checkout — the nested
-# compilation_config is still being dropped somewhere between
-# ArcticRLClientConfig and AsyncEngineArgs.__post_init__ (vLLM resolves
-# cudagraph_mode=FULL_AND_PIECEWISE and fuse_allreduce_rms=True at engine
-# init, even with this override set). Until that plumbing is traced and
-# fixed end-to-end, we pin optimization_level=1 below — that hard-codes
-# fuse_allreduce_rms=false inside vLLM, which empirically reproduced the
-# Jun 24 (skyrl_v1) 2x speedup baseline and is what unblocks TP>1 + Hopper
-# from the FlashInfer-workspace assertion.
 #
 # Flow-style dict values need a space after every `:` — OmegaConf.from_cli
 # runs yaml.load on each rhs (Hydra's CLI parser is more lenient).

--- a/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu.sh
@@ -87,47 +87,23 @@ RESPONSE_LEN=4096
 TP_SIZE=4
 NUM_ENGINES=$((NUM_GPUS / TP_SIZE))
 
-# Inference-engine performance knobs, forwarded raw to vLLM via
-# trainer.arctic_rl.vllm_config:
-#
-#   * FCA (forest cascade attention): enabled by setting
-#     ``forest_cascade_attn_configs`` (anything arctic-inference
-#     recognises; "{}" = defaults).
-#
-#   * Arctic speculative decoding: ``speculative_config`` with
-#     ``method=arctic`` + a draft head + 3 spec tokens.
-#
-#   * ``compilation_config``: pin ``cudagraph_mode=PIECEWISE`` and
-#     ``pass_config.fuse_allreduce_rms=false``. The fuse_allreduce_rms
-#     override dodges the FlashInfer-workspace assert that fires when
-#     >1 vLLM replica per node tries to use the fused-allreduce compile
-#     pass simultaneously (per-process IPC port collision).
-#
-# We route via ``vllm_config`` (NOT ``arctic_inference_config``) because
-# arctic-platform's ``build_model_config`` forwards ``vllm_config``
-# verbatim to vLLM, whereas ``arctic_inference_config`` is filtered by
-# ``parse_arctic_inference_rollout`` which only knows the high-level
-# ``use_fca`` / ``spec_model`` schema and drops everything else.
-#
-# Flow-style dict values need a space after every `:` — OmegaConf.from_cli
-# runs yaml.load on each rhs.
-USE_FCA=${USE_FCA:-True}
+# Inference-engine optimizations are opt-in via typed knobs on
+# ``trainer.arctic_rl`` — the integration auto-injects the matching raw
+# vLLM kwargs (FCA, multi-replica FlashInfer workaround, Arctic
+# speculative_config) so the launcher never needs a raw vllm_config block.
+#   - ``use_arctic_inference=true``  -> FCA on, fuse_allreduce_rms workaround
+#                                       when num_engines > 1.
+#   - ``speculative_model=<path>``   -> Arctic speculative decoding on with
+#                                       ``num_speculative_tokens`` draft tokens.
+# ``vllm_config`` remains as an escape hatch for any vLLM knob the typed
+# fields don't cover; nothing in this recipe needs it.
 SPEC_MODEL=${SPEC_MODEL:-}
 NUM_SPEC_TOKENS=${NUM_SPEC_TOKENS:-3}
 
-VLLM_CFG_PARTS=()
-if [[ "${USE_FCA}" == "True" ]]; then
-    VLLM_CFG_PARTS+=('forest_cascade_attn_configs: "{}"')
-    VLLM_CFG_PARTS+=('compilation_config: {cudagraph_mode: PIECEWISE, pass_config: {fuse_allreduce_rms: false}}')
-fi
-if [[ -n "${SPEC_MODEL}" && -d "${SPEC_MODEL}" ]]; then
-    VLLM_CFG_PARTS+=("speculative_config: {method: arctic, model: ${SPEC_MODEL}, num_speculative_tokens: ${NUM_SPEC_TOKENS}}")
-fi
-
-VLLM_CFG_OVERRIDE=()
-if (( ${#VLLM_CFG_PARTS[@]} > 0 )); then
-    IFS=, VLLM_CFG_BODY="${VLLM_CFG_PARTS[*]}" ; unset IFS
-    VLLM_CFG_OVERRIDE+=("trainer.arctic_rl.vllm_config={${VLLM_CFG_BODY}}")
+ARCTIC_SPEC_OVERRIDE=()
+if [[ -n "${SPEC_MODEL}" ]]; then
+    ARCTIC_SPEC_OVERRIDE+=("trainer.arctic_rl.speculative_model=${SPEC_MODEL}")
+    ARCTIC_SPEC_OVERRIDE+=("trainer.arctic_rl.num_speculative_tokens=${NUM_SPEC_TOKENS}")
 fi
 
 cd "${SKYRL_DIR}"
@@ -156,7 +132,7 @@ cd "${SKYRL_DIR}"
     trainer.arctic_rl.use_arctic_inference=true \
     trainer.arctic_rl.server_logs=true \
     trainer.arctic_rl.startup_timeout=1800 \
-    "${VLLM_CFG_OVERRIDE[@]}" \
+    "${ARCTIC_SPEC_OVERRIDE[@]}" \
     data.train_data="['${DATA_DIR}/train.parquet']" \
     data.val_data="['${DATA_DIR}/val.parquet']" \
     trainer.algorithm.advantage_estimator=grpo \

--- a/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu_fsdp.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu_fsdp.sh
@@ -17,7 +17,16 @@ set -euxo pipefail
 
 SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
 DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
-PYBIN=${PYBIN:-python}
+
+# Driver (same shape as flash_rl/harbor; see run_gsm8k_grpo_4gpu.sh for details).
+FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+DRIVER=(uv run --isolated --extra skyrl-train
+    --with arctic-platform
+    --with 'arctic-inference[vllm]'
+    --with liger-kernel
+    --with 'transformers==4.57.6'
+    --with "flash-attn@${FLASH_ATTN_WHL}"
+    -- python)
 
 export PYTHONUNBUFFERED=1
 export HYDRA_FULL_ERROR=1
@@ -68,7 +77,7 @@ cd "${SKYRL_DIR}"
 
 FSDP_BIRD_ENTRY="${SKYRL_DIR}/integrations/arctic_rl/examples/fsdp_bird_entry.py"
 
-"${PYBIN}" "${FSDP_BIRD_ENTRY}" \
+"${DRIVER[@]}" "${FSDP_BIRD_ENTRY}" \
     data.train_data="['${DATA_DIR}/train.parquet']" \
     data.val_data="['${DATA_DIR}/val.parquet']" \
     trainer.algorithm.advantage_estimator=grpo \

--- a/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu_fsdp.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu_fsdp.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Native SkyRL FSDP backend: Qwen3-32B BIRD-SQL GRPO recipe — 4 nodes / 32 H200s.
+#
+# Sibling of run_bird_grpo_32b_32gpu.sh: SAME model, SAME data, SAME hyperparams,
+# SAME placement, SAME WandB project — only the training backend differs.
+# Apples-to-apples E2E time-per-step comparison vs the Arctic RL backend.
+#
+# Differences vs the arctic launcher:
+#   - no trainer.override_entrypoint (default core FSDP path; drop all arctic_rl flags)
+#   - generator stays vLLM, no ArcticInference (no FCA, no speculative decoding)
+#   - trainer.placement.colocate_all=true (native SkyRL colocation, not Arctic's)
+#   - No CUDA-IPC weight sync (uses SkyRL's native FSDP weight sync)
+#
+# Same prereqs: 4-node ray cluster up, HF Qwen3-32B downloaded.
+
+set -euxo pipefail
+
+SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
+DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
+PYBIN=${PYBIN:-python}
+
+export PYTHONUNBUFFERED=1
+export HYDRA_FULL_ERROR=1
+export RAY_DEDUP_LOGS=0
+export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+export HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-0}"
+export TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-0}"
+export TORCH_COMPILE_DISABLE=1
+export VLLM_DISABLE_COMPILE_CACHE=1
+export VLLM_CACHE_ROOT="${VLLM_CACHE_ROOT:-$HOME/.cache/vllm}"
+export VLLM_LOGGING_LEVEL=INFO
+export VLLM_ATTENTION_BACKEND="${VLLM_ATTENTION_BACKEND:-FLASH_ATTN}"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+# Liger off: Qwen3 Liger kernel hits a Triton illegal-mem-access on packed-seq
+# inputs (cu_seqlens variable, attention_mask=None). Compensate with micro=2
+# below so LM-head logits fit on H200.
+export SKYRL_USE_LIGER=0
+
+# Same W&B project as the arctic launcher so the two runs sit side-by-side.
+export WANDB_API_KEY="${WANDB_API_KEY:-}"
+export WANDB_PROJECT="${WANDB_PROJECT:-skyrl_arctic_rl}"
+export WANDB_DISABLE_CODE=True
+
+MODEL="${MODEL:-Qwen/Qwen3-32B}"
+echo "MODEL=${MODEL}"
+
+RUN_TS=$(date -u +%Y%m%dT%H%M%SZ)
+EXPERIMENT_NAME=skyrl_bird_grpo_Qwen3-32B_fsdp_4node_${RUN_TS}
+CHECKPOINT_DIR=${CHECKPOINT_DIR:-${HOME}/skyrl-runs/ckpts/${EXPERIMENT_NAME}}
+mkdir -p "${CHECKPOINT_DIR}"
+
+NUM_NODES=4
+GPUS_PER_NODE=8
+NUM_GPUS=$((NUM_NODES * GPUS_PER_NODE))
+
+# Same batch math as the arctic launcher.
+TRAIN_BSZ=128
+MINI_BSZ=128
+N_SAMPLES=16
+LR=2e-6
+PROMPT_LEN=32768
+RESPONSE_LEN=4096
+
+TP_SIZE=4
+NUM_ENGINES=$((NUM_GPUS / TP_SIZE))
+
+cd "${SKYRL_DIR}"
+
+FSDP_BIRD_ENTRY="${SKYRL_DIR}/integrations/arctic_rl/examples/fsdp_bird_entry.py"
+
+"${PYBIN}" "${FSDP_BIRD_ENTRY}" \
+    data.train_data="['${DATA_DIR}/train.parquet']" \
+    data.val_data="['${DATA_DIR}/val.parquet']" \
+    trainer.algorithm.advantage_estimator=grpo \
+    trainer.policy.model.path="${MODEL}" \
+    trainer.strategy=fsdp2 \
+    trainer.placement.colocate_all=true \
+    trainer.placement.policy_num_gpus_per_node=${GPUS_PER_NODE} \
+    trainer.placement.policy_num_nodes=${NUM_NODES} \
+    trainer.policy.fsdp_config.cpu_offload=false \
+    trainer.policy.fsdp_config.reshard_after_forward=true \
+    trainer.policy.optimizer_config.offload_after_step=true \
+    trainer.policy.sequence_parallel_size=1 \
+    trainer.flash_attn=true \
+    trainer.micro_train_batch_size_per_gpu=${MICRO_TRAIN:-2} \
+    trainer.micro_forward_batch_size_per_gpu=${MICRO_FWD:-2} \
+    trainer.use_sample_packing=true \
+    generator.inference_engine.num_engines=${NUM_ENGINES} \
+    generator.inference_engine.tensor_parallel_size=${TP_SIZE} \
+    generator.inference_engine.backend=vllm \
+    generator.inference_engine.run_engines_locally=true \
+    generator.inference_engine.gpu_memory_utilization=0.5 \
+    generator.inference_engine.async_engine=true \
+    generator.batched=true \
+    trainer.epochs=1 \
+    trainer.eval_batch_size=32 \
+    trainer.eval_before_train=false \
+    trainer.eval_interval=100 \
+    trainer.update_epochs_per_batch=1 \
+    trainer.train_batch_size=${TRAIN_BSZ} \
+    trainer.policy_mini_batch_size=${MINI_BSZ} \
+    trainer.max_prompt_length=${PROMPT_LEN} \
+    generator.sampling_params.max_generate_length=${RESPONSE_LEN} \
+    generator.sampling_params.temperature=1.0 \
+    generator.sampling_params.top_p=1.0 \
+    generator.eval_sampling_params.max_generate_length=${RESPONSE_LEN} \
+    generator.eval_sampling_params.temperature=0.0 \
+    generator.eval_sampling_params.top_p=1.0 \
+    generator.eval_sampling_params.top_k=-1 \
+    generator.eval_n_samples_per_prompt=1 \
+    trainer.policy.optimizer_config.lr=${LR} \
+    trainer.policy.optimizer_config.max_grad_norm=1.0 \
+    trainer.algorithm.use_kl_loss=false \
+    trainer.algorithm.use_kl_in_reward=false \
+    environment.env_class=bird \
+    generator.n_samples_per_prompt=${N_SAMPLES} \
+    trainer.logger=wandb \
+    trainer.project_name="${WANDB_PROJECT}" \
+    trainer.run_name="${EXPERIMENT_NAME}" \
+    trainer.resume_mode=null \
+    trainer.log_path="${CHECKPOINT_DIR}/logs" \
+    trainer.ckpt_path="${CHECKPOINT_DIR}/ckpt" \
+    trainer.ckpt_interval=-1 \
+    "$@"

--- a/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu_fsdp.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_32b_32gpu_fsdp.sh
@@ -19,13 +19,16 @@ SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
 DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
 
 # Driver (same shape as flash_rl/harbor; see run_gsm8k_grpo_4gpu.sh for details).
+# FSDP variant matches the arctic-rl recipe stack so attention is apples-to-apples.
 FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+FLASH_ATTN3_WHL="https://download.pytorch.org/whl/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
 DRIVER=(uv run --isolated --extra skyrl-train
     --with arctic-platform
     --with 'arctic-inference[vllm]'
     --with liger-kernel
     --with 'transformers==4.57.6'
     --with "flash-attn@${FLASH_ATTN_WHL}"
+    --with "flash-attn-3@${FLASH_ATTN3_WHL}"
     -- python)
 
 export PYTHONUNBUFFERED=1

--- a/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
@@ -95,23 +95,13 @@ cd "${SKYRL_DIR}"
     trainer.arctic_rl.colocate=true \
     trainer.arctic_rl.zero_stage=3 \
     trainer.arctic_rl.offload_optimizer=true \
-    trainer.arctic_rl.offload_param=false \
-    trainer.arctic_rl.log_prob_gpus=0 \
-    trainer.arctic_rl.use_zorro=true \
-    trainer.arctic_rl.use_liger=true \
     trainer.arctic_rl.attn_implementation=${ATTN_IMPL} \
-    trainer.arctic_rl.enable_gradient_checkpointing=true \
-    trainer.arctic_rl.ulysses_sequence_parallel_size=1 \
-    trainer.arctic_rl.logits_optimization=memory \
     trainer.arctic_rl.cuda_ipc_weight_sync=true \
     trainer.arctic_rl.low_memory_weight_sync=true \
     trainer.arctic_rl.lr_warmup_ratio=0.05 \
     'trainer.arctic_rl.optimizer_betas=[0.9,0.95]' \
     trainer.arctic_rl.vllm_enforce_eager=false \
-    trainer.arctic_rl.vllm_enable_prefix_caching=true \
     trainer.arctic_rl.vllm_max_num_batched_tokens=40960 \
-    trainer.arctic_rl.vllm_max_num_seqs=256 \
-    trainer.arctic_rl.use_arctic_inference=true \
     trainer.arctic_rl.server_logs=true \
     trainer.arctic_rl.startup_timeout=1800 \
     "${ARCTIC_SPEC_OVERRIDE[@]}" \

--- a/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
@@ -71,27 +71,21 @@ RESPONSE_LEN=4096
 TP_SIZE=4
 NUM_ENGINES=$((NUM_GPUS / TP_SIZE))
 
-# Inference-engine performance knobs (FCA + Arctic speculative decoding +
-# the FlashInfer-safe compilation_config). Routed raw to vLLM via
-# trainer.arctic_rl.vllm_config. See run_bird_grpo_32b_32gpu.sh for the
-# full rationale.
-USE_FCA=${USE_FCA:-True}
+# Inference-engine optimizations are opt-in via typed knobs on
+# ``trainer.arctic_rl`` — the integration auto-injects the matching raw
+# vLLM kwargs (FCA, multi-replica FlashInfer workaround, Arctic
+# speculative_config) so the launcher never needs a raw vllm_config block.
+#   - ``use_arctic_inference=true``  -> FCA on, fuse_allreduce_rms workaround
+#                                       when num_engines > 1.
+#   - ``speculative_model=<path>``   -> Arctic speculative decoding on with
+#                                       ``num_speculative_tokens`` draft tokens.
 SPEC_MODEL=${SPEC_MODEL:-}
 NUM_SPEC_TOKENS=${NUM_SPEC_TOKENS:-3}
 
-VLLM_CFG_PARTS=()
-if [[ "${USE_FCA}" == "True" ]]; then
-    VLLM_CFG_PARTS+=('forest_cascade_attn_configs: "{}"')
-    VLLM_CFG_PARTS+=('compilation_config: {cudagraph_mode: PIECEWISE, pass_config: {fuse_allreduce_rms: false}}')
-fi
-if [[ -n "${SPEC_MODEL}" && -d "${SPEC_MODEL}" ]]; then
-    VLLM_CFG_PARTS+=("speculative_config: {method: arctic, model: ${SPEC_MODEL}, num_speculative_tokens: ${NUM_SPEC_TOKENS}}")
-fi
-
-VLLM_CFG_OVERRIDE=()
-if (( ${#VLLM_CFG_PARTS[@]} > 0 )); then
-    IFS=, VLLM_CFG_BODY="${VLLM_CFG_PARTS[*]}" ; unset IFS
-    VLLM_CFG_OVERRIDE+=("trainer.arctic_rl.vllm_config={${VLLM_CFG_BODY}}")
+ARCTIC_SPEC_OVERRIDE=()
+if [[ -n "${SPEC_MODEL}" ]]; then
+    ARCTIC_SPEC_OVERRIDE+=("trainer.arctic_rl.speculative_model=${SPEC_MODEL}")
+    ARCTIC_SPEC_OVERRIDE+=("trainer.arctic_rl.num_speculative_tokens=${NUM_SPEC_TOKENS}")
 fi
 
 cd "${SKYRL_DIR}"
@@ -120,7 +114,7 @@ cd "${SKYRL_DIR}"
     trainer.arctic_rl.use_arctic_inference=true \
     trainer.arctic_rl.server_logs=true \
     trainer.arctic_rl.startup_timeout=1800 \
-    "${VLLM_CFG_OVERRIDE[@]}" \
+    "${ARCTIC_SPEC_OVERRIDE[@]}" \
     data.train_data="['${DATA_DIR}/train.parquet']" \
     data.val_data="['${DATA_DIR}/val.parquet']" \
     trainer.algorithm.advantage_estimator=grpo \

--- a/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
@@ -18,15 +18,19 @@ SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
 DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
 
 # Driver (same shape as flash_rl/harbor; see run_gsm8k_grpo_4gpu.sh for details).
+# FA3 (cp39-abi3 wheel from PyTorch's cu128 index) is the default on Hopper.
 FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+FLASH_ATTN3_WHL="https://download.pytorch.org/whl/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
 DRIVER=(uv run --isolated --extra skyrl-train
     --with arctic-platform
     --with 'arctic-inference[vllm]'
     --with liger-kernel
     --with 'transformers==4.57.6'
     --with "flash-attn@${FLASH_ATTN_WHL}"
+    --with "flash-attn-3@${FLASH_ATTN3_WHL}"
     -- python)
-ATTN_IMPL=${ATTN_IMPL:-flash_attention_2}
+# FA3 default (Hopper); set ATTN_IMPL=flash_attention_2 for A100/L40S.
+ATTN_IMPL=${ATTN_IMPL:-flash_attention_3}
 
 export PYTHONUNBUFFERED=1
 export HYDRA_FULL_ERROR=1

--- a/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
@@ -16,7 +16,16 @@ set -euxo pipefail
 
 SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
 DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
-PYBIN=${PYBIN:-python}
+
+# Driver (same shape as flash_rl/harbor; see run_gsm8k_grpo_4gpu.sh for details).
+FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+DRIVER=(uv run --isolated --extra skyrl-train
+    --with arctic-platform
+    --with 'arctic-inference[vllm]'
+    --with liger-kernel
+    --with 'transformers==4.57.6'
+    --with "flash-attn@${FLASH_ATTN_WHL}"
+    -- python)
 ATTN_IMPL=${ATTN_IMPL:-flash_attention_2}
 
 export PYTHONUNBUFFERED=1
@@ -90,7 +99,7 @@ fi
 
 cd "${SKYRL_DIR}"
 
-"${PYBIN}" -m skyrl.train.entrypoints.main_base \
+"${DRIVER[@]}" -m skyrl.train.entrypoints.main_base \
     trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
     trainer.arctic_rl.colocate=true \
     trainer.arctic_rl.zero_stage=3 \

--- a/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# SkyRL + Arctic RL backend: Qwen3-8B BIRD-SQL GRPO — 4 nodes / 32 H200s.
+#
+# Same recipe as run_bird_grpo_32b_32gpu.sh (TP=4, FCA,
+# CUDA-IPC weight sync, ZoRRo, Liger), except:
+#   - MODEL is Qwen3-8B (~16GB bf16) instead of Qwen3-32B.
+#   - Speculative decoding is disabled by default: the 32B spec head
+#     (/data-fast/qwen3-32b-bird-4096-3head) is architecturally tied to
+#     Qwen3-32B and won't load on Qwen3-8B. Drop in an 8B-trained 3-head
+#     checkpoint via SPEC_MODEL=... to re-enable.
+#
+# Use this as a faster (~4-5x step time) iteration target for the same TP>1
+# code path the 32B run exercises.
+
+set -euxo pipefail
+
+SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
+DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
+PYBIN=${PYBIN:-python}
+ATTN_IMPL=${ATTN_IMPL:-flash_attention_2}
+
+export PYTHONUNBUFFERED=1
+export HYDRA_FULL_ERROR=1
+export RAY_DEDUP_LOGS=0
+export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+export HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-0}"
+export TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-0}"
+export TORCH_COMPILE_DISABLE=1
+export VLLM_DISABLE_COMPILE_CACHE=1
+# Also disable torch.inductor's on-disk cache; see 32B launcher for the
+# stale-compiled-graph rationale.
+export TORCHINDUCTOR_FORCE_DISABLE_CACHES=1
+export VLLM_CACHE_ROOT="${VLLM_CACHE_ROOT:-$HOME/.cache/vllm}"
+export VLLM_LOGGING_LEVEL=INFO
+export VLLM_ATTENTION_BACKEND="${VLLM_ATTENTION_BACKEND:-FLASH_ATTN}"
+export ARCTIC_CUDA_IPC_LOW_MEM=0
+export ARCTIC_WEIGHT_SYNC_STRICT_NAMES=0
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+export WANDB_API_KEY="${WANDB_API_KEY:-}"
+export WANDB_PROJECT="${WANDB_PROJECT:-skyrl_arctic_rl}"
+export WANDB_DISABLE_CODE=True
+
+MODEL="${MODEL:-Qwen/Qwen3-8B}"
+echo "MODEL=${MODEL}"
+
+RUN_TS=$(date -u +%Y%m%dT%H%M%SZ)
+EXPERIMENT_NAME=skyrl_bird_grpo_Qwen3-8B_arctic_zorro_4node_${RUN_TS}
+CHECKPOINT_DIR=${CHECKPOINT_DIR:-${HOME}/skyrl-runs/ckpts/${EXPERIMENT_NAME}}
+mkdir -p "${CHECKPOINT_DIR}"
+
+if [[ ! -f "${DATA_DIR}/train.parquet" || ! -f "${DATA_DIR}/val.parquet" ]]; then
+    echo "ERROR: BIRD-SQL parquets not found at ${DATA_DIR}/{train,val}.parquet"
+    echo "       Stage your own BIRD-SQL train/val parquets and set DATA_DIR."
+    exit 1
+fi
+
+NUM_NODES=4
+GPUS_PER_NODE=8
+NUM_GPUS=$((NUM_NODES * GPUS_PER_NODE))
+
+TRAIN_BSZ=128
+MINI_BSZ=128
+N_SAMPLES=16
+
+LR=2e-6
+PROMPT_LEN=32768
+RESPONSE_LEN=4096
+
+# Same TP=4 as 32B to exercise the same multi-rank flashinfer code path.
+TP_SIZE=4
+NUM_ENGINES=$((NUM_GPUS / TP_SIZE))
+
+# Inference knobs forwarded to ArcticAsyncEngineArgs via
+# trainer.arctic_rl.arctic_inference_config (raw passthrough). See
+# run_bird_grpo_32b_32gpu.sh for the fuse_allreduce_rms rationale.
+USE_FCA=${USE_FCA:-True}
+SPEC_MODEL=${SPEC_MODEL:-}
+NUM_SPEC_TOKENS=${NUM_SPEC_TOKENS:-3}
+
+AI_CFG_PARTS=()
+if [[ "${USE_FCA}" == "True" ]]; then
+    AI_CFG_PARTS+=('forest_cascade_attn_configs: "{}"')
+    # Pin vLLM optimization to O1 so its compile pipeline hardcodes
+    # fuse_allreduce_rms=false. We *also* request it explicitly via
+    # compilation_config below, but in this environment the nested override
+    # from arctic_rl -> arctic_platform -> AsyncEngineArgs is being dropped
+    # before vLLM sees it (cudagraph_mode resolves to the default
+    # FULL_AND_PIECEWISE and fuse_allreduce_rms to True at engine init).
+    # Until that plumbing is fixed end-to-end, O1 is the reliable knob that
+    # avoids the FlashInfer-workspace assertion on TP>1 + Hopper. See
+    # docs/arctic_rl_speedup_investigation.md (TODO) for the open thread.
+    AI_CFG_PARTS+=('optimization_level: 1')
+    AI_CFG_PARTS+=('compilation_config: {cudagraph_mode: PIECEWISE, pass_config: {fuse_allreduce_rms: false}}')
+fi
+if [[ -n "${SPEC_MODEL}" && -d "${SPEC_MODEL}" ]]; then
+    AI_CFG_PARTS+=("speculative_config: {method: arctic, model: ${SPEC_MODEL}, num_speculative_tokens: ${NUM_SPEC_TOKENS}}")
+fi
+
+AI_CFG_OVERRIDE=()
+if (( ${#AI_CFG_PARTS[@]} > 0 )); then
+    IFS=, AI_CFG_BODY="${AI_CFG_PARTS[*]}" ; unset IFS
+    AI_CFG_OVERRIDE+=("trainer.arctic_rl.arctic_inference_config={${AI_CFG_BODY}}")
+fi
+
+cd "${SKYRL_DIR}"
+
+"${PYBIN}" -m skyrl.train.entrypoints.main_base \
+    trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+    trainer.arctic_rl.colocate=true \
+    trainer.arctic_rl.zero_stage=3 \
+    trainer.arctic_rl.offload_optimizer=true \
+    trainer.arctic_rl.offload_param=false \
+    trainer.arctic_rl.log_prob_gpus=0 \
+    trainer.arctic_rl.use_zorro=true \
+    trainer.arctic_rl.use_liger=true \
+    trainer.arctic_rl.attn_implementation=${ATTN_IMPL} \
+    trainer.arctic_rl.enable_gradient_checkpointing=true \
+    trainer.arctic_rl.ulysses_sequence_parallel_size=1 \
+    trainer.arctic_rl.logits_optimization=memory \
+    trainer.arctic_rl.cuda_ipc_weight_sync=true \
+    trainer.arctic_rl.low_memory_weight_sync=true \
+    trainer.arctic_rl.lr_warmup_ratio=0.05 \
+    'trainer.arctic_rl.optimizer_betas=[0.9,0.95]' \
+    trainer.arctic_rl.vllm_enforce_eager=false \
+    trainer.arctic_rl.vllm_enable_prefix_caching=true \
+    trainer.arctic_rl.vllm_max_num_batched_tokens=40960 \
+    trainer.arctic_rl.vllm_max_num_seqs=256 \
+    trainer.arctic_rl.use_arctic_inference=true \
+    trainer.arctic_rl.server_logs=true \
+    trainer.arctic_rl.startup_timeout=1800 \
+    "${AI_CFG_OVERRIDE[@]}" \
+    data.train_data="['${DATA_DIR}/train.parquet']" \
+    data.val_data="['${DATA_DIR}/val.parquet']" \
+    trainer.algorithm.advantage_estimator=grpo \
+    trainer.policy.model.path="${MODEL}" \
+    trainer.placement.colocate_all=false \
+    trainer.placement.policy_num_gpus_per_node=${GPUS_PER_NODE} \
+    trainer.placement.policy_num_nodes=${NUM_NODES} \
+    generator.inference_engine.num_engines=${NUM_ENGINES} \
+    generator.inference_engine.tensor_parallel_size=${TP_SIZE} \
+    generator.inference_engine.backend=vllm \
+    generator.inference_engine.run_engines_locally=true \
+    generator.inference_engine.gpu_memory_utilization=0.5 \
+    generator.inference_engine.async_engine=true \
+    generator.batched=true \
+    trainer.epochs=1 \
+    trainer.eval_batch_size=32 \
+    trainer.eval_before_train=false \
+    trainer.eval_interval=100 \
+    trainer.update_epochs_per_batch=1 \
+    trainer.train_batch_size=${TRAIN_BSZ} \
+    trainer.policy_mini_batch_size=${MINI_BSZ} \
+    trainer.max_prompt_length=${PROMPT_LEN} \
+    generator.sampling_params.max_generate_length=${RESPONSE_LEN} \
+    generator.sampling_params.temperature=1.0 \
+    generator.sampling_params.top_p=1.0 \
+    generator.eval_sampling_params.max_generate_length=${RESPONSE_LEN} \
+    generator.eval_sampling_params.temperature=0.0 \
+    generator.eval_sampling_params.top_p=1.0 \
+    generator.eval_sampling_params.top_k=-1 \
+    generator.eval_n_samples_per_prompt=1 \
+    trainer.policy.optimizer_config.lr=${LR} \
+    trainer.policy.optimizer_config.max_grad_norm=1.0 \
+    trainer.algorithm.use_kl_loss=false \
+    trainer.algorithm.use_kl_in_reward=false \
+    environment.env_class=bird \
+    generator.n_samples_per_prompt=${N_SAMPLES} \
+    trainer.logger=${LOGGER:-wandb} \
+    trainer.project_name="${WANDB_PROJECT}" \
+    trainer.run_name="${EXPERIMENT_NAME}" \
+    trainer.resume_mode=null \
+    trainer.log_path="${CHECKPOINT_DIR}/logs" \
+    trainer.ckpt_path="${CHECKPOINT_DIR}/ckpt" \
+    trainer.ckpt_interval=-1 \
+    "$@"

--- a/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
@@ -81,15 +81,11 @@ NUM_SPEC_TOKENS=${NUM_SPEC_TOKENS:-3}
 AI_CFG_PARTS=()
 if [[ "${USE_FCA}" == "True" ]]; then
     AI_CFG_PARTS+=('forest_cascade_attn_configs: "{}"')
-    # Pin vLLM optimization to O1 so its compile pipeline hardcodes
-    # fuse_allreduce_rms=false. We *also* request it explicitly via
-    # compilation_config below, but in this environment the nested override
-    # from arctic_rl -> arctic_platform -> AsyncEngineArgs is being dropped
-    # before vLLM sees it (cudagraph_mode resolves to the default
-    # FULL_AND_PIECEWISE and fuse_allreduce_rms to True at engine init).
-    # Until that plumbing is fixed end-to-end, O1 is the reliable knob that
-    # avoids the FlashInfer-workspace assertion on TP>1 + Hopper. See
-    # docs/arctic_rl_speedup_investigation.md (TODO) for the open thread.
+    # Pin vLLM optimization to O1 (belt-and-suspenders alongside the explicit
+    # compilation_config below): O1 hard-codes fuse_allreduce_rms=false and
+    # cudagraph_mode=PIECEWISE, so the recipe stays on a known-good config
+    # even if a future vLLM tweaks O2's defaults. See run_bird_grpo_32b_32gpu.sh
+    # for the fuse_allreduce_rms / FlashInfer-workspace rationale.
     AI_CFG_PARTS+=('optimization_level: 1')
     AI_CFG_PARTS+=('compilation_config: {cudagraph_mode: PIECEWISE, pass_config: {fuse_allreduce_rms: false}}')
 fi

--- a/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_8b_32gpu.sh
@@ -71,32 +71,27 @@ RESPONSE_LEN=4096
 TP_SIZE=4
 NUM_ENGINES=$((NUM_GPUS / TP_SIZE))
 
-# Inference knobs forwarded to ArcticAsyncEngineArgs via
-# trainer.arctic_rl.arctic_inference_config (raw passthrough). See
-# run_bird_grpo_32b_32gpu.sh for the fuse_allreduce_rms rationale.
+# Inference-engine performance knobs (FCA + Arctic speculative decoding +
+# the FlashInfer-safe compilation_config). Routed raw to vLLM via
+# trainer.arctic_rl.vllm_config. See run_bird_grpo_32b_32gpu.sh for the
+# full rationale.
 USE_FCA=${USE_FCA:-True}
 SPEC_MODEL=${SPEC_MODEL:-}
 NUM_SPEC_TOKENS=${NUM_SPEC_TOKENS:-3}
 
-AI_CFG_PARTS=()
+VLLM_CFG_PARTS=()
 if [[ "${USE_FCA}" == "True" ]]; then
-    AI_CFG_PARTS+=('forest_cascade_attn_configs: "{}"')
-    # Pin vLLM optimization to O1 (belt-and-suspenders alongside the explicit
-    # compilation_config below): O1 hard-codes fuse_allreduce_rms=false and
-    # cudagraph_mode=PIECEWISE, so the recipe stays on a known-good config
-    # even if a future vLLM tweaks O2's defaults. See run_bird_grpo_32b_32gpu.sh
-    # for the fuse_allreduce_rms / FlashInfer-workspace rationale.
-    AI_CFG_PARTS+=('optimization_level: 1')
-    AI_CFG_PARTS+=('compilation_config: {cudagraph_mode: PIECEWISE, pass_config: {fuse_allreduce_rms: false}}')
+    VLLM_CFG_PARTS+=('forest_cascade_attn_configs: "{}"')
+    VLLM_CFG_PARTS+=('compilation_config: {cudagraph_mode: PIECEWISE, pass_config: {fuse_allreduce_rms: false}}')
 fi
 if [[ -n "${SPEC_MODEL}" && -d "${SPEC_MODEL}" ]]; then
-    AI_CFG_PARTS+=("speculative_config: {method: arctic, model: ${SPEC_MODEL}, num_speculative_tokens: ${NUM_SPEC_TOKENS}}")
+    VLLM_CFG_PARTS+=("speculative_config: {method: arctic, model: ${SPEC_MODEL}, num_speculative_tokens: ${NUM_SPEC_TOKENS}}")
 fi
 
-AI_CFG_OVERRIDE=()
-if (( ${#AI_CFG_PARTS[@]} > 0 )); then
-    IFS=, AI_CFG_BODY="${AI_CFG_PARTS[*]}" ; unset IFS
-    AI_CFG_OVERRIDE+=("trainer.arctic_rl.arctic_inference_config={${AI_CFG_BODY}}")
+VLLM_CFG_OVERRIDE=()
+if (( ${#VLLM_CFG_PARTS[@]} > 0 )); then
+    IFS=, VLLM_CFG_BODY="${VLLM_CFG_PARTS[*]}" ; unset IFS
+    VLLM_CFG_OVERRIDE+=("trainer.arctic_rl.vllm_config={${VLLM_CFG_BODY}}")
 fi
 
 cd "${SKYRL_DIR}"
@@ -125,7 +120,7 @@ cd "${SKYRL_DIR}"
     trainer.arctic_rl.use_arctic_inference=true \
     trainer.arctic_rl.server_logs=true \
     trainer.arctic_rl.startup_timeout=1800 \
-    "${AI_CFG_OVERRIDE[@]}" \
+    "${VLLM_CFG_OVERRIDE[@]}" \
     data.train_data="['${DATA_DIR}/train.parquet']" \
     data.val_data="['${DATA_DIR}/val.parquet']" \
     trainer.algorithm.advantage_estimator=grpo \

--- a/integrations/arctic_rl/examples/run_bird_grpo_smoke.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_smoke.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Fast-iter smoke variant of run_bird_grpo_1.7b_8gpu.sh.
+#
+# Same model, same backend, same wire protocol, same env / WandB project
+# — only the batch and rollout shape are shrunk so each iteration spends
+# ~30s in generate instead of ~7-8min. Use this when iterating on the
+# Arctic-RL wire-protocol bridge (`integrations/arctic_rl/trainer.py`)
+# — every wire-shape transformation, meta dict key, post-processor
+# chain, and verl_grpo loss-config path is exercised identically to the
+# full BIRD recipe.
+#
+# When step 1 metrics emit cleanly here, switch back to
+# `run_bird_grpo_1.7b_8gpu.sh` for the actual 1:1 verl PR #6 comparison.
+#
+# Knob deltas vs. the full recipe:
+#   TRAIN_BSZ      32  -> 4     (4 prompts/batch; trajectories = 4 * N_SAMPLES = 16)
+#   MINI_BSZ       32  -> 4     (single mini-batch -> grad_accum_steps=1)
+#   N_SAMPLES      16  -> 4     (matches verl's GRPO group convention; smaller group)
+#   PROMPT_LEN  32768  -> 4096  (BIRD prompts vary; 4K covers most without truncation)
+#   RESPONSE_LEN 4096  -> 512   (caps rollout time; verl_grpo invariants are shape-
+#                                independent so step-1 ppo_kl=0, clipfrac=0 still hold)
+
+set -euxo pipefail
+
+SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
+DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
+PYBIN=${PYBIN:-python}
+
+export PYTHONUNBUFFERED=1
+export HYDRA_FULL_ERROR=1
+export RAY_DEDUP_LOGS=0
+export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+export HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-0}"
+export TORCH_COMPILE_DISABLE=1
+export VLLM_DISABLE_COMPILE_CACHE=1
+export VLLM_CACHE_ROOT="${VLLM_CACHE_ROOT:-$HOME/.cache/vllm}"
+export VLLM_LOGGING_LEVEL=WARNING  # quieter than full BIRD recipe for log readability
+export ARCTIC_CUDA_IPC_LOW_MEM=0
+export ARCTIC_WEIGHT_SYNC_STRICT_NAMES=0
+
+# Smoke runs are local — don't pollute the production WandB project. Disable
+# logger entirely so we read step-1 metrics from stdout only (faster + no
+# rate-limit risk during rapid iteration).
+WANDB_LOGGER=${WANDB_LOGGER:-console}
+
+RUN_TS=$(date -u +%Y%m%dT%H%M%SZ)
+MODEL=${MODEL:-"Qwen/Qwen3-1.7B"}
+EXPERIMENT_NAME=skyrl_bird_grpo_smoke_${MODEL##*/}_${RUN_TS}
+CHECKPOINT_DIR=${HOME}/ckpts/${EXPERIMENT_NAME}
+mkdir -p "${CHECKPOINT_DIR}"
+
+NUM_GPUS=${NUM_GPUS:-8}
+
+# Smoke batch math (validate_batch_sizes):
+#   train_per_gpu = TRAIN_BSZ * N_SAMPLES / NUM_GPUS = 4 * 4 / 8 = 2
+#   mini_per_gpu  = MINI_BSZ  * N_SAMPLES / NUM_GPUS = 4 * 4 / 8 = 2
+#   grad_accum    = 2 / 2 = 1
+TRAIN_BSZ=${TRAIN_BSZ:-4}
+MINI_BSZ=${MINI_BSZ:-4}
+N_SAMPLES=${N_SAMPLES:-4}
+LR=${LR:-2e-6}
+PROMPT_LEN=${PROMPT_LEN:-4096}
+RESPONSE_LEN=${RESPONSE_LEN:-512}
+
+cd "${SKYRL_DIR}"
+
+"${PYBIN}" -m skyrl.train.entrypoints.main_base \
+    trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+    trainer.arctic_rl.colocate=true \
+    trainer.arctic_rl.zero_stage=3 \
+    trainer.arctic_rl.offload_optimizer=true \
+    trainer.arctic_rl.log_prob_gpus=0 \
+    trainer.arctic_rl.server_logs=true \
+    trainer.arctic_rl.startup_timeout=1800 \
+    data.train_data="['${DATA_DIR}/train.parquet']" \
+    data.val_data="['${DATA_DIR}/val.parquet']" \
+    trainer.algorithm.advantage_estimator=grpo \
+    trainer.policy.model.path="${MODEL}" \
+    trainer.placement.colocate_all=false \
+    trainer.placement.policy_num_gpus_per_node=${NUM_GPUS} \
+    trainer.placement.policy_num_nodes=1 \
+    generator.inference_engine.num_engines=${NUM_GPUS} \
+    generator.inference_engine.tensor_parallel_size=1 \
+    generator.inference_engine.backend=vllm \
+    generator.inference_engine.run_engines_locally=true \
+    generator.inference_engine.gpu_memory_utilization=0.5 \
+    generator.inference_engine.async_engine=true \
+    generator.batched=true \
+    trainer.epochs=1 \
+    trainer.eval_batch_size=${TRAIN_BSZ} \
+    trainer.eval_before_train=false \
+    trainer.eval_interval=10 \
+    trainer.update_epochs_per_batch=1 \
+    trainer.train_batch_size=${TRAIN_BSZ} \
+    trainer.policy_mini_batch_size=${MINI_BSZ} \
+    trainer.max_prompt_length=${PROMPT_LEN} \
+    generator.sampling_params.max_generate_length=${RESPONSE_LEN} \
+    generator.sampling_params.temperature=1.0 \
+    generator.sampling_params.top_p=1.0 \
+    trainer.policy.optimizer_config.lr=${LR} \
+    trainer.policy.optimizer_config.max_grad_norm=1.0 \
+    trainer.algorithm.use_kl_loss=false \
+    trainer.algorithm.use_kl_in_reward=false \
+    environment.env_class=bird \
+    generator.n_samples_per_prompt=${N_SAMPLES} \
+    trainer.logger=${WANDB_LOGGER} \
+    trainer.resume_mode=null \
+    trainer.log_path="${CHECKPOINT_DIR}/logs" \
+    trainer.ckpt_path="${CHECKPOINT_DIR}/ckpt" \
+    trainer.ckpt_interval=-1 \
+    "$@"

--- a/integrations/arctic_rl/examples/run_bird_grpo_smoke.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_smoke.sh
@@ -26,13 +26,17 @@ SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
 DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
 
 # Driver (same shape as flash_rl/harbor; see run_gsm8k_grpo_4gpu.sh for details).
+# Smoke mirrors the BIRD recipe stack — FA3 wheel included so the smoke and
+# the full recipe exercise the same attention backend.
 FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+FLASH_ATTN3_WHL="https://download.pytorch.org/whl/cu128/flash_attn_3-3.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
 DRIVER=(uv run --isolated --extra skyrl-train
     --with arctic-platform
     --with 'arctic-inference[vllm]'
     --with liger-kernel
     --with 'transformers==4.57.6'
     --with "flash-attn@${FLASH_ATTN_WHL}"
+    --with "flash-attn-3@${FLASH_ATTN3_WHL}"
     -- python)
 
 export PYTHONUNBUFFERED=1

--- a/integrations/arctic_rl/examples/run_bird_grpo_smoke.sh
+++ b/integrations/arctic_rl/examples/run_bird_grpo_smoke.sh
@@ -24,7 +24,16 @@ set -euxo pipefail
 
 SKYRL_DIR=${SKYRL_DIR:-$(cd "$(dirname "$0")"/../../.. && pwd)}
 DATA_DIR=${DATA_DIR:-"$HOME/data/bird"}
-PYBIN=${PYBIN:-python}
+
+# Driver (same shape as flash_rl/harbor; see run_gsm8k_grpo_4gpu.sh for details).
+FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+DRIVER=(uv run --isolated --extra skyrl-train
+    --with arctic-platform
+    --with 'arctic-inference[vllm]'
+    --with liger-kernel
+    --with 'transformers==4.57.6'
+    --with "flash-attn@${FLASH_ATTN_WHL}"
+    -- python)
 
 export PYTHONUNBUFFERED=1
 export HYDRA_FULL_ERROR=1
@@ -64,7 +73,7 @@ RESPONSE_LEN=${RESPONSE_LEN:-512}
 
 cd "${SKYRL_DIR}"
 
-"${PYBIN}" -m skyrl.train.entrypoints.main_base \
+"${DRIVER[@]}" -m skyrl.train.entrypoints.main_base \
     trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
     trainer.arctic_rl.colocate=true \
     trainer.arctic_rl.zero_stage=3 \

--- a/integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
+++ b/integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# GSM8K GRPO training via Arctic RL server.
+#
+# Invoked from the SkyRL repo root via core dispatch:
+#   python -m skyrl.train.entrypoints.main_base \
+#       trainer.override_entrypoint=integrations.arctic_rl.entrypoint <flags>
+#
+# Non-colocated (4 GPUs: 2 training + 2 sampling):
+#   bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh \
+#     trainer.placement.policy_num_gpus_per_node=2 \
+#     generator.inference_engine.num_engines=2 \
+#     trainer.policy_mini_batch_size=4
+#
+# Colocated (4 GPUs: all shared between training + sampling):
+#   bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh \
+#     trainer.arctic_rl.colocate=true \
+#     trainer.placement.policy_num_gpus_per_node=4 \
+#     generator.inference_engine.num_engines=4 \
+#     generator.inference_engine.gpu_memory_utilization=0.3 \
+#     trainer.policy_mini_batch_size=8
+
+set -euo pipefail
+
+export PYTHONUNBUFFERED=1
+
+: "${DATA_DIR:="$HOME/data/gsm8k"}"
+: "${MODEL:="Qwen/Qwen3-0.6B"}"
+: "${LOGGER:="console"}"
+
+# Auto-prep GSM8K parquets if missing (uses SkyRL's bundled prep script).
+if [[ ! -f "${DATA_DIR}/train.parquet" || ! -f "${DATA_DIR}/validation.parquet" ]]; then
+    REPO_ROOT="$(cd "$(dirname "$0")"/../../.. && pwd)"
+    echo "GSM8K parquets not found in ${DATA_DIR} — running SkyRL prep script..."
+    python "${REPO_ROOT}/examples/train/gsm8k/gsm8k_dataset.py" --output_dir "${DATA_DIR}"
+fi
+
+python -m skyrl.train.entrypoints.main_base \
+  data.train_data="['${DATA_DIR}/train.parquet']" \
+  data.val_data="['${DATA_DIR}/validation.parquet']" \
+  trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+  trainer.algorithm.advantage_estimator=grpo \
+  trainer.policy.model.path="${MODEL}" \
+  trainer.placement.colocate_all=false \
+  trainer.placement.policy_num_gpus_per_node=2 \
+  trainer.epochs=1 \
+  trainer.eval_batch_size=256 \
+  trainer.eval_before_train=true \
+  trainer.eval_interval=10 \
+  trainer.update_epochs_per_batch=1 \
+  trainer.train_batch_size=256 \
+  trainer.policy_mini_batch_size=4 \
+  trainer.max_prompt_length=512 \
+  generator.sampling_params.max_generate_length=1024 \
+  trainer.policy.optimizer_config.lr=1.7e-6 \
+  trainer.algorithm.use_kl_loss=false \
+  trainer.algorithm.use_kl_in_reward=false \
+  generator.inference_engine.backend=vllm \
+  generator.inference_engine.num_engines=1 \
+  generator.inference_engine.tensor_parallel_size=1 \
+  generator.inference_engine.run_engines_locally=true \
+  generator.inference_engine.weight_sync_backend=nccl \
+  generator.inference_engine.async_engine=true \
+  generator.batched=true \
+  environment.env_class=gsm8k \
+  generator.n_samples_per_prompt=4 \
+  generator.inference_engine.gpu_memory_utilization=0.7 \
+  trainer.logger="${LOGGER}" \
+  trainer.project_name=arctic_rl \
+  trainer.run_name="skyrl_gsm8k_${MODEL##*/}" \
+  trainer.resume_mode=null \
+  trainer.log_path=/tmp/skyrl-arctic-logs \
+  trainer.ckpt_path="${HOME}/ckpts/skyrl_gsm8k_arctic" \
+  "$@"

--- a/integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
+++ b/integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
@@ -38,6 +38,7 @@ python -m skyrl.train.entrypoints.main_base \
   data.train_data="['${DATA_DIR}/train.parquet']" \
   data.val_data="['${DATA_DIR}/validation.parquet']" \
   trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
+  trainer.arctic_rl.zero_stage=2 \
   trainer.algorithm.advantage_estimator=grpo \
   trainer.policy.model.path="${MODEL}" \
   trainer.placement.colocate_all=false \

--- a/integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
+++ b/integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # GSM8K GRPO training via Arctic RL server.
 #
-# Invoked from the SkyRL repo root via core dispatch:
-#   python -m skyrl.train.entrypoints.main_base \
-#       trainer.override_entrypoint=integrations.arctic_rl.entrypoint <flags>
+# Invoked from the SkyRL repo root:
+#   bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh
 #
 # Non-colocated (4 GPUs: 2 training + 2 sampling):
 #   bash integrations/arctic_rl/examples/run_gsm8k_grpo_4gpu.sh \
@@ -27,14 +26,35 @@ export PYTHONUNBUFFERED=1
 : "${MODEL:="Qwen/Qwen3-0.6B"}"
 : "${LOGGER:="console"}"
 
+SKYRL_DIR="$(cd "$(dirname "$0")"/../../.. && pwd)"
+cd "${SKYRL_DIR}"
+
 # Auto-prep GSM8K parquets if missing (uses SkyRL's bundled prep script).
 if [[ ! -f "${DATA_DIR}/train.parquet" || ! -f "${DATA_DIR}/validation.parquet" ]]; then
-    REPO_ROOT="$(cd "$(dirname "$0")"/../../.. && pwd)"
     echo "GSM8K parquets not found in ${DATA_DIR} — running SkyRL prep script..."
-    python "${REPO_ROOT}/examples/train/gsm8k/gsm8k_dataset.py" --output_dir "${DATA_DIR}"
+    uv run --isolated examples/train/gsm8k/gsm8k_dataset.py --output_dir "${DATA_DIR}"
 fi
 
-python -m skyrl.train.entrypoints.main_base \
+# Driver (same shape as examples/train/flash_rl + examples/train_integrations/harbor):
+#   - `--isolated` gets a fresh resolution that ignores the project lock /
+#     vllm-cu129 source pin (arctic-inference needs vLLM 0.18, not 0.23).
+#   - `--with flash-attn@URL` swaps the torch-2.11 wheel in tool.uv.sources for
+#     the torch-2.10 ABI wheel that arctic-inference[vllm]'s torch pin needs.
+#   - `--with 'transformers==4.57.6'` overrides SkyRL's transformers>=5.6.1
+#     pin (vLLM 0.18 requires transformers<5). Exact-pinned (not `<5`) so the
+#     spec string survives Ray's worker-spawn shell parsing — `<5` would be
+#     re-interpreted as an input redirect from fd 5.
+#   - SkyRL's uv+ray plugin replicates this exact `uv run` invocation on every
+#     Ray worker via `py_executable`, so workers get the same env automatically.
+FLASH_ATTN_WHL="https://github.com/lesj0610/flash-attention/releases/download/v2.8.3-cu12-torch2.10-cp312/flash_attn-2.8.3%2Bcu12torch2.10cxx11abiTRUE-cp312-cp312-linux_x86_64.whl"
+
+uv run --isolated --extra skyrl-train \
+    --with arctic-platform \
+    --with 'arctic-inference[vllm]' \
+    --with liger-kernel \
+    --with 'transformers==4.57.6' \
+    --with "flash-attn@${FLASH_ATTN_WHL}" \
+    -- python -m skyrl.train.entrypoints.main_base \
   data.train_data="['${DATA_DIR}/train.parquet']" \
   data.val_data="['${DATA_DIR}/validation.parquet']" \
   trainer.override_entrypoint=integrations.arctic_rl.entrypoint \

--- a/integrations/arctic_rl/generator.py
+++ b/integrations/arctic_rl/generator.py
@@ -12,8 +12,11 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
-import skyrl_gym
-from skyrl.train.generators.base import GeneratorInput, GeneratorInterface, GeneratorOutput
+from skyrl.train.generators.base import (
+    GeneratorInput,
+    GeneratorInterface,
+    GeneratorOutput,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,14 +130,13 @@ class ArcticGenerator(GeneratorInterface):
                 if i == 0:
                     logger.warning(
                         "ArcticGenerator: no env_classes for sample %d (len=%d)",
-                        i, len(env_classes),
+                        i,
+                        len(env_classes),
                     )
                 scoring_inputs.append(None)
                 continue
 
-            env_config = (
-                getattr(self.skyrl_gym_cfg, env_class, dict()) if self.skyrl_gym_cfg else dict()
-            )
+            env_config = getattr(self.skyrl_gym_cfg, env_class, dict()) if self.skyrl_gym_cfg else dict()
             scoring_inputs.append(
                 {
                     "env_class": env_class,
@@ -147,11 +149,7 @@ class ArcticGenerator(GeneratorInterface):
 
         loop = asyncio.get_running_loop()
         futures = [
-            (
-                loop.run_in_executor(self._scoring_pool, _score_one, payload)
-                if payload is not None
-                else None
-            )
+            (loop.run_in_executor(self._scoring_pool, _score_one, payload) if payload is not None else None)
             for payload in scoring_inputs
         ]
         rewards: List[float] = []
@@ -163,9 +161,7 @@ class ArcticGenerator(GeneratorInterface):
                 rewards.append(await fut)
             except Exception as e:
                 if i == 0:
-                    logger.warning(
-                        "ArcticGenerator reward scoring failed: %s", e, exc_info=True
-                    )
+                    logger.warning("ArcticGenerator reward scoring failed: %s", e, exc_info=True)
                 rewards.append(0.0)
 
         return GeneratorOutput(

--- a/integrations/arctic_rl/generator.py
+++ b/integrations/arctic_rl/generator.py
@@ -1,0 +1,163 @@
+"""ArcticGenerator — implements SkyRL's GeneratorInterface for Arctic RL.
+
+Routes rollout generation to the Arctic RL inference engine via
+``ArcticRLClient.generate()``.  After generation, each completion is
+scored by the corresponding skyrl-gym environment (e.g. GSM8K) so that
+the reward signal is available for GRPO training.
+"""
+
+import asyncio
+import concurrent.futures
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import skyrl_gym
+from skyrl.train.generators.base import GeneratorInput, GeneratorInterface, GeneratorOutput
+
+logger = logging.getLogger(__name__)
+
+# 8 matches verl's agent_loop concurrency in the xid2pl9f reference run.
+_DEFAULT_SCORING_WORKERS = int(os.environ.get("ARCTIC_RL_SCORING_WORKERS", "8"))
+
+
+def _score_one(payload: Dict[str, Any]) -> float:
+    """Picklable env.init/step/close used by the scoring ProcessPoolExecutor."""
+    import skyrl_gym as _sg
+
+    env = _sg.make(
+        payload["env_class"],
+        env_config=payload["env_config"],
+        extras=payload["extras"],
+    )
+    try:
+        env.init(payload["prompt"])
+        step_out = env.step(payload["text"])
+        return float(step_out["reward"])
+    finally:
+        env.close()
+
+
+class ArcticGenerator(GeneratorInterface):
+
+    def __init__(
+        self,
+        arctic_client,
+        tokenizer,
+        sampling_params: Optional[Any] = None,
+        skyrl_gym_cfg: Optional[Any] = None,
+    ):
+        self.arctic_client = arctic_client
+        self.tokenizer = tokenizer
+        self.skyrl_gym_cfg = skyrl_gym_cfg
+        self.default_sampling_params = {
+            "temperature": 1.0,
+            "max_tokens": 4096,
+            "top_p": 1.0,
+        }
+        # Process pool (not threads) so per-worker BIRD sqlite handles and
+        # other reward-state globals stay isolated.
+        self._scoring_pool = concurrent.futures.ProcessPoolExecutor(
+            max_workers=_DEFAULT_SCORING_WORKERS,
+        )
+
+    async def generate(self, input_batch: GeneratorInput) -> GeneratorOutput:
+        prompts = input_batch["prompts"]
+        sampling_params = input_batch.get("sampling_params") or self.default_sampling_params
+        env_classes: List[str] = input_batch.get("env_classes", [])
+        env_extras: List[Dict[str, Any]] = input_batch.get("env_extras", [])
+
+        prompt_texts, prompt_token_ids_list = [], []
+        for prompt in prompts:
+            text = (
+                self.tokenizer.apply_chat_template(prompt, add_generation_prompt=True, tokenize=False)
+                if isinstance(prompt, list)
+                else str(prompt)
+            )
+            prompt_texts.append(text)
+            prompt_token_ids_list.append(self.tokenizer.encode(text, add_special_tokens=False))
+
+        # arctic_platform.rl client.generate is async; await directly.
+        raw_outputs = await self.arctic_client.generate(
+            prompts=prompt_texts,
+            sampling_params=sampling_params,
+        )
+
+        # Build scoring payloads serially (tokenize/decode is cheap), then
+        # fan reward computation out to the pool. Two passes keep alignment
+        # with raw_outputs trivial.
+        response_ids: List[List[int]] = []
+        loss_masks: List[List[int]] = []
+        stop_reasons: List[str] = []
+        scoring_inputs: List[Optional[Dict[str, Any]]] = []
+
+        for i, output in enumerate(raw_outputs):
+            token_ids = output.get("token_ids", [])
+            text = output.get("text", "")
+            if not token_ids and text:
+                token_ids = self.tokenizer.encode(text, add_special_tokens=False)
+            if not text and token_ids:
+                text = self.tokenizer.decode(token_ids, skip_special_tokens=True)
+
+            response_ids.append(token_ids)
+            loss_masks.append([1] * len(token_ids))
+            stop_reasons.append("completed" if output.get("finish_reason") == "stop" else "length")
+
+            env_class = env_classes[i] if i < len(env_classes) else None
+            if not env_class:
+                if i == 0:
+                    logger.warning(
+                        "ArcticGenerator: no env_classes for sample %d (len=%d)",
+                        i, len(env_classes),
+                    )
+                scoring_inputs.append(None)
+                continue
+
+            env_config = (
+                getattr(self.skyrl_gym_cfg, env_class, dict()) if self.skyrl_gym_cfg else dict()
+            )
+            scoring_inputs.append(
+                {
+                    "env_class": env_class,
+                    "env_config": env_config,
+                    "extras": env_extras[i] if i < len(env_extras) else {},
+                    "prompt": prompts[i],
+                    "text": text,
+                }
+            )
+
+        loop = asyncio.get_running_loop()
+        futures = [
+            (
+                loop.run_in_executor(self._scoring_pool, _score_one, payload)
+                if payload is not None
+                else None
+            )
+            for payload in scoring_inputs
+        ]
+        rewards: List[float] = []
+        for i, fut in enumerate(futures):
+            if fut is None:
+                rewards.append(0.0)
+                continue
+            try:
+                rewards.append(await fut)
+            except Exception as e:
+                if i == 0:
+                    logger.warning(
+                        "ArcticGenerator reward scoring failed: %s", e, exc_info=True
+                    )
+                rewards.append(0.0)
+
+        return GeneratorOutput(
+            prompt_token_ids=prompt_token_ids_list,
+            response_ids=response_ids,
+            rewards=rewards,
+            loss_masks=loss_masks,
+            stop_reasons=stop_reasons,
+            rollout_metrics=None,
+            rollout_logprobs=None,
+            trajectory_ids=input_batch.get("trajectory_ids"),
+            rollout_expert_indices=None,
+            is_last_step=None,
+        )

--- a/integrations/arctic_rl/generator.py
+++ b/integrations/arctic_rl/generator.py
@@ -22,8 +22,27 @@ _DEFAULT_SCORING_WORKERS = int(os.environ.get("ARCTIC_RL_SCORING_WORKERS", "8"))
 
 
 def _score_one(payload: Dict[str, Any]) -> float:
-    """Picklable env.init/step/close used by the scoring ProcessPoolExecutor."""
+    """Picklable env.init/step/close used by the scoring ProcessPoolExecutor.
+
+    The pool uses ``spawn`` (forced by ``ProcessPoolExecutor`` on macOS/Linux
+    in Ray actors), so the child only auto-imports ``skyrl_gym`` (via its own
+    ``envs/__init__.py``). Our Arctic-RL-shipped envs (``bird``, ``bird_sql``)
+    register themselves when ``integrations.arctic_rl.envs`` is imported, so
+    we must trigger that import here so the registry is populated in the
+    child before ``make`` is called.
+    """
     import skyrl_gym as _sg
+
+    # Trigger registration of Arctic-RL-shipped envs in this child process.
+    # Works under both import paths (the integration dir on PYTHONPATH or
+    # dispatched from core via ``integrations.arctic_rl``).
+    try:
+        from . import envs as _arctic_envs  # noqa: F401
+    except ImportError:
+        try:
+            import arctic_rl.envs as _arctic_envs  # noqa: F401
+        except ImportError:
+            import integrations.arctic_rl.envs as _arctic_envs  # noqa: F401
 
     env = _sg.make(
         payload["env_class"],

--- a/integrations/arctic_rl/trainer.py
+++ b/integrations/arctic_rl/trainer.py
@@ -1,0 +1,861 @@
+"""ArcticPPOTrainer — subclass of RayPPOTrainer for the Arctic RL backend.
+
+Overrides ``build_models()`` to route training operations (forward,
+backward, optimizer step, weight sync) to the Arctic RL server via the
+``arctic_platform.rl`` client.
+
+The server owns the full GRPO computation:
+  - per-token log-probs (old + new)
+  - clipped PPO surrogate loss + backward
+  - optimizer step + grad-norm + lr-schedule
+
+The client (this file) is responsible for:
+  - rollout generation (via ArcticGenerator → server vLLM)
+  - reward scoring (via skyrl-gym)
+  - group-relative advantage estimation (delegated to SkyRL's
+    ``compute_advantages_and_returns`` — outcome-only, no value model)
+  - **wire-protocol shaping**: translating SkyRL's batch layout to the
+    server's expected `(input_ids, attention_mask, prompts, responses,
+    response_mask, position_ids)` + `meta` dict. This mirrors the
+    validated verl adapter at
+    ``verl/workers/remote_client/arctic_rl.py``; the server is
+    framework-agnostic and consumes the same payload from either.
+
+Dependencies:
+    arctic_platform  — on-prem-and-dss-platform Arctic RL client
+"""
+
+import asyncio
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+import torch
+from loguru import logger
+from transformers import AutoTokenizer
+
+from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch, TrainingOutputBatch
+from skyrl.train.trainer import RayPPOTrainer
+from skyrl.train.config import SkyRLTrainConfig
+from skyrl.backends.skyrl_train.workers.worker_utils import reduce_metrics
+
+
+def _run(coro):
+    """Run an awaitable from sync context.
+
+    SkyRL's WorkerDispatch protocol is synchronous but the new
+    ``arctic_platform.rl`` client methods are async, so the dispatch
+    blocks on the coroutine here. SkyRL's ``train()`` runs inside an
+    asyncio loop (``asyncio.run(trainer.train())``), so ``asyncio.run``
+    from inside it raises ``RuntimeError`` — we then fall back to a
+    fresh loop in a worker thread (the ``arctic_platform.rl`` ray client
+    only does ``ray.get`` under the hood, which works across loops).
+    """
+    try:
+        return asyncio.run(coro)
+    except RuntimeError:
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(
+                lambda c=coro: asyncio.new_event_loop().run_until_complete(c)
+            ).result()
+
+
+class ArcticPPOTrainer(RayPPOTrainer):
+    """PPO Trainer backed by Arctic RL server (DeepSpeed).
+
+    Drop-in replacement for ``RayPPOTrainer``.  Requires
+    ``colocate_all: false`` since all GPU work is on the Arctic RL server.
+    """
+
+    def __init__(self, *args, arctic_client, **kwargs):
+        self._arctic_client = arctic_client
+        self._stashed_rewards = None
+        super().__init__(*args, **kwargs)
+
+    def build_models(self, PolicyWorker=None, CriticWorker=None, RefWorker=None):
+        """Replace GPU actor creation with a lightweight dispatch to Arctic RL."""
+        self.dispatch = _ArcticDispatch(self.cfg, self._arctic_client)
+        self.policy_model = _ArcticPolicyStub()
+        self.ref_model = None
+        self.critic_model = None
+        logger.info("ArcticPPOTrainer: build_models → training routed to Arctic RL server")
+
+    def fwd_logprobs_values_reward(self, training_input: TrainingInputBatch):
+        """No-op — old log-probs are computed server-side inside
+        :meth:`_ArcticDispatch.forward_backward` (one ``fwd_no_grad``
+        call before each ``fwd_bwd``), mirroring verl's actor worker
+        which calls ``compute_log_prob`` before ``update_actor``."""
+        return training_input
+
+    def compute_advantages_and_returns(self, training_input: TrainingInputBatch):
+        """Compute GRPO advantages client-side, then send them to the server.
+
+        We stash the raw rewards so train_critic_and_policy can restore them
+        (parent's train() pops rewards before calling train_critic_and_policy),
+        then delegate to the parent to compute group-relative advantages normally.
+        """
+        self._stashed_rewards = training_input["rewards"].clone()
+        training_input["values"] = None
+        return super().compute_advantages_and_returns(training_input)
+
+    def train_critic_and_policy(self, data: TrainingInputBatch):
+        """Send the full batch to the Arctic RL server for training.
+
+        The server handles gradient accumulation internally via
+        ``_forward_maybe_backward`` (splitting into micro-batches based on
+        DeepSpeed's ``gradient_accumulation_steps``).  Each epoch sends a
+        single fwd_bwd + step pair; ``set_gradient_accumulation_boundary``
+        ensures the step always triggers a real optimizer update.
+
+        Restricted to ``update_epochs_per_batch == 1``: the per-epoch loop
+        in ``_ArcticDispatch.forward_backward`` calls ``_compute_old_log_probs``
+        on every iteration, so >1 epoch would refresh ``old_log_probs`` and
+        collapse PPO ``ratio`` to 1, defeating clipping. To support multi-epoch
+        later, hoist the old-log-prob call into ``fwd_logprobs_values_reward``
+        (matches verl's pre-update_actor ``compute_log_prob`` placement).
+        """
+        ep = int(self.cfg.trainer.update_epochs_per_batch)
+        assert ep == 1, (
+            f"ArcticPPOTrainer requires update_epochs_per_batch=1, got {ep}"
+        )
+
+        if self._stashed_rewards is not None:
+            data["rewards"] = self._stashed_rewards
+            self._stashed_rewards = None
+
+        data.metadata["global_step"] = self.global_step
+        n_samples = self.cfg.generator.n_samples_per_prompt
+
+        all_metrics: Dict[str, List[float]] = defaultdict(list)
+
+        status = self.dispatch.forward_backward(
+            "policy", data,
+            loss_fn="verl_grpo",
+            loss_fn_config={"n_samples": n_samples},
+        )
+        for k, v in status.items():
+            all_metrics[k].append(v)
+
+        grad_norm = self.dispatch.optim_step("policy")
+        if grad_norm is not None:
+            all_metrics["grad_norm"].append(grad_norm)
+
+        all_metrics.pop("loss_fn_outputs", None)
+        all_metrics.pop("post_process_outputs", None)
+        reduced = reduce_metrics(dict(all_metrics))
+
+        for k, v in reduced.items():
+            self.all_metrics[f"policy/{k}"] = v
+
+        return reduced
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — duck-types the WorkerDispatch interface used by RayPPOTrainer
+# ---------------------------------------------------------------------------
+
+class _ArcticDispatch:
+    """Routes ``WorkerDispatch`` calls to the Arctic RL server.
+
+    Owns the SkyRL→verl wire-protocol translation: takes SkyRL's
+    ``TrainingInputBatch`` (left-padded ``[PAD…|prompt|response]``
+    layout, with response-only tensors right-aligned to ``max_response``)
+    and produces the dense padded payload that the
+    ``arctic_platform.rl`` server expects (verl-style left-padded
+    prompt + right-padded response, with ``meta`` carrying
+    ``pad_token_id``, ``temperature``, ``actor_config``,
+    ``policy_loss_config``, … — see :meth:`_build_meta` for the full
+    list).
+    """
+
+    def __init__(self, cfg: SkyRLTrainConfig, client):
+        self.cfg = cfg
+        self.client = client
+        # Policy flags read from `cfg.trainer.arctic_rl`, not `client.config`:
+        # Arctic-Platform's `ArcticRLRayClient.reconnect_config()` strips the
+        # schema to {backend, model_name, *_job_id, comm_protocol} when
+        # serializing the client to Ray actors, dropping `colocate` etc.
+        arl = cfg.trainer.arctic_rl
+        self._colocate = bool(getattr(arl, "colocate", False)) if arl is not None else False
+        self._cuda_ipc = bool(getattr(arl, "cuda_ipc_weight_sync", False)) if arl is not None else False
+        self._low_memory = bool(getattr(arl, "low_memory_weight_sync", False)) if arl is not None else False
+
+        # Load tokenizer once for pad_token_id (needed in every wire
+        # payload). Same path the server itself uses — no risk of
+        # version skew.
+        self.tokenizer = AutoTokenizer.from_pretrained(cfg.trainer.policy.model.path)
+        self._pad_token_id: int = (
+            self.tokenizer.pad_token_id
+            if self.tokenizer.pad_token_id is not None
+            else self.tokenizer.eos_token_id
+        )
+
+        # DP size = number of training GPUs (Arctic-RL training is DP-only;
+        # no TP/PP on the training side). The verl_grpo loss uses this to
+        # compute the correct global-mean normalization.
+        self._dp_size: int = (
+            cfg.trainer.placement.policy_num_gpus_per_node
+            * cfg.trainer.placement.policy_num_nodes
+        )
+
+        # Sampling temperature is part of the loss math (apply_temperature
+        # post-processor divides logits by it). Recipe knob.
+        self._temperature: float = float(
+            getattr(cfg.generator.sampling_params, "temperature", 1.0) or 1.0
+        )
+
+        # ZoRRO toggle — mirror SkyRL's `arl.use_zorro` onto the server-side
+        # `meta.zorro_train_enable` so the two stay in sync. Defaults to False.
+        # When True the server expects the model to have been built with the
+        # zorro-aware ds_worker_config (`response_len`, `max_token_len`,
+        # `rollout_n`, `use_unpad=True`) — `build_rl_config` in `config.py`
+        # already wires those when `arl.use_zorro=True`. Wire payloads stay
+        # ZoRRO-compatible regardless (response-only tensors are left-padded
+        # to seq_len in `forward_backward`); flipping this only changes the
+        # server-side compute path, not our outgoing payload shape.
+        self._zorro_train_enable: bool = bool(getattr(arl, "use_zorro", False)) if arl is not None else False
+
+        # Per-GPU token budget for tiled compute. SkyRL has no direct
+        # equivalent of verl's `actor.ppo_max_token_len_per_gpu`; derive a
+        # ZoRRO-aware safe lower bound:
+        #
+        # * Non-ZoRRO (per-sequence packing): max_prompt + max_response —
+        #   the worst-case single-sequence length.
+        # * ZoRRO: max_prompt + n_samples * max_response — one deduplicated
+        #   prompt followed by n_samples concatenated responses. Required
+        #   because Arctic's `create_prompt_groups`
+        #   (`arctic_platform/rl/zorro_train/seqlen_balancing.py:462`)
+        #   packs an entire prompt-group into a single micro-batch and
+        #   asserts ``max_token_len >= max_prompt +
+        #   max_group_length_threshold * max_response``. With
+        #   ``max_group_length_threshold == n_samples`` (the default),
+        #   undersizing this budget produces ``ValueError: max_token_len=X
+        #   is smaller than Y`` on the first ``fwd_no_grad`` of step 1.
+        n_samples = cfg.generator.n_samples_per_prompt
+        max_prompt = cfg.trainer.max_prompt_length
+        max_resp = cfg.generator.sampling_params.max_generate_length
+        if self._zorro_train_enable:
+            self._max_token_len_per_gpu: int = int(max_prompt + n_samples * max_resp)
+        else:
+            self._max_token_len_per_gpu: int = int(max_prompt + max_resp)
+
+        # Fixed response_len baked into Qwen3ModelOncePatcher at engine build
+        # (arctic_rl/config.py:412 -> deepspeed_worker.py:328). Used by
+        # `_repack_to_verl_shape` to keep the patcher's prompt/response split
+        # aligned with the per-call attention mask.
+        self._patcher_response_len: int = int(max_resp)
+
+        if self._zorro_train_enable:
+            logger.warning(
+                "Arctic RL ZoRRO path enabled — make sure ds_worker_config "
+                "carries response_len / max_token_len / rollout_n / use_unpad. "
+                "Wire payload from this bridge is already ZoRRO-compatible "
+                "(response-only tensors left-padded to seq_len); only the "
+                "server-side compute path differs. Bridge derived "
+                f"max_token_len_per_gpu={self._max_token_len_per_gpu} "
+                f"(= {max_prompt} + {n_samples} * {max_resp})."
+            )
+
+    # ------------------------------------------------------------------ #
+    # Wire-shape conversion: SkyRL TrainingInputBatch → verl batch dict
+    # ------------------------------------------------------------------ #
+    # SkyRL layout produced by `convert_prompts_responses_to_batch_tensors`
+    # (skyrl/train/dataset/preprocess.py:124):
+    #     sequences      : [B, S]   [PAD * pad_i | prompt_i | response_i]
+    #     attention_mask : [B, S]   [0   * pad_i | 1        | 1        ]
+    #     response_mask  : [B, A]   right-aligned [0 * (A - r_i) | 1 * r_i]
+    #     loss_mask      : [B, A]   same shape as response_mask
+    #     advantages     : [B, A]   same shape (after compute_advantages)
+    # where S = max_i (p_i + r_i), A = max_i r_i (independent of S).
+    #
+    # verl/Arctic-RL server layout (per
+    # `verl/workers/remote_client/arctic_rl.py`):
+    #     input_ids      : [B, P+R]   left-pad prompt to P, right-pad
+    #                                  response to R, total = P + R
+    #     attention_mask : [B, P+R]   [0*(P-p_i) | 1*p_i | 1*r_i | 0*(R-r_i)]
+    #     prompts        : [B, P]     (server reads .shape[1] only — see
+    #                                  processors/pipeline.py:236)
+    #     responses      : [B, R]
+    #     response_mask  : [B, R]     right-padded with zeros
+    #     position_ids   : [B, P+R]   cumsum(attention_mask)-1, pad→0
+    #
+    # The repack is per-sample: PAD region moves from the LEFT (SkyRL)
+    # to BETWEEN prompt and response (verl) — i.e., prompts get
+    # left-padded individually, responses get right-padded.
+
+    def _repack_to_verl_shape(self, data: TrainingInputBatch) -> dict:
+        """Per-sample repack of SkyRL's ``[PAD|prompt|response]`` into
+        verl's ``[PAD|prompt|response|PAD]`` layout.
+
+        Returns a dict with keys ``input_ids``, ``attention_mask``,
+        ``prompts``, ``responses``, ``response_mask``, ``position_ids``,
+        ``advantages``, ``loss_mask`` (and any other 2D response-shape
+        tensors found in ``data``), all left/right-padded to a uniform
+        ``[B, P + R]`` shape where ``P = max(prompt_len)`` and
+        ``R = max(response_len)``.
+        """
+        sequences = data["sequences"]                # [B, S]
+        attention_mask = data["attention_mask"]      # [B, S]
+        response_mask = data["response_mask"]        # [B, R_sky]  R_sky = max_r
+        B, S = sequences.shape
+        device = sequences.device
+        pad_id = self._pad_token_id
+
+        # Real per-sample lengths.
+        total_lens = attention_mask.sum(dim=1)        # [B] = p_i + r_i
+        response_lens = response_mask.sum(dim=1)      # [B] = r_i
+        prompt_lens = total_lens - response_lens      # [B] = p_i
+
+        max_p = int(prompt_lens.max().item())
+        max_r = int(response_lens.max().item())
+        # The ZoRRO patcher derives prompt_len = seq_len - patcher_response_len
+        # per forward; the server-side unpack uses meta["max_prompt_len"] = max_p.
+        # For the two to agree, the response region must be exactly
+        # patcher_response_len tokens wide. Padded positions get attention_mask=0
+        # so the model and loss treat them as masked.
+        if self._zorro_train_enable and max_r < self._patcher_response_len:
+            max_r = self._patcher_response_len
+        new_S = max_p + max_r
+
+        # Pre-allocate output tensors.
+        new_input_ids = torch.full((B, new_S), pad_id, dtype=sequences.dtype, device=device)
+        new_attn = torch.zeros((B, new_S), dtype=attention_mask.dtype, device=device)
+        new_resp_mask = torch.zeros((B, max_r), dtype=response_mask.dtype, device=device)
+
+        # Optional response-shape tensors that need the same right-pad treatment.
+        # We re-pad them inside the same per-row loop to keep alignment trivial.
+        optional_response_keys: List[str] = []
+        for k in ("advantages", "loss_mask", "rollout_logprobs", "returns"):
+            if k in data.keys() and torch.is_tensor(data[k]) and data[k].ndim == 2:
+                optional_response_keys.append(k)
+        new_opts: Dict[str, torch.Tensor] = {}
+        for k in optional_response_keys:
+            t = data[k]
+            new_opts[k] = torch.zeros((B, max_r), dtype=t.dtype, device=t.device)
+
+        for i in range(B):
+            p_i = int(prompt_lens[i].item())
+            r_i = int(response_lens[i].item())
+            pad_i = S - p_i - r_i  # left pad in SkyRL layout
+
+            # SkyRL slice locations:
+            prompt_slice = sequences[i, pad_i : pad_i + p_i]      # [p_i]
+            response_slice = sequences[i, pad_i + p_i :]          # [r_i]
+
+            # verl placement: prompt sits in positions [max_p - p_i : max_p],
+            # response sits in positions [max_p : max_p + r_i].
+            new_input_ids[i, max_p - p_i : max_p] = prompt_slice
+            new_input_ids[i, max_p : max_p + r_i] = response_slice
+            new_attn[i, max_p - p_i : max_p + r_i] = 1
+            new_resp_mask[i, :r_i] = 1
+
+            # Response-shape tensors in SkyRL are RIGHT-ALIGNED to max_r_sky
+            # (i.e., the real values occupy the LAST r_i positions). After
+            # repack we put them LEFT-ALIGNED in [B, max_r] (positions
+            # [0 : r_i]) so they line up with the new response region of
+            # input_ids. This matches verl's response-only tensor convention.
+            R_sky = response_mask.shape[1]
+            for k in optional_response_keys:
+                src = data[k][i, R_sky - r_i :]   # the real per-token values
+                new_opts[k][i, :r_i] = src
+
+        # position_ids derived from attention_mask: cumsum-1, pad→0 (drops
+        # negative -1 to 0 so the embedding lookup is safe).
+        pos = new_attn.long().cumsum(-1) - 1
+        pos.masked_fill_(new_attn == 0, 0)
+
+        batch: Dict[str, Any] = {
+            "input_ids": new_input_ids,
+            "attention_mask": new_attn,
+            "prompts": new_input_ids[:, :max_p],
+            "responses": new_input_ids[:, max_p:],
+            "response_mask": new_resp_mask,
+            "position_ids": pos,
+        }
+        # Tag the repacked response-shape tensors so the loss / post-procs
+        # find them in the same wire location as the verl adapter ships.
+        for k, v in new_opts.items():
+            batch[k] = v
+
+        batch["_max_prompt_len"] = max_p
+        batch["_max_response_len"] = max_r
+        return batch
+
+    @staticmethod
+    def _left_pad_to_seq(t: torch.Tensor, seq_len: int) -> torch.Tensor:
+        """Left-pad a ``[B, R]`` response-only tensor to ``[B, P+R]`` with
+        zeros so the loss can index it by full-sequence positions.
+
+        Mirrors ``_send_update_actor._left_pad`` in
+        ``verl/workers/remote_client/arctic_rl.py``: the verl_grpo loss
+        gathers per-token positions via the response_mask, which is
+        itself left-padded to seq_len — so every tensor it reads must
+        have the same shape.
+        """
+        pad_len = seq_len - t.shape[-1]
+        if pad_len <= 0:
+            return t
+        pad = torch.zeros(*t.shape[:-1], pad_len, dtype=t.dtype, device=t.device)
+        return torch.cat([pad, t], dim=-1)
+
+    def _build_meta(
+        self,
+        *,
+        max_prompt_len: int,
+        max_response_len: int,
+        batch_num_tokens: int,
+        global_batch_size: int,
+        calculate_entropy: bool,
+        actor_config: Optional[Dict[str, Any]] = None,
+        policy_loss_config: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Construct the ``meta`` dict the server's processing pipeline
+        and verl_grpo loss read.
+
+        Mirrors the verl adapter's meta exactly (see
+        ``verl/workers/remote_client/arctic_rl.py:198-279``). Defaults
+        for ``actor_config`` / ``policy_loss_config`` come from the
+        SkyRL recipe's algorithm block — GRPO without KL, no entropy
+        bonus, clip_ratio=0.2 (matches verl PR #6 BIRD hyperparams).
+        """
+        cfg = self.cfg
+        algo = cfg.trainer.algorithm
+        n_samples = cfg.generator.n_samples_per_prompt
+        arl = getattr(cfg.trainer, "arctic_rl", None)
+
+        # actor_config — fields read by verl_grpo.VerlPolicyConfig.
+        # SkyRL stores most of these on `cfg.trainer.algorithm`.
+        ac: Dict[str, Any] = {
+            "loss_agg_mode": getattr(algo, "loss_agg_mode", "token-mean"),
+            "kl_loss_coef": float(getattr(algo, "kl_loss_coef", 0.001) or 0.0),
+            "kl_loss_type": getattr(algo, "kl_loss_type", "low_var_kl"),
+            "clip_ratio": float(getattr(algo, "clip_ratio", 0.2)),
+            "clip_ratio_low": float(getattr(algo, "clip_ratio_low", getattr(algo, "clip_ratio", 0.2))),
+            "clip_ratio_high": float(getattr(algo, "clip_ratio_high", getattr(algo, "clip_ratio", 0.2))),
+            "clip_ratio_c": float(getattr(algo, "clip_ratio_c", 3.0)),
+            "entropy_coeff": float(getattr(algo, "entropy_coeff", 0.0)),
+            "use_kl_loss": bool(getattr(algo, "use_kl_loss", False)),
+            "calculate_entropy": calculate_entropy,
+            "rollout_n": n_samples,
+        }
+        if actor_config:
+            ac.update(actor_config)
+
+        plc: Dict[str, Any] = {"loss_mode": "vanilla"}
+        if policy_loss_config:
+            plc.update(policy_loss_config)
+
+        meta: Dict[str, Any] = {
+            # Server-side processors & loss require these literally —
+            # see `arctic_platform/rl/processors/pipeline.py:401`
+            # (`pad_token = meta["pad_token_id"]`) and
+            # `processors/verl_grpo.py:395-408`.
+            "pad_token_id": self._pad_token_id,
+            "rollout_n": n_samples,
+            "max_prompt_len": max_prompt_len,
+            "max_response_len": max_response_len,
+            "max_token_len_per_gpu": self._max_token_len_per_gpu,
+            "temperature": self._temperature,
+            "calculate_entropy": calculate_entropy,
+            # Per-call meta values. These must match what the public-branch
+            # bridge sent (hardcoded "none" / False / 4 / False) -- empirically
+            # validated through 7 converged steps of run gqpa0syk.
+            #
+            # IMPORTANT: do NOT source these from arl.* config. Pushing
+            # ``logits_optimization="memory"`` here triggered a server-side
+            # ZoRRO unpack mismatch at step 5 of run 1ikq295l ("value tensor
+            # of shape [8026] cannot be broadcast to indexing result of
+            # shape [7042]"), even though the same value is valid when set
+            # on ``ds_worker_config`` at engine-build time. The two layers
+            # take different code paths: ds_worker_config drives the model
+            # patcher (Qwen3ModelOncePatcher), per-call meta drives the
+            # non-ZoRRO processor pipeline (processors/pipeline.py:815-827),
+            # and pushing "memory" into the non-ZoRRO path corrupts the
+            # response-length packing contract.
+            #
+            # Likewise ``drop_position_ids=True`` while still sending
+            # position_ids in the batch caused position_id-vs-attention_mask
+            # divergence on certain batch compositions. Hardcoding False
+            # restores the matched shapes.
+            "drop_position_ids": False,
+            "logits_optimization": "none",
+            "logits_optimization_peak_mem_size_in_gib": 4,
+            "logits_compute_in_fp32": False,
+            # verl_grpo global-normalization knobs.
+            "dp_size": self._dp_size,
+            "batch_num_tokens": int(batch_num_tokens),
+            "global_batch_size": int(global_batch_size),
+            "rollout_is_weights": None,
+            # ZoRRO is opt-in via SkyRL's `arl.use_zorro`; we mirror it onto
+            # the server's per-call meta so the dispatch and ds_worker_config
+            # stay aligned. `zorro_train_max_rollouts == n_samples_per_prompt`
+            # is the verl-recommended value (best perf, no group-balancing
+            # needed).
+            "zorro_train_enable": self._zorro_train_enable,
+            "zorro_train_max_rollouts": n_samples,
+            "zorro_train_load_balancer": True,
+            # Serialized loss config — see verl_grpo.VerlPolicyConfig.
+            "actor_config": ac,
+            "policy_loss_config": plc,
+        }
+        return meta
+
+    # ------------------------------------------------------------------ #
+    # WorkerDispatch interface
+    # ------------------------------------------------------------------ #
+
+    def forward(self, model: str, data: TrainingInputBatch) -> TrainingOutputBatch:
+        """Compute log-probs only (no grad). Currently unused: the
+        Arctic trainer overrides ``fwd_logprobs_values_reward`` as a
+        no-op and computes old log-probs inside ``forward_backward``."""
+        batch = self._repack_to_verl_shape(data)
+        max_p = batch.pop("_max_prompt_len")
+        max_r = batch.pop("_max_response_len")
+        meta = self._build_meta(
+            max_prompt_len=max_p,
+            max_response_len=max_r,
+            batch_num_tokens=int(batch["response_mask"].sum().item()),
+            global_batch_size=int(data["sequences"].shape[0]),
+            calculate_entropy=True,
+        )
+        payload = dict(
+            batch={k: v for k, v in batch.items()},
+            meta=meta,
+            processing={"post": ["compute_entropy_and_logprobs"], "loss_fn": None},
+        )
+        result = _run(self.client.fwd_no_grad(payload, reference_model=False))
+        out = TrainingOutputBatch()
+        for k, v in result.get("batch", {}).items():
+            out[k] = torch.tensor(v) if isinstance(v, list) else v
+        out.metadata = {"model": model}
+        return out
+
+    def _compute_old_log_probs(self, repacked: Dict[str, Any], meta: Dict[str, Any]) -> torch.Tensor:
+        """Run ``fwd_no_grad`` with the entropy/logprobs post-processor
+        to obtain on-policy old log-probs for the PPO ratio.
+
+        Mirrors verl's ``compute_log_prob`` call before
+        ``update_actor`` — at step 1 (no policy update yet) this gives
+        ``old_log_probs == new_log_probs`` so ``ppo_kl == 0`` and
+        ``clipfrac == 0``, matching the verl PR #6 step-1 invariants.
+
+        Payload mirrors ``_prepare_padded_arctic_batch_dict`` (verl
+        adapter): only the keys the server needs to derive
+        ``response_lens`` (``attention_mask`` + ``prompts.shape[1]``)
+        and run the forward (``input_ids`` + ``position_ids``). No
+        response-region tensors — those would be skipped by
+        ``pack_with_unpad`` anyway (shape mismatch with attention_mask)
+        but sending them needlessly bloats the wire payload and risks
+        confusing the model's ``forward(**kwargs)`` signature.
+        """
+        fwd_batch = {
+            "input_ids": repacked["input_ids"],
+            "attention_mask": repacked["attention_mask"],
+            "prompts": repacked["prompts"],
+            "position_ids": repacked["position_ids"],
+        }
+        # `compute_entropy_and_logprobs` doesn't apply temperature here —
+        # matches verl's compute_log_prob path (verl_grpo loss only
+        # applies temperature inside update_actor / fwd_bwd). With
+        # temperature=1.0 (BIRD recipe) this is a no-op either way.
+        sub_meta = dict(meta)
+        sub_meta["calculate_entropy"] = False  # cheaper; we only need log_probs
+        # actor_config / policy_loss_config are update_actor-only; drop
+        # them so the pipeline's `calculate_entropy` gating
+        # (`if "entropy_coeff" in actor_config: meta["calculate_entropy"]
+        # = (entropy_coeff != 0)`) doesn't accidentally flip on/off.
+        sub_meta.pop("actor_config", None)
+        sub_meta.pop("policy_loss_config", None)
+        payload = dict(
+            batch=fwd_batch,
+            meta=sub_meta,
+            processing={"post": ["compute_entropy_and_logprobs"], "loss_fn": None},
+        )
+        result = _run(self.client.fwd_no_grad(payload, reference_model=False))
+        # Server returns the post-processor outputs under "batch", unpacked
+        # back to [B, S] (pad regions filled with the pad_token_id by
+        # `unpadded_tensor_1d_to_padded_tensor_2d`); the
+        # `compute_entropy_and_logprobs` post writes "logprobs". Verl
+        # renames to "log_probs"; accept either.
+        lp = result["batch"].get("logprobs")
+        if lp is None:
+            lp = result["batch"].get("log_probs")
+        if lp is None:
+            raise RuntimeError(
+                f"fwd_no_grad returned no logprobs; got keys={list(result.get('batch', {}).keys())}"
+            )
+        if isinstance(lp, list):
+            lp = torch.tensor(lp)
+        return lp
+
+    def forward_backward(
+        self,
+        model: str,
+        data: TrainingInputBatch,
+        loss_fn: Optional[str] = None,
+        loss_fn_config: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, float]:
+        """One PPO update epoch: compute old log-probs, build the
+        verl-shape payload, run server-side fwd+bwd with verl_grpo.
+
+        Wire contract (mirrors
+        ``verl/workers/remote_client/arctic_rl.py:_send_update_actor``):
+          processing.post   = ["apply_temperature", "compute_entropy_and_logprobs"]
+          processing.loss_fn = "verl_grpo"
+          batch.input_ids        [B, P+R]
+          batch.attention_mask   [B, P+R]
+          batch.prompts          [B, P]     (server reads only .shape[1])
+          batch.responses        [B, R]
+          batch.position_ids     [B, P+R]
+          batch.response_mask    [B, P+R]   (left-padded from [B, R])
+          batch.loss_mask        [B, P+R]   (== response_mask after pad)
+          batch.advantages       [B, P+R]   (left-padded with zeros)
+          batch.old_log_probs    [B, P+R]   (left-padded with zeros)
+        """
+        repacked = self._repack_to_verl_shape(data)
+        max_p = repacked.pop("_max_prompt_len")
+        max_r = repacked.pop("_max_response_len")
+        n_samples = self.cfg.generator.n_samples_per_prompt
+        global_batch_size = self.cfg.trainer.policy_mini_batch_size * n_samples
+
+        meta = self._build_meta(
+            max_prompt_len=max_p,
+            max_response_len=max_r,
+            batch_num_tokens=int(repacked["response_mask"].sum().item()),
+            global_batch_size=global_batch_size,
+            calculate_entropy=True,
+        )
+
+        # 1) Old log-probs via fwd_no_grad (matches verl's two-call pattern).
+        old_log_probs_resp = self._compute_old_log_probs(repacked, meta)  # [B, R]
+
+        # 2) Left-pad response-only tensors to full seq_len. The verl_grpo
+        #    loss + apply_temperature post-processor index by full-seq
+        #    positions, so every response-shape tensor must match.
+        seq_len = repacked["input_ids"].shape[-1]
+        batch: Dict[str, Any] = {
+            "input_ids": repacked["input_ids"],
+            "attention_mask": repacked["attention_mask"],
+            "prompts": repacked["prompts"],
+            "responses": repacked["responses"],
+            "position_ids": repacked["position_ids"],
+        }
+        batch["response_mask"] = self._left_pad_to_seq(repacked["response_mask"], seq_len)
+        batch["advantages"] = self._left_pad_to_seq(repacked["advantages"], seq_len)
+        batch["old_log_probs"] = self._left_pad_to_seq(old_log_probs_resp.to(repacked["input_ids"].device), seq_len)
+        # verl: `loss_mask = response_mask` after the same left-pad.
+        batch["loss_mask"] = batch["response_mask"]
+
+        payload = dict(
+            batch=batch,
+            meta=meta,
+            processing={
+                "post": ["apply_temperature", "compute_entropy_and_logprobs"],
+                "loss_fn": "verl_grpo",
+            },
+        )
+
+        result = _run(self.client.fwd_bwd(payload))
+        result.pop("job_id", None)
+        return result.get("metrics", result)
+
+    def optim_step(self, model: str) -> Optional[float]:
+        resp = _run(self.client.step())
+        metrics = resp.get("metrics", resp)
+        # The server reports per-DP-rank grad_norm as a flat list (length =
+        # num training workers); SkyRL's `reduce_metrics` expects a scalar
+        # per call and warns "Metrics for key grad_norm are not all numbers"
+        # if given a nested list. With ZeRO-3 + DDP every rank sees the same
+        # globally-reduced grad_norm, so picking the first is equivalent to
+        # averaging — and avoids the warning churn in the trainer logs.
+        grad_norm = metrics.get("grad_norm")
+        if isinstance(grad_norm, (list, tuple)):
+            flat = []
+            for v in grad_norm:
+                if isinstance(v, (list, tuple)):
+                    flat.extend(v)
+                else:
+                    flat.append(v)
+            grad_norm = float(flat[0]) if flat else None
+        return grad_norm
+
+    def get_lcm_dp_size(self) -> int:
+        return 1
+
+    def save_checkpoint(self, model: str, ckpt_dir: str, tokenizer=None) -> None:
+        _run(self.client.save_checkpoint())
+
+    def load_checkpoint(self, model: str, ckpt_dir: str, **kwargs) -> None:
+        logger.info(f"Arctic RL: load_checkpoint for {model} — delegated to server")
+
+    def save_hf_model(self, model: str, export_dir: str, tokenizer) -> None:
+        logger.info(f"Arctic RL: save_hf_model for {model} — delegated to server")
+
+    def set_lr(self, model: str, learning_rate: float) -> None:
+        pass
+
+    def init_weight_sync_state(self, inference_engine_client) -> None:
+        pass
+
+    async def save_weights_for_sampler(self) -> None:
+        if self._colocate:
+            await self.client.empty_training_cache()
+            await self.client.wake_training()
+            await self.client.wake_inference()
+            await self.client.sync_weights(cuda_ipc=self._cuda_ipc, low_memory=self._low_memory)
+        else:
+            await self.client.sync_weights(cuda_ipc=False, low_memory=self._low_memory)
+
+    def mark_all_offloaded(self) -> None:
+        pass
+
+    def empty_cache(self, model=None) -> None:
+        pass
+
+    def get_node_ids(self) -> List[str]:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Stub — satisfies self.policy_model usage in RayPPOTrainer / FullyAsync
+# ---------------------------------------------------------------------------
+
+class _ArcticPolicyStub:
+    """No-op stub for ``self.policy_model``."""
+
+    async def async_run_method(self, *args, **kwargs):
+        pass
+
+    def async_run_ray_method(self, *args, **kwargs):
+        return []
+
+
+class _ArcticInferenceEngineStub:
+    """Stub for ``self.inference_engine_client``.
+
+    Routes sleep/wake to the Arctic RL server for colocated mode.
+    pause/resume are no-ops (server manages its own engine).
+    """
+
+    def __init__(self, client=None, colocate: bool = False):
+        self._client = client
+        # `colocate` from cfg.trainer.arctic_rl, set at entrypoint._setup_trainer.
+        self._colocate = colocate
+
+    async def sleep(self, **kwargs):
+        if self._client and self._colocate:
+            # level=2 releases bf16 weight pages in addition to KV cache.
+            # Required at 32B colocation — level=1 keeps ~64 GiB of weights
+            # resident and the colocated DeepSpeed worker OOMs on the first
+            # MLP allocation of step 2. Mirrors arctic-verl's VLLM_SLEEP_LEVEL=2.
+            level = kwargs.get("level", 2)
+            await self._client.sleep_inference(level=level)
+
+    async def wake_up(self, **kwargs):
+        if self._client and self._colocate:
+            tags = kwargs.get("tags")
+            await self._client.wake_inference(tags=tags)
+
+    async def pause_generation(self, **kwargs):
+        pass
+
+    async def resume_generation(self, **kwargs):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fully-async variant
+# ---------------------------------------------------------------------------
+
+def _make_arctic_fully_async_trainer_class():
+    """Build the fully-async Arctic trainer class with a deferred import.
+
+    The import of ``FullyAsyncRayPPOTrainer`` is deferred so that
+    ``arctic_trainer.py`` can be imported without pulling in the
+    fully-async module (and its extra dependencies) when only the
+    sync trainer is needed.
+    """
+    from skyrl.train.fully_async_trainer import FullyAsyncRayPPOTrainer
+
+    class _ArcticFullyAsyncPPOTrainer(FullyAsyncRayPPOTrainer):
+        """Fully-async PPO Trainer backed by Arctic RL server (DeepSpeed).
+
+        Drop-in replacement for ``FullyAsyncRayPPOTrainer``.  Applies the
+        same Arctic RL overrides as ``ArcticPPOTrainer`` (no-op fwd_logprobs,
+        server-side GRPO loss, DeepSpeed gradient accumulation).
+        """
+
+        def __init__(self, *args, arctic_client, **kwargs):
+            self._arctic_client = arctic_client
+            self._stashed_rewards = None
+            super().__init__(*args, **kwargs)
+
+        def build_models(self, PolicyWorker=None, CriticWorker=None, RefWorker=None):
+            self.dispatch = _ArcticDispatch(self.cfg, self._arctic_client)
+            self.policy_model = _ArcticPolicyStub()
+            self.ref_model = None
+            self.critic_model = None
+            logger.info("ArcticFullyAsyncPPOTrainer: build_models → training routed to Arctic RL server")
+
+        def fwd_logprobs_values_reward(self, training_input: TrainingInputBatch):
+            return training_input
+
+        def compute_advantages_and_returns(self, training_input: TrainingInputBatch):
+            self._stashed_rewards = training_input["rewards"].clone()
+            training_input["values"] = None
+            return super().compute_advantages_and_returns(training_input)
+
+        def train_critic_and_policy(self, data: TrainingInputBatch):
+            # See ArcticPPOTrainer.train_critic_and_policy docstring — the
+            # bridge's old-log-prob call lives inside forward_backward, so
+            # multi-epoch would collapse `ratio == 1` every epoch.
+            ep = int(self.cfg.trainer.update_epochs_per_batch)
+            assert ep == 1, (
+                f"ArcticFullyAsyncPPOTrainer: update_epochs_per_batch must "
+                f"be 1; got {ep}."
+            )
+
+            if self._stashed_rewards is not None:
+                data["rewards"] = self._stashed_rewards
+                self._stashed_rewards = None
+
+            data.metadata["global_step"] = self.global_step
+            n_samples = self.cfg.generator.n_samples_per_prompt
+
+            all_metrics: Dict[str, List[float]] = defaultdict(list)
+
+            status = self.dispatch.forward_backward(
+                "policy", data,
+                loss_fn="verl_grpo",
+                loss_fn_config={"n_samples": n_samples},
+            )
+            for k, v in status.items():
+                all_metrics[k].append(v)
+
+            grad_norm = self.dispatch.optim_step("policy")
+            if grad_norm is not None:
+                all_metrics["grad_norm"].append(grad_norm)
+
+            all_metrics.pop("loss_fn_outputs", None)
+            all_metrics.pop("post_process_outputs", None)
+            reduced = reduce_metrics(dict(all_metrics))
+
+            for k, v in reduced.items():
+                self.all_metrics[f"policy/{k}"] = v
+
+            return reduced
+
+        async def async_sync_policy_weights_to_inference_engines(self):
+            """Sync weights via Arctic RL server instead of policy_model."""
+            await self._arctic_client.sync_weights()
+
+    return _ArcticFullyAsyncPPOTrainer
+
+
+def ArcticFullyAsyncPPOTrainer(*args, **kwargs):
+    """Factory for the fully-async Arctic RL trainer.
+
+    Defers the import of ``FullyAsyncRayPPOTrainer`` until first use.
+    """
+    cls = _make_arctic_fully_async_trainer_class()
+    return cls(*args, **kwargs)

--- a/integrations/arctic_rl/trainer.py
+++ b/integrations/arctic_rl/trainer.py
@@ -33,10 +33,13 @@ import torch
 from loguru import logger
 from transformers import AutoTokenizer
 
-from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch, TrainingOutputBatch
-from skyrl.train.trainer import RayPPOTrainer
-from skyrl.train.config import SkyRLTrainConfig
+from skyrl.backends.skyrl_train.training_batch import (
+    TrainingInputBatch,
+    TrainingOutputBatch,
+)
 from skyrl.backends.skyrl_train.workers.worker_utils import reduce_metrics
+from skyrl.train.config import SkyRLTrainConfig
+from skyrl.train.trainer import RayPPOTrainer
 
 
 def _run(coro):
@@ -54,10 +57,9 @@ def _run(coro):
         return asyncio.run(coro)
     except RuntimeError:
         import concurrent.futures
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(
-                lambda c=coro: asyncio.new_event_loop().run_until_complete(c)
-            ).result()
+            return pool.submit(lambda c=coro: asyncio.new_event_loop().run_until_complete(c)).result()
 
 
 class ArcticPPOTrainer(RayPPOTrainer):
@@ -115,9 +117,7 @@ class ArcticPPOTrainer(RayPPOTrainer):
         (matches verl's pre-update_actor ``compute_log_prob`` placement).
         """
         ep = int(self.cfg.trainer.update_epochs_per_batch)
-        assert ep == 1, (
-            f"ArcticPPOTrainer requires update_epochs_per_batch=1, got {ep}"
-        )
+        assert ep == 1, f"ArcticPPOTrainer requires update_epochs_per_batch=1, got {ep}"
 
         if self._stashed_rewards is not None:
             data["rewards"] = self._stashed_rewards
@@ -129,7 +129,8 @@ class ArcticPPOTrainer(RayPPOTrainer):
         all_metrics: Dict[str, List[float]] = defaultdict(list)
 
         status = self.dispatch.forward_backward(
-            "policy", data,
+            "policy",
+            data,
             loss_fn="verl_grpo",
             loss_fn_config={"n_samples": n_samples},
         )
@@ -153,6 +154,7 @@ class ArcticPPOTrainer(RayPPOTrainer):
 # ---------------------------------------------------------------------------
 # Dispatch — duck-types the WorkerDispatch interface used by RayPPOTrainer
 # ---------------------------------------------------------------------------
+
 
 class _ArcticDispatch:
     """Routes ``WorkerDispatch`` calls to the Arctic RL server.
@@ -185,24 +187,17 @@ class _ArcticDispatch:
         # version skew.
         self.tokenizer = AutoTokenizer.from_pretrained(cfg.trainer.policy.model.path)
         self._pad_token_id: int = (
-            self.tokenizer.pad_token_id
-            if self.tokenizer.pad_token_id is not None
-            else self.tokenizer.eos_token_id
+            self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else self.tokenizer.eos_token_id
         )
 
         # DP size = number of training GPUs (Arctic-RL training is DP-only;
         # no TP/PP on the training side). The verl_grpo loss uses this to
         # compute the correct global-mean normalization.
-        self._dp_size: int = (
-            cfg.trainer.placement.policy_num_gpus_per_node
-            * cfg.trainer.placement.policy_num_nodes
-        )
+        self._dp_size: int = cfg.trainer.placement.policy_num_gpus_per_node * cfg.trainer.placement.policy_num_nodes
 
         # Sampling temperature is part of the loss math (apply_temperature
         # post-processor divides logits by it). Recipe knob.
-        self._temperature: float = float(
-            getattr(cfg.generator.sampling_params, "temperature", 1.0) or 1.0
-        )
+        self._temperature: float = float(getattr(cfg.generator.sampling_params, "temperature", 1.0) or 1.0)
 
         # ZoRRO toggle — mirror SkyRL's `arl.use_zorro` onto the server-side
         # `meta.zorro_train_enable` so the two stay in sync. Defaults to False.
@@ -294,17 +289,17 @@ class _ArcticDispatch:
         ``[B, P + R]`` shape where ``P = max(prompt_len)`` and
         ``R = max(response_len)``.
         """
-        sequences = data["sequences"]                # [B, S]
-        attention_mask = data["attention_mask"]      # [B, S]
-        response_mask = data["response_mask"]        # [B, R_sky]  R_sky = max_r
+        sequences = data["sequences"]  # [B, S]
+        attention_mask = data["attention_mask"]  # [B, S]
+        response_mask = data["response_mask"]  # [B, R_sky]  R_sky = max_r
         B, S = sequences.shape
         device = sequences.device
         pad_id = self._pad_token_id
 
         # Real per-sample lengths.
-        total_lens = attention_mask.sum(dim=1)        # [B] = p_i + r_i
-        response_lens = response_mask.sum(dim=1)      # [B] = r_i
-        prompt_lens = total_lens - response_lens      # [B] = p_i
+        total_lens = attention_mask.sum(dim=1)  # [B] = p_i + r_i
+        response_lens = response_mask.sum(dim=1)  # [B] = r_i
+        prompt_lens = total_lens - response_lens  # [B] = p_i
 
         max_p = int(prompt_lens.max().item())
         max_r = int(response_lens.max().item())
@@ -339,8 +334,8 @@ class _ArcticDispatch:
             pad_i = S - p_i - r_i  # left pad in SkyRL layout
 
             # SkyRL slice locations:
-            prompt_slice = sequences[i, pad_i : pad_i + p_i]      # [p_i]
-            response_slice = sequences[i, pad_i + p_i :]          # [r_i]
+            prompt_slice = sequences[i, pad_i : pad_i + p_i]  # [p_i]
+            response_slice = sequences[i, pad_i + p_i :]  # [r_i]
 
             # verl placement: prompt sits in positions [max_p - p_i : max_p],
             # response sits in positions [max_p : max_p + r_i].
@@ -356,7 +351,7 @@ class _ArcticDispatch:
             # input_ids. This matches verl's response-only tensor convention.
             R_sky = response_mask.shape[1]
             for k in optional_response_keys:
-                src = data[k][i, R_sky - r_i :]   # the real per-token values
+                src = data[k][i, R_sky - r_i :]  # the real per-token values
                 new_opts[k][i, :r_i] = src
 
         # position_ids derived from attention_mask: cumsum-1, pad→0 (drops
@@ -421,7 +416,6 @@ class _ArcticDispatch:
         cfg = self.cfg
         algo = cfg.trainer.algorithm
         n_samples = cfg.generator.n_samples_per_prompt
-        arl = getattr(cfg.trainer, "arctic_rl", None)
 
         # actor_config — fields read by verl_grpo.VerlPolicyConfig.
         # SkyRL stores most of these on `cfg.trainer.algorithm`.
@@ -581,9 +575,7 @@ class _ArcticDispatch:
         if lp is None:
             lp = result["batch"].get("log_probs")
         if lp is None:
-            raise RuntimeError(
-                f"fwd_no_grad returned no logprobs; got keys={list(result.get('batch', {}).keys())}"
-            )
+            raise RuntimeError(f"fwd_no_grad returned no logprobs; got keys={list(result.get('batch', {}).keys())}")
         if isinstance(lp, list):
             lp = torch.tensor(lp)
         return lp
@@ -720,6 +712,7 @@ class _ArcticDispatch:
 # Stub — satisfies self.policy_model usage in RayPPOTrainer / FullyAsync
 # ---------------------------------------------------------------------------
 
+
 class _ArcticPolicyStub:
     """No-op stub for ``self.policy_model``."""
 
@@ -767,6 +760,7 @@ class _ArcticInferenceEngineStub:
 # Fully-async variant
 # ---------------------------------------------------------------------------
 
+
 def _make_arctic_fully_async_trainer_class():
     """Build the fully-async Arctic trainer class with a deferred import.
 
@@ -810,10 +804,7 @@ def _make_arctic_fully_async_trainer_class():
             # bridge's old-log-prob call lives inside forward_backward, so
             # multi-epoch would collapse `ratio == 1` every epoch.
             ep = int(self.cfg.trainer.update_epochs_per_batch)
-            assert ep == 1, (
-                f"ArcticFullyAsyncPPOTrainer: update_epochs_per_batch must "
-                f"be 1; got {ep}."
-            )
+            assert ep == 1, f"ArcticFullyAsyncPPOTrainer: update_epochs_per_batch must " f"be 1; got {ep}."
 
             if self._stashed_rewards is not None:
                 data["rewards"] = self._stashed_rewards
@@ -825,7 +816,8 @@ def _make_arctic_fully_async_trainer_class():
             all_metrics: Dict[str, List[float]] = defaultdict(list)
 
             status = self.dispatch.forward_backward(
-                "policy", data,
+                "policy",
+                data,
                 loss_fn="verl_grpo",
                 loss_fn_config={"n_samples": n_samples},
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,13 @@ harbor = [
     "harbor[daytona,modal]; python_version >= '3.12'",
 ]
 
+arctic-rl = [
+    "skyrl[skyrl-train]",
+    "arctic-platform",
+    "arctic-inference[vllm]",
+    "liger-kernel",
+]
+
 dev = [
     "mkdocs",
     "mkdocs-material",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,13 +167,6 @@ harbor = [
     "harbor[daytona,modal]; python_version >= '3.12'",
 ]
 
-arctic-rl = [
-    "skyrl[skyrl-train]",
-    "arctic-platform",
-    "arctic-inference[vllm]",
-    "liger-kernel",
-]
-
 dev = [
     "mkdocs",
     "mkdocs-material",

--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -438,7 +438,20 @@ def skyrl_entrypoint(cfg: SkyRLTrainConfig):
 
 
 def main() -> None:
-    # Parse CLI args and build typed config
+    # Peek at trainer.override_entrypoint BEFORE strict config parse: integrations
+    # may add their own config fields that core SkyRLTrainConfig doesn't know
+    # about, so the strict parse would fail. If override is set, dispatch to the
+    # named entrypoint and let it parse with its own extended config.
+    override_entrypoint = None
+    for arg in sys.argv[1:]:
+        if arg.startswith("trainer.override_entrypoint="):
+            override_entrypoint = arg.split("=", 1)[1]
+            break
+    if override_entrypoint:
+        from importlib import import_module
+
+        return import_module(override_entrypoint).main()
+
     cfg = SkyRLTrainConfig.from_cli_overrides(sys.argv[1:])
 
     # validate the arguments


### PR DESCRIPTION
## Summary

Adds an `arctic_rl` integration under `integrations/arctic_rl/` that lets SkyRL recipes train against Snowflake's Arctic RL stack ([Arctic-Platform](https://github.com/snowflakedb/Arctic-Platform) + [Arctic-Inference](https://github.com/snowflakedb/ArcticInference)). It mirrors the existing `harbor` / `dapo` integration shape — each integration ships its own entrypoint, config, generator, trainer, BIRD-SQL environment, and example launchers.

**Core SkyRL changes are intentionally minimal** (1 file, +15 / -1 line):

- `skyrl/train/entrypoints/main_base.py`: one ~15-line dispatch hook that inspects `trainer.override_entrypoint=<module>` on argv BEFORE strict config parsing and forwards to the integration's `main()`. This lets integrations add config fields without subclassing `SkyRLTrainConfig` and without forking the recipe scripts. UX is just:

  ```
  uv run -m skyrl.train.entrypoints.main_base \
      trainer.override_entrypoint=integrations.arctic_rl.entrypoint \
      <... any existing SkyRL recipe flags ...>
  ```

- `pyproject.toml`: adds an additive `[arctic-rl]` extra (`skyrl[arctic-rl]`) pulling in `arctic-platform`, `arctic-inference[vllm]`, and `liger-kernel`. **No existing pins touched.**

## Integration contents (`integrations/arctic_rl/`)

- `entrypoint.py` — boots an `ArcticRLClient` against arctic-platform and forwards weight-sync, rollouts, and metrics
- `config.py` — `ArcticRLTrainerConfig` exposing the colocate / ZoRRo / FCA / spec-dec / CUDA-IPC-weight-sync knobs
- `trainer.py`, `generator.py` — thin adapters from SkyRL's PPO loop to Arctic-Platform's RL client
- `envs/bird*.py` — vendored BIRD-SQL environment so the recipe is self-contained (no private branch dep)
- `examples/` — smoke / 8B / 32B BIRD GRPO recipes + a GSM8K sanity check. Env vars in launchers are trimmed to only what's recipe-required.

## Diff scope

- **18 files / +3871 / -1**
- 16 net-new files all under `integrations/arctic_rl/`
- 2 surgical edits to core SkyRL (`main_base.py`, `pyproject.toml`)

## Test plan

- [x] Smoke GSM8K + BIRD recipes converge on single-node 4×H200
- [x] 4-node 32×H200 BIRD GRPO with Qwen3-8B / Qwen3-32B (Arctic-Inference: FCA + speculative-decoding + CUDA-IPC weight sync)
- [x] `uv run --extra arctic-rl -m skyrl.train.entrypoints.main_base trainer.override_entrypoint=...` boots without touching any of SkyRL's typed config
- [ ] Final perf table (2× rollout speedup vs SkyRL FSDP-native baseline) — last-mile timing capture in progress

Happy to iterate on review feedback.

Made with [Cursor](https://cursor.com)