### PR TITLE
[bugfix] Fused LM Head Compatibility with HybridModel

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/fused_lm_head.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/fused_lm_head.py
@@ -54,6 +54,7 @@ def call_model_with_fused_lm_head(
         raise NotImplementedError("fused_lm_head_logprob does not support MXFP8 output projection")
     if unwrapped_model.config.use_mup:
         raise NotImplementedError("fused_lm_head_logprob does not support MuP logit scaling")
+    # Standard GPTModel objects directly take `output_processor`, just call the model like normal
     if "output_processor" in inspect.signature(unwrapped_model.forward).parameters:
         return model(
             *args,
@@ -69,10 +70,12 @@ def call_model_with_fused_lm_head(
     if not unwrapped_model.post_process:
         return model(*args, **kwargs)
 
+    # Manually mark output layer as not offloadable; this is normally done by Megatron post-processing, but we disable that
     if unwrapped_model.config.fine_grained_activation_offloading:
         for parameter in unwrapped_model.output_layer.parameters():
             off_interface.mark_not_offloadable(parameter)
 
+    # Disable post-processing since we manually handle the LM head output downstream
     unwrapped_model.post_process = False
     try:
         hidden_states = model(*args, **kwargs)

--- a/skyrl/backends/skyrl_train/distributed/megatron/fused_lm_head.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/fused_lm_head.py
@@ -1,0 +1,92 @@
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+from torch import Tensor
+
+
+def fused_lm_head_output_processor(
+    *,
+    hidden_states: Tensor,
+    output_layer: Any,
+    output_weight: Tensor | None = None,
+    context: dict[str, Any] | None = None,
+    **_: Any,
+) -> Tensor:
+    """Return hidden states and retain the LM-head weight for fused log-probs."""
+    if context is not None:
+        context["lm_head_weight"] = output_weight if output_weight is not None else output_layer.weight
+
+    if output_layer.sequence_parallel:
+        from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
+
+        hidden_states = gather_from_sequence_parallel_region(
+            hidden_states,
+            tensor_parallel_output_grad=True,
+            group=output_layer.tp_group,
+        )
+    elif output_layer.allreduce_dgrad:
+        from megatron.core.tensor_parallel import copy_to_tensor_model_parallel_region
+
+        hidden_states = copy_to_tensor_model_parallel_region(hidden_states, group=output_layer.tp_group)
+
+    return hidden_states.transpose(0, 1).contiguous()
+
+
+def call_model_with_fused_lm_head(
+    model: Any,
+    *args: Any,
+    output_processor: Callable[..., Any],
+    output_processor_context: dict[str, Any],
+    **kwargs: Any,
+) -> Any:
+    """Run GPT-style or HybridModel forwards without materializing logits."""
+    # Megatron is optional outside the Megatron backend, so keep these imports lazy.
+    from megatron.core.fp8_utils import is_mxfp8_output_proj_active
+    from megatron.core.models.hybrid.hybrid_model import HybridModel
+    from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+        FineGrainedActivationOffloadingInterface as off_interface,
+    )
+    from megatron.core.utils import unwrap_model
+
+    unwrapped_model = unwrap_model(model)
+    if is_mxfp8_output_proj_active(unwrapped_model.config):
+        raise NotImplementedError("fused_lm_head_logprob does not support MXFP8 output projection")
+    if unwrapped_model.config.use_mup:
+        raise NotImplementedError("fused_lm_head_logprob does not support MuP logit scaling")
+    if "output_processor" in inspect.signature(unwrapped_model.forward).parameters:
+        return model(
+            *args,
+            output_processor=output_processor,
+            output_processor_context=output_processor_context,
+            **kwargs,
+        )
+    if not isinstance(unwrapped_model, HybridModel):
+        raise NotImplementedError(f"fused_lm_head_logprob is not supported for {type(unwrapped_model).__name__}")
+
+    if unwrapped_model.config.mtp_num_layers:
+        raise NotImplementedError("fused_lm_head_logprob does not support HybridModel with MTP enabled")
+    if not unwrapped_model.post_process:
+        return model(*args, **kwargs)
+
+    if unwrapped_model.config.fine_grained_activation_offloading:
+        for parameter in unwrapped_model.output_layer.parameters():
+            off_interface.mark_not_offloadable(parameter)
+
+    unwrapped_model.post_process = False
+    try:
+        hidden_states = model(*args, **kwargs)
+    finally:
+        unwrapped_model.post_process = True
+
+    output_weight = (
+        unwrapped_model.shared_embedding_or_output_weight()
+        if unwrapped_model.share_embeddings_and_output_weights
+        else None
+    )
+    return output_processor(
+        hidden_states=hidden_states,
+        output_layer=unwrapped_model.output_layer,
+        output_weight=output_weight,
+        context=output_processor_context,
+    )

--- a/skyrl/backends/skyrl_train/distributed/megatron/fused_lm_head.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/fused_lm_head.py
@@ -25,12 +25,15 @@ def fused_lm_head_output_processor(
             tensor_parallel_output_grad=True,
             group=output_layer.tp_group,
         )
-    elif output_layer.allreduce_dgrad:
+
+    hidden_states = hidden_states.transpose(0, 1).contiguous()
+
+    if not output_layer.sequence_parallel and output_layer.allreduce_dgrad:
         from megatron.core.tensor_parallel import copy_to_tensor_model_parallel_region
 
         hidden_states = copy_to_tensor_model_parallel_region(hidden_states, group=output_layer.tp_group)
 
-    return hidden_states.transpose(0, 1).contiguous()
+    return hidden_states
 
 
 def call_model_with_fused_lm_head(

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -9,6 +9,10 @@ from megatron.core.distributed import finalize_model_grads
 from megatron.core.pipeline_parallel import get_forward_backward_func
 from omegaconf import OmegaConf
 
+from skyrl.backends.skyrl_train.distributed.megatron.fused_lm_head import (
+    call_model_with_fused_lm_head,
+    fused_lm_head_output_processor,
+)
 from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
     get_model_config,
     make_batch_generator,
@@ -80,35 +84,6 @@ def _build_packed_targets(
     packed_indices = cu_padded[:-1].unsqueeze(1) + token_offsets
     targets[packed_indices[attention_mask]] = sequences[attention_mask]
     return targets.unsqueeze(0)
-
-
-def _fused_lm_head_output_processor(**kwargs):
-    """GPTModel ``output_processor`` hook for the fused LM-head log-prob path.
-
-    Skips the output-layer matmul (so the [S, B, vocab//TP] logits are never
-    built), returns the decoder hidden states in [b, s, h] layout (the same
-    layout the default logits path returns), and stashes the resolved
-    output-layer weight into the caller-provided ``context`` dict so the fused
-    log-prob / entropy can run downstream with it.
-    """
-    hidden_states = kwargs["hidden_states"]
-    output_layer = kwargs["output_layer"]
-    ctx = kwargs.get("context")
-    if ctx is not None:
-        output_weight = kwargs.get("output_weight")
-        ctx["lm_head_weight"] = output_weight if output_weight is not None else output_layer.weight
-    # With sequence parallelism the decoder hidden states are sharded along the
-    # sequence dim; the ColumnParallelLinear output layer all-gathers them before
-    # projecting (megatron tensor_parallel/layers.py). We skip that layer, so
-    # replicate the gather here. tensor_parallel_output_grad=True makes the
-    # backward reduce-scatter the hidden grad across TP ranks — exactly the sum
-    # of each rank's vocab-slice grad_hidden that the fused op produces.
-    if getattr(output_layer, "sequence_parallel", False):
-        from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
-
-        hidden_states = gather_from_sequence_parallel_region(hidden_states, tensor_parallel_output_grad=True)
-    # [s, b, h] -> [b, s, h], matching `logits.transpose(0, 1)` in the default path.
-    return hidden_states.transpose(0, 1).contiguous()
 
 
 class MegatronModelWrapper:
@@ -343,12 +318,13 @@ class MegatronModelWrapper:
                 # (e.g. PPO reference logprobs) at long context would still
                 # materialize the full [B, S, vocab//TP] logits and OOM.
                 _op_ctx: dict = {}
-                outputs = model(
+                outputs = call_model_with_fused_lm_head(
+                    model,
                     new_sequences,
                     new_position_ids,
                     to_te_attention_mask(new_attention_mask),
                     packed_seq_params=packed_seq_params,
-                    output_processor=_fused_lm_head_output_processor,
+                    output_processor=fused_lm_head_output_processor,
                     output_processor_context=_op_ctx,
                     **vlm_inputs,
                 )
@@ -800,12 +776,13 @@ class MegatronModelWrapper:
                 # output_processor returns decoder hidden states (not logits) and
                 # stashes the LM-head weight; loss_func then fuses the projection.
                 _op_ctx: dict = {}
-                outputs = model(
+                outputs = call_model_with_fused_lm_head(
+                    model,
                     new_sequences,
                     new_position_ids,
                     to_te_attention_mask(new_attention_mask),
                     packed_seq_params=packed_seq_params,
-                    output_processor=_fused_lm_head_output_processor,
+                    output_processor=fused_lm_head_output_processor,
                     output_processor_context=_op_ctx,
                     **vlm_inputs,
                 )

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -9,6 +9,10 @@ from megatron.core.distributed import finalize_model_grads
 from megatron.core.pipeline_parallel import get_forward_backward_func
 from omegaconf import OmegaConf
 
+from skyrl.backends.skyrl_train.distributed.megatron.fused_lm_head import (
+    call_model_with_fused_lm_head,
+    fused_lm_head_output_processor,
+)
 from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
     get_model_config,
     make_batch_generator,
@@ -145,35 +149,6 @@ def _copy_tensor_tree_to_device(value: Any, device: int) -> Any:
 
 def _copy_tensor_dict_to_device(batch: Dict[str, Any], device: int) -> Dict[str, Any]:
     return {key: _copy_tensor_tree_to_device(value, device) for key, value in batch.items()}
-
-
-def _fused_lm_head_output_processor(**kwargs):
-    """GPTModel ``output_processor`` hook for the fused LM-head log-prob path.
-
-    Skips the output-layer matmul (so the [S, B, vocab//TP] logits are never
-    built), returns the decoder hidden states in [b, s, h] layout (the same
-    layout the default logits path returns), and stashes the resolved
-    output-layer weight into the caller-provided ``context`` dict so the fused
-    log-prob / entropy can run downstream with it.
-    """
-    hidden_states = kwargs["hidden_states"]
-    output_layer = kwargs["output_layer"]
-    ctx = kwargs.get("context")
-    if ctx is not None:
-        output_weight = kwargs.get("output_weight")
-        ctx["lm_head_weight"] = output_weight if output_weight is not None else output_layer.weight
-    # With sequence parallelism the decoder hidden states are sharded along the
-    # sequence dim; the ColumnParallelLinear output layer all-gathers them before
-    # projecting (megatron tensor_parallel/layers.py). We skip that layer, so
-    # replicate the gather here. tensor_parallel_output_grad=True makes the
-    # backward reduce-scatter the hidden grad across TP ranks — exactly the sum
-    # of each rank's vocab-slice grad_hidden that the fused op produces.
-    if getattr(output_layer, "sequence_parallel", False):
-        from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
-
-        hidden_states = gather_from_sequence_parallel_region(hidden_states, tensor_parallel_output_grad=True)
-    # [s, b, h] -> [b, s, h], matching `logits.transpose(0, 1)` in the default path.
-    return hidden_states.transpose(0, 1).contiguous()
 
 
 class MegatronModelWrapper:
@@ -468,12 +443,13 @@ class MegatronModelWrapper:
                 # (e.g. PPO reference logprobs) at long context would still
                 # materialize the full [B, S, vocab//TP] logits and OOM.
                 _op_ctx: dict = {}
-                outputs = model(
+                outputs = call_model_with_fused_lm_head(
+                    model,
                     new_sequences,
                     new_position_ids,
                     to_te_attention_mask(new_attention_mask),
                     packed_seq_params=packed_seq_params,
-                    output_processor=_fused_lm_head_output_processor,
+                    output_processor=fused_lm_head_output_processor,
                     output_processor_context=_op_ctx,
                     **model_replay_kwargs,
                     **vlm_inputs,
@@ -1127,12 +1103,13 @@ class MegatronModelWrapper:
                     # output_processor returns decoder hidden states (not logits) and
                     # stashes the LM-head weight; loss_func then fuses the projection.
                     _op_ctx: dict = {}
-                    outputs = model(
+                    outputs = call_model_with_fused_lm_head(
+                        model,
                         new_sequences,
                         new_position_ids,
                         to_te_attention_mask(new_attention_mask),
                         packed_seq_params=packed_seq_params,
-                        output_processor=_fused_lm_head_output_processor,
+                        output_processor=fused_lm_head_output_processor,
                         output_processor_context=_op_ctx,
                         **model_replay_kwargs,
                         **vlm_inputs,

--- a/tests/backends/skyrl_train/distributed/test_fused_lm_head.py
+++ b/tests/backends/skyrl_train/distributed/test_fused_lm_head.py
@@ -1,0 +1,228 @@
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from skyrl.backends.skyrl_train.distributed.megatron.fused_lm_head import (
+    call_model_with_fused_lm_head,
+    fused_lm_head_output_processor,
+)
+
+
+@pytest.fixture
+def hybrid_model_type(monkeypatch):
+    megatron = types.ModuleType("megatron")
+    core = types.ModuleType("megatron.core")
+    fp8_utils = types.ModuleType("megatron.core.fp8_utils")
+    models = types.ModuleType("megatron.core.models")
+    hybrid = types.ModuleType("megatron.core.models.hybrid")
+    hybrid_model = types.ModuleType("megatron.core.models.hybrid.hybrid_model")
+    pipeline_parallel = types.ModuleType("megatron.core.pipeline_parallel")
+    activation_offload = types.ModuleType("megatron.core.pipeline_parallel.fine_grained_activation_offload")
+    utils = types.ModuleType("megatron.core.utils")
+
+    class HybridModel:
+        def forward(self): ...
+
+    class OffloadInterface:
+        @staticmethod
+        def mark_not_offloadable(parameter):
+            parameter.offloading_activation = False
+
+    hybrid_model.HybridModel = HybridModel
+    activation_offload.FineGrainedActivationOffloadingInterface = OffloadInterface
+    fp8_utils.is_mxfp8_output_proj_active = lambda config: config.mxfp8_output_projection
+    utils.unwrap_model = lambda model: model.module
+    megatron.core = core
+    core.models = models
+    core.pipeline_parallel = pipeline_parallel
+    models.hybrid = hybrid
+    hybrid.hybrid_model = hybrid_model
+    pipeline_parallel.fine_grained_activation_offload = activation_offload
+    monkeypatch.setitem(sys.modules, "megatron", megatron)
+    monkeypatch.setitem(sys.modules, "megatron.core", core)
+    monkeypatch.setitem(sys.modules, "megatron.core.fp8_utils", fp8_utils)
+    monkeypatch.setitem(sys.modules, "megatron.core.models", models)
+    monkeypatch.setitem(sys.modules, "megatron.core.models.hybrid", hybrid)
+    monkeypatch.setitem(sys.modules, "megatron.core.models.hybrid.hybrid_model", hybrid_model)
+    monkeypatch.setitem(sys.modules, "megatron.core.pipeline_parallel", pipeline_parallel)
+    monkeypatch.setitem(
+        sys.modules,
+        "megatron.core.pipeline_parallel.fine_grained_activation_offload",
+        activation_offload,
+    )
+    monkeypatch.setitem(sys.modules, "megatron.core.utils", utils)
+    return HybridModel
+
+
+def _make_hybrid(
+    hybrid_model_type,
+    *,
+    post_process=True,
+    mxfp8_output_projection=False,
+    use_mup=False,
+    fine_grained_activation_offloading=False,
+    mtp_num_layers=None,
+):
+    model = hybrid_model_type()
+    model.post_process = post_process
+    model.config = SimpleNamespace(
+        fine_grained_activation_offloading=fine_grained_activation_offloading,
+        mtp_num_layers=mtp_num_layers,
+        mxfp8_output_projection=mxfp8_output_projection,
+        use_mup=use_mup,
+    )
+    model.mtp_process = mtp_num_layers is not None
+    model.share_embeddings_and_output_weights = False
+    output_parameter = SimpleNamespace(offloading_activation=True)
+    model.output_layer = SimpleNamespace(weight="lm-head-weight", parameters=lambda: iter((output_parameter,)))
+    return model
+
+
+def test_hybrid_processes_hidden_states_and_restores_post_process(hybrid_model_type):
+    hybrid = _make_hybrid(hybrid_model_type, fine_grained_activation_offloading=True)
+    hybrid.share_embeddings_and_output_weights = True
+    hybrid.shared_embedding_or_output_weight = Mock(return_value="shared-weight")
+    wrapped_model = Mock(module=hybrid, side_effect=lambda *_args, **_kwargs: "hidden-states")
+    processor = Mock(return_value="processed")
+
+    output = call_model_with_fused_lm_head(
+        wrapped_model,
+        "input",
+        output_processor=processor,
+        output_processor_context={},
+        packed_seq_params="packed",
+    )
+
+    assert output == "processed"
+    assert hybrid.post_process is True
+    assert next(hybrid.output_layer.parameters()).offloading_activation is False
+    wrapped_model.assert_called_once_with("input", packed_seq_params="packed")
+    processor.assert_called_once_with(
+        hidden_states="hidden-states",
+        output_layer=hybrid.output_layer,
+        output_weight="shared-weight",
+        context={},
+    )
+
+
+def test_hybrid_pipeline_stage_skips_output_processor(hybrid_model_type):
+    hybrid = _make_hybrid(hybrid_model_type, post_process=False)
+    wrapped_model = Mock(module=hybrid, return_value="pipeline-hidden-states")
+    processor = Mock()
+
+    output = call_model_with_fused_lm_head(
+        wrapped_model,
+        "input",
+        output_processor=processor,
+        output_processor_context={},
+    )
+
+    assert output == "pipeline-hidden-states"
+    wrapped_model.assert_called_once_with("input")
+    processor.assert_not_called()
+
+
+def test_native_model_uses_output_processor_hook(hybrid_model_type):
+    class NativeInnerModel:
+        config = SimpleNamespace(mxfp8_output_projection=False, use_mup=False)
+
+        def forward(self, *, output_processor=None, output_processor_context=None): ...
+
+    processor = Mock()
+    context = {}
+    model = Mock(module=NativeInnerModel(), return_value="native-output")
+
+    output = call_model_with_fused_lm_head(
+        model,
+        "input",
+        output_processor=processor,
+        output_processor_context=context,
+    )
+
+    assert output == "native-output"
+    model.assert_called_once_with(
+        "input",
+        output_processor=processor,
+        output_processor_context=context,
+    )
+
+
+def test_hybrid_restores_post_process_when_forward_fails(hybrid_model_type):
+    hybrid = _make_hybrid(hybrid_model_type)
+    wrapped_model = Mock(module=hybrid, side_effect=RuntimeError("forward failed"))
+
+    with pytest.raises(RuntimeError, match="forward failed"):
+        call_model_with_fused_lm_head(
+            wrapped_model,
+            "input",
+            output_processor=Mock(),
+            output_processor_context={},
+        )
+
+    assert hybrid.post_process is True
+
+
+@pytest.mark.parametrize(
+    "mxfp8,use_mup,mtp_num_layers,match",
+    [
+        (True, False, None, "MXFP8"),
+        (False, True, None, "MuP"),
+        (False, False, 1, "MTP"),
+    ],
+)
+def test_hybrid_rejects_unsupported_output_paths(hybrid_model_type, mxfp8, use_mup, mtp_num_layers, match):
+    hybrid = _make_hybrid(
+        hybrid_model_type,
+        mxfp8_output_projection=mxfp8,
+        use_mup=use_mup,
+        mtp_num_layers=mtp_num_layers,
+    )
+    wrapped_model = Mock(module=hybrid)
+
+    with pytest.raises(NotImplementedError, match=match):
+        call_model_with_fused_lm_head(
+            wrapped_model,
+            "input",
+            output_processor=Mock(),
+            output_processor_context={},
+        )
+    wrapped_model.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "sequence_parallel,allreduce_dgrad",
+    [(True, False), (False, True)],
+)
+def test_fused_lm_head_uses_tensor_parallel_grad_path(monkeypatch, sequence_parallel, allreduce_dgrad):
+    tensor_parallel = types.ModuleType("megatron.core.tensor_parallel")
+    gather = Mock(side_effect=lambda tensor, **_kwargs: tensor)
+    copy = Mock(side_effect=lambda tensor, **_kwargs: tensor)
+    tensor_parallel.gather_from_sequence_parallel_region = gather
+    tensor_parallel.copy_to_tensor_model_parallel_region = copy
+    monkeypatch.setitem(sys.modules, "megatron.core.tensor_parallel", tensor_parallel)
+
+    hidden_states = torch.ones((2, 1, 3))
+    output_layer = SimpleNamespace(
+        allreduce_dgrad=allreduce_dgrad,
+        sequence_parallel=sequence_parallel,
+        tp_group="tp-group",
+        weight=torch.ones(1),
+    )
+
+    output = fused_lm_head_output_processor(hidden_states=hidden_states, output_layer=output_layer, context={})
+
+    assert torch.equal(output, hidden_states.transpose(0, 1))
+    if sequence_parallel:
+        gather.assert_called_once_with(
+            hidden_states,
+            tensor_parallel_output_grad=True,
+            group="tp-group",
+        )
+        copy.assert_not_called()
+    else:
+        copy.assert_called_once_with(hidden_states, group="tp-group")
+        gather.assert_not_called()

--- a/tests/backends/skyrl_train/distributed/test_fused_lm_head.py
+++ b/tests/backends/skyrl_train/distributed/test_fused_lm_head.py
@@ -214,8 +214,9 @@ def test_fused_lm_head_uses_tensor_parallel_grad_path(monkeypatch, sequence_para
     )
 
     output = fused_lm_head_output_processor(hidden_states=hidden_states, output_layer=output_layer, context={})
+    transposed_hidden_states = hidden_states.transpose(0, 1).contiguous()
 
-    assert torch.equal(output, hidden_states.transpose(0, 1))
+    assert torch.equal(output, transposed_hidden_states)
     if sequence_parallel:
         gather.assert_called_once_with(
             hidden_states,
@@ -224,5 +225,41 @@ def test_fused_lm_head_uses_tensor_parallel_grad_path(monkeypatch, sequence_para
         )
         copy.assert_not_called()
     else:
-        copy.assert_called_once_with(hidden_states, group="tp-group")
+        copy.assert_called_once()
+        assert torch.equal(copy.call_args.args[0], transposed_hidden_states)
+        assert copy.call_args.args[0].is_contiguous()
+        assert copy.call_args.kwargs == {"group": "tp-group"}
         gather.assert_not_called()
+
+
+def test_fused_lm_head_allreduce_dgrad_receives_contiguous_gradient(monkeypatch):
+    tensor_parallel = types.ModuleType("megatron.core.tensor_parallel")
+    backward_state = {}
+
+    class CopyToTensorModelParallelRegion(torch.autograd.Function):
+        @staticmethod
+        def forward(_ctx, tensor):
+            return tensor
+
+        @staticmethod
+        def backward(_ctx, grad_output):
+            backward_state["is_contiguous"] = grad_output.is_contiguous()
+            return grad_output
+
+    def copy_to_tensor_model_parallel_region(tensor, group=None):
+        assert group == "tp-group"
+        return CopyToTensorModelParallelRegion.apply(tensor)
+
+    tensor_parallel.copy_to_tensor_model_parallel_region = copy_to_tensor_model_parallel_region
+    monkeypatch.setitem(sys.modules, "megatron.core.tensor_parallel", tensor_parallel)
+
+    hidden_states = torch.ones((2, 1, 3), requires_grad=True)
+    output_layer = SimpleNamespace(
+        allreduce_dgrad=True,
+        sequence_parallel=False,
+        tp_group="tp-group",
+        weight=torch.ones(1),
+    )
+
+    output = fused_lm_head_output_processor(hidden_states=hidden_states, output_layer=output_layer, context={})
+    output.backward(torch.randn_like(output))


### PR DESCRIPTION
## Problem

The fused LM-head path introduced in #1841 passes `output_processor` and `output_processor_context` to the Megatron model. This works for `GPTModel`, whose `forward` method exposes that hook, but Nemotron-3 uses Megatron's `HybridModel`, which does not.

As a result, enabling `trainer.fused_lm_head_logprob` for a Nemotron-3 policy or reference model fails on the first fused forward pass, before training begins.

## Reproduction

Prepare the GSM8K data as described in [`examples/train/nemotron_3/README.md`](https://github.com/NovaSky-AI/SkyRL/tree/main/examples/train/nemotron_3), then run the existing 8-GPU Nemotron-3 example with fused LM-head log-probs enabled:

```bash
bash examples/train/nemotron_3/run_nemotron_3_nano_4b_gsm8k.sh \
  trainer.fused_lm_head_logprob=true
```

On `main` before this fix, the failure terminates with:

```text
Traceback (most recent call last):
  File ".../skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py", line 803, in forward_step
    outputs = model(
  File ".../torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File ".../torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
TypeError: HybridModel.forward() got an unexpected keyword argument 'output_processor'
```

Ray and launcher frames above this traceback tail vary by environment; the `HybridModel.forward` error is the underlying failure.

## Fix

This PR adds a compatibility helper for fused LM-head forwards:

- Models with a native `output_processor` parameter retain the existing `GPTModel` path.
- On the final pipeline stage, `HybridModel` temporarily disables `post_process` to return decoder hidden states, restores it even if forward fails, and invokes the same fused output processor with the model's output layer.
- Intermediate pipeline stages continue returning hidden states unchanged.
- The skipped `ColumnParallelLinear` behavior is preserved for sequence-parallel gathers and non-sequence-parallel input-gradient reduction.
- Fine-grained activation offloading still marks output-layer parameters as non-offloadable before `post_process` changes.

MXFP8 output projection, MuP output scaling, and HybridModel MTP remain explicit unsupported cases because bypassing their normal output paths would change semantics.

## Why this fixes the bug

The fused loss needs decoder hidden states and the LM-head weight, not materialized vocabulary logits. `GPTModel` already exposes those through its output-processor hook. The compatibility path obtains the same inputs from `HybridModel` without passing unsupported kwargs or monkey-patching Megatron, then reuses the existing fused processor. The default non-fused path is unchanged.

## Validation

- `uv run --isolated --extra dev --extra ray pytest -q tests/backends/skyrl_train/distributed/test_fused_lm_head.py` — 9 passed
- targeted pre-commit hooks on all changed files — Ruff, Black, and secret scanning passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Megatron forward/post_process and tensor-parallel gradient paths for fused log-probs; incorrect handling could break Nemotron training or TP correctness, but scope is gated behind fused_lm_head_logprob and covered by new tests.
> 
> **Overview**
> Fixes **`trainer.fused_lm_head_logprob`** for Nemotron-style Megatron **`HybridModel`**, which does not accept `output_processor` on `forward` (unlike `GPTModel`).
> 
> Fused LM-head logic moves into **`fused_lm_head.py`**: **`call_model_with_fused_lm_head`** routes native models through the existing hook and, on the last pipeline stage, temporarily turns off **`post_process`** so **`HybridModel`** returns decoder hidden states, then runs the shared **`fused_lm_head_output_processor`** (LM-head weight in context, no full logits). Intermediate PP stages skip the processor; **`post_process`** is restored in a **`finally`** block. The processor now mirrors skipped **`ColumnParallelLinear`** behavior (sequence-parallel gather with **`tp_group`**, **`copy_to_tensor_model_parallel_region`** when **`allreduce_dgrad`**).
> 
> **`MegatronModelWrapper`** inference and training forwards call the helper instead of passing kwargs directly. MXFP8 output projection, MuP, and HybridModel MTP stay explicit **`NotImplementedError`**s. Unit tests cover Hybrid/GPT paths, PP staging, unsupported configs, and TP grad plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 888b7360cd8d2774219d9c359c66b985d20a4d5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->