### PR TITLE
[fix] Return loss_fn_outputs in input order with token-based microbatching

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1203,6 +1203,11 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         # token-based batching can reorder them back to the input-sample order below.
         per_microbatch_loss_fn_outputs = []
         for m_batch, metrics in zip(micro_buffer, metrics_list):
+            # metrics is None on non-last pipeline stages; append [] to keep the per-microbatch
+            # alignment with micro_buffer that the reorder below relies on.
+            if metrics is None:
+                per_microbatch_loss_fn_outputs.append([])
+                continue
             # Extract loss_fn_outputs before reduce_metrics (it's not a scalar metric)
             per_microbatch_loss_fn_outputs.append(metrics.pop("loss_fn_outputs", []))
             # Skip fully-padding microbatches: their metrics (clip_ratio=0, policy_entropy=0,

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1198,12 +1198,13 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         if self.empty_cuda_cache:
             torch.cuda.empty_cache()
 
-        # Aggregate metrics across micro-batches
-        all_loss_fn_outputs = []  # Handle separately from scalar metrics
+        # Aggregate metrics across micro-batches. Collect loss_fn_outputs per micro-batch
+        # (packed order, including intra-microbatch and whole-microbatch padding) so
+        # token-based batching can reorder them back to the input-sample order below.
+        per_microbatch_loss_fn_outputs = []
         for m_batch, metrics in zip(micro_buffer, metrics_list):
             # Extract loss_fn_outputs before reduce_metrics (it's not a scalar metric)
-            if "loss_fn_outputs" in metrics:
-                all_loss_fn_outputs.extend(metrics.pop("loss_fn_outputs"))
+            per_microbatch_loss_fn_outputs.append(metrics.pop("loss_fn_outputs", []))
             # Skip fully-padding microbatches: their metrics (clip_ratio=0, policy_entropy=0,
             # ...) are meaningless and would drag down the mean-reduced metrics. Summed
             # metrics (e.g. policy_loss) are unaffected since padding contributes 0, but
@@ -1212,6 +1213,11 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
                 continue
             for k, v in metrics.items():
                 all_metrics[k].append(v)
+
+        if microbatch_iterator is not None:
+            all_loss_fn_outputs = microbatch_iterator.reorder_loss_fn_outputs(per_microbatch_loss_fn_outputs)
+        else:
+            all_loss_fn_outputs = [output for microbatch in per_microbatch_loss_fn_outputs for output in microbatch]
 
         # TODO: SFT path still averages metrics across microbatches and workers.
         # This needs to be unified with the RL path which sums.

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -784,7 +784,8 @@ class PolicyWorkerBase(Worker):
             max_tokens_per_microbatch=self.cfg.max_tokens_per_microbatch,
         )
         all_metrics = defaultdict(list)
-        all_loss_fn_outputs = []  # Handle separately from scalar metrics
+        # Collected per-microbatch (in iteration order) then reordered to input-sample order.
+        per_microbatch_loss_fn_outputs = []
 
         for microbatch in microbatch_iterator:
             experience = BaseBatchIterator.batch_to_experience(microbatch)
@@ -794,11 +795,13 @@ class PolicyWorkerBase(Worker):
             )
 
             # Extract loss_fn_outputs before reduce_metrics (it's not a scalar metric)
-            if "loss_fn_outputs" in metrics:
-                all_loss_fn_outputs.extend(metrics.pop("loss_fn_outputs"))
+            per_microbatch_loss_fn_outputs.append(metrics.pop("loss_fn_outputs", []))
 
             for k, v in metrics.items():
                 all_metrics[k].append(v)
+
+        # Token-based batching yields microbatches in packed order; restore input-sample order.
+        all_loss_fn_outputs = microbatch_iterator.reorder_loss_fn_outputs(per_microbatch_loss_fn_outputs)
 
         # TODO: SFT path still averages metrics across microbatches and workers.
         # This needs to be unified with the RL path which sums.

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 import torch
 import torch.distributed as dist
@@ -128,6 +128,13 @@ class BaseBatchIterator:
     def reorder_and_combine_batches(self, batches: List[TensorBatch]) -> TensorBatch:
         """Reorder and combine output batches to form a single output."""
         raise NotImplementedError
+
+    def reorder_loss_fn_outputs(self, per_microbatch_outputs: List[List[Any]]) -> List[Any]:
+        """Flatten per-microbatch ``loss_fn_outputs`` into a single list in input-sample order.
+
+        Sample-based splitting preserves order, so a flat concatenation suffices.
+        """
+        return [output for microbatch in per_microbatch_outputs for output in microbatch]
 
     @staticmethod
     def batch_to_experience(batch: TrainingInputBatch):
@@ -401,6 +408,25 @@ class TokenBasedBatchIterator(BaseBatchIterator):
         reordered_batch = type(ref_microbatch)(reordered_data)
         reordered_batch.metadata = ref_microbatch.metadata
         return reordered_batch
+
+    def reorder_loss_fn_outputs(self, per_microbatch_outputs: List[List[Any]]) -> List[Any]:
+        """Reorder per-microbatch ``loss_fn_outputs`` back to the original input-sample order.
+
+        ``per_microbatch_outputs[i]`` holds the outputs for microbatch ``i`` (real
+        microbatches first, in packed order, followed by any padding microbatches).
+        Padding microbatches and intra-microbatch padding samples are dropped: only real
+        samples appear in ``self._microbatches``, and real samples precede padding within a
+        microbatch, so indexing by ``sample_idx`` naturally skips them.
+        """
+        if not any(per_microbatch_outputs):
+            return []
+
+        reordered: List[Any] = [None] * len(self._token_counts)
+        for microbatch_idx, original_indices in enumerate(self._microbatches):
+            outputs = per_microbatch_outputs[microbatch_idx]
+            for sample_idx, original_idx in enumerate(original_indices):
+                reordered[original_idx] = outputs[sample_idx]
+        return reordered
 
 
 def get_microbatch_iterator(

--- a/tests/backends/skyrl_train/test_token_based_batching_utils.py
+++ b/tests/backends/skyrl_train/test_token_based_batching_utils.py
@@ -160,6 +160,33 @@ class TestTokenBasedBatchIterator:
         for i in range(batch.batch_size):
             assert torch.equal(reordered["sequences"][i], batch["sequences"][i])
 
+    def test_reorder_loss_fn_outputs(self):
+        """reorder_loss_fn_outputs restores input-sample order and drops padding entries."""
+        batch = self._make_batch([10, 3, 8, 5])
+        iterator = TokenBasedBatchIterator(batch, max_tokens_per_microbatch=12)
+        # Packing reorders samples (e.g. [[0], [2], [3, 1]]); a naive flatten would be wrong.
+        assert [i for mb in iterator._microbatches for i in mb] != list(range(batch.batch_size))
+
+        # Mimic the worker: real samples first (tagged with their original index), then an
+        # intra-microbatch padding sample appended at the tail.
+        per_microbatch_outputs = []
+        for mb_indices in iterator._microbatches:
+            outputs = [{"orig": idx} for idx in mb_indices]
+            outputs.append({"orig": "pad"})
+            per_microbatch_outputs.append(outputs)
+        # A whole padding microbatch appended to equalize the DP microbatch count.
+        per_microbatch_outputs.append([{"orig": "pad"}])
+
+        reordered = iterator.reorder_loss_fn_outputs(per_microbatch_outputs)
+        assert reordered == [{"orig": i} for i in range(batch.batch_size)]
+
+    def test_reorder_loss_fn_outputs_empty(self):
+        """No loss_fn_outputs produced (all microbatches empty) -> empty result."""
+        batch = self._make_batch([10, 3, 8, 5])
+        iterator = TokenBasedBatchIterator(batch, max_tokens_per_microbatch=12)
+        empty = [[] for _ in iterator._microbatches]
+        assert iterator.reorder_loss_fn_outputs(empty) == []
+
     def test_get_microbatch_iterator_factory(self):
         batch = self._make_batch([10, 10, 5, 5])
 


### PR DESCRIPTION
## Summary

When `trainer.max_tokens_per_microbatch > 0`, `forward_backward` bin-packs samples into microbatches by token count. The per-sample `loss_fn_outputs` were then collected in **packed microbatch order** rather than the original input-sample order, breaking the API contract that `loss_fn_outputs[i]` corresponds to input sample `i`.

Downstream consumers rely on that contract — e.g. the Tinker backend (`skyrl/backends/skyrl_train_backend.py`) indexes `per_sample_outputs[i]` by input sample index when building `ForwardBackwardOutput`. The result was silently misaligned per-sample logprobs / elementwise-loss (wrong training signal, not a crash).

This affects both backends, and Megatron additionally leaked padding entries into the output:
- **FSDP** (`workers/worker.py`): outputs `extend`-ed in packed iteration order; the iterator already had `reorder_and_combine_batches` for the forward-only path, but `forward_backward` never reordered.
- **Megatron** (`workers/megatron/megatron_worker.py`): same packed-order issue, plus (a) intra-microbatch padding samples (each microbatch is padded to a uniform size for Megatron's schedule) and (b) whole padding microbatches (added to equalize DP counts) both produced entries that were included.

Only the training `forward_backward` path was affected — the forward-only / logprob paths already reorder and strip padding.

## Fix

- Add `BaseBatchIterator.reorder_loss_fn_outputs(per_microbatch_outputs)` — a flat concatenation (order-preserving for sample-based iterators).
- Override it in `TokenBasedBatchIterator` to map per-microbatch outputs back to original input order using the existing packing index map, dropping padding (padding microbatches aren't in `self._microbatches`; intra-microbatch padding sits after the real samples, so indexing by `sample_idx` skips it).
- Both FSDP and Megatron `forward_backward` now collect `loss_fn_outputs` per-microbatch and reorder before returning.

Purely an output-assembly fix — the forward/loss/backward math inside each microbatch is unchanged.

## Testing

- `tests/backends/skyrl_train/test_token_based_batching_utils.py`: added `test_reorder_loss_fn_outputs` (asserts a non-identity packing round-trips to input order and drops both padding kinds) and `test_reorder_loss_fn_outputs_empty`.
- `uv run --isolated --extra dev --extra skyrl-train pytest tests/backends/skyrl_train/test_token_based_batching_utils.py` → 18 passed.
- `ruff` + `black` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
