### PR TITLE
[tinker] Remove backend-specific config leak in sample batching

### DIFF
--- a/skyrl/backends/backend.py
+++ b/skyrl/backends/backend.py
@@ -170,3 +170,12 @@ class AbstractBackend(ABC):
             model_id: The model identifier
         """
         pass
+
+    def max_sample_batch_size(self) -> int:
+        """Maximum number of sample sequences to batch together; 0 means unlimited.
+
+        Intentionally a concrete default (not @abstractmethod): backends without a
+        sampling cap (e.g. the FSDP/Megatron backend, which samples via vLLM) need no
+        boilerplate and rely on this default. Backends that cap sampling override it.
+        """
+        return 0

--- a/skyrl/backends/jax.py
+++ b/skyrl/backends/jax.py
@@ -829,6 +829,9 @@ class JaxBackendImpl(AbstractBackend):
         logger.info(f"Applied optimizer step for model {model_id} (adapter {adapter_index}), metrics={output_metrics}")
         return types.OptimStepOutput(metrics=output_metrics)
 
+    def max_sample_batch_size(self) -> int:
+        return self.config.sample_max_num_sequences
+
     def sample(
         self,
         prepared_batch: types.PreparedSampleBatch,

--- a/skyrl/backends/ray_jax.py
+++ b/skyrl/backends/ray_jax.py
@@ -178,6 +178,9 @@ class RayJaxBackend(AbstractBackend):
         results = ray.get([w.optim_step.remote(model_id, request_data) for w in self.workers])
         return results[0]
 
+    def max_sample_batch_size(self) -> int:
+        return self.config.sample_max_num_sequences
+
     def sample(self, prepared_batch: types.PreparedSampleBatch) -> dict[str, types.SampleOutput | types.ErrorResponse]:
         results = ray.get([w.sample.remote(prepared_batch) for w in self.workers])
         return results[0]

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -419,10 +419,9 @@ class TinkerEngine:
             if checkpoint_id == "" or model_checkpoints.setdefault(op.model_id, checkpoint_id) == checkpoint_id:
                 batchable.append(op)
 
-        # TODO: This leaks the abstraction by accessing backend-specific config.
-        # We should find a better way to handle this going forward.
-        if self.config.backend == "jax" and self.backend.config.sample_max_num_sequences > 0:
-            batchable = batchable[: self.backend.config.sample_max_num_sequences]
+        cap = self.backend.max_sample_batch_size()
+        if cap > 0:
+            batchable = batchable[:cap]
 
         return {str(f.request_id): (f.model_id, types.SampleInput.model_validate(f.request_data)) for f in batchable}
 

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -287,3 +287,75 @@ def test_find_single_requests_barrier_is_per_model(scheduling_engine):
         assert list(singles.keys()) == ["2", "5"]
         assert singles["2"][0] == "model_a"
         assert singles["5"][0] == "model_b"
+
+
+class _StubBackend:
+    """Minimal backend exposing only max_sample_batch_size, for find_batchable_sample tests."""
+
+    def __init__(self, cap: int):
+        self._cap = cap
+
+    def max_sample_batch_size(self) -> int:
+        return self._cap
+
+
+def _sample_request_data():
+    """A valid base-model (checkpoint_id="") SampleInput payload for a pending SAMPLE row."""
+    return types.SampleInput(
+        base_model=BASE_MODEL,
+        prompt=types.ModelInput(chunks=[types.EncodedTextChunk(tokens=[1, 2, 3])]),
+        sampling_params=types.SamplingParams(temperature=0.0, max_tokens=4, seed=0),
+        num_samples=1,
+        checkpoint_id="",
+        prompt_logprobs=False,
+    ).model_dump(mode="json")
+
+
+def test_find_batchable_sample_applies_backend_cap(scheduling_engine):
+    """find_batchable_sample limits the batch to backend.max_sample_batch_size() when it is > 0.
+
+    The engine asks the backend for the cap via the AbstractBackend interface; it no longer
+    reads any backend-specific config. The scheduling_engine fixture intentionally leaves
+    engine.config unset, so a reintroduced self.config.backend branch would fail here.
+    """
+    engine = scheduling_engine
+    engine.backend = _StubBackend(cap=2)
+
+    with Session(engine.db_engine) as session:
+        for _ in range(3):
+            session.add(
+                FutureDB(
+                    request_type=types.RequestType.SAMPLE,
+                    model_id="model_a",
+                    request_data=_sample_request_data(),
+                    status=RequestStatus.PENDING,
+                )
+            )
+        session.commit()
+
+    with Session(engine.db_engine) as session:
+        batchable = engine.find_batchable_sample(session)
+        # 3 pending sample requests, cap=2 -> only the first 2 (by request_id) are batched.
+        assert list(batchable.keys()) == ["1", "2"]
+
+
+def test_find_batchable_sample_no_cap_when_zero(scheduling_engine):
+    """A backend reporting max_sample_batch_size() == 0 imposes no limit (default for fsdp/megatron)."""
+    engine = scheduling_engine
+    engine.backend = _StubBackend(cap=0)
+
+    with Session(engine.db_engine) as session:
+        for _ in range(3):
+            session.add(
+                FutureDB(
+                    request_type=types.RequestType.SAMPLE,
+                    model_id="model_a",
+                    request_data=_sample_request_data(),
+                    status=RequestStatus.PENDING,
+                )
+            )
+        session.commit()
+
+    with Session(engine.db_engine) as session:
+        batchable = engine.find_batchable_sample(session)
+        assert len(batchable) == 3


### PR DESCRIPTION
TinkerEngine.find_batchable_sample checked `self.config.backend == "jax"` and read the JAX backend's `sample_max_num_sequences` directly, leaking backend-specific config into the engine (a pre-existing TODO).

Add `max_sample_batch_size()` to AbstractBackend with a default of 0 (unlimited); the JAX backends (JaxBackendImpl, RayJaxBackend) override it to return their configured cap. The engine now asks the backend through this interface and no longer branches on the backend type. FSDP/Megatron keep the default of 0, so behavior is unchanged for every backend.

Also add unit tests for find_batchable_sample covering the cap behavior: cap > 0 truncates the batch, cap == 0 leaves it unchanged.

Note: `max_sample_batch_size()` is intentionally a concrete default (not `@abstractmethod`) so backends without a sampling cap (FSDP/Megatron) need no boilerplate — mirroring the existing `for_engine` default in transfer_strategy.py.

Tested: `uv run --extra dev --extra jax --extra tinker pytest tests/tinker/test_engine.py` → 13 passed.