### PR TITLE
[fsdp] Fix redundant downloading of shards across ranks for FSDP checkpointing

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -476,10 +476,13 @@ class FSDPStrategy(DistributedStrategy):
         rank = self.get_rank()
         world_size = self.world_size
 
-        with io.local_read_dir(ckpt_dir) as read_dir:
-            model_path = os.path.join(read_dir, f"model_world_size_{world_size}_rank_{rank}.pt")
-            optim_path = os.path.join(read_dir, f"optim_world_size_{world_size}_rank_{rank}.pt")
-            extra_path = os.path.join(read_dir, f"extra_state_world_size_{world_size}_rank_{rank}.pt")
+        model_file = f"model_world_size_{world_size}_rank_{rank}.pt"
+        optim_file = f"optim_world_size_{world_size}_rank_{rank}.pt"
+        extra_file = f"extra_state_world_size_{world_size}_rank_{rank}.pt"
+        with io.local_read_files(ckpt_dir, [model_file, optim_file, extra_file]) as read_dir:
+            model_path = os.path.join(read_dir, model_file)
+            optim_path = os.path.join(read_dir, optim_file)
+            extra_path = os.path.join(read_dir, extra_file)
 
             # Check if checkpoint files exist
             if not io.exists(model_path):

--- a/skyrl/backends/skyrl_train/utils/io/io.py
+++ b/skyrl/backends/skyrl_train/utils/io/io.py
@@ -217,3 +217,35 @@ def local_read_dir(input_path: str):
         if not exists(input_path):
             raise FileNotFoundError(f"Path does not exist: {input_path}")
         yield input_path
+
+
+@contextmanager
+def local_read_files(input_dir, filenames):
+    """
+    Context manager that provides a local directory with specific files from input_dir.
+
+    For local paths, returns the path directly.
+    For cloud paths, downloads specified files to a temporary directory.
+
+    Args:
+        input_dir: The source directory (local or cloud)
+        filenames: List of filenames to download
+
+    Yields:
+        str: Local directory path containing the requested files
+
+    Example:
+        with local_read_files("s3://bucket/model", ["config.json", "pytorch_model.bin"]) as read_dir:
+            # Load files from read_dir
+            config_path = os.path.join(read_dir, "config.json")
+            model_path = os.path.join(read_dir, "pytorch_model.bin")
+    """
+    if is_cloud_path(input_dir):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for name in filenames:
+                src = input_dir.rstrip("/") + "/" + name
+                if exists(src):
+                    download_file(src, os.path.join(temp_dir, name))
+            yield temp_dir
+    else:
+        yield input_dir

--- a/skyrl/backends/skyrl_train/utils/io/io.py
+++ b/skyrl/backends/skyrl_train/utils/io/io.py
@@ -248,4 +248,6 @@ def local_read_files(input_dir, filenames):
                     download_file(src, os.path.join(temp_dir, name))
             yield temp_dir
     else:
+        if not exists(input_dir):
+            raise FileNotFoundError(f"Path does not exist: {input_dir}")
         yield input_dir

--- a/tests/backends/skyrl_train/utils/test_local_read_files.py
+++ b/tests/backends/skyrl_train/utils/test_local_read_files.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+from skyrl.backends.skyrl_train.utils.io.io import local_read_files
+
+
+@patch("skyrl.backends.skyrl_train.utils.io.io.download_file")
+@patch("skyrl.backends.skyrl_train.utils.io.io.exists")
+@patch("skyrl.backends.skyrl_train.utils.io.io.is_cloud_path")
+def test_cloud_downloads_only_requested_files(mock_is_cloud_path, mock_exists, mock_download_file):
+    """
+    Test that when a cloud path is provided, only the requested files are downloaded to a temporary directory.
+    """
+    mock_is_cloud_path.return_value = True
+    mock_exists.return_value = True
+
+    requested = [
+        "model_world_size_8_rank_3.pt",
+        "optim_world_size_8_rank_3.pt",
+        "extra_state_world_size_8_rank_3.pt",
+    ]
+    with local_read_files("s3://bucket/global_step_1/policy", requested):
+        pass
+
+    downloaded = [call.args[0] for call in mock_download_file.call_args_list]
+    assert len(downloaded) == len(requested)
+    for name in requested:
+        assert any(name in src for src in downloaded)
+
+
+@patch("skyrl.backends.skyrl_train.utils.io.io.download_file")
+@patch("skyrl.backends.skyrl_train.utils.io.io.is_cloud_path")
+def test_local_path_does_not_download(mock_is_cloud_path, mock_download_file):
+    """
+    Test that when a local path is provided, no download occurs and the path is returned directly
+    """
+    mock_is_cloud_path.return_value = False
+
+    with local_read_files("/some/local/dir", ["a.pt", "b.pt"]) as read_dir:
+        assert read_dir == "/some/local/dir"
+
+    mock_download_file.assert_not_called()

--- a/tests/backends/skyrl_train/utils/test_local_read_files.py
+++ b/tests/backends/skyrl_train/utils/test_local_read_files.py
@@ -28,12 +28,14 @@ def test_cloud_downloads_only_requested_files(mock_is_cloud_path, mock_exists, m
 
 
 @patch("skyrl.backends.skyrl_train.utils.io.io.download_file")
+@patch("skyrl.backends.skyrl_train.utils.io.io.exists")
 @patch("skyrl.backends.skyrl_train.utils.io.io.is_cloud_path")
-def test_local_path_does_not_download(mock_is_cloud_path, mock_download_file):
+def test_local_path_does_not_download(mock_is_cloud_path, mock_exists, mock_download_file):
     """
     Test that when a local path is provided, no download occurs and the path is returned directly
     """
     mock_is_cloud_path.return_value = False
+    mock_exists.return_value = True
 
     with local_read_files("/some/local/dir", ["a.pt", "b.pt"]) as read_dir:
         assert read_dir == "/some/local/dir"


### PR DESCRIPTION
## Summary

When using FSDP with cloud checkpointing, each rank downloads the full
checkpoint on load even though it only needs its own shard. This PR makes
each rank fetch only its own shard files, cutting per-node download from
`N * full_checkpoint` to `1 * full_checkpoint` (N = world_size).

- Adds `io.local_read_files()`: downloads a given list of files from a cloud
  directory into a temp dir (returns the dir directly for local paths).
  Built on the `download_file()` helper added in #1414.
- `FSDPStrategy.load_checkpoint` now uses `local_read_files` to fetch only
  this rank's `model` / `optim` / `extra_state` shard files, instead of
  `local_read_dir` (which downloads the whole directory).
- Adds `tests/backends/skyrl_train/utils/test_local_read_files.py`.

Follows the approach in #1414 (the Megatron counterpart of this change).
Part of #800.

## Test plan

- [x] `test_local_read_files.py` — asserts only the requested files are
      downloaded for cloud paths, and no download for local paths.
