### PR TITLE
[fix] Avoid inference engine initialization for the SFT code path

### DIFF
--- a/skyrl/backends/renderer.py
+++ b/skyrl/backends/renderer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from typing import TYPE_CHECKING, NamedTuple, Union
+from typing import Any, Dict, NamedTuple, Protocol, Union
 
 import torch
 
@@ -16,10 +16,16 @@ from skyrl.tinker.types import (
     RenderedModelInput,
 )
 
-if TYPE_CHECKING:
-    from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
-        RemoteInferenceClient,
-    )
+
+class RendererClientProtocol(Protocol):
+    """Anything that can serve vLLM's ``/v1/chat/completions/render``.
+
+    Satisfied by ``RemoteInferenceClient`` (render requests fan out across the
+    inference-engine API servers) and ``RenderServerClient`` (a single
+    CPU-only render server on the driver node).
+    """
+
+    async def render_chat_completion(self, request_payload: Dict[str, Any]) -> Dict[str, Any]: ...
 
 
 def render_model_input(model_inputs: list[ModelInput]) -> list[RenderedModelInput]:
@@ -80,7 +86,7 @@ class VLLMRenderer:
     placeholder tokens and optional kwargs_data (serialized pixel_values, etc).
     """
 
-    def __init__(self, client: RemoteInferenceClient, model_name: str) -> None:
+    def __init__(self, client: RendererClientProtocol, model_name: str) -> None:
         self._client = client
         self._model_name = model_name
 

--- a/skyrl/backends/skyrl_train/inference_servers/render_server.py
+++ b/skyrl/backends/skyrl_train/inference_servers/render_server.py
@@ -1,0 +1,229 @@
+"""
+CPURenderServer - process wrapper around vLLM's GPU-less render server.
+
+vLLM's render app (``vllm launch render``) serves ``/v1/chat/completions/render``
+-- chat-template application, tokenization, and multi-modal preprocessing
+(image placeholder tokens + serialized ``pixel_values`` / ``image_grid_thw``) --
+without creating an engine: no model weights, no KV cache, no GPU memory.
+This lets the training path render VLM inputs without initializing any
+inference engine.
+
+The stock CLI infers the device from the current platform, which fails on
+GPU-less nodes (e.g. a Ray head node) with the CUDA wheel. The child process
+here forces vLLM's CPU platform and an explicit ``cpu`` device instead, so the
+server runs identically on CPU-only and GPU nodes.
+
+Usage::
+
+    server = CPURenderServer(model_path)
+    url = server.start()
+    client = RenderServerClient(url)
+    # ... VLLMRenderer(client, model_path) ...
+    server.shutdown()
+"""
+
+import logging
+import multiprocessing
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import httpx
+
+from skyrl.backends.skyrl_train.inference_servers.common import find_and_reserve_port
+from skyrl.env_vars import SKYRL_WAIT_UNTIL_INFERENCE_SERVER_HEALTHY_TIMEOUT_S
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_START_PORT = 8801
+_RENDER_HOST = "127.0.0.1"
+
+
+def _run_render_server(model_path: str, port: int, log_file: Optional[str]) -> None:
+    """Target for the render-server child process.
+
+    Must be top-level for pickling with spawn. All vLLM imports happen here so
+    the CPU platform can be seeded before anything resolves it.
+    """
+    if log_file is not None:
+        Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(log_file, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        os.dup2(fd, sys.stdout.fileno())
+        os.dup2(fd, sys.stderr.fileno())
+        os.close(fd)
+
+    # Rendering is pure CPU preprocessing; hide GPUs so the child can never
+    # touch device memory even on GPU nodes.
+    os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+    # Force the CPU platform before any other vLLM import resolves it. The
+    # CUDA wheel cannot infer a device on a GPU-less Linux box, and with GPUs
+    # hidden above the same holds on GPU nodes.
+    import vllm.platforms
+    from vllm.platforms.cpu import CpuPlatform
+
+    vllm.platforms._current_platform = CpuPlatform()
+
+    import asyncio
+
+    from vllm import envs
+    from vllm.config import DeviceConfig, VllmConfig
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.entrypoints.openai.api_server import (
+        build_and_serve_renderer,
+        setup_server,
+    )
+    from vllm.entrypoints.openai.cli_args import make_arg_parser
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    async def _serve() -> None:
+        # Mirrors vLLM's `vllm launch render` (entrypoints/cli/launch.py)
+        # except for the explicit cpu DeviceConfig, which the CLI hardcodes
+        # to "auto" (platform inference).
+        parser = make_arg_parser(FlexibleArgumentParser())
+        args = parser.parse_args(
+            ["--model", model_path, "--host", _RENDER_HOST, "--port", str(port), "--trust-remote-code"]
+        )
+
+        listen_address, sock = setup_server(args)
+        engine_args = AsyncEngineArgs.from_cli_args(args)
+        model_config = engine_args.create_model_config()
+        # Render servers preprocess data only -- no inference, no quantized
+        # kernels. Clear quantization so VllmConfig skips quant validation.
+        model_config.quantization = None
+        # Render servers never allocate KV cache; suppress the spurious CPU
+        # KV cache space warning from CpuPlatform.check_and_update_config.
+        envs.VLLM_CPU_KVCACHE_SPACE = 0
+
+        vllm_config = VllmConfig(model_config=model_config, device_config=DeviceConfig(device="cpu"))
+        shutdown_task = await build_and_serve_renderer(vllm_config, listen_address, sock, args)
+        try:
+            await shutdown_task
+        finally:
+            sock.close()
+
+    asyncio.run(_serve())
+
+
+class CPURenderServer:
+    """Process wrapper around vLLM's GPU-less render server.
+
+    The server blocks its event loop while serving, so it runs in a child
+    process that can be terminated on ``shutdown()``. Spawn (not fork) is used
+    so the child gets a clean interpreter where the CPU platform is seeded
+    before any vLLM import resolves it.
+    """
+
+    def __init__(self, model_path: str, log_path: Optional[str] = None):
+        """
+        Args:
+            model_path: HuggingFace model name/path whose processor renders inputs.
+            log_path: Directory for server log files. When set, a file
+                ``render-server-YYMMDD_HHMMSS.log`` is created under this path
+                and the child process's stdout/stderr are redirected there.
+        """
+        self._model_path = model_path
+        self._log_path = log_path
+        self._process: Optional[multiprocessing.Process] = None
+
+        # Reserve the port to prevent races between discovery and server startup.
+        self._port, self._port_reservation = find_and_reserve_port(_DEFAULT_START_PORT)
+        logger.info(f"CPURenderServer: model={model_path}, port={self._port}")
+
+    @property
+    def url(self) -> str:
+        return f"http://{_RENDER_HOST}:{self._port}"
+
+    def start(self) -> str:
+        """Spawn the render-server process and return its URL once healthy.
+
+        Raises:
+            RuntimeError: If the server process crashes or is not healthy
+                within ``SKYRL_WAIT_UNTIL_INFERENCE_SERVER_HEALTHY_TIMEOUT_S``.
+        """
+        log_file = None
+        if self._log_path is not None:
+            timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
+            log_file = str(Path(self._log_path) / f"render-server-{timestamp}.log")
+
+        # Release the port reservation right before the server rebinds.
+        if self._port_reservation is not None:
+            self._port_reservation.close()
+            self._port_reservation = None
+
+        ctx = multiprocessing.get_context("spawn")
+        self._process = ctx.Process(
+            target=_run_render_server,
+            args=(self._model_path, self._port, log_file),
+            daemon=True,
+            name="cpu-render-server",
+        )
+        self._process.start()
+
+        deadline = time.monotonic() + SKYRL_WAIT_UNTIL_INFERENCE_SERVER_HEALTHY_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if not self._process.is_alive():
+                raise RuntimeError(
+                    f"CPU render server process exited with code {self._process.exitcode} "
+                    f"before becoming healthy{f'; see {log_file}' if log_file else ''}"
+                )
+            try:
+                resp = httpx.get(f"{self.url}/health", timeout=5.0)
+                if resp.status_code == 200:
+                    logger.info(f"CPU render server healthy at {self.url}")
+                    return self.url
+            except httpx.HTTPError:
+                pass
+            time.sleep(1.0)
+
+        self.shutdown()
+        raise RuntimeError(
+            f"CPU render server not healthy within {SKYRL_WAIT_UNTIL_INFERENCE_SERVER_HEALTHY_TIMEOUT_S}s"
+            f"{f'; see {log_file}' if log_file else ''}"
+        )
+
+    def shutdown(self) -> None:
+        """Terminate the render-server process (idempotent)."""
+        if self._port_reservation is not None:
+            self._port_reservation.close()
+            self._port_reservation = None
+        if self._process is not None:
+            if self._process.is_alive():
+                self._process.terminate()
+                self._process.join(timeout=10)
+                if self._process.is_alive():
+                    self._process.kill()
+                    self._process.join(timeout=5)
+            self._process = None
+            logger.info("CPU render server shut down")
+
+
+class RenderServerClient:
+    """Minimal async client for a render server, compatible with ``VLLMRenderer``.
+
+    Implements only ``render_chat_completion`` with the same request/response
+    contract as ``RemoteInferenceClient.render_chat_completion``: the payload
+    is ``{"json": <OpenAI chat-completion request body>}`` and the response is
+    the parsed JSON of ``/v1/chat/completions/render``.
+    """
+
+    def __init__(self, url: str, timeout: float = 300.0):
+        self._url = url
+        self._timeout = timeout
+
+    async def render_chat_completion(self, request_payload: Dict[str, Any]) -> Dict[str, Any]:
+        body = dict(request_payload["json"])
+        # Routing hints are meaningless for a single local server.
+        body.pop("session_id", None)
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self._url}/v1/chat/completions/render",
+                json=body,
+                headers={"Content-Type": "application/json"},
+                timeout=self._timeout,
+            )
+            resp.raise_for_status()
+            return resp.json()

--- a/skyrl/backends/skyrl_train/inference_servers/render_server.py
+++ b/skyrl/backends/skyrl_train/inference_servers/render_server.py
@@ -22,6 +22,7 @@ Usage::
     server.shutdown()
 """
 
+import asyncio
 import logging
 import multiprocessing
 import os
@@ -34,7 +35,10 @@ from typing import Any, Dict, Optional
 import httpx
 
 from skyrl.backends.skyrl_train.inference_servers.common import find_and_reserve_port
-from skyrl.env_vars import SKYRL_WAIT_UNTIL_INFERENCE_SERVER_HEALTHY_TIMEOUT_S
+from skyrl.env_vars import (
+    SKYRL_HTTP_CONNECTION_LIMIT,
+    SKYRL_WAIT_UNTIL_INFERENCE_SERVER_HEALTHY_TIMEOUT_S,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -213,17 +217,49 @@ class RenderServerClient:
     def __init__(self, url: str, timeout: float = 300.0):
         self._url = url
         self._timeout = timeout
+        self._client: Optional[httpx.AsyncClient] = None
+        self._client_loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Get or create the pooled httpx client.
+
+        Mirrors ``RemoteInferenceClient._get_session``: the client (and its
+        connection pool) is reused across requests, but rebuilt when the
+        running event loop has changed — callers drive the renderer via
+        ``asyncio.run`` per batch, so a client bound to a previous (now
+        closed) loop is unusable. The stale client is dropped without
+        ``aclose()`` (its loop is gone); its transports are released on GC.
+        """
+        current_loop = asyncio.get_running_loop()
+        if self._client is not None and (self._client_loop is not current_loop or self._client.is_closed):
+            self._client = None
+        if self._client is None:
+            # keepalive_expiry must be shorter than the server's keep-alive
+            # timeout (uvicorn default: 5s). Otherwise the pool reuses
+            # connections the server has already closed, causing ECONNRESET
+            # under high concurrency.
+            self._client = httpx.AsyncClient(
+                limits=httpx.Limits(max_connections=SKYRL_HTTP_CONNECTION_LIMIT, keepalive_expiry=2),
+                timeout=self._timeout,
+            )
+            self._client_loop = current_loop
+        return self._client
 
     async def render_chat_completion(self, request_payload: Dict[str, Any]) -> Dict[str, Any]:
         body = dict(request_payload["json"])
         # Routing hints are meaningless for a single local server.
         body.pop("session_id", None)
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{self._url}/v1/chat/completions/render",
-                json=body,
-                headers={"Content-Type": "application/json"},
-                timeout=self._timeout,
-            )
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._get_client().post(
+            f"{self._url}/v1/chat/completions/render",
+            json=body,
+            headers={"Content-Type": "application/json"},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def aclose(self) -> None:
+        """Close the pooled client (if one exists on the current loop)."""
+        if self._client is not None and self._client_loop is asyncio.get_running_loop():
+            await self._client.aclose()
+        self._client = None
+        self._client_loop = None

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -14,7 +14,11 @@ from ray.util.placement_group import placement_group
 from transformers import AutoTokenizer
 
 from skyrl.backends.backend import AbstractBackend
-from skyrl.backends.renderer import VLLMRenderer, render_model_input
+from skyrl.backends.renderer import (
+    RendererClientProtocol,
+    VLLMRenderer,
+    render_model_input,
+)
 from skyrl.backends.skyrl_train.inference_servers.utils import resolve_policy_model_name
 from skyrl.backends.skyrl_train.training_batch import (
     TensorList,
@@ -372,15 +376,23 @@ class SkyRLTrainBackend(AbstractBackend):
         if is_colocated:
             asyncio.run(client.sleep())
 
-    def _create_render_client(self):
-        """Lazily start a CPU-only render server and return a client for it.
+    def _create_render_client(self) -> RendererClientProtocol:
+        """Return a client for vLLM's ``/v1/chat/completions/render``.
 
-        Rendering image chunks needs vLLM's ``/v1/chat/completions/render``,
-        but not an inference engine: the render-only server loads just the
-        tokenizer and HF processor on CPU (no weights, no KV cache, no GPU).
-        This keeps the training path (forward / forward_backward) free of
-        inference-engine startup for VLM workloads too.
+        Two branches:
+
+        - Inference engines already initialized (e.g. VLM RL, where sampling
+          brought them up): reuse ``RemoteInferenceClient`` so render requests
+          fan out across all engine API servers rather than funneling through
+          a single driver-local process.
+        - Engines not initialized (e.g. VLM SFT): lazily start a CPU-only
+          render server. It loads just the tokenizer and HF processor (no
+          weights, no KV cache, no GPU), keeping the training path
+          (forward / forward_backward) free of inference-engine startup.
         """
+        if self._inference_engines_initialized:
+            return self._inference_engine_client
+
         from skyrl.backends.skyrl_train.inference_servers.render_server import (
             CPURenderServer,
             RenderServerClient,
@@ -404,6 +416,15 @@ class SkyRLTrainBackend(AbstractBackend):
         self._dispatch.set_inference_engine_client(self._inference_engine_client)
         self.init_weight_sync_state()
         self._inference_engines_initialized = True
+
+        # The engines' API servers also expose the render endpoint, fanning
+        # render requests across all engines. Drop any CPU-render-backed
+        # renderer so the next image batch rebuilds against the engine client.
+        if self._renderer is not None:
+            self._renderer = None
+        if self._render_server is not None:
+            self._render_server.shutdown()
+            self._render_server = None
 
     def _lora_signature_from(self, lora_config: types.LoraConfig) -> tuple:
         # Tinker's public LoraConfig only exposes rank + alpha (plus

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -125,6 +125,9 @@ class SkyRLTrainBackend(AbstractBackend):
         self._inference_engine_client = None
         self._inference_engines_initialized = False
         self._renderer = None
+        # CPU-only render server for multi-modal preprocessing; started
+        # lazily on the first image-bearing training batch.
+        self._render_server = None
         # Captured at first LoRA create_model; subsequent create_models must
         # match this signature exactly. None when no LoRA model is registered.
         self._base_lora_signature: tuple | None = None
@@ -369,6 +372,28 @@ class SkyRLTrainBackend(AbstractBackend):
         if is_colocated:
             asyncio.run(client.sleep())
 
+    def _create_render_client(self):
+        """Lazily start a CPU-only render server and return a client for it.
+
+        Rendering image chunks needs vLLM's ``/v1/chat/completions/render``,
+        but not an inference engine: the render-only server loads just the
+        tokenizer and HF processor on CPU (no weights, no KV cache, no GPU).
+        This keeps the training path (forward / forward_backward) free of
+        inference-engine startup for VLM workloads too.
+        """
+        from skyrl.backends.skyrl_train.inference_servers.render_server import (
+            CPURenderServer,
+            RenderServerClient,
+        )
+
+        if self._render_server is None:
+            self._render_server = CPURenderServer(
+                self._cfg.trainer.policy.model.path,
+                log_path=self._cfg.trainer.log_path,
+            )
+            self._render_server.start()
+        return RenderServerClient(self._render_server.url)
+
     def _ensure_inference_engines(self):
         """Lazily create inference engines and init weight sync on first sampling-related call."""
         if self._inference_engines_initialized:
@@ -511,6 +536,9 @@ class SkyRLTrainBackend(AbstractBackend):
         if self._inference_router:
             self._inference_router.shutdown()
             self._inference_router = None
+        if self._render_server is not None:
+            self._render_server.shutdown()
+            self._render_server = None
         ray.shutdown()
         self._model_ids_to_role = {}
         self._model_metadata = {}
@@ -533,8 +561,8 @@ class SkyRLTrainBackend(AbstractBackend):
             return TrainingInputBatch({})
 
         # Only image chunks need vLLM's render endpoint. Text-only batches
-        # (the SFT path) render locally so pure training runs never pay for
-        # inference-engine startup.
+        # render locally, and image batches use a CPU-only render server, so
+        # the training path never pays for inference-engine startup.
         has_image_chunks = any(
             isinstance(chunk, (types.ImageChunk, types.ImageAssetPointerChunk))
             for model_input in prepared_batch.all_model_inputs
@@ -542,8 +570,7 @@ class SkyRLTrainBackend(AbstractBackend):
         )
         if has_image_chunks:
             if self._renderer is None:
-                self._ensure_inference_engines()
-                self._renderer = VLLMRenderer(self._inference_engine_client, self._cfg.trainer.policy.model.path)
+                self._renderer = VLLMRenderer(self._create_render_client(), self._cfg.trainer.policy.model.path)
             rendered_inputs = asyncio.run(self._renderer(prepared_batch.all_model_inputs))
         else:
             rendered_inputs = render_model_input(prepared_batch.all_model_inputs)

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -14,7 +14,7 @@ from ray.util.placement_group import placement_group
 from transformers import AutoTokenizer
 
 from skyrl.backends.backend import AbstractBackend
-from skyrl.backends.renderer import VLLMRenderer
+from skyrl.backends.renderer import VLLMRenderer, render_model_input
 from skyrl.backends.skyrl_train.inference_servers.utils import resolve_policy_model_name
 from skyrl.backends.skyrl_train.training_batch import (
     TensorList,
@@ -532,10 +532,21 @@ class SkyRLTrainBackend(AbstractBackend):
         if not prepared_batch.all_model_inputs:
             return TrainingInputBatch({})
 
-        if self._renderer is None:
-            self._ensure_inference_engines()
-            self._renderer = VLLMRenderer(self._inference_engine_client, self._cfg.trainer.policy.model.path)
-        rendered_inputs = asyncio.run(self._renderer(prepared_batch.all_model_inputs))
+        # Only image chunks need vLLM's render endpoint. Text-only batches
+        # (the SFT path) render locally so pure training runs never pay for
+        # inference-engine startup.
+        has_image_chunks = any(
+            isinstance(chunk, (types.ImageChunk, types.ImageAssetPointerChunk))
+            for model_input in prepared_batch.all_model_inputs
+            for chunk in model_input.chunks
+        )
+        if has_image_chunks:
+            if self._renderer is None:
+                self._ensure_inference_engines()
+                self._renderer = VLLMRenderer(self._inference_engine_client, self._cfg.trainer.policy.model.path)
+            rendered_inputs = asyncio.run(self._renderer(prepared_batch.all_model_inputs))
+        else:
+            rendered_inputs = render_model_input(prepared_batch.all_model_inputs)
 
         all_input_ids = [r.prompt_ids for r in rendered_inputs]
 

--- a/tests/tinker/skyrl_train/test_render_server.py
+++ b/tests/tinker/skyrl_train/test_render_server.py
@@ -83,6 +83,32 @@ def test_render_image_input_via_cpu_server(render_server):
     assert mm_kwargs["image_grid_thw"].shape[-1] == 3  # (t, h, w) per image
 
 
+def test_render_client_pools_within_loop_and_survives_loop_change(render_server):
+    """One RenderServerClient reused across asyncio.run calls (per-batch pattern).
+
+    Within a loop the pooled httpx client is reused; across loops (each
+    ``asyncio.run`` creates a fresh one) the client is rebuilt instead of
+    failing on the dead loop.
+    """
+    client = RenderServerClient(render_server.url)
+    renderer = VLLMRenderer(client, model_name=TINY_VLM)
+    model_input = types.ModelInput(chunks=[types.ImageChunk(data=base64.b64encode(_tiny_png()), format="png")])
+
+    async def render_twice_same_loop():
+        await renderer([model_input])
+        first = client._client
+        await renderer([model_input])
+        assert client._client is first, "pooled client must be reused within one event loop"
+        return first
+
+    first_client = asyncio.run(render_twice_same_loop())
+
+    # Second batch: new event loop -> client must be rebuilt, not reused.
+    rendered = asyncio.run(renderer([model_input]))[0]
+    assert rendered.multi_modal_placeholders is not None
+    assert client._client is not first_client, "client bound to a closed loop must be rebuilt"
+
+
 def test_render_text_only_makes_no_http_call(render_server):
     """Text-only inputs are rendered locally even when a render client is wired."""
 

--- a/tests/tinker/skyrl_train/test_render_server.py
+++ b/tests/tinker/skyrl_train/test_render_server.py
@@ -1,0 +1,96 @@
+"""End-to-end test for the CPU-only render server used by the VLM training path.
+
+Starts vLLM's GPU-less render server (``CPURenderServer``) for a tiny VLM and
+renders an image-bearing ModelInput through ``VLLMRenderer`` backed by
+``RenderServerClient``. No inference engines (and no GPUs) are involved. Run:
+  uv run --isolated --extra tinker --extra fsdp --with pytest pytest tests/tinker/skyrl_train/test_render_server.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import struct
+import zlib
+
+import pytest
+import torch
+
+# Skip if the SkyRL-Train backend deps (ray/vllm) cannot be imported
+pytest.importorskip("skyrl.backends.skyrl_train_backend")
+
+from skyrl.backends.renderer import VLLMRenderer  # noqa: E402
+from skyrl.backends.skyrl_train.inference_servers.render_server import (  # noqa: E402
+    CPURenderServer,
+    RenderServerClient,
+)
+from skyrl.tinker import types  # noqa: E402
+
+TINY_VLM = "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration"
+
+
+def _tiny_png(w: int = 64, h: int = 64) -> bytes:
+    """Minimal valid RGB PNG (no PIL dependency)."""
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        c = tag + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c))
+
+    ihdr = struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0)
+    raw = b"".join(b"\x00" + b"\x7f\x7f\x7f" * w for _ in range(h))
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", zlib.compress(raw)) + chunk(b"IEND", b"")
+
+
+@pytest.fixture(scope="module")
+def render_server():
+    server = CPURenderServer(TINY_VLM)
+    try:
+        server.start()
+        yield server
+    finally:
+        server.shutdown()
+
+
+def test_render_image_input_via_cpu_server(render_server):
+    """VLLMRenderer against the CPU render server yields placeholder tokens and vision tensors."""
+    renderer = VLLMRenderer(RenderServerClient(render_server.url), model_name=TINY_VLM)
+
+    prefix_tokens = [1, 2, 3]
+    suffix_tokens = [7, 8]
+    model_input = types.ModelInput(
+        chunks=[
+            types.EncodedTextChunk(tokens=prefix_tokens),
+            types.ImageChunk(data=base64.b64encode(_tiny_png()), format="png"),
+            types.EncodedTextChunk(tokens=suffix_tokens),
+        ]
+    )
+
+    rendered = asyncio.run(renderer([model_input]))[0]
+
+    # Placeholder tokens are spliced between the text chunks.
+    assert rendered.multi_modal_placeholders is not None
+    (placeholder,) = rendered.multi_modal_placeholders
+    assert placeholder.offset == len(prefix_tokens)
+    assert placeholder.length > 0
+    assert len(rendered.prompt_ids) == len(prefix_tokens) + placeholder.length + len(suffix_tokens)
+    assert rendered.prompt_ids[: len(prefix_tokens)] == prefix_tokens
+    assert rendered.prompt_ids[-len(suffix_tokens) :] == suffix_tokens
+
+    # Vision tensors are decoded from the server's serialized kwargs_data.
+    mm_kwargs = rendered.multi_modal_kwargs
+    assert isinstance(mm_kwargs["pixel_values"], torch.Tensor)
+    assert isinstance(mm_kwargs["image_grid_thw"], torch.Tensor)
+    assert mm_kwargs["image_grid_thw"].shape[-1] == 3  # (t, h, w) per image
+
+
+def test_render_text_only_makes_no_http_call(render_server):
+    """Text-only inputs are rendered locally even when a render client is wired."""
+
+    class _ExplodingClient:
+        async def render_chat_completion(self, request_payload):
+            raise AssertionError("text-only input must not hit the render endpoint")
+
+    renderer = VLLMRenderer(_ExplodingClient(), model_name=TINY_VLM)
+    model_input = types.ModelInput(chunks=[types.EncodedTextChunk(tokens=[1, 2, 3])])
+    rendered = asyncio.run(renderer([model_input]))[0]
+    assert rendered.prompt_ids == [1, 2, 3]

--- a/tests/tinker/skyrl_train/test_text_only_batch_no_inference.py
+++ b/tests/tinker/skyrl_train/test_text_only_batch_no_inference.py
@@ -1,0 +1,78 @@
+"""Verifies the training (forward/forward_backward) path does not bring up
+inference engines for text-only batches.
+
+``_to_training_batch`` only needs vLLM's render endpoint for image chunks;
+text-only batches — the SFT code path — must render locally so pure training
+runs never pay for inference-engine startup. No inference engines are brought
+up, so this runs on CPU. Requires the SkyRL-Train backend deps (ray/vllm). Run:
+  uv run --isolated --extra tinker --extra fsdp --with pytest pytest tests/tinker/skyrl_train/test_text_only_batch_no_inference.py
+"""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+
+import pytest
+
+# Skip if skyrl_train_backend.py cannot be imported
+skyrl_train_backend = pytest.importorskip("skyrl.backends.skyrl_train_backend")
+
+from skyrl.tinker import types  # noqa: E402
+from skyrl.tinker.engine import prepare_model_pass_batch  # noqa: E402
+
+PAD_TOKEN_ID = 0
+
+
+class _EngineInitCalled(Exception):
+    """Sentinel raised by the stubbed _ensure_inference_engines."""
+
+
+def _fake_backend() -> SimpleNamespace:
+    def _ensure_inference_engines():
+        raise _EngineInitCalled
+
+    return SimpleNamespace(
+        _renderer=None,
+        _inference_engine_client=None,
+        _cfg=None,
+        _tokenizer=SimpleNamespace(pad_token_id=PAD_TOKEN_ID),
+        _ensure_inference_engines=_ensure_inference_engines,
+    )
+
+
+def _prepared_batch(model_input: types.ModelInput) -> types.PreparedModelPassBatch:
+    datum = types.Datum(
+        model_input=model_input,
+        loss_fn_inputs=types.LossFnInputs(
+            target_tokens=types.TensorData(data=[2, 3, 4]),
+            weights=types.TensorData(data=[1.0, 1.0, 1.0]),
+            advantages=types.TensorData(data=[]),
+            logprobs=types.TensorData(data=[]),
+        ),
+    )
+    requests = {"req1": ("model1", types.ForwardBackwardInput(data=[datum], loss_fn="cross_entropy"))}
+    return prepare_model_pass_batch(requests)
+
+
+def test_text_only_batch_skips_inference_engines():
+    """Text-only (SFT) batches render locally without touching inference engines."""
+    fake_self = _fake_backend()
+    prepared_batch = _prepared_batch(types.ModelInput(chunks=[types.EncodedTextChunk(tokens=[1, 2, 3])]))
+
+    batch = skyrl_train_backend.SkyRLTrainBackend._to_training_batch(fake_self, prepared_batch, role="policy")
+
+    # Full sequence = input tokens + last target token (SkyRL-Train shifts internally).
+    assert batch["sequences"].tolist() == [[1, 2, 3, 4]]
+    assert batch["attention_mask"].tolist() == [[1, 1, 1, 1]]
+    assert fake_self._renderer is None
+
+
+def test_image_batch_still_initializes_inference_engines():
+    """Batches with image chunks still go through the lazy engine init."""
+    fake_self = _fake_backend()
+    image_chunk = types.ImageChunk(data=base64.b64encode(b"not-a-real-png"), format="png")
+    prepared_batch = _prepared_batch(types.ModelInput(chunks=[types.EncodedTextChunk(tokens=[1, 2, 3]), image_chunk]))
+
+    with pytest.raises(_EngineInitCalled):
+        skyrl_train_backend.SkyRLTrainBackend._to_training_batch(fake_self, prepared_batch, role="policy")

--- a/tests/tinker/skyrl_train/test_text_only_batch_no_inference.py
+++ b/tests/tinker/skyrl_train/test_text_only_batch_no_inference.py
@@ -84,3 +84,47 @@ def test_image_batch_uses_render_server_not_engines():
 
     with pytest.raises(_RenderServerUsed):
         skyrl_train_backend.SkyRLTrainBackend._to_training_batch(fake_self, prepared_batch, role="policy")
+
+
+def test_render_client_prefers_engine_client_when_initialized():
+    """Once engines are up (RL), rendering reuses the engine client instead of a CPU server."""
+    engine_client = object()
+    fake_self = SimpleNamespace(
+        _inference_engines_initialized=True,
+        _inference_engine_client=engine_client,
+        _render_server=None,
+        _cfg=None,
+    )
+    client = skyrl_train_backend.SkyRLTrainBackend._create_render_client(fake_self)
+    assert client is engine_client
+    assert fake_self._render_server is None
+
+
+def test_engine_init_invalidates_cpu_render_state():
+    """When engines come up, the CPU-render-backed renderer and server are dropped
+    so the next image batch rebuilds against the engine client."""
+
+    class _RenderServerStub:
+        def __init__(self):
+            self.shutdown_called = False
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    render_server = _RenderServerStub()
+    fake_self = SimpleNamespace(
+        _inference_engines_initialized=False,
+        _inference_engine_client=object(),
+        _create_new_inference_client=lambda: None,
+        _dispatch=SimpleNamespace(set_inference_engine_client=lambda client: None),
+        init_weight_sync_state=lambda: None,
+        _renderer=object(),
+        _render_server=render_server,
+    )
+
+    skyrl_train_backend.SkyRLTrainBackend._ensure_inference_engines(fake_self)
+
+    assert fake_self._inference_engines_initialized
+    assert fake_self._renderer is None
+    assert render_server.shutdown_called
+    assert fake_self._render_server is None

--- a/tests/tinker/skyrl_train/test_text_only_batch_no_inference.py
+++ b/tests/tinker/skyrl_train/test_text_only_batch_no_inference.py
@@ -28,9 +28,16 @@ class _EngineInitCalled(Exception):
     """Sentinel raised by the stubbed _ensure_inference_engines."""
 
 
+class _RenderServerUsed(Exception):
+    """Sentinel raised by the stubbed _create_render_client."""
+
+
 def _fake_backend() -> SimpleNamespace:
     def _ensure_inference_engines():
         raise _EngineInitCalled
+
+    def _create_render_client():
+        raise _RenderServerUsed
 
     return SimpleNamespace(
         _renderer=None,
@@ -38,6 +45,7 @@ def _fake_backend() -> SimpleNamespace:
         _cfg=None,
         _tokenizer=SimpleNamespace(pad_token_id=PAD_TOKEN_ID),
         _ensure_inference_engines=_ensure_inference_engines,
+        _create_render_client=_create_render_client,
     )
 
 
@@ -68,11 +76,11 @@ def test_text_only_batch_skips_inference_engines():
     assert fake_self._renderer is None
 
 
-def test_image_batch_still_initializes_inference_engines():
-    """Batches with image chunks still go through the lazy engine init."""
+def test_image_batch_uses_render_server_not_engines():
+    """Batches with image chunks go to the CPU render server, never the engines."""
     fake_self = _fake_backend()
     image_chunk = types.ImageChunk(data=base64.b64encode(b"not-a-real-png"), format="png")
     prepared_batch = _prepared_batch(types.ModelInput(chunks=[types.EncodedTextChunk(tokens=[1, 2, 3]), image_chunk]))
 
-    with pytest.raises(_EngineInitCalled):
+    with pytest.raises(_RenderServerUsed):
         skyrl_train_backend.SkyRLTrainBackend._to_training_batch(fake_self, prepared_batch, role="policy")


### PR DESCRIPTION
## What does this PR do?

Avoids inference engine initialization for the SFT code path in the Tinker SkyRL-Train backend (P0).

`_to_training_batch` — the batch-conversion step behind every `forward` / `forward_backward` request — unconditionally called `_ensure_inference_engines()` just to construct a `VLLMRenderer`. As a result, pure SFT workloads (`forward_backward` + `optim_step`, never sampling) still booted the full vLLM inference engine fleet and weight-sync state, wasting GPU memory and startup time.

## Changes

- `skyrl/backends/skyrl_train_backend.py`: `_to_training_batch` now scans the batch for `ImageChunk` / `ImageAssetPointerChunk`:
  - **Text-only batches (the SFT path)** render locally via `render_model_input` — no inference engines, no HTTP.
  - **Image-bearing (VLM) batches** keep the existing lazy engine init + `VLLMRenderer`, which needs vLLM's `/render` endpoint for image placeholder tokens.
- The other `_ensure_inference_engines()` call sites (`sample`, `save_sampler_checkpoint`) genuinely need engines and are unchanged.

For text-only inputs `VLLMRenderer` is equivalent to `render_model_input` (already pinned by `test_matches_render_model_input`), so rendered output is identical.

## Tests

- New CPU test `tests/tinker/skyrl_train/test_text_only_batch_no_inference.py`:
  - a text-only batch converts correctly with `_ensure_inference_engines` stubbed to raise (proving it is never called)
  - an image batch still triggers the lazy engine init
- Existing `tests/backends/skyrl_train/test_renderer.py` (5/5) and `tests/tinker/skyrl_train/test_sample_session_routing.py` pass.

## Follow-up: CPU-only render server for VLM batches (commit 2)

Image-bearing training batches previously still initialized the inference engines just to reach vLLM's `/v1/chat/completions/render`. Rendering is pure CPU preprocessing, so the backend now runs vLLM's GPU-less render server (`vllm launch render` equivalent) in a child process and points `VLLMRenderer` at it via a minimal `RenderServerClient`.

- New `CPURenderServer` forces vLLM's CPU platform + explicit `cpu` device in the child so it also works on GPU-less nodes (e.g. Ray head nodes) where the CUDA wheel cannot infer a device.
- Started lazily on the first image-bearing batch; torn down in `delete_model`.
- **Result: `forward`/`forward_backward` never initialize inference engines for any workload** — engines start only for `sample` and `save_weights_for_sampler`.
- New end-to-end CPU test `tests/tinker/skyrl_train/test_render_server.py` renders a real image through the server and asserts placeholder splicing plus decoded `pixel_values`/`image_grid_thw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)