### PR TITLE
[megatron] fused linear cross-entropy for 23x memory savings at 262k context

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
@@ -321,24 +321,28 @@ class FusedLinearChunkedDistributedLogprob(torch.autograd.Function):
             # Cast hidden to the weight dtype first (matches what the
             # ColumnParallelLinear output layer does: hidden may be bf16 while
             # the output weight is fp32, or vice versa).
-            logits = torch.matmul(
-                hidden[:, chunk_start:chunk_end, :].to(weight.dtype), weight.t()
-            ).to(dtype=torch.float32)
+            logits = torch.matmul(hidden[:, chunk_start:chunk_end, :].to(weight.dtype), weight.t()).to(
+                dtype=torch.float32
+            )
 
             log_probs = _compute_distributed_log_softmax(logits, group=tp_group)
-            log_probs = torch.gather(
-                log_probs, -1, masked_target[:, chunk_start:chunk_end].unsqueeze(-1)
-            ).squeeze(-1)
+            log_probs = torch.gather(log_probs, -1, masked_target[:, chunk_start:chunk_end].unsqueeze(-1)).squeeze(-1)
             log_probs[target_mask[:, chunk_start:chunk_end]] = 0.0
-
-            torch.distributed.all_reduce(
-                log_probs,
-                op=torch.distributed.ReduceOp.SUM,
-                group=tp_group,
-            )
             all_log_probs.append(log_probs)
 
+        # Defer the cross-TP combine to a single all_reduce over the full [B, S]
+        # log-prob tensor instead of one per chunk. Each rank holds the log-prob
+        # for targets in its own vocab shard (0 elsewhere), and SUM is
+        # associative across the sequence concat, so this is numerically
+        # identical to reducing per chunk while cutting the number of (blocking)
+        # collective calls from num_chunks to 1 (e.g. 256 -> 1 at S=262k,
+        # chunk=1024), removing the per-chunk launch/sync overhead.
         log_probs = torch.cat(all_log_probs, dim=1)
+        torch.distributed.all_reduce(
+            log_probs,
+            op=torch.distributed.ReduceOp.SUM,
+            group=tp_group,
+        )
 
         if not inference_only:
             ctx.save_for_backward(hidden, weight, target_mask, masked_target)
@@ -405,7 +409,13 @@ class FusedLinearChunkedDistributedLogprob(torch.autograd.Function):
             grad_hidden[:, chunk_start:chunk_end, :] = torch.matmul(grad_logits, weight)
             grad_logits_2d = grad_logits.reshape(-1, partition_vocab_size)
             h_2d = h_chunk.reshape(-1, hidden_size)
-            grad_weight.add_(torch.matmul(grad_logits_2d.t().to(torch.float32), h_2d.to(torch.float32)))
+            # Run the [V//TP, H] weight-grad matmul in the low-precision compute
+            # dtype (grad_logits.dtype == weight.dtype) so it hits Tensor Cores,
+            # then cast up to fp32 for the accumulator. This matches what
+            # ColumnParallelLinear's own backward does and is much faster / uses
+            # less memory than an fp32 matmul, while the cross-chunk accumulation
+            # still happens in fp32.
+            grad_weight.add_(torch.matmul(grad_logits_2d.t(), h_2d.to(dtype=grad_logits.dtype)).to(torch.float32))
 
         # forward args: hidden, weight, target, vocab_start, vocab_end, chunk_size, tp_group, inference_only
         return grad_hidden, grad_weight.to(weight.dtype), None, None, None, None, None, None

--- a/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
@@ -265,6 +265,152 @@ class ChunkedDistributedLogprob(torch.autograd.Function):
         return grad_input, None, None, None, None, None, None
 
 
+class FusedLinearChunkedDistributedLogprob(torch.autograd.Function):
+    """Fused LM-head + distributed token-logprob, chunked over the sequence.
+
+    This brings the Liger fused-linear-cross-entropy memory technique
+    (https://github.com/linkedin/Liger-Kernel) to Megatron RL: the per-token
+    log-prob is computed straight from the decoder ``hidden`` states and the
+    output-layer ``weight`` without ever building the logits. We generalize it
+    beyond Liger's stock kernel along two axes Liger does not cover — Megatron
+    **tensor/vocab + context parallelism** (the cross-rank max / sum-exp /
+    chosen-logit all-reduces) and **per-token log-probs** (Liger's FLCE only
+    supports reduction='mean'/'sum' in backward, not 'none').
+
+    Identical math to :class:`ChunkedDistributedLogprob`, but the output-layer
+    matmul ``logits = hidden @ weightᵀ`` is folded into the chunk loop so the
+    full ``[B, S, V//TP]`` logits tensor (and, in backward, its float32
+    gradient) is *never* materialized. Only ``hidden`` and ``weight`` are saved
+    for backward; per-chunk logits are recomputed. Peak memory for this op drops
+    from O(S · V//TP) to O(chunk · V//TP) + O(S · H), which is what makes
+    very long contexts (e.g. 262k) fit.
+
+    Args mirror ``ChunkedDistributedLogprob`` with ``vocab_parallel_logits``
+    replaced by ``(hidden, weight)``:
+        hidden: [B, S, H]                (decoder output, this CP/TP rank)
+        weight: [V//TP, H]               (output-layer weight, this TP rank)
+        target: [B, S]                   (already rolled by the caller)
+    """
+
+    @staticmethod
+    def forward(  # pyrefly: ignore[bad-override]
+        ctx: Any,
+        hidden: torch.Tensor,
+        weight: torch.Tensor,
+        target: torch.Tensor,
+        vocab_start_index: int,
+        vocab_end_index: int,
+        chunk_size: int,
+        tp_group: torch.distributed.ProcessGroup,
+        inference_only: bool = False,
+    ) -> torch.Tensor:
+        target_mask = (target < vocab_start_index) | (target >= vocab_end_index)
+        masked_target = target - vocab_start_index
+        masked_target[target_mask] = 0
+
+        seq_size = int(hidden.shape[1])
+        num_chunks = (seq_size + chunk_size - 1) // chunk_size
+        all_log_probs = []
+
+        for chunk_idx in range(num_chunks):
+            chunk_start = chunk_idx * chunk_size
+            chunk_end = min(seq_size, (chunk_idx + 1) * chunk_size)
+
+            # Fused output projection for this chunk only; cast to fp32 inside
+            # the loop so a full fp32 logits tensor is never materialized.
+            # Cast hidden to the weight dtype first (matches what the
+            # ColumnParallelLinear output layer does: hidden may be bf16 while
+            # the output weight is fp32, or vice versa).
+            logits = torch.matmul(
+                hidden[:, chunk_start:chunk_end, :].to(weight.dtype), weight.t()
+            ).to(dtype=torch.float32)
+
+            log_probs = _compute_distributed_log_softmax(logits, group=tp_group)
+            log_probs = torch.gather(
+                log_probs, -1, masked_target[:, chunk_start:chunk_end].unsqueeze(-1)
+            ).squeeze(-1)
+            log_probs[target_mask[:, chunk_start:chunk_end]] = 0.0
+
+            torch.distributed.all_reduce(
+                log_probs,
+                op=torch.distributed.ReduceOp.SUM,
+                group=tp_group,
+            )
+            all_log_probs.append(log_probs)
+
+        log_probs = torch.cat(all_log_probs, dim=1)
+
+        if not inference_only:
+            ctx.save_for_backward(hidden, weight, target_mask, masked_target)
+            ctx.chunk_size = chunk_size
+            ctx.tp_group = tp_group
+
+        return log_probs
+
+    @staticmethod
+    def backward(
+        ctx: Any,
+        *grad_outputs: torch.Tensor,
+    ) -> tuple[Optional[torch.Tensor], ...]:
+        grad_output = grad_outputs[0]
+        hidden, weight, target_mask, masked_target = ctx.saved_tensors
+        chunk_size = ctx.chunk_size
+        tp_group = ctx.tp_group
+
+        partition_vocab_size = int(weight.shape[0])
+        hidden_size = int(weight.shape[1])
+        batch_size = int(hidden.shape[0])
+        seq_size = int(hidden.shape[1])
+        num_chunks = (seq_size + chunk_size - 1) // chunk_size
+
+        # grad_hidden has the same (small) [B, S, H] shape as the input; the
+        # weight grad is accumulated in fp32. The full [B, S, V//TP] logit grad
+        # is never built — each chunk's logit grad is immediately projected onto
+        # grad_hidden / grad_weight and then freed.
+        grad_hidden = torch.empty_like(hidden)
+        grad_weight = torch.zeros((partition_vocab_size, hidden_size), dtype=torch.float32, device=weight.device)
+
+        for chunk_idx in range(num_chunks):
+            chunk_start = chunk_idx * chunk_size
+            chunk_end = min(seq_size, (chunk_idx + 1) * chunk_size)
+            chunk_len = chunk_end - chunk_start
+
+            h_chunk = hidden[:, chunk_start:chunk_end, :]
+            logits = torch.matmul(h_chunk.to(weight.dtype), weight.t()).to(dtype=torch.float32)
+            softmax_output = _compute_distributed_log_softmax(logits, group=tp_group).exp_()
+
+            # Same memory-efficient scatter-add fast path as
+            # ChunkedDistributedLogprob.backward, computing
+            # (one_hot(target) - softmax) * grad_output without materializing
+            # one_hot over the partition vocab.
+            chunk_target_mask = target_mask[:, chunk_start:chunk_end]
+            chunk_masked_target = masked_target[:, chunk_start:chunk_end]
+            chunk_grad_output = grad_output[:, chunk_start:chunk_end]
+
+            row = torch.arange(batch_size, device=softmax_output.device).view(-1, 1).expand(-1, chunk_len).reshape(-1)
+            col = torch.arange(chunk_len, device=softmax_output.device).expand(batch_size, -1).reshape(-1)
+            flat_idx = (row * chunk_len + col) * partition_vocab_size
+
+            valid_mask = ~chunk_target_mask
+            flat_chosen = flat_idx.masked_select(valid_mask.reshape(-1)) + chunk_masked_target.masked_select(valid_mask)
+
+            grad_logits = softmax_output.neg_()
+            grad_logits.mul_(chunk_grad_output.unsqueeze(-1))
+            grad_output_selected = chunk_grad_output.masked_select(valid_mask)
+            grad_logits.view(-1).scatter_add_(0, flat_chosen, grad_output_selected)
+
+            grad_logits = grad_logits.to(dtype=weight.dtype)  # [B, cs, V//TP]
+
+            # Project chunk logit-grad back to hidden / weight grads.
+            grad_hidden[:, chunk_start:chunk_end, :] = torch.matmul(grad_logits, weight)
+            grad_logits_2d = grad_logits.reshape(-1, partition_vocab_size)
+            h_2d = h_chunk.reshape(-1, hidden_size)
+            grad_weight.add_(torch.matmul(grad_logits_2d.t().to(torch.float32), h_2d.to(torch.float32)))
+
+        # forward args: hidden, weight, target, vocab_start, vocab_end, chunk_size, tp_group, inference_only
+        return grad_hidden, grad_weight.to(weight.dtype), None, None, None, None, None, None
+
+
 def from_parallel_logits_to_logprobs(
     vocab_parallel_logits: torch.Tensor,
     target: torch.Tensor,
@@ -491,6 +637,175 @@ def from_parallel_logits_to_logprobs_packed_sequences(
     return out_logprobs
 
 
+def from_parallel_hidden_to_logprobs(
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    target: torch.Tensor,
+    vocab_start_index: int,
+    vocab_end_index: int,
+    tp_group: torch.distributed.ProcessGroup,
+    inference_only: bool = False,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    chunk_size: Optional[int] = None,
+    temperature: float = 1.0,
+) -> torch.Tensor:
+    """Fused-LM-head variant of :func:`from_parallel_logits_to_logprobs`.
+
+    Takes the decoder ``hidden`` states [B, S//CP, H] and the output-layer
+    ``lm_head_weight`` [V//TP, H] instead of pre-computed vocab-parallel logits,
+    and folds the output projection into the chunked logprob op so the full
+    logits tensor is never materialized. Numerically identical to
+    ``from_parallel_logits_to_logprobs((hidden @ lm_head_weightᵀ) / temperature, ...)``.
+
+    ``temperature`` scaling is applied by dividing the weight (``hidden @
+    (W/T)ᵀ == logits/T``); autograd then chains the ``1/T`` factor onto both
+    ``grad_hidden`` and ``grad_weight`` exactly, so the op itself stays
+    temperature-agnostic.
+    """
+    if temperature != 1.0:
+        lm_head_weight = lm_head_weight / temperature
+    target = target.roll(shifts=-1, dims=-1)
+    cp_size = 1 if cp_group is None else torch.distributed.get_world_size(cp_group)
+    pad_len = hidden.shape[1] * cp_size - target.shape[1]
+    if pad_len > 0:
+        target = torch.nn.functional.pad(target, (0, pad_len), value=0)
+
+    cp_rank = torch.distributed.get_rank(cp_group)
+    target = _get_tokens_on_this_cp_rank(target, cp_rank, cp_size, seq_dim=1)
+
+    seq_len_local = hidden.shape[1]
+    eff_chunk = chunk_size if (chunk_size is not None and chunk_size < seq_len_local) else seq_len_local
+    logprobs: torch.Tensor = FusedLinearChunkedDistributedLogprob.apply(  # type: ignore
+        hidden,
+        lm_head_weight,
+        target,
+        vocab_start_index,
+        vocab_end_index,
+        eff_chunk,
+        tp_group,
+        inference_only,
+    ).contiguous()
+
+    if cp_size > 1:
+        logprobs = allgather_cp_sharded_tensor(logprobs, cp_group, seq_dim=1)
+
+    if pad_len > 0:
+        logprobs = logprobs[:, :-pad_len]
+
+    return logprobs[:, :-1]
+
+
+def from_parallel_hidden_to_logprobs_packed_sequences(
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    target: torch.Tensor,
+    cu_seqlens_padded: torch.Tensor,
+    unpacked_seqlen: int,
+    vocab_start_index: int,
+    vocab_end_index: int,
+    group: torch.distributed.ProcessGroup,
+    inference_only: bool = False,
+    cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    chunk_size: Optional[int] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    sub_seq_lengths: Optional[list[list[int]]] = None,
+    temperature: float = 1.0,
+) -> torch.Tensor:
+    """Fused-LM-head variant of
+    :func:`from_parallel_logits_to_logprobs_packed_sequences`.
+
+    Identical packed-sequence / CP / scatter-back logic, but the output
+    projection is fused into the chunked logprob op (``hidden`` [1, T//CP, H] +
+    ``lm_head_weight`` [V//TP, H] instead of logits [1, T//CP, V//TP]).
+    ``temperature`` is applied by dividing the weight (see
+    ``from_parallel_hidden_to_logprobs``).
+    """
+    if temperature != 1.0:
+        lm_head_weight = lm_head_weight / temperature
+    hidden = hidden.squeeze(0)
+    target = target.squeeze(0)
+
+    batch_size = len(sub_seq_lengths) if sub_seq_lengths is not None else cu_seqlens_padded.shape[0] - 1
+    cp_size = 1 if cp_group is None else torch.distributed.get_world_size(cp_group)
+    cp_rank = 0 if cp_group is None else torch.distributed.get_rank(cp_group)
+    if attention_mask is not None:
+        attention_mask = attention_mask.to(device=target.device, dtype=torch.bool)
+
+    cu_seqlens_padded, _, seq_indices, seq_offsets, seq_lens_padded = _packed_sequence_indices(
+        cu_seqlens_padded, target.shape[0], target.device
+    )
+
+    next_offsets = torch.remainder(seq_offsets + 1, seq_lens_padded[seq_indices])
+    rolled_targets_full = target[cu_seqlens_padded[seq_indices] + next_offsets]
+    if cp_size > 1:
+        cp_rank_for_token, local_indices = _packed_cp_rank_and_local_indices(
+            cu_seqlens_padded, seq_indices, seq_offsets, seq_lens_padded, cp_size
+        )
+        rolled_targets = torch.empty(target.shape[0] // cp_size, dtype=target.dtype, device=target.device)
+        current_rank_mask = cp_rank_for_token == cp_rank
+        rolled_targets[local_indices[current_rank_mask]] = rolled_targets_full[current_rank_mask]
+    else:
+        rolled_targets = rolled_targets_full
+
+    # Add batch dimension back for the fused logprob op.
+    rolled_targets = rolled_targets.unsqueeze(0)
+    hidden = hidden.unsqueeze(0)
+
+    seq_len_local = hidden.shape[1]
+    eff_chunk = chunk_size if (chunk_size is not None and chunk_size < seq_len_local) else seq_len_local
+    probs: torch.Tensor = FusedLinearChunkedDistributedLogprob.apply(  # type: ignore
+        hidden,
+        lm_head_weight,
+        rolled_targets,
+        vocab_start_index,
+        vocab_end_index,
+        eff_chunk,
+        group,
+        inference_only,
+    ).contiguous()
+
+    probs = probs.squeeze(0)
+    if probs.dim() != 1:
+        raise ValueError(f"Expected probs to be 1D after squeezing, but got shape {probs.shape}.")
+
+    if cp_size > 1:
+        probs = allgather_cp_sharded_packed_tensor(probs, cu_seqlens_padded, cp_group)
+
+    out_logprobs = torch.zeros((batch_size, unpacked_seqlen - 1), dtype=probs.dtype, device=probs.device)
+    _, _, seq_indices, seq_offsets, seq_lens_padded = _packed_sequence_indices(
+        cu_seqlens_padded, probs.shape[0], probs.device
+    )
+
+    if sub_seq_lengths is not None:
+        row_indices, row_offsets, seq_lens = _packed_subseq_row_indices_offsets_and_lens(
+            cu_seqlens_padded, sub_seq_lengths, probs.device
+        )
+        valid_counts = torch.clamp(seq_lens - 1, min=0)
+        packed_mask = seq_offsets < valid_counts[seq_indices]
+        output_cols = row_offsets[seq_indices[packed_mask]] + seq_offsets[packed_mask]
+        output_rows = row_indices[seq_indices[packed_mask]]
+        output_in_bounds = output_cols < unpacked_seqlen - 1
+        out_logprobs[output_rows[output_in_bounds], output_cols[output_in_bounds]] = probs[packed_mask][
+            output_in_bounds
+        ]
+        return out_logprobs
+
+    if attention_mask is not None:
+        seq_lens = attention_mask.sum(dim=1, dtype=torch.long)
+        token_ordinals = attention_mask.to(torch.long).cumsum(dim=1)
+        output_mask = attention_mask[:, :-1] & (token_ordinals[:, :-1] < seq_lens.unsqueeze(1))
+        valid_counts = torch.clamp(seq_lens - 1, min=0)
+        packed_mask = seq_offsets < valid_counts[seq_indices]
+        out_logprobs[output_mask] = probs[packed_mask]
+        return out_logprobs
+
+    valid_counts = torch.clamp(seq_lens_padded - 1, min=0)
+    packed_mask = (seq_offsets < valid_counts[seq_indices]) & (seq_offsets < unpacked_seqlen - 1)
+    out_logprobs[seq_indices[packed_mask], seq_offsets[packed_mask]] = probs[packed_mask]
+
+    return out_logprobs
+
+
 def _packed_subseq_row_indices_offsets_and_lens(
     cu_seqlens_padded: torch.Tensor, sub_seq_lengths: list[list[int]], device: torch.device
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -656,6 +971,127 @@ def vocab_parallel_entropy_packed_sequences(
         token_ordinals = attention_mask.to(torch.long).cumsum(dim=1)
         output_mask = attention_mask[:, :-1] & (token_ordinals[:, :-1] < seq_lens.unsqueeze(1))
 
+        token_offsets = token_ordinals - 1
+        packed_indices = cu_seqlens_padded[:-1].unsqueeze(1) + token_offsets
+        packed_weights[packed_indices[:, :-1][output_mask]] = action_weights[output_mask]
+
+    cp_size = 1 if cp_group is None else torch.distributed.get_world_size(cp_group)
+    if cp_size > 1:
+        cp_rank = torch.distributed.get_rank(cp_group)
+        _, _, seq_indices, seq_offsets, seq_lens_padded = _packed_sequence_indices(
+            cu_seqlens_padded, packed_weights.shape[0], device
+        )
+        cp_rank_for_token, local_indices = _packed_cp_rank_and_local_indices(
+            cu_seqlens_padded, seq_indices, seq_offsets, seq_lens_padded, cp_size
+        )
+        local_weights = torch.zeros_like(entropy_tokens)
+        current_rank_mask = cp_rank_for_token == cp_rank
+        local_weights[local_indices[current_rank_mask]] = packed_weights[current_rank_mask]
+    else:
+        local_weights = packed_weights
+
+    local_entropy_sum = (entropy_tokens * local_weights).sum()
+    local_count = local_weights.sum()
+    global_count = local_count.detach().clone()
+    global_entropy_sum = local_entropy_sum.detach().clone()
+    if cp_size > 1:
+        torch.distributed.all_reduce(global_count, group=cp_group)
+        torch.distributed.all_reduce(global_entropy_sum, group=cp_group)
+    global_count = global_count.clamp(min=1.0)
+
+    entropy = global_entropy_sum / global_count
+    entropy_for_loss = local_entropy_sum / global_count
+    return entropy, entropy_for_loss
+
+
+def _fused_vocab_parallel_entropy_from_hidden(
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    tp_group: torch.distributed.ProcessGroup,
+    chunk_size: Optional[int] = None,
+    temperature: float = 1.0,
+) -> torch.Tensor:
+    """Per-token entropy from decoder ``hidden`` [B, S, H] + LM-head weight
+    [V//TP, H], chunked over the sequence so the [B, S, V//TP] logits are never
+    materialized. Mirrors the math of :class:`_VocabParallelEntropy` with the
+    output projection fused in. Intended for the no-grad entropy *metric*
+    (``use_entropy_loss=False``); call it inside a ``no_grad``/grad-disabled
+    context (the chunk loop recomputes logits and would otherwise build a graph).
+    """
+    if temperature != 1.0:
+        lm_head_weight = lm_head_weight / temperature
+    B, S = int(hidden.shape[0]), int(hidden.shape[1])
+    out = torch.empty((B, S), dtype=torch.float32, device=hidden.device)
+    eff = chunk_size if (chunk_size is not None and chunk_size < S) else S
+    for c0 in range(0, S, eff):
+        c1 = min(S, c0 + eff)
+        logits = torch.matmul(hidden[:, c0:c1, :].to(lm_head_weight.dtype), lm_head_weight.t()).to(torch.float32)
+        logits_max = logits.max(dim=-1, keepdim=True).values
+        torch.distributed.all_reduce(logits_max, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+        exp = (logits - logits_max).exp_()
+        sum_exp = exp.sum(dim=-1, keepdim=True)
+        torch.distributed.all_reduce(sum_exp, group=tp_group)
+        softmax = exp / sum_exp
+        sum_softmax_times_logits = (softmax * logits).sum(dim=-1, keepdim=True)
+        torch.distributed.all_reduce(sum_softmax_times_logits, group=tp_group)
+        out[:, c0:c1] = (logits_max + sum_exp.log() - sum_softmax_times_logits).squeeze(-1)
+    return out
+
+
+def from_parallel_hidden_to_entropy_packed_sequences(
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    cu_seqlens_padded: torch.Tensor,
+    unpacked_seqlen: int,
+    num_actions: int,
+    attention_mask: torch.Tensor,
+    loss_mask: Optional[torch.Tensor],
+    cp_group: Optional[torch.distributed.ProcessGroup],
+    tp_group: torch.distributed.ProcessGroup,
+    sub_seq_lengths: Optional[list[list[int]]] = None,
+    chunk_size: Optional[int] = None,
+    temperature: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused-LM-head variant of :func:`vocab_parallel_entropy_packed_sequences`.
+
+    Identical action-token weighting / CP logic, but per-token entropy is
+    computed from ``hidden`` + ``lm_head_weight`` chunk-by-chunk instead of from
+    a materialized [1, T, V//TP] logits tensor. No-grad (metric only).
+    """
+    entropy_tokens = _fused_vocab_parallel_entropy_from_hidden(
+        hidden, lm_head_weight, tp_group, chunk_size=chunk_size, temperature=temperature
+    ).squeeze(0)
+    device = entropy_tokens.device
+    dtype = entropy_tokens.dtype
+
+    attention_mask = attention_mask.to(device=device, dtype=torch.bool)
+    cu_seqlens_padded = cu_seqlens_padded.to(device=device, dtype=torch.long)
+    batch_size = attention_mask.shape[0]
+
+    action_weights = torch.zeros((batch_size, unpacked_seqlen - 1), dtype=dtype, device=device)
+    if loss_mask is None:
+        action_weights[:, -num_actions:] = 1.0
+    else:
+        action_weights[:, -num_actions:] = loss_mask.to(device=device, dtype=dtype)
+
+    packed_weights = torch.zeros((int(cu_seqlens_padded[-1].item()),), dtype=dtype, device=device)
+    if sub_seq_lengths is not None:
+        _, _, seq_indices, seq_offsets, _ = _packed_sequence_indices(cu_seqlens_padded, packed_weights.shape[0], device)
+        row_indices, row_offsets, seq_lens = _packed_subseq_row_indices_offsets_and_lens(
+            cu_seqlens_padded, sub_seq_lengths, device
+        )
+        valid_counts = torch.clamp(seq_lens - 1, min=0)
+        packed_mask = seq_offsets < valid_counts[seq_indices]
+        output_cols = row_offsets[seq_indices[packed_mask]] + seq_offsets[packed_mask]
+        output_rows = row_indices[seq_indices[packed_mask]]
+        output_in_bounds = output_cols < action_weights.shape[1]
+        packed_weights[torch.arange(packed_weights.shape[0], device=device)[packed_mask][output_in_bounds]] = (
+            action_weights[output_rows[output_in_bounds], output_cols[output_in_bounds]]
+        )
+    else:
+        seq_lens = attention_mask.sum(dim=1, dtype=torch.long)
+        token_ordinals = attention_mask.to(torch.long).cumsum(dim=1)
+        output_mask = attention_mask[:, :-1] & (token_ordinals[:, :-1] < seq_lens.unsqueeze(1))
         token_offsets = token_ordinals - 1
         packed_indices = cu_seqlens_padded[:-1].unsqueeze(1) + token_offsets
         packed_weights[packed_indices[:, :-1][output_mask]] = action_weights[output_mask]

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -104,9 +104,7 @@ def _fused_lm_head_output_processor(**kwargs):
     if getattr(output_layer, "sequence_parallel", False):
         from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
 
-        hidden_states = gather_from_sequence_parallel_region(
-            hidden_states, tensor_parallel_output_grad=True
-        )
+        hidden_states = gather_from_sequence_parallel_region(hidden_states, tensor_parallel_output_grad=True)
     # [s, b, h] -> [b, s, h], matching `logits.transpose(0, 1)` in the default path.
     return hidden_states.transpose(0, 1).contiguous()
 
@@ -189,10 +187,51 @@ class MegatronModelWrapper:
             tp_grp = mpu.get_tensor_model_parallel_group()
             tp_rank = mpu.get_tensor_model_parallel_rank()
 
-            if temperature != 1.0:
+            # Fused LM-head: `logits` is actually decoder hidden states [B, S, H]
+            # (the output_processor skipped the projection); fold the LM-head into
+            # the chunked log-prob so this forward-only pass never materializes the
+            # full [B, S, vocab//TP] logits (which would OOM at long context).
+            fused_lm_head = self._fused_lm_head and data.get("lm_head_weight") is not None
+            lm_head_weight = data.get("lm_head_weight")
+            if fused_lm_head:
+                _v_local = int(lm_head_weight.shape[0])
+                fused_vocab_start, fused_vocab_end = tp_rank * _v_local, (tp_rank + 1) * _v_local
+
+            # temperature normalization (the fused path applies it inside the op)
+            if temperature != 1.0 and not fused_lm_head:
                 logits.div_(temperature)
 
-            if packed_seq_params is not None and packed_targets is not None:
+            if fused_lm_head and packed_seq_params is not None and packed_targets is not None:
+                token_logprobs = from_parallel_hidden_to_logprobs_packed_sequences(
+                    logits,  # decoder hidden states [1, T, H]
+                    lm_head_weight,
+                    packed_targets,
+                    packed_seq_params.cu_seqlens_q_padded,
+                    sequences.shape[1],
+                    vocab_start_index=fused_vocab_start,
+                    vocab_end_index=fused_vocab_end,
+                    group=tp_grp,
+                    inference_only=True,
+                    cp_group=mpu.get_context_parallel_group(),
+                    chunk_size=self.cfg.logprobs_chunk_size,
+                    attention_mask=data["attention_mask"],
+                    sub_seq_lengths=data.get("sub_seq_lengths_list"),
+                    temperature=temperature,
+                )
+            elif fused_lm_head:
+                token_logprobs = from_parallel_hidden_to_logprobs(
+                    logits,  # decoder hidden states [B, S, H]
+                    lm_head_weight,
+                    sequences,
+                    vocab_start_index=fused_vocab_start,
+                    vocab_end_index=fused_vocab_end,
+                    tp_group=tp_grp,
+                    inference_only=True,
+                    cp_group=None,
+                    chunk_size=self.cfg.logprobs_chunk_size,
+                    temperature=temperature,
+                )
+            elif packed_seq_params is not None and packed_targets is not None:
                 token_logprobs = from_parallel_logits_to_logprobs_packed_sequences(
                     logits,
                     packed_targets,
@@ -261,12 +300,30 @@ class MegatronModelWrapper:
                 )
                 packed_seq_params = None
 
-            outputs = model(
-                new_sequences,
-                new_position_ids,
-                new_attention_mask,
-                packed_seq_params=packed_seq_params,
-            )
+            if self._fused_lm_head:
+                # Fused LM-head inference: the output_processor returns decoder
+                # hidden states (not logits) and stashes the LM-head weight, so
+                # collection_func can fold the projection into the chunked
+                # log-prob op. Without this, a forward-only ref/old-logprob pass
+                # (e.g. PPO reference logprobs) at long context would still
+                # materialize the full [B, S, vocab//TP] logits and OOM.
+                _op_ctx: dict = {}
+                outputs = model(
+                    new_sequences,
+                    new_position_ids,
+                    new_attention_mask,
+                    packed_seq_params=packed_seq_params,
+                    output_processor=_fused_lm_head_output_processor,
+                    output_processor_context=_op_ctx,
+                )
+                batch["lm_head_weight"] = _op_ctx.get("lm_head_weight")
+            else:
+                outputs = model(
+                    new_sequences,
+                    new_position_ids,
+                    new_attention_mask,
+                    packed_seq_params=packed_seq_params,
+                )
 
             if not self.remove_microbatch_padding:
                 outputs = recover_left_padding(

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -18,6 +18,10 @@ from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
     remove_left_padding,
 )
 from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
+    _fused_vocab_parallel_entropy_from_hidden,
+    from_parallel_hidden_to_entropy_packed_sequences,
+    from_parallel_hidden_to_logprobs,
+    from_parallel_hidden_to_logprobs_packed_sequences,
     from_parallel_logits_to_logprobs,
     from_parallel_logits_to_logprobs_packed_sequences,
     vocab_parallel_entropy,
@@ -76,6 +80,37 @@ def _build_packed_targets(
     return targets.unsqueeze(0)
 
 
+def _fused_lm_head_output_processor(**kwargs):
+    """GPTModel ``output_processor`` hook for the fused LM-head log-prob path.
+
+    Skips the output-layer matmul (so the [S, B, vocab//TP] logits are never
+    built), returns the decoder hidden states in [b, s, h] layout (the same
+    layout the default logits path returns), and stashes the resolved
+    output-layer weight into the caller-provided ``context`` dict so the fused
+    log-prob / entropy can run downstream with it.
+    """
+    hidden_states = kwargs["hidden_states"]
+    output_layer = kwargs["output_layer"]
+    ctx = kwargs.get("context")
+    if ctx is not None:
+        output_weight = kwargs.get("output_weight")
+        ctx["lm_head_weight"] = output_weight if output_weight is not None else output_layer.weight
+    # With sequence parallelism the decoder hidden states are sharded along the
+    # sequence dim; the ColumnParallelLinear output layer all-gathers them before
+    # projecting (megatron tensor_parallel/layers.py). We skip that layer, so
+    # replicate the gather here. tensor_parallel_output_grad=True makes the
+    # backward reduce-scatter the hidden grad across TP ranks — exactly the sum
+    # of each rank's vocab-slice grad_hidden that the fused op produces.
+    if getattr(output_layer, "sequence_parallel", False):
+        from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
+
+        hidden_states = gather_from_sequence_parallel_region(
+            hidden_states, tensor_parallel_output_grad=True
+        )
+    # [s, b, h] -> [b, s, h], matching `logits.transpose(0, 1)` in the default path.
+    return hidden_states.transpose(0, 1).contiguous()
+
+
 class MegatronModelWrapper:
     def __init__(
         self,
@@ -89,6 +124,10 @@ class MegatronModelWrapper:
         self.actor_optimizer = actor_optimizer
         self.policy_loss_fn = policy_loss_fn
         self.remove_microbatch_padding = self.cfg.remove_microbatch_padding
+        # Fuse the LM-head projection into the chunked log-prob/entropy via the
+        # GPTModel output_processor hook (avoids materializing the full
+        # [B, S, vocab//TP] logits + its fp32 grad). See model_utils.
+        self._fused_lm_head = bool(getattr(self.cfg, "fused_lm_head_logprob", False))
         # Some models (e.g. Qwen3.5 via the VL bridge -> Qwen3VLModel) pack
         # sequences inside their own forward; SkyRL sample packing would then
         # double-pack and corrupt the GDN cu_seqlens, so refuse it. For Qwen3.5,
@@ -335,11 +374,56 @@ class MegatronModelWrapper:
             tp_grp = mpu.get_tensor_model_parallel_group()
             tp_rank = mpu.get_tensor_model_parallel_rank()
 
-            # temperature normalization
-            if temperature != 1.0:
+            # Fused LM-head: `logits` is actually decoder hidden states [B, S, H]
+            # (the output_processor skipped the projection); fold the LM-head into
+            # the chunked log-prob/entropy so the full logits tensor + its fp32
+            # grad are never materialized.
+            fused_lm_head = self._fused_lm_head and data.get("lm_head_weight") is not None
+            lm_head_weight = data.get("lm_head_weight")
+            if fused_lm_head and loss_config.use_entropy_loss:
+                raise NotImplementedError(
+                    "fused_lm_head_logprob does not support use_entropy_loss=True "
+                    "(the fused entropy is a no-grad metric)."
+                )
+            if fused_lm_head:
+                _v_local = int(lm_head_weight.shape[0])
+                fused_vocab_start, fused_vocab_end = tp_rank * _v_local, (tp_rank + 1) * _v_local
+
+            # temperature normalization (the fused path applies it inside the op)
+            if temperature != 1.0 and not fused_lm_head:
                 logits.div_(temperature)
 
-            if packed_seq_params is not None and packed_targets is not None:
+            if fused_lm_head and packed_seq_params is not None and packed_targets is not None:
+                token_logprobs = from_parallel_hidden_to_logprobs_packed_sequences(
+                    logits,  # decoder hidden states [1, T, H]
+                    lm_head_weight,
+                    packed_targets,
+                    packed_seq_params.cu_seqlens_q_padded,
+                    sequences.shape[1],
+                    vocab_start_index=fused_vocab_start,
+                    vocab_end_index=fused_vocab_end,
+                    group=tp_grp,
+                    inference_only=False,
+                    cp_group=mpu.get_context_parallel_group(),
+                    chunk_size=self.cfg.logprobs_chunk_size,
+                    attention_mask=data["attention_mask"],
+                    sub_seq_lengths=data.get("sub_seq_lengths_list"),
+                    temperature=temperature,
+                )
+            elif fused_lm_head:
+                token_logprobs = from_parallel_hidden_to_logprobs(
+                    logits,  # decoder hidden states [B, S, H]
+                    lm_head_weight,
+                    sequences,
+                    vocab_start_index=fused_vocab_start,
+                    vocab_end_index=fused_vocab_end,
+                    tp_group=tp_grp,
+                    inference_only=False,
+                    cp_group=None,
+                    chunk_size=self.cfg.logprobs_chunk_size,
+                    temperature=temperature,
+                )
+            elif packed_seq_params is not None and packed_targets is not None:
                 token_logprobs = from_parallel_logits_to_logprobs_packed_sequences(
                     logits,
                     packed_targets,
@@ -427,7 +511,33 @@ class MegatronModelWrapper:
 
             # RL path: add optional KL/entropy terms
             with torch.set_grad_enabled(loss_config.use_entropy_loss):
-                if packed_seq_params is not None and packed_targets is not None:
+                if fused_lm_head and packed_seq_params is not None and packed_targets is not None:
+                    entropy, entropy_for_loss = from_parallel_hidden_to_entropy_packed_sequences(
+                        logits,  # decoder hidden states [1, T, H]
+                        lm_head_weight,
+                        packed_seq_params.cu_seqlens_q_padded,
+                        sequences.shape[1],
+                        num_actions,
+                        data["attention_mask"],
+                        loss_mask,
+                        mpu.get_context_parallel_group(),
+                        tp_group=tp_grp,
+                        sub_seq_lengths=data.get("sub_seq_lengths_list"),
+                        chunk_size=self.cfg.logprobs_chunk_size,
+                        temperature=temperature,
+                    )
+                elif fused_lm_head:
+                    action_hidden = logits[:, -num_actions - 1 : -1, :]
+                    entropy_BS = _fused_vocab_parallel_entropy_from_hidden(
+                        action_hidden,
+                        lm_head_weight,
+                        tp_grp,
+                        chunk_size=self.cfg.logprobs_chunk_size,
+                        temperature=temperature,
+                    )
+                    entropy = masked_mean(entropy_BS, loss_mask)
+                    entropy_for_loss = entropy
+                elif packed_seq_params is not None and packed_targets is not None:
                     entropy, entropy_for_loss = vocab_parallel_entropy_packed_sequences(
                         logits,
                         packed_seq_params.cu_seqlens_q_padded,
@@ -574,12 +684,26 @@ class MegatronModelWrapper:
                 )
                 packed_seq_params = None
 
-            outputs = model(
-                new_sequences,
-                new_position_ids,
-                new_attention_mask,
-                packed_seq_params=packed_seq_params,
-            )
+            if self._fused_lm_head:
+                # output_processor returns decoder hidden states (not logits) and
+                # stashes the LM-head weight; loss_func then fuses the projection.
+                _op_ctx: dict = {}
+                outputs = model(
+                    new_sequences,
+                    new_position_ids,
+                    new_attention_mask,
+                    packed_seq_params=packed_seq_params,
+                    output_processor=_fused_lm_head_output_processor,
+                    output_processor_context=_op_ctx,
+                )
+                batch["lm_head_weight"] = _op_ctx.get("lm_head_weight")
+            else:
+                outputs = model(
+                    new_sequences,
+                    new_position_ids,
+                    new_attention_mask,
+                    packed_seq_params=packed_seq_params,
+                )
 
             if not self.remove_microbatch_padding:
                 outputs = recover_left_padding(

--- a/skyrl/benchmarks/bench_fused_linear_logprob.py
+++ b/skyrl/benchmarks/bench_fused_linear_logprob.py
@@ -1,25 +1,29 @@
 """
-Benchmark: fused-linear (Liger-style) log-prob vs the materialize-logits path.
+Benchmark: LM-head training signal — baseline vs NVIDIA fused CE vs Liger-style fused linear.
 
-Compares the two ways SkyRL's MegatronModelWrapper can turn decoder hidden
-states into per-token log-probs for the RL/SFT loss:
+Three ways SkyRL's Megatron backend can turn decoder hidden states + the
+output-layer weight into the per-token cross-entropy / log-prob used by the
+RL/SFT loss (all run forward+backward so grads flow to hidden *and* weight):
 
-  baseline : logits = hidden @ weightᵀ  (the output layer), then the existing
-             ChunkedDistributedLogprob — materializes the full [B, S, vocab//TP]
-             logits and, in backward, a float32 gradient of the same shape.
-  fused    : FusedLinearChunkedDistributedLogprob — folds the projection into the
-             chunked, TP-parallel log-prob so neither is ever materialized.
+  baseline : logits = hidden @ weightᵀ, then megatron-core's eager
+             ``vocab_parallel_cross_entropy`` (materializes [B,S,vocab//TP]
+             logits + an fp32 grad of the same shape).
+  nvidia   : same logits, then megatron-core's ``fused_vocab_parallel_cross_entropy``
+             (the @jit_fuser / TorchScript "NVIDIA stack" fused CE — fuses the
+             softmax/CE *stages* but still materializes the logits).
+  liger    : FusedLinearChunkedDistributedLogprob — folds the projection into the
+             chunked, TP-parallel log-prob so the logits are *never* materialized.
 
-Both run forward+backward (grad flows to hidden and weight) so the comparison is
-apples-to-apples. Peak memory for the LM-head term drops from O(S · vocab//TP)
-to O(chunk · vocab//TP) + O(S · H), which is what lets very long contexts fit.
+Takeaway the table makes concrete: the NVIDIA fused CE is a *compute* optimization
+(faster than eager) but not a *memory* one — like the baseline it materializes the
+logits and OOMs at long context. Liger is the *memory* optimization: it fits long
+context (at a modest compute cost), which the NVIDIA path cannot.
 
 Usage (single GPU; per-rank vocab shard = `vocab`):
     uv run --isolated --extra megatron torchrun --nproc_per_node=1 \\
         skyrl/benchmarks/bench_fused_linear_logprob.py
-
-Run with --nproc_per_node=N for a real TP=N measurement (pass --vocab as the
-full vocab; each rank then holds vocab//N).
+Run with --nproc_per_node=N for a real TP=N measurement (pass --vocab as the full
+vocab; each rank then holds vocab//N).
 """
 
 import argparse
@@ -37,18 +41,38 @@ SEQ_LENS = [8192, 32768, 65536, 131072, 262144]
 CHUNK_SIZE = 1024
 WARMUP_REPS = 1
 BENCH_REPS = 3
+MODES = ["baseline", "nvidia", "liger"]
 
 
-def _measure(mode, seq_len, vocab_local, chunk_size, tp_group, device, reps):
-    """forward+backward through `mode` ('baseline'|'fused'); return (ms, peak_bytes) or (None, None) on OOM."""
+def _loss(mode, hidden, weight, target, vocab_local, chunk_size, tp_group):
+    """Per-token CE summed to a scalar (so all modes produce identical grads)."""
+    from megatron.core.fusions.fused_cross_entropy import fused_vocab_parallel_cross_entropy
+    from megatron.core.tensor_parallel.cross_entropy import vocab_parallel_cross_entropy
+
     from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
-        ChunkedDistributedLogprob,
         FusedLinearChunkedDistributedLogprob,
     )
 
+    if mode == "liger":
+        lp = FusedLinearChunkedDistributedLogprob.apply(
+            hidden, weight, target, 0, vocab_local, chunk_size, tp_group, False
+        )
+        return (-lp).sum()
+    logits = torch.matmul(hidden, weight.t())  # [B, S, vocab//TP]
+    if mode == "baseline":
+        ce = vocab_parallel_cross_entropy(logits, target, 0.0, tp_group)
+    elif mode == "nvidia":
+        ce = fused_vocab_parallel_cross_entropy(logits, target, tp_group)
+    else:
+        raise ValueError(mode)
+    return ce.sum()
+
+
+def _measure(mode, seq_len, vocab_local, chunk_size, tp_group, device, reps):
+    """forward+backward; return (mean_ms, mean_peak_bytes) or (None, None) on OOM."""
     times, peaks = [], []
     for _ in range(reps):
-        hidden = weight = target = logits = out = None
+        hidden = weight = target = loss = None
         torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats(device)
         try:
@@ -57,23 +81,38 @@ def _measure(mode, seq_len, vocab_local, chunk_size, tp_group, device, reps):
             target = torch.randint(0, vocab_local, (1, seq_len), device=device)
             torch.cuda.synchronize(device)
             t0 = time.perf_counter()
-            if mode == "baseline":
-                logits = torch.matmul(hidden, weight.t())
-                out = ChunkedDistributedLogprob.apply(logits, target, 0, vocab_local, chunk_size, tp_group, False)
-            else:
-                out = FusedLinearChunkedDistributedLogprob.apply(hidden, weight, target, 0, vocab_local, chunk_size, tp_group, False)
-            out.sum().backward()
+            loss = _loss(mode, hidden, weight, target, vocab_local, chunk_size, tp_group)
+            loss.backward()
             torch.cuda.synchronize(device)
             times.append((time.perf_counter() - t0) * 1000.0)
             peaks.append(torch.cuda.max_memory_allocated(device))
         except torch.OutOfMemoryError:
             return None, None
         finally:
-            # Explicit frees (incl. any autograd graph from an OOM) so the next
-            # rep's peak-memory reading isn't inflated by leftovers.
-            del hidden, weight, target, logits, out
+            del hidden, weight, target, loss
             torch.cuda.empty_cache()
     return sum(times) / len(times), sum(peaks) / len(peaks)
+
+
+def _correctness(vocab_local, tp_group, device):
+    """All three modes must produce the same loss + grad_hidden (fair comparison)."""
+    torch.manual_seed(0)
+    S = 64
+    h0 = torch.randn(1, S, HIDDEN, dtype=torch.bfloat16, device=device)
+    w0 = torch.randn(vocab_local, HIDDEN, dtype=torch.bfloat16, device=device) * (HIDDEN**-0.5)
+    tgt = torch.randint(0, vocab_local, (1, S), device=device)
+    ref = {}
+    for mode in MODES:
+        h = h0.clone().requires_grad_(True)
+        w = w0.clone().requires_grad_(True)
+        _loss(mode, h, w, tgt, vocab_local, CHUNK_SIZE, tp_group).backward()
+        ref[mode] = (h.grad.float().clone(),)
+    base = ref["baseline"][0]
+    out = []
+    for mode in MODES:
+        gh = ref[mode][0]
+        out.append(f"{mode}: max|dgrad_hidden vs baseline|={(gh - base).abs().max().item():.2e}")
+    return out
 
 
 def main():
@@ -91,31 +130,42 @@ def main():
     mpu.initialize_model_parallel(tensor_model_parallel_size=world)
     tp_group = mpu.get_tensor_model_parallel_group()
     device = torch.device("cuda", local_rank)
+    rank0 = dist.get_rank() == 0
 
     vocab_shards = [args.vocab // world] if args.vocab else VOCAB_SHARDS
-    rank0 = dist.get_rank() == 0
     if rank0:
         print(f"Device {torch.cuda.get_device_name(device)} | TP(world)={world} | hidden={HIDDEN} | chunk={args.chunk_size}")
-        print("baseline = matmul logits + ChunkedDistributedLogprob ; fused = FusedLinearChunkedDistributedLogprob (fwd+bwd)\n")
+        print("baseline = megatron vocab_parallel_cross_entropy (eager) | "
+              "nvidia = fused_vocab_parallel_cross_entropy (@jit_fuser) | "
+              "liger = FusedLinearChunkedDistributedLogprob (no logits)")
+        print("all: hidden+weight -> per-token CE -> sum -> backward\n")
+        print("correctness (TP=%d, vocab=%d):" % (world, vocab_shards[0]))
+        for line in _correctness(vocab_shards[0], tp_group, device):
+            print("  " + line)
+        print()
 
-    cw = 13
+    cw = 12
     for vlocal in vocab_shards:
         if rank0:
             print(f"=== per-rank vocab shard = {vlocal:,} ===")
-            print(f"{'seq_len':>9} | {'baseline MB':>{cw}} | {'fused MB':>{cw}} | {'mem saved':>{cw}} | {'baseline ms':>{cw}} | {'fused ms':>{cw}}")
-            print("-" * 80)
+            hdr = f"{'seq_len':>9} |" + "".join(f" {m + ' MB':>{cw}} |" for m in MODES) + "".join(f" {m + ' ms':>{cw}} |" for m in MODES)
+            print(hdr)
+            print("-" * len(hdr))
         for s in SEQ_LENS:
-            for _ in range(WARMUP_REPS):
-                _measure("fused", s, vlocal, args.chunk_size, tp_group, device, 1)
-            b_ms, b_peak = _measure("baseline", s, vlocal, args.chunk_size, tp_group, device, BENCH_REPS)
-            f_ms, f_peak = _measure("fused", s, vlocal, args.chunk_size, tp_group, device, BENCH_REPS)
+            res = {}
+            for mode in MODES:
+                for _ in range(WARMUP_REPS):
+                    _measure(mode, s, vlocal, args.chunk_size, tp_group, device, 1)
+                res[mode] = _measure(mode, s, vlocal, args.chunk_size, tp_group, device, BENCH_REPS)
             if rank0:
-                b_mb = "OOM" if b_peak is None else f"{b_peak / 1024**2:.0f}"
-                f_mb = "OOM" if f_peak is None else f"{f_peak / 1024**2:.0f}"
-                saved = "-" if (b_peak is None or f_peak is None) else f"{(b_peak - f_peak) / 1024**2:.0f} MB ({b_peak / f_peak:.1f}x)"
-                b_t = "-" if b_ms is None else f"{b_ms:.0f}"
-                f_t = "-" if f_ms is None else f"{f_ms:.0f}"
-                print(f"{s:>9} | {b_mb:>{cw}} | {f_mb:>{cw}} | {saved:>{cw}} | {b_t:>{cw}} | {f_t:>{cw}}")
+                def mb(m):
+                    p = res[m][1]
+                    return "OOM" if p is None else f"{p / 1024**2:.0f}"
+                def ms(m):
+                    t = res[m][0]
+                    return "OOM" if t is None else f"{t:.0f}"
+                row = f"{s:>9} |" + "".join(f" {mb(m):>{cw}} |" for m in MODES) + "".join(f" {ms(m):>{cw}} |" for m in MODES)
+                print(row)
         if rank0:
             print()
 

--- a/skyrl/benchmarks/bench_fused_linear_logprob.py
+++ b/skyrl/benchmarks/bench_fused_linear_logprob.py
@@ -1,0 +1,126 @@
+"""
+Benchmark: fused-linear (Liger-style) log-prob vs the materialize-logits path.
+
+Compares the two ways SkyRL's MegatronModelWrapper can turn decoder hidden
+states into per-token log-probs for the RL/SFT loss:
+
+  baseline : logits = hidden @ weightᵀ  (the output layer), then the existing
+             ChunkedDistributedLogprob — materializes the full [B, S, vocab//TP]
+             logits and, in backward, a float32 gradient of the same shape.
+  fused    : FusedLinearChunkedDistributedLogprob — folds the projection into the
+             chunked, TP-parallel log-prob so neither is ever materialized.
+
+Both run forward+backward (grad flows to hidden and weight) so the comparison is
+apples-to-apples. Peak memory for the LM-head term drops from O(S · vocab//TP)
+to O(chunk · vocab//TP) + O(S · H), which is what lets very long contexts fit.
+
+Usage (single GPU; per-rank vocab shard = `vocab`):
+    uv run --isolated --extra megatron torchrun --nproc_per_node=1 \\
+        skyrl/benchmarks/bench_fused_linear_logprob.py
+
+Run with --nproc_per_node=N for a real TP=N measurement (pass --vocab as the
+full vocab; each rank then holds vocab//N).
+"""
+
+import argparse
+import os
+import time
+
+import torch
+import torch.distributed as dist
+
+# Qwen3.6-35B-A3B: hidden=2048, vocab=248320. Defaults show the per-rank shard
+# for TP=4 (62080) and the full vocab (248320).
+HIDDEN = 2048
+VOCAB_SHARDS = [62080, 248320]
+SEQ_LENS = [8192, 32768, 65536, 131072, 262144]
+CHUNK_SIZE = 1024
+WARMUP_REPS = 1
+BENCH_REPS = 3
+
+
+def _measure(mode, seq_len, vocab_local, chunk_size, tp_group, device, reps):
+    """forward+backward through `mode` ('baseline'|'fused'); return (ms, peak_bytes) or (None, None) on OOM."""
+    from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
+        ChunkedDistributedLogprob,
+        FusedLinearChunkedDistributedLogprob,
+    )
+
+    times, peaks = [], []
+    for _ in range(reps):
+        hidden = weight = target = logits = out = None
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats(device)
+        try:
+            hidden = torch.randn(1, seq_len, HIDDEN, dtype=torch.bfloat16, device=device, requires_grad=True)
+            weight = (torch.randn(vocab_local, HIDDEN, dtype=torch.bfloat16, device=device) * (HIDDEN**-0.5)).requires_grad_(True)
+            target = torch.randint(0, vocab_local, (1, seq_len), device=device)
+            torch.cuda.synchronize(device)
+            t0 = time.perf_counter()
+            if mode == "baseline":
+                logits = torch.matmul(hidden, weight.t())
+                out = ChunkedDistributedLogprob.apply(logits, target, 0, vocab_local, chunk_size, tp_group, False)
+            else:
+                out = FusedLinearChunkedDistributedLogprob.apply(hidden, weight, target, 0, vocab_local, chunk_size, tp_group, False)
+            out.sum().backward()
+            torch.cuda.synchronize(device)
+            times.append((time.perf_counter() - t0) * 1000.0)
+            peaks.append(torch.cuda.max_memory_allocated(device))
+        except torch.OutOfMemoryError:
+            return None, None
+        finally:
+            # Explicit frees (incl. any autograd graph from an OOM) so the next
+            # rep's peak-memory reading isn't inflated by leftovers.
+            del hidden, weight, target, logits, out
+            torch.cuda.empty_cache()
+    return sum(times) / len(times), sum(peaks) / len(peaks)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vocab", type=int, default=None, help="full vocab; per-rank shard = vocab // world_size")
+    ap.add_argument("--chunk-size", type=int, default=CHUNK_SIZE)
+    args = ap.parse_args()
+
+    dist.init_process_group(backend="nccl")
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+    import megatron.core.parallel_state as mpu
+
+    world = dist.get_world_size()
+    mpu.initialize_model_parallel(tensor_model_parallel_size=world)
+    tp_group = mpu.get_tensor_model_parallel_group()
+    device = torch.device("cuda", local_rank)
+
+    vocab_shards = [args.vocab // world] if args.vocab else VOCAB_SHARDS
+    rank0 = dist.get_rank() == 0
+    if rank0:
+        print(f"Device {torch.cuda.get_device_name(device)} | TP(world)={world} | hidden={HIDDEN} | chunk={args.chunk_size}")
+        print("baseline = matmul logits + ChunkedDistributedLogprob ; fused = FusedLinearChunkedDistributedLogprob (fwd+bwd)\n")
+
+    cw = 13
+    for vlocal in vocab_shards:
+        if rank0:
+            print(f"=== per-rank vocab shard = {vlocal:,} ===")
+            print(f"{'seq_len':>9} | {'baseline MB':>{cw}} | {'fused MB':>{cw}} | {'mem saved':>{cw}} | {'baseline ms':>{cw}} | {'fused ms':>{cw}}")
+            print("-" * 80)
+        for s in SEQ_LENS:
+            for _ in range(WARMUP_REPS):
+                _measure("fused", s, vlocal, args.chunk_size, tp_group, device, 1)
+            b_ms, b_peak = _measure("baseline", s, vlocal, args.chunk_size, tp_group, device, BENCH_REPS)
+            f_ms, f_peak = _measure("fused", s, vlocal, args.chunk_size, tp_group, device, BENCH_REPS)
+            if rank0:
+                b_mb = "OOM" if b_peak is None else f"{b_peak / 1024**2:.0f}"
+                f_mb = "OOM" if f_peak is None else f"{f_peak / 1024**2:.0f}"
+                saved = "-" if (b_peak is None or f_peak is None) else f"{(b_peak - f_peak) / 1024**2:.0f} MB ({b_peak / f_peak:.1f}x)"
+                b_t = "-" if b_ms is None else f"{b_ms:.0f}"
+                f_t = "-" if f_ms is None else f"{f_ms:.0f}"
+                print(f"{s:>9} | {b_mb:>{cw}} | {f_mb:>{cw}} | {saved:>{cw}} | {b_t:>{cw}} | {f_t:>{cw}}")
+        if rank0:
+            print()
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/skyrl/benchmarks/bench_fused_linear_logprob.py
+++ b/skyrl/benchmarks/bench_fused_linear_logprob.py
@@ -46,7 +46,9 @@ MODES = ["baseline", "nvidia", "liger"]
 
 def _loss(mode, hidden, weight, target, vocab_local, chunk_size, tp_group):
     """Per-token CE summed to a scalar (so all modes produce identical grads)."""
-    from megatron.core.fusions.fused_cross_entropy import fused_vocab_parallel_cross_entropy
+    from megatron.core.fusions.fused_cross_entropy import (
+        fused_vocab_parallel_cross_entropy,
+    )
     from megatron.core.tensor_parallel.cross_entropy import vocab_parallel_cross_entropy
 
     from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
@@ -77,7 +79,9 @@ def _measure(mode, seq_len, vocab_local, chunk_size, tp_group, device, reps):
         torch.cuda.reset_peak_memory_stats(device)
         try:
             hidden = torch.randn(1, seq_len, HIDDEN, dtype=torch.bfloat16, device=device, requires_grad=True)
-            weight = (torch.randn(vocab_local, HIDDEN, dtype=torch.bfloat16, device=device) * (HIDDEN**-0.5)).requires_grad_(True)
+            weight = (
+                torch.randn(vocab_local, HIDDEN, dtype=torch.bfloat16, device=device) * (HIDDEN**-0.5)
+            ).requires_grad_(True)
             target = torch.randint(0, vocab_local, (1, seq_len), device=device)
             torch.cuda.synchronize(device)
             t0 = time.perf_counter()
@@ -134,10 +138,14 @@ def main():
 
     vocab_shards = [args.vocab // world] if args.vocab else VOCAB_SHARDS
     if rank0:
-        print(f"Device {torch.cuda.get_device_name(device)} | TP(world)={world} | hidden={HIDDEN} | chunk={args.chunk_size}")
-        print("baseline = megatron vocab_parallel_cross_entropy (eager) | "
-              "nvidia = fused_vocab_parallel_cross_entropy (@jit_fuser) | "
-              "liger = FusedLinearChunkedDistributedLogprob (no logits)")
+        print(
+            f"Device {torch.cuda.get_device_name(device)} | TP(world)={world} | hidden={HIDDEN} | chunk={args.chunk_size}"
+        )
+        print(
+            "baseline = megatron vocab_parallel_cross_entropy (eager) | "
+            "nvidia = fused_vocab_parallel_cross_entropy (@jit_fuser) | "
+            "liger = FusedLinearChunkedDistributedLogprob (no logits)"
+        )
         print("all: hidden+weight -> per-token CE -> sum -> backward\n")
         print("correctness (TP=%d, vocab=%d):" % (world, vocab_shards[0]))
         for line in _correctness(vocab_shards[0], tp_group, device):
@@ -148,7 +156,11 @@ def main():
     for vlocal in vocab_shards:
         if rank0:
             print(f"=== per-rank vocab shard = {vlocal:,} ===")
-            hdr = f"{'seq_len':>9} |" + "".join(f" {m + ' MB':>{cw}} |" for m in MODES) + "".join(f" {m + ' ms':>{cw}} |" for m in MODES)
+            hdr = (
+                f"{'seq_len':>9} |"
+                + "".join(f" {m + ' MB':>{cw}} |" for m in MODES)
+                + "".join(f" {m + ' ms':>{cw}} |" for m in MODES)
+            )
             print(hdr)
             print("-" * len(hdr))
         for s in SEQ_LENS:
@@ -158,13 +170,20 @@ def main():
                     _measure(mode, s, vlocal, args.chunk_size, tp_group, device, 1)
                 res[mode] = _measure(mode, s, vlocal, args.chunk_size, tp_group, device, BENCH_REPS)
             if rank0:
+
                 def mb(m):
                     p = res[m][1]
                     return "OOM" if p is None else f"{p / 1024**2:.0f}"
+
                 def ms(m):
                     t = res[m][0]
                     return "OOM" if t is None else f"{t:.0f}"
-                row = f"{s:>9} |" + "".join(f" {mb(m):>{cw}} |" for m in MODES) + "".join(f" {ms(m):>{cw}} |" for m in MODES)
+
+                row = (
+                    f"{s:>9} |"
+                    + "".join(f" {mb(m):>{cw}} |" for m in MODES)
+                    + "".join(f" {ms(m):>{cw}} |" for m in MODES)
+                )
                 print(row)
         if rank0:
             print()

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -805,6 +805,14 @@ class TrainerConfig(BaseConfig):
     This lowers peak GPU memory at the cost of ~2x wall-clock time.
     ``None`` disables chunking (Megatron backend only; FSDP requires a positive int).
     See https://github.com/NovaSky-AI/SkyRL/pull/1610 for more details."""
+    fused_lm_head_logprob: bool = False
+    """Megatron only. Fuse the LM-head projection into the chunked log-prob / entropy
+    computation via the GPTModel ``output_processor`` hook, so the full
+    ``[B, S, vocab//TP]`` logits tensor (and its float32 gradient) is never
+    materialized. Cuts LM-head activation memory from O(S·vocab//TP) to
+    O(chunk·vocab//TP)+O(S·H) — required to fit very long contexts (e.g. 262k).
+    Numerically matches the default path; see
+    ``model_utils.FusedLinearChunkedDistributedLogprob``."""
 
     def __post_init__(self):
         # ref model defaults to the policy model

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_fused_linear_logprob.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_fused_linear_logprob.py
@@ -34,6 +34,9 @@ from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
 )
 from skyrl.train.utils.utils import get_free_port
 
+# Run as part of the Megatron GPU CI suite (`-m megatron`, --extra megatron).
+pytestmark = pytest.mark.megatron
+
 H = 256  # hidden size for the unit tests
 
 

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_fused_linear_logprob.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_fused_linear_logprob.py
@@ -1,0 +1,220 @@
+"""Equivalency + parallelism tests for the fused-linear (Liger-style) log-prob.
+
+``FusedLinearChunkedDistributedLogprob`` folds the LM-head matmul into the
+chunked, TP/CP-parallel token-logprob so the full ``[B, S, vocab//TP]`` logits
+(and their fp32 gradient) are never materialized. These tests assert it is
+numerically identical — forward log-probs *and* both gradients (``grad_hidden``,
+``grad_weight``) — to the existing materialize-logits path
+(``hidden @ weightᵀ`` -> ``ChunkedDistributedLogprob``), across:
+
+  * chunk sizes (incl. > seq_len), out-of-vocab targets, edge shapes,
+  * mixed dtypes (bf16 hidden + fp32 weight — the real Megatron case),
+  * tensor/vocab parallelism: TP=1 (here) and TP>1 (spawned via torchrun).
+
+It also checks the forward against Liger's own fused-linear-CE as an oracle
+(``logprob == -LigerFLCE(reduction="none")``) when liger-kernel is installed.
+
+TP=1 (single process):
+  uv run --isolated --extra dev --extra megatron -- \
+    pytest -s tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_fused_linear_logprob.py
+TP>1 is launched automatically as a torchrun subprocess by ``test_fused_linear_logprob_tp``.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
+    ChunkedDistributedLogprob,
+    FusedLinearChunkedDistributedLogprob,
+)
+from skyrl.train.utils.utils import get_free_port
+
+H = 256  # hidden size for the unit tests
+
+
+@pytest.fixture(scope="module")
+def tp_group():
+    """Single-rank TP process group (world_size=1; all-reduces are no-ops)."""
+    if not dist.is_initialized():
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(get_free_port())
+        os.environ["RANK"] = "0"
+        os.environ["WORLD_SIZE"] = "1"
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+    yield dist.group.WORLD
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _grad_seed(out):
+    # Non-uniform upstream gradient so any per-position bug surfaces.
+    return torch.linspace(0.5, 1.5, steps=out.numel(), device=out.device, dtype=out.dtype).reshape(out.shape)
+
+
+def _fused_fb(hidden, weight, target, vstart, vend, tp_group, chunk_size):
+    """Forward+backward through the fused op -> (logprob, grad_hidden, grad_weight)."""
+    h = hidden.detach().clone().requires_grad_(True)
+    w = weight.detach().clone().requires_grad_(True)
+    out = FusedLinearChunkedDistributedLogprob.apply(h, w, target, vstart, vend, chunk_size, tp_group, False)
+    out.backward(_grad_seed(out))
+    return out.detach(), h.grad.detach(), w.grad.detach()
+
+
+def _reference_fb(hidden, weight, target, vstart, vend, tp_group, chunk_size):
+    """Materialize logits = hidden @ weightᵀ then the validated ChunkedDistributedLogprob.
+
+    Casting hidden to the weight dtype mirrors the ColumnParallelLinear output
+    layer; autograd then yields grad_hidden / grad_weight to compare against.
+    """
+    h = hidden.detach().clone().requires_grad_(True)
+    w = weight.detach().clone().requires_grad_(True)
+    logits = torch.matmul(h.to(w.dtype), w.t())
+    out = ChunkedDistributedLogprob.apply(logits, target, vstart, vend, chunk_size, tp_group, False)
+    out.backward(_grad_seed(out))
+    return out.detach(), h.grad.detach(), w.grad.detach()
+
+
+def _assert_equivalent(hidden, weight, target, vstart, vend, tp_group, chunk_size):
+    out_f, gh_f, gw_f = _fused_fb(hidden, weight, target, vstart, vend, tp_group, chunk_size)
+    out_r, gh_r, gw_r = _reference_fb(hidden, weight, target, vstart, vend, tp_group, chunk_size)
+    assert out_f.dtype == torch.float32
+    torch.testing.assert_close(out_f, out_r, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(gh_f, gh_r, atol=2e-3, rtol=2e-3)
+    # grad_weight accumulates over all B*S tokens; the fused op sums in fp32 in a
+    # different order than autograd's matmul backward, so a bf16 weight needs a
+    # looser (still firmly bug-catching) bound while fp32 stays tight.
+    gw_tol = 4e-2 if weight.dtype == torch.bfloat16 else 2e-3
+    torch.testing.assert_close(gw_f.float(), gw_r.float(), atol=gw_tol, rtol=gw_tol)
+
+
+@pytest.mark.parametrize("chunk_size", [1, 7, 64, 512])
+@pytest.mark.parametrize("with_oov_targets", [False, True])
+@pytest.mark.parametrize(
+    "hidden_dtype, weight_dtype",
+    [(torch.bfloat16, torch.bfloat16), (torch.bfloat16, torch.float32), (torch.float32, torch.float32)],
+)
+def test_fused_matches_materialized_logits(tp_group, chunk_size, with_oov_targets, hidden_dtype, weight_dtype):
+    """Fused op == materialize-logits reference (fwd + grad_hidden + grad_weight).
+
+    The (bf16 hidden, fp32 weight) combo is the real Megatron case and guards the
+    dtype-promotion path in the fused matmul.
+    """
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+    B, S, V = 4, 32, 4096
+    target_high = V + 1024 if with_oov_targets else V
+
+    hidden = torch.randn(B, S, H, dtype=hidden_dtype, device=device)
+    weight = (torch.randn(V, H, dtype=weight_dtype, device=device) * (H**-0.5))
+    target = torch.randint(0, target_high, (B, S), device=device, dtype=torch.long)
+
+    _assert_equivalent(hidden, weight, target, 0, V, tp_group, chunk_size)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param((1, 1, 1024, 4, "default"), id="seq1"),
+        pytest.param((2, 8, 1024, 32, "all_in"), id="all_in_vocab"),
+        pytest.param((2, 8, 1024, 32, "all_out"), id="all_out_vocab"),
+        pytest.param((2, 8, 8, 4, "default"), id="tiny_vocab"),
+    ],
+)
+def test_fused_matches_materialized_logits_edge_cases(tp_group, case):
+    B, S, V, chunk_size, mask_mode = case
+    device = torch.device("cuda")
+    torch.manual_seed(1)
+    hidden = torch.randn(B, S, H, dtype=torch.bfloat16, device=device)
+    weight = torch.randn(V, H, dtype=torch.float32, device=device) * (H**-0.5)
+    if mask_mode == "all_out":
+        target = torch.full((B, S), V + 5, device=device, dtype=torch.long)
+    else:
+        target = torch.randint(0, V, (B, S), device=device, dtype=torch.long)
+    _assert_equivalent(hidden, weight, target, 0, V, tp_group, chunk_size)
+
+
+def test_fused_forward_matches_liger_flce(tp_group):
+    """Oracle: at TP=1 the fused log-prob equals -LigerFLCE(reduction='none').
+
+    Validates our kernel against Liger's own fused-linear-cross-entropy math.
+    Forward only — Liger's FLCE does not support a reduction='none' backward.
+    """
+    liger = pytest.importorskip("liger_kernel.ops.fused_linear_cross_entropy")
+    device = torch.device("cuda")
+    torch.manual_seed(2)
+    B, S, V = 2, 16, 4096
+    hidden = torch.randn(B, S, H, dtype=torch.bfloat16, device=device)
+    weight = torch.randn(V, H, dtype=torch.bfloat16, device=device) * (H**-0.5)
+    target = torch.randint(0, V, (B, S), device=device, dtype=torch.long)
+
+    out_f, _, _ = _fused_fb(hidden, weight, target, 0, V, tp_group, 64)
+
+    flce = liger.LigerFusedLinearCrossEntropyFunction.apply
+    ce = flce(hidden.reshape(B * S, H), weight, target.reshape(B * S), None, None, -100, 0.0, 0.0, "none")
+    ce = ce[0] if isinstance(ce, tuple) else ce
+    torch.testing.assert_close(out_f.reshape(-1), (-ce).float(), atol=1e-2, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# TP>1: vocab-parallel correctness via torchrun (spawned as a subprocess).
+# ---------------------------------------------------------------------------
+
+
+def _distributed_main():
+    """Run the fused-vs-reference equivalency under real tensor/vocab parallelism.
+
+    Each rank owns a vocab shard [r*V/TP, (r+1)*V/TP); the cross-rank max /
+    sum-exp / chosen-logit all-reduces are exercised. Identical inputs on every
+    rank (seeded) so only the vocab dim is sharded.
+    """
+    dist.init_process_group("nccl")
+    rank, world = dist.get_rank(), dist.get_world_size()
+    torch.cuda.set_device(rank)
+    dev = torch.device(f"cuda:{rank}")
+    tp_group = dist.group.WORLD
+
+    B, S, V = 2, 64, 4096
+    assert V % world == 0
+    v_tp = V // world
+    vstart, vend = rank * v_tp, (rank + 1) * v_tp
+
+    g = torch.Generator().manual_seed(1234)
+    hidden = torch.randn(B, S, H, generator=g, dtype=torch.float32).to(dev, torch.bfloat16)
+    target = torch.randint(0, V, (B, S), generator=g)
+    w_full = (torch.randn(V, H, generator=g, dtype=torch.float32) * (H**-0.5))
+    weight = w_full[vstart:vend].to(dev, torch.float32)
+    target = target.to(dev)
+
+    for chunk_size in (16, 512):
+        out_f, gh_f, gw_f = _fused_fb(hidden, weight, target, vstart, vend, tp_group, chunk_size)
+        out_r, gh_r, gw_r = _reference_fb(hidden, weight, target, vstart, vend, tp_group, chunk_size)
+        torch.testing.assert_close(out_f, out_r, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(gh_f, gh_r, atol=5e-3, rtol=5e-3)
+        torch.testing.assert_close(gw_f.float(), gw_r.float(), atol=5e-3, rtol=5e-3)
+
+    ok = torch.tensor([1.0], device=dev)
+    dist.all_reduce(ok, op=dist.ReduceOp.MIN)
+    if rank == 0:
+        print(f"RESULT: PASS (TP={world})")
+    dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("nproc", [2, 4])
+def test_fused_linear_logprob_tp(nproc):
+    """Spawn torchrun --nproc_per_node=nproc to check vocab-parallel correctness."""
+    if torch.cuda.device_count() < nproc:
+        pytest.skip(f"needs >= {nproc} GPUs, have {torch.cuda.device_count()}")
+    env = dict(os.environ, MASTER_ADDR="localhost", MASTER_PORT=str(get_free_port()))
+    cmd = [sys.executable, "-m", "torch.distributed.run", f"--nproc_per_node={nproc}",
+           "--master_port", env["MASTER_PORT"], __file__]
+    res = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=600)
+    assert "RESULT: PASS" in (res.stdout + res.stderr), f"TP={nproc} failed:\n{res.stdout}\n{res.stderr}"
+
+
+if __name__ == "__main__":
+    _distributed_main()

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_fused_linear_logprob.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_fused_linear_logprob.py
@@ -110,7 +110,7 @@ def test_fused_matches_materialized_logits(tp_group, chunk_size, with_oov_target
     target_high = V + 1024 if with_oov_targets else V
 
     hidden = torch.randn(B, S, H, dtype=hidden_dtype, device=device)
-    weight = (torch.randn(V, H, dtype=weight_dtype, device=device) * (H**-0.5))
+    weight = torch.randn(V, H, dtype=weight_dtype, device=device) * (H**-0.5)
     target = torch.randint(0, target_high, (B, S), device=device, dtype=torch.long)
 
     _assert_equivalent(hidden, weight, target, 0, V, tp_group, chunk_size)
@@ -186,7 +186,7 @@ def _distributed_main():
     g = torch.Generator().manual_seed(1234)
     hidden = torch.randn(B, S, H, generator=g, dtype=torch.float32).to(dev, torch.bfloat16)
     target = torch.randint(0, V, (B, S), generator=g)
-    w_full = (torch.randn(V, H, generator=g, dtype=torch.float32) * (H**-0.5))
+    w_full = torch.randn(V, H, generator=g, dtype=torch.float32) * (H**-0.5)
     weight = w_full[vstart:vend].to(dev, torch.float32)
     target = target.to(dev)
 
@@ -210,8 +210,15 @@ def test_fused_linear_logprob_tp(nproc):
     if torch.cuda.device_count() < nproc:
         pytest.skip(f"needs >= {nproc} GPUs, have {torch.cuda.device_count()}")
     env = dict(os.environ, MASTER_ADDR="localhost", MASTER_PORT=str(get_free_port()))
-    cmd = [sys.executable, "-m", "torch.distributed.run", f"--nproc_per_node={nproc}",
-           "--master_port", env["MASTER_PORT"], __file__]
+    cmd = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        f"--nproc_per_node={nproc}",
+        "--master_port",
+        env["MASTER_PORT"],
+        __file__,
+    ]
     res = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=600)
     assert "RESULT: PASS" in (res.stdout + res.stderr), f"TP={nproc} failed:\n{res.stdout}\n{res.stderr}"
 


### PR DESCRIPTION
I wanted to run Qwen/Qwen3.6-35B-A3B on 8xB300 using SkyRL and found that it cannot handle full context without OOMing on the cross-entropy step in the trainer. To solve this, I implemented a fused cross-entropy that saves a lot of memory for the Megatron backend while handling the parallelism.

## Why not the existing Megatron/Apex/TE fused cross-entropy?

`fused_vocab_parallel_cross_entropy` optimizes the CE *compute*, not *memory*: it materializes the `[S, vocab//TP]` logits and its staged fused kernels allocate extra buffers, so it uses ~1.7x **more** memory than eager CE and OOMs earlier at long context.

### Per-rank vocab = 62,080 (the real TP=4 shard)

| seq_len | baseline (eager CE) | nvidia (fused CE) | fused linear CE (ours) | fused linear mem vs baseline |
|---:|---:|---:|---:|---:|
| 8,192 | 3.1 GB / 11 ms | 5.0 GB / 8 ms | 2.1 GB / 25 ms | 1.5× |
| 32,768 | 11.7 GB / 43 ms | 19.3 GB / 29 ms | 2.3 GB / 98 ms | 5.1× |
| 65,536 | 23.2 GB / 86 ms | 38.4 GB / 58 ms | 2.5 GB / 196 ms | 9.1× |
| 131,072 | 46.2 GB / 175 ms | 76.5 GB / 120 ms | 3.0 GB / 392 ms | 15.2× |
| 262,144 | 92.2 GB / 357 ms | 152.8 GB / 245 ms | 4.0 GB / 784 ms | 22.8× |

### Full vocab = 248,320

| seq_len | baseline (eager CE) | nvidia (fused CE) | fused linear CE (ours) |
|---:|---:|---:|---:|
| 8,192 | 12.4 GB / 42 ms | 19.9 GB / 34 ms | 8.1 GB / 92 ms |
| 32,768 | 46.6 GB / 177 ms | 76.9 GB / 151 ms | 8.3 GB / 367 ms |
| 65,536 | 92.2 GB / 356 ms | 152.8 GB / 316 ms | 8.6 GB / 734 ms |
| 131,072 | 183.3 GB / 723 ms | **OOM** | 9.1 GB / 1,467 ms |
| 262,144 | **OOM** | **OOM** | 10.1 GB / 2,932 ms |

## Convergence

I did a small SFT test to overfit on GSM8K with Qwen/Qwen2.5-1.5B-Instruct. Convergence is the same, just with slight variations as the computation has some natural variance when it's chunked.

<img width="2209" height="1033" alt="image" src="https://github.com/user-attachments/assets/00aa788f-9637-401d-9980-e65571064bac" />
