### PR TITLE
[megatron] add opt-in async distributed checkpoint save

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -316,6 +316,7 @@ class MegatronStrategy(DistributedStrategy):
                 checkpoint_dir=work_dir,
                 sharded_strategy=save_strategy,
                 async_sharded_save=async_save,
+                async_strategy=self.megatron_config.async_dist_ckpt_strategy,
                 validate_access_integrity=True,
             )
             if async_save:

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -299,16 +299,30 @@ class MegatronStrategy(DistributedStrategy):
             save_strategy, mpu.get_data_parallel_group(with_context_parallel=True)
         )
 
+        async_save = self.megatron_config.async_dist_ckpt_save
+        if async_save and io.is_cloud_path(ckpt_dir):
+            # local_work_dir uploads on context exit, which would race the still-running
+            # background write. Async is only safe writing in-place to a local/shared FS.
+            self.print(f"async_dist_ckpt_save unsupported for cloud path {ckpt_dir}; saving synchronously")
+            async_save = False
+        if async_save:
+            # The queue holds one in-flight write; the prior checkpoint dir must be
+            # fully written before this save reuses it.
+            ckpt_base.async_calls.maybe_finalize_async_calls(blocking=True)
+
         with io.local_work_dir(ckpt_dir) as work_dir:
-            # TODO(tgriggs): Support configurable async saves.
             async_save_request = dist_checkpointing.save(
                 sharded_state_dict=sharded_state_dict,
                 checkpoint_dir=work_dir,
                 sharded_strategy=save_strategy,
-                async_sharded_save=False,
+                async_sharded_save=async_save,
                 validate_access_integrity=True,
             )
-            assert async_save_request is None, "Async save is not yet supported for Megatron"
+            if async_save:
+                # Shards are staged to host; the disk write runs in the background.
+                ckpt_base.async_calls.schedule_async_request(async_save_request)
+            else:
+                assert async_save_request is None, "save() must not return a request when sync"
 
             # Only global rank 0 saves the Huggingface config and tokenizer.
             if self.is_rank_0():
@@ -319,9 +333,19 @@ class MegatronStrategy(DistributedStrategy):
             self._save_lora_adapters(unwrapped_model, ckpt_dir)
 
         dist.barrier()
-        ckpt_base.async_calls.close()
-        ckpt_base.async_calls = AsyncCallsQueue(persistent=True)
+        if not async_save:
+            # Async path keeps the pending request alive in the queue until its finalize;
+            # tearing it down here would orphan that write.
+            ckpt_base.async_calls.close()
+            ckpt_base.async_calls = AsyncCallsQueue(persistent=True)
         self.print(f"Checkpoint successfully saved to {ckpt_dir}")
+
+    def finalize_pending_saves(self) -> None:
+        """Block until any in-flight async checkpoint write completes.
+
+        No-op when ``async_dist_ckpt_save`` is off or nothing is pending.
+        """
+        ckpt_base.async_calls.maybe_finalize_async_calls(blocking=True)
 
     def _get_rank_path(self, ckpt_dir):
         tp_rank = mpu.get_tensor_model_parallel_rank()
@@ -364,6 +388,9 @@ class MegatronStrategy(DistributedStrategy):
     ):
         if not ckpt_dir or not io.exists(ckpt_dir):
             raise FileNotFoundError(f"Checkpoint directory not found: {ckpt_dir}")
+
+        # A reload must observe a fully-written checkpoint.
+        self.finalize_pending_saves()
 
         # Extract base model.
         model: List[nn.Module] = model.actor_module

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -478,6 +478,12 @@ class Worker(DistributedTorchRayActor):
             tokenizer=tokenizer,
         )
 
+    def finalize_pending_saves(self):
+        """Block until any in-flight async checkpoint write completes (no-op otherwise)."""
+        finalize = getattr(self.strategy, "finalize_pending_saves", None)
+        if finalize is not None:
+            finalize()
+
     def load_checkpoint(self, ckpt_dir: str, load_optimizer_states: bool = True, load_lr_scheduler_states: bool = True):
         _, states = self.strategy.load_checkpoint(
             model=self.model,

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -485,6 +485,10 @@ class WorkerDispatch:
             )
         )
 
+    def finalize_pending_saves(self, model: str) -> None:
+        """Block until any in-flight async checkpoint write for ``model`` completes."""
+        ray.get(self._actor_groups[model].async_run_ray_method("pass_through", "finalize_pending_saves"))
+
     def load_checkpoint(
         self,
         model: str,

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -1200,6 +1200,9 @@ class SkyRLTrainBackend(AbstractBackend):
             # Save checkpoint directory (includes optimizer state automatically)
             self._dispatch.save_checkpoint(model=role, ckpt_dir=ckpt_dir, tokenizer=self._tokenizer, model_id=model_id)
 
+            # Drain any in-flight async write so the tar can't capture a partial checkpoint.
+            self._dispatch.finalize_pending_saves(role)
+
             # Create tar archive
             self._create_tar_from_directory(ckpt_dir, output_path)
 

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -394,6 +394,12 @@ class MegatronConfig(BaseConfig):
     tokens (renormalized), ``O(seq*k)`` memory instead of ``O(seq*vocab)`` -- fits at large vocab
     without fragmentation. Reconciled across the TP group, so it scales to any parallel size.
     ``None`` uses the exact full-vocab loss. Typical: 64-128."""
+    async_dist_ckpt_save: bool = False
+    """Write the torch_dist checkpoint from a background process so training resumes
+    immediately; the pending write is finalized at the next checkpoint and at shutdown.
+    The on-disk format is identical to a synchronous save. Only the sharded
+    model/optimizer state is async -- the rank-0 HF config/tokenizer write stays inline.
+    Falls back to synchronous for cloud paths."""
 
     def __post_init__(self):
         # Backfill defaults for any keys the user didn't override so an override dict

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -400,6 +400,9 @@ class MegatronConfig(BaseConfig):
     The on-disk format is identical to a synchronous save. Only the sharded
     model/optimizer state is async -- the rank-0 HF config/tokenizer write stays inline.
     Falls back to synchronous for cloud paths."""
+    async_dist_ckpt_strategy: str = "mcore"
+    """Backend for the async write. ``mcore`` needs no extra deps; megatron-core's own
+    default ``nvrx`` requires nvidia-resiliency-ext. Only used when async saves are on."""
 
     def __post_init__(self):
         # Backfill defaults for any keys the user didn't override so an override dict

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -686,6 +686,12 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 await asyncio.to_thread(self.save_models)
                 logger.info("Saved final model.")
 
+        # Drain any in-flight async checkpoint write before teardown. Unconditional:
+        # a save may have happened outside the periodic path. No-op when nothing is pending.
+        self.dispatch.finalize_pending_saves("policy")
+        if self.has_critic:
+            self.dispatch.finalize_pending_saves("critic")
+
         if self._vllm_metrics_scraper is not None:
             await self._vllm_metrics_scraper.aclose()
         self.tracker.finish()

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -2114,6 +2114,10 @@ class SFTTrainer:
                 logger.info(f"Saving final HF model at step {final_step}")
                 self.save_hf_model()
 
+        # Drain any in-flight async checkpoint write before teardown. Unconditional:
+        # a save may have happened outside the periodic path. No-op when nothing is pending.
+        self.dispatch.finalize_pending_saves("policy")
+
         # Final eval pass (skip if the last step already ran eval).
         # NOTE: The last in-loop tracker.log(..., commit=True) at step=num_steps
         # advanced wandb's internal step counter to num_steps+1. Logging the

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -581,6 +581,13 @@ class RayPPOTrainer:
             with Timer("save_hf_model", self.all_timings):
                 self.save_models()
                 logger.info("Saved final model.")
+
+        # Drain any in-flight async checkpoint write before teardown. Unconditional:
+        # a save may have happened outside the periodic path. No-op when nothing is pending.
+        self.dispatch.finalize_pending_saves("policy")
+        if self.has_critic:
+            self.dispatch.finalize_pending_saves("critic")
+
         if self._vllm_metrics_scraper is not None:
             await self._vllm_metrics_scraper.aclose()
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py
@@ -63,18 +63,20 @@ def get_test_actor_config(strategy: str) -> SkyRLTrainConfig:
 
 
 @pytest.mark.parametrize(
-    ("strategy", "lora", "fully_reshardable", "optimizer_cpu_offload"),
+    ("strategy", "lora", "fully_reshardable", "optimizer_cpu_offload", "async_save"),
     [
-        ("fsdp", False, False, False),
-        pytest.param("megatron", False, False, False, marks=pytest.mark.megatron),
-        pytest.param("megatron", False, False, True, marks=pytest.mark.megatron),
-        pytest.param("megatron", True, False, False, marks=[pytest.mark.megatron, pytest.mark.lora]),
-        pytest.param("megatron", False, True, False, marks=pytest.mark.megatron),
+        ("fsdp", False, False, False, False),
+        pytest.param("megatron", False, False, False, False, marks=pytest.mark.megatron),
+        pytest.param("megatron", False, False, False, True, marks=pytest.mark.megatron),
+        pytest.param("megatron", False, False, True, False, marks=pytest.mark.megatron),
+        pytest.param("megatron", True, False, False, False, marks=[pytest.mark.megatron, pytest.mark.lora]),
+        pytest.param("megatron", False, True, False, False, marks=pytest.mark.megatron),
         pytest.param(
             "megatron",
             False,
             True,
             True,
+            False,
             marks=[
                 pytest.mark.megatron,
                 pytest.mark.skip(
@@ -88,13 +90,14 @@ def get_test_actor_config(strategy: str) -> SkyRLTrainConfig:
     ids=[
         "fsdp",
         "megatron",
+        "megatron_async_dist_ckpt_save",
         "megatron_optimizer_cpu_offload",
         "megatron_lora",
         "megatron_fully_reshardable",
         "megatron_fully_reshardable_optimizer_cpu_offload",
     ],
 )
-def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardable, optimizer_cpu_offload):
+def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardable, optimizer_cpu_offload, async_save):
     """
     Test checkpointing logic by:
     1. Creating model and doing one training step
@@ -113,6 +116,8 @@ def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardabl
     if optimizer_cpu_offload:
         cfg.trainer.policy.megatron_config.optimizer_config_kwargs["optimizer_cpu_offload"] = True
         cfg.trainer.policy.megatron_config.optimizer_config_kwargs["optimizer_offload_fraction"] = 1
+    if async_save:
+        cfg.trainer.policy.megatron_config.async_dist_ckpt_save = True
 
     checkpoint_dir = None
     try:


### PR DESCRIPTION
## Summary

The Megatron `torch_dist` checkpoint save is fully parallel across ranks but **synchronous** — training blocks for the entire shard-write duration on every `ckpt_interval`. For large models checkpointing frequently, that stall is significant.

This adds an opt-in `MegatronConfig.async_dist_ckpt_save` (default `False`, so existing behavior is unchanged). When enabled, `dist_checkpointing.save` stages each rank's shards to host memory and writes them to disk in a background process, letting training resume immediately. This replaces the long-standing `TODO(tgriggs): Support configurable async saves` in `megatron_strategy.py`.

## Changes

- `MegatronConfig.async_dist_ckpt_save` knob (off by default).
- `MegatronStrategy.save_checkpoint`: passes `async_sharded_save` through and schedules the returned request on the existing persistent `AsyncCallsQueue` instead of asserting it is `None`. Blocks on the previous async save before issuing a new one.
- `MegatronStrategy.finalize_pending_saves()`: drains in-flight writes; called at the start of `load_checkpoint` and exposed up through `Worker` → `WorkerDispatch` → end-of-training in the sync, fully-async, and SFT trainers.

## Correctness

- On-disk format is identical to the synchronous save.
- The pending write is finalized before the next save, before any reload, and at end of training.
- Async falls back to synchronous for cloud destinations, where `local_work_dir` uploads on context exit and would otherwise race a partial checkpoint. Only active for local/shared filesystems.

## Test plan

- [ ] GPU run with `async_dist_ckpt_save=true`: verify checkpoints are byte-identical to sync saves and reload correctly.
- [ ] Confirm training resumes before the disk write completes (timing/save_checkpoint drops).
- [ ] Verify final checkpoint at end of training is fully written before exit.