### PR TITLE
Add bounded-memory training and colocation controls

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -20,7 +20,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 from typing import Any, Dict, List, Optional, Union
 
 import torch
@@ -210,8 +209,6 @@ def offload_megatron_grads_to_cpu(models):
             for _, param in model_chunk.named_parameters():
                 if param.grad is not None:
                     param.grad = param.grad.to("cpu", non_blocking=True)
-    gc.collect()
-    torch.cuda.empty_cache()
 
 
 @torch.no_grad()
@@ -223,8 +220,6 @@ def load_megatron_grads_to_gpu(models):
             for _, param in model_chunk.named_parameters():
                 if param.grad is not None:
                     param.grad = param.grad.to(torch.cuda.current_device(), non_blocking=True)
-    gc.collect()
-    torch.cuda.empty_cache()
 
 
 @torch.no_grad()
@@ -259,8 +254,6 @@ def offload_megatron_model_to_cpu(models):
         else:
             for _, param in model_chunk.named_parameters():
                 param.data = param.data.to("cpu", non_blocking=True)
-    gc.collect()
-    torch.cuda.empty_cache()
 
 
 @torch.no_grad()
@@ -280,8 +273,6 @@ def load_megatron_model_to_gpu(models):
             device_id = torch.cuda.current_device()
             for _, param in model_chunk.named_parameters():
                 param.data = param.data.to(device_id, non_blocking=True)
-    gc.collect()
-    torch.cuda.empty_cache()
 
 
 @torch.no_grad()
@@ -381,8 +372,6 @@ def offload_megatron_optimizer(optimizers):
                 v["exp_avg"] = v["exp_avg"].to("cpu", non_blocking=True)
             if "exp_avg_sq" in v:
                 v["exp_avg_sq"] = v["exp_avg_sq"].to("cpu", non_blocking=True)
-        gc.collect()
-        torch.cuda.empty_cache()
 
 
 @torch.no_grad()
@@ -404,8 +393,6 @@ def load_megatron_optimizer(optimizers):
                     v["exp_avg"] = v["exp_avg"].to(torch.cuda.current_device(), non_blocking=True)
                 if "exp_avg_sq" in v:
                     v["exp_avg_sq"] = v["exp_avg_sq"].to(torch.cuda.current_device(), non_blocking=True)
-        gc.collect()
-        torch.cuda.empty_cache()
 
 
 def preprocess_packed_seqs(

--- a/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
@@ -1410,7 +1410,7 @@ def vocab_parallel_entropy_weighted_sum(
     """Compute ``sum(entropy * weights)`` with bounded temporary memory."""
     resolved_chunk_size = _resolve_vocab_entropy_chunk_size(vocab_parallel_logits, chunk_size, chunk_memory_mb)
     if resolved_chunk_size is None:
-        entropy_tokens = _VocabParallelEntropy.apply(vocab_parallel_logits).squeeze(0)
+        entropy_tokens = _VocabParallelEntropy.apply(vocab_parallel_logits)
         return (entropy_tokens * weights).sum()
 
     # Keep an autograd edge even when every chunk is masked out.
@@ -1421,6 +1421,6 @@ def vocab_parallel_entropy_weighted_sum(
         weight_chunk = weights[start:end]
         if torch.count_nonzero(weight_chunk).item() == 0:
             continue
-        entropy_chunk = _VocabParallelEntropy.apply(vocab_parallel_logits[..., start:end, :]).squeeze(0)
+        entropy_chunk = _VocabParallelEntropy.apply(vocab_parallel_logits[..., start:end, :])
         local_entropy_sum = local_entropy_sum + (entropy_chunk * weight_chunk).sum()
     return local_entropy_sum

--- a/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 import warnings
+from math import prod
 from typing import Any, Optional
 
 import megatron.core.parallel_state as mpu
@@ -1367,7 +1368,10 @@ def _resolve_vocab_entropy_chunk_size(
         return chunk_size if chunk_size < seq_len else None
 
     budget_bytes = int(chunk_memory_mb) * 1024 * 1024
-    bytes_per_token = int(vocab_parallel_logits.shape[-1]) * vocab_parallel_logits.element_size() * peak_factor
+    leading_elements = prod(vocab_parallel_logits.shape[:-2])
+    bytes_per_token = (
+        leading_elements * int(vocab_parallel_logits.shape[-1]) * vocab_parallel_logits.element_size() * peak_factor
+    )
     if bytes_per_token <= 0:
         return None
 

--- a/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
@@ -1001,6 +1001,8 @@ def vocab_parallel_entropy_packed_sequences(
     loss_mask: Optional[torch.Tensor],
     cp_group: Optional[torch.distributed.ProcessGroup],
     sub_seq_lengths: Optional[list[list[int]]] = None,
+    chunk_size: Optional[int] = None,
+    chunk_memory_mb: int = 512,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Compute action-token entropy directly on TP+CP sharded packed logits.
 
@@ -1009,9 +1011,8 @@ def vocab_parallel_entropy_packed_sequences(
         local term is normalized by the global action-token count. Megatron's
         schedule already applies the CP loss scale for two-output loss funcs.
     """
-    entropy_tokens = vocab_parallel_entropy(vocab_parallel_logits).squeeze(0)
-    device = entropy_tokens.device
-    dtype = entropy_tokens.dtype
+    device = vocab_parallel_logits.device
+    dtype = vocab_parallel_logits.dtype
 
     attention_mask = attention_mask.to(device=device, dtype=torch.bool)
     cu_seqlens_padded = cu_seqlens_padded.to(device=device, dtype=torch.long)
@@ -1055,13 +1056,18 @@ def vocab_parallel_entropy_packed_sequences(
         cp_rank_for_token, local_indices = _packed_cp_rank_and_local_indices(
             cu_seqlens_padded, seq_indices, seq_offsets, seq_lens_padded, cp_size
         )
-        local_weights = torch.zeros_like(entropy_tokens)
+        local_weights = torch.zeros((int(vocab_parallel_logits.shape[-2]),), dtype=dtype, device=device)
         current_rank_mask = cp_rank_for_token == cp_rank
         local_weights[local_indices[current_rank_mask]] = packed_weights[current_rank_mask]
     else:
         local_weights = packed_weights
 
-    local_entropy_sum = (entropy_tokens * local_weights).sum()
+    local_entropy_sum = vocab_parallel_entropy_weighted_sum(
+        vocab_parallel_logits,
+        local_weights,
+        chunk_size=chunk_size,
+        chunk_memory_mb=chunk_memory_mb,
+    )
     local_count = local_weights.sum()
     global_count = local_count.detach().clone()
     global_entropy_sum = local_entropy_sum.detach().clone()
@@ -1333,7 +1339,48 @@ class _VocabParallelEntropy(torch.autograd.Function):
         return softmax_logits
 
 
-def vocab_parallel_entropy(vocab_parallel_logits: torch.Tensor) -> torch.Tensor:
+def _floor_power_of_two(value: int) -> int:
+    return 1 << (value.bit_length() - 1)
+
+
+def _resolve_vocab_entropy_chunk_size(
+    vocab_parallel_logits: torch.Tensor,
+    chunk_size: Optional[int],
+    chunk_memory_mb: int,
+    peak_factor: int = 4,
+) -> Optional[int]:
+    """Resolve the sequence chunk size for vocab entropy.
+
+    ``None`` disables chunking. ``0`` uses the runtime vocab shard and dtype to
+    choose a size. Positive values specify the number of tokens per chunk.
+    """
+    if chunk_size is None:
+        return None
+    if chunk_size < 0:
+        raise ValueError(f"chunk_size must be non-negative or None, got {chunk_size}")
+    if chunk_memory_mb <= 0:
+        raise ValueError(f"chunk_memory_mb must be positive, got {chunk_memory_mb}")
+    seq_len = int(vocab_parallel_logits.shape[-2])
+    if seq_len <= 0:
+        return None
+    if chunk_size > 0:
+        return chunk_size if chunk_size < seq_len else None
+
+    budget_bytes = int(chunk_memory_mb) * 1024 * 1024
+    bytes_per_token = int(vocab_parallel_logits.shape[-1]) * vocab_parallel_logits.element_size() * peak_factor
+    if bytes_per_token <= 0:
+        return None
+
+    auto_chunk = max(1, min(seq_len, budget_bytes // bytes_per_token))
+    auto_chunk = _floor_power_of_two(auto_chunk)
+    return auto_chunk if auto_chunk < seq_len else None
+
+
+def vocab_parallel_entropy(
+    vocab_parallel_logits: torch.Tensor,
+    chunk_size: Optional[int] = None,
+    chunk_memory_mb: int = 512,
+) -> torch.Tensor:
     """Compute entropy when the logits are sharded in tp ranks
 
     Args:
@@ -1342,4 +1389,38 @@ def vocab_parallel_entropy(vocab_parallel_logits: torch.Tensor) -> torch.Tensor:
     Returns: (total_nnz,)
 
     """
-    return _VocabParallelEntropy.apply(vocab_parallel_logits)
+    resolved_chunk_size = _resolve_vocab_entropy_chunk_size(vocab_parallel_logits, chunk_size, chunk_memory_mb)
+    if resolved_chunk_size is None:
+        return _VocabParallelEntropy.apply(vocab_parallel_logits)
+
+    entropy_chunks = []
+    seq_len = int(vocab_parallel_logits.shape[-2])
+    for start in range(0, seq_len, resolved_chunk_size):
+        end = min(start + resolved_chunk_size, seq_len)
+        entropy_chunks.append(_VocabParallelEntropy.apply(vocab_parallel_logits[..., start:end, :]))
+    return torch.cat(entropy_chunks, dim=-1)
+
+
+def vocab_parallel_entropy_weighted_sum(
+    vocab_parallel_logits: torch.Tensor,
+    weights: torch.Tensor,
+    chunk_size: Optional[int] = None,
+    chunk_memory_mb: int = 512,
+) -> torch.Tensor:
+    """Compute ``sum(entropy * weights)`` with bounded temporary memory."""
+    resolved_chunk_size = _resolve_vocab_entropy_chunk_size(vocab_parallel_logits, chunk_size, chunk_memory_mb)
+    if resolved_chunk_size is None:
+        entropy_tokens = _VocabParallelEntropy.apply(vocab_parallel_logits).squeeze(0)
+        return (entropy_tokens * weights).sum()
+
+    # Keep an autograd edge even when every chunk is masked out.
+    local_entropy_sum = vocab_parallel_logits[..., :0, :].sum()
+    seq_len = int(vocab_parallel_logits.shape[-2])
+    for start in range(0, seq_len, resolved_chunk_size):
+        end = min(start + resolved_chunk_size, seq_len)
+        weight_chunk = weights[start:end]
+        if torch.count_nonzero(weight_chunk).item() == 0:
+            continue
+        entropy_chunk = _VocabParallelEntropy.apply(vocab_parallel_logits[..., start:end, :]).squeeze(0)
+        local_entropy_sum = local_entropy_sum + (entropy_chunk * weight_chunk).sum()
+    return local_entropy_sum

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -38,6 +38,7 @@ from skyrl.backends.skyrl_train.mtp.soft_ce import (
     shift_mask_for_mtp,
     unpadded_vocab_shard_width,
 )
+from skyrl.backends.skyrl_train.training_batch import TensorList
 from skyrl.backends.skyrl_train.utils.ppo_utils import (
     PolicyLossRegistry,
     compute_approx_kl,
@@ -125,6 +126,23 @@ def _build_packed_valid_mask(
     return mask.unsqueeze(0)
 
 
+def _copy_tensor_tree_to_device(value: Any, device: int) -> Any:
+    """Move all tensors in a nested microbatch to a CUDA device."""
+    if torch.is_tensor(value) or isinstance(value, TensorList):
+        return value.to(device=device, non_blocking=True)
+    if isinstance(value, dict):
+        return {key: _copy_tensor_tree_to_device(item, device) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_copy_tensor_tree_to_device(item, device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_copy_tensor_tree_to_device(item, device) for item in value)
+    return value
+
+
+def _copy_tensor_dict_to_device(batch: Dict[str, Any], device: int) -> Dict[str, Any]:
+    return {key: _copy_tensor_tree_to_device(value, device) for key, value in batch.items()}
+
+
 def _fused_lm_head_output_processor(**kwargs):
     """GPTModel ``output_processor`` hook for the fused LM-head log-prob path.
 
@@ -162,6 +180,7 @@ class MegatronModelWrapper:
         actor_optimizer: Optional[torch.optim.Optimizer] = None,
         policy_loss_fn: Optional[Callable] = None,
         is_vlm: bool = False,
+        cpu_resident_microbatches: bool = False,
     ):
         self.cfg = config
         self.actor_module = actor_module
@@ -169,6 +188,7 @@ class MegatronModelWrapper:
         self.policy_loss_fn = policy_loss_fn
         self.remove_microbatch_padding = self.cfg.remove_microbatch_padding
         self.is_vlm = is_vlm
+        self.cpu_resident_microbatches = cpu_resident_microbatches
         # Fuse the LM-head projection into the chunked log-prob/entropy via the
         # GPTModel output_processor hook (avoids materializing the full
         # [B, S, vocab//TP] logits + its fp32 grad). See model_utils.
@@ -325,6 +345,8 @@ class MegatronModelWrapper:
 
         def forward_step(batch_iter, model):
             batch = next(batch_iter)
+            if self.cpu_resident_microbatches:
+                batch = _copy_tensor_dict_to_device(batch, torch.cuda.current_device())
 
             model_config = get_model_config(model)
             fp8_enabled = is_fp8_enabled(getattr(model_config, "fp8", None))
@@ -793,10 +815,16 @@ class MegatronModelWrapper:
                         loss_mask,
                         mpu.get_context_parallel_group(),
                         sub_seq_lengths=data.get("sub_seq_lengths_list"),
+                        chunk_size=self.cfg.vocab_entropy_chunk_size,
+                        chunk_memory_mb=self.cfg.vocab_entropy_chunk_memory_mb,
                     )
                 else:
                     action_logits = logits[:, -num_actions - 1 : -1, :]
-                    entropy_BS = vocab_parallel_entropy(action_logits)
+                    entropy_BS = vocab_parallel_entropy(
+                        action_logits,
+                        chunk_size=self.cfg.vocab_entropy_chunk_size,
+                        chunk_memory_mb=self.cfg.vocab_entropy_chunk_memory_mb,
+                    )
                     entropy = masked_mean(entropy_BS, loss_mask)
                     entropy_for_loss = entropy
 
@@ -891,6 +919,8 @@ class MegatronModelWrapper:
             # for recover_left_padding and setup_per_microbatch_replay_forward. Especially relevant
             # after this PR https://github.com/NovaSky-AI/SkyRL/pull/1285.
             batch = next(batch_iter)
+            if self.cpu_resident_microbatches:
+                batch = _copy_tensor_dict_to_device(batch, torch.cuda.current_device())
 
             model_config = get_model_config(model)
             fp8_enabled = is_fp8_enabled(getattr(model_config, "fp8", None))

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -180,7 +180,6 @@ class MegatronModelWrapper:
         actor_optimizer: Optional[torch.optim.Optimizer] = None,
         policy_loss_fn: Optional[Callable] = None,
         is_vlm: bool = False,
-        cpu_resident_microbatches: bool = False,
     ):
         self.cfg = config
         self.actor_module = actor_module
@@ -188,7 +187,6 @@ class MegatronModelWrapper:
         self.policy_loss_fn = policy_loss_fn
         self.remove_microbatch_padding = self.cfg.remove_microbatch_padding
         self.is_vlm = is_vlm
-        self.cpu_resident_microbatches = cpu_resident_microbatches
         # Fuse the LM-head projection into the chunked log-prob/entropy via the
         # GPTModel output_processor hook (avoids materializing the full
         # [B, S, vocab//TP] logits + its fp32 grad). See model_utils.
@@ -345,8 +343,9 @@ class MegatronModelWrapper:
 
         def forward_step(batch_iter, model):
             batch = next(batch_iter)
-            if self.cpu_resident_microbatches:
-                batch = _copy_tensor_dict_to_device(batch, torch.cuda.current_device())
+            # Microbatches are held on CPU and transferred just before their forward
+            # step to cap resident input memory (no-op if already on device).
+            batch = _copy_tensor_dict_to_device(batch, torch.cuda.current_device())
 
             model_config = get_model_config(model)
             fp8_enabled = is_fp8_enabled(getattr(model_config, "fp8", None))
@@ -919,8 +918,9 @@ class MegatronModelWrapper:
             # for recover_left_padding and setup_per_microbatch_replay_forward. Especially relevant
             # after this PR https://github.com/NovaSky-AI/SkyRL/pull/1285.
             batch = next(batch_iter)
-            if self.cpu_resident_microbatches:
-                batch = _copy_tensor_dict_to_device(batch, torch.cuda.current_device())
+            # Microbatches are held on CPU and transferred just before their forward
+            # step to cap resident input memory (no-op if already on device).
+            batch = _copy_tensor_dict_to_device(batch, torch.cuda.current_device())
 
             model_config = get_model_config(model)
             fp8_enabled = is_fp8_enabled(getattr(model_config, "fp8", None))

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -650,8 +650,6 @@ class MegatronWorker:
             micro_batches = data.chunk(self.cfg.micro_forward_batch_size_per_gpu)
 
         for micro in micro_batches:
-            if not self.model.cpu_resident_microbatches:
-                micro.to(torch.cuda.current_device())
             attention_mask = micro["attention_mask"]
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 0)
@@ -978,7 +976,6 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             actor_optimizer=self.optimizer,
             policy_loss_fn=self.policy_loss_fn,
             is_vlm=self.is_vlm,
-            cpu_resident_microbatches=self.cfg.policy.megatron_config.cpu_resident_microbatches,
         )
 
         self.empty_cuda_cache = self.cfg.policy.megatron_config.empty_cuda_cache
@@ -1020,8 +1017,6 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         all_loss_fn_outputs: List[Dict[str, Any]] = []
 
         self._drop_pixel_values_on_non_first_pp_stage(data)
-        if not self.cfg.policy.megatron_config.cpu_resident_microbatches:
-            data.to(torch.cuda.current_device())
 
         # Build micro-batch dicts expected by forward_backward_mini_batch
         micro_buffer = []
@@ -1130,8 +1125,6 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         all_metrics = defaultdict(list)
 
         self._drop_pixel_values_on_non_first_pp_stage(data)
-        if not self.cfg.policy.megatron_config.cpu_resident_microbatches:
-            data.to(torch.cuda.current_device())
 
         use_token_batching = self.cfg.max_tokens_per_microbatch > 0
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -643,7 +643,6 @@ class MegatronWorker:
 
         # Build micro-batch dicts expected by policy.forward_mini_batch
         micro_dicts = []
-        device = torch.cuda.current_device()
 
         if microbatch_iterator is not None:
             micro_batches = microbatch_iterator
@@ -651,7 +650,8 @@ class MegatronWorker:
             micro_batches = data.chunk(self.cfg.micro_forward_batch_size_per_gpu)
 
         for micro in micro_batches:
-            micro.to(device)
+            if not self.model.cpu_resident_microbatches:
+                micro.to(torch.cuda.current_device())
             attention_mask = micro["attention_mask"]
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 0)
@@ -978,6 +978,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             actor_optimizer=self.optimizer,
             policy_loss_fn=self.policy_loss_fn,
             is_vlm=self.is_vlm,
+            cpu_resident_microbatches=self.cfg.policy.megatron_config.cpu_resident_microbatches,
         )
 
         self.empty_cuda_cache = self.cfg.policy.megatron_config.empty_cuda_cache
@@ -1019,8 +1020,8 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         all_loss_fn_outputs: List[Dict[str, Any]] = []
 
         self._drop_pixel_values_on_non_first_pp_stage(data)
-        # Move data to GPU
-        data.to(torch.cuda.current_device())
+        if not self.cfg.policy.megatron_config.cpu_resident_microbatches:
+            data.to(torch.cuda.current_device())
 
         # Build micro-batch dicts expected by forward_backward_mini_batch
         micro_buffer = []
@@ -1129,8 +1130,8 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         all_metrics = defaultdict(list)
 
         self._drop_pixel_values_on_non_first_pp_stage(data)
-        # Move data to GPU
-        data.to(torch.cuda.current_device())
+        if not self.cfg.policy.megatron_config.cpu_resident_microbatches:
+            data.to(torch.cuda.current_device())
 
         use_token_batching = self.cfg.max_tokens_per_microbatch > 0
 

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -244,8 +244,9 @@ class Worker(DistributedTorchRayActor):
         raise NotImplementedError()
 
     def empty_cache(self) -> None:
-        """Empty GPU memory cache on Worker's CUDA device"""
-        torch.cuda.empty_cache()
+        """Empty this worker's CUDA allocator cache."""
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def _set_expandable_segments(self, enabled: bool) -> None:
         """Toggle PyTorch's CUDA ``expandable_segments`` allocator at runtime.
@@ -567,6 +568,9 @@ class PPORayActorGroup:
         self.colocate_all = colocate_all
         self.sequence_parallel_size = sequence_parallel_size
         self.record_memory = record_memory
+        self._pg = pg
+        self._num_gpus_per_actor = num_gpus_per_actor
+        self._last_dp_size: Optional[int] = None
         self._initiate_actors(pg, num_gpus_per_actor)
 
     def _initiate_actors(self, pg: Optional[ResolvedPlacementGroup], num_gpus_per_actor: float):
@@ -678,6 +682,8 @@ class PPORayActorGroup:
         ray.get([actor.init_worker_process_group.remote() for actor in self._actor_handlers])
         logger.info("Initialized process group for RayActorGroup")
         self.actor_infos = [ActorInfo(actor, ray.get(actor.get_mesh_rank.remote())) for actor in self._actor_handlers]
+        if self.actor_infos:
+            self._last_dp_size = self.actor_infos[0].rank.dp_size
         logger.info(f"Mesh Ranks: {[actor_info.rank for actor_info in self.actor_infos]}")
 
     def async_init_model(
@@ -692,6 +698,15 @@ class PPORayActorGroup:
             A list of ray object refs.
         """
         return [actor.init_model.remote(*args, **kwargs) for actor in self._actor_handlers]
+
+    def get_dp_size(self) -> int:
+        """Return the current or last-known data-parallel size for this actor group."""
+        if self.actor_infos:
+            self._last_dp_size = self.actor_infos[0].rank.dp_size
+            return self._last_dp_size
+        if self._last_dp_size is None:
+            raise RuntimeError("Cannot determine data-parallel size before actor group initialization.")
+        return self._last_dp_size
 
     def offload_to_cpu(self, nonblocking=False, offload_optimizer=True, offload_model=True):
         """Offload all worker state to CPU.

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -568,8 +568,6 @@ class PPORayActorGroup:
         self.colocate_all = colocate_all
         self.sequence_parallel_size = sequence_parallel_size
         self.record_memory = record_memory
-        self._pg = pg
-        self._num_gpus_per_actor = num_gpus_per_actor
         self._last_dp_size: Optional[int] = None
         self._initiate_actors(pg, num_gpus_per_actor)
 

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -110,16 +110,16 @@ class WorkerDispatch:
         """Get LCM of all models' dp_size."""
         import math
 
-        dp_size = self._actor_groups["policy"].actor_infos[0].rank.dp_size
+        dp_size = self._actor_groups["policy"].get_dp_size()
         if "critic" in self._actor_groups:
-            dp_size = math.lcm(dp_size, self._actor_groups["critic"].actor_infos[0].rank.dp_size)
+            dp_size = math.lcm(dp_size, self._actor_groups["critic"].get_dp_size())
         if "ref" in self._actor_groups:
-            dp_size = math.lcm(dp_size, self._actor_groups["ref"].actor_infos[0].rank.dp_size)
+            dp_size = math.lcm(dp_size, self._actor_groups["ref"].get_dp_size())
         return dp_size
 
     def dp_size(self, model: str) -> int:
         """Return the data-parallel size for ``model`` (e.g. "policy")."""
-        return self._actor_groups[model].actor_infos[0].rank.dp_size
+        return self._actor_groups[model].get_dp_size()
 
     def _should_manage_offload(self, model: str) -> bool:
         """Check if we need to manage offload for this model."""
@@ -137,6 +137,11 @@ class WorkerDispatch:
             return [m for m in ["policy", "ref"] if m in self._actor_groups]
         return [model]
 
+    def _offload_inactive_model(self, model: str) -> None:
+        """Offload an inactive colocated model to CPU."""
+        self._actor_groups[model].offload_to_cpu()
+        self._gpu_state[model] = GPUState()
+
     def _ensure_on_gpu(self, model: str, need_optimizer: bool = True, need_model: bool = True) -> None:
         """Ensure model is on GPU, offloading others in same colocation group if needed."""
         if not self._should_manage_offload(model):
@@ -147,26 +152,27 @@ class WorkerDispatch:
 
         group = self._get_colocation_group(model)
 
-        # Offload others in the same colocation group
+        # Offload others in the same colocation group.
         for other in group:
             if other != model and other in self._actor_groups:
                 state = self._gpu_state[other]
                 if state.model_on_gpu or state.optimizer_on_gpu:
-                    self._actor_groups[other].offload_to_cpu()
-                    self._gpu_state[other] = GPUState()
+                    self._offload_inactive_model(other)
 
-        # Backload requested model
+        # Reload only missing state; model weights may remain resident while the
+        # optimizer is offloaded.
         state = self._gpu_state[model]
-        needs_backload = (need_model and not state.model_on_gpu) or (need_optimizer and not state.optimizer_on_gpu)
+        backload_model = need_model and not state.model_on_gpu
+        backload_optimizer = need_optimizer and not state.optimizer_on_gpu
 
-        if needs_backload:
+        if backload_model or backload_optimizer:
             self._actor_groups[model].backload_to_gpu(
-                backload_optimizer=need_optimizer,
-                backload_model=need_model,
+                backload_optimizer=backload_optimizer,
+                backload_model=backload_model,
             )
-            if need_model:
+            if backload_model:
                 self._gpu_state[model].model_on_gpu = True
-            if need_optimizer:
+            if backload_optimizer:
                 self._gpu_state[model].optimizer_on_gpu = True
 
     def _offload(self, model: str, offload_optimizer: bool = True, offload_model: bool = True) -> None:
@@ -516,8 +522,7 @@ class WorkerDispatch:
                 if other != model and other in self._actor_groups:
                     state = self._gpu_state[other]
                     if state.model_on_gpu or state.optimizer_on_gpu:
-                        self._actor_groups[other].offload_to_cpu()
-                        self._gpu_state[other] = GPUState()
+                        self._offload_inactive_model(other)
 
         kwargs = {"model_path": model_path}
         if num_training_steps is not None:

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -372,6 +372,8 @@ class MegatronConfig(BaseConfig):
         default_factory=lambda: copy.deepcopy(DEFAULT_TRANSFORMER_CONFIG_KWARGS)
     )
     empty_cuda_cache: Optional[bool] = True
+    cpu_resident_microbatches: bool = False
+    """Keep policy batches on CPU and transfer each microbatch before its forward step."""
     model_config_kwargs: dict = field(default_factory=dict)
     dist_ckpt_optim_fully_reshardable: bool = False
     freeze_moe_router: bool = False
@@ -999,6 +1001,12 @@ class TrainerConfig(BaseConfig):
     This lowers peak GPU memory at the cost of ~2x wall-clock time.
     ``None`` disables chunking (Megatron backend only; FSDP requires a positive int).
     See https://github.com/NovaSky-AI/SkyRL/pull/1610 for more details."""
+    vocab_entropy_chunk_size: Optional[int] = 0
+    """Chunk size along the sequence dimension when computing Megatron vocab entropy.
+    ``0`` auto-sizes from the local vocab shard size and ``vocab_entropy_chunk_memory_mb``.
+    ``None`` disables chunking."""
+    vocab_entropy_chunk_memory_mb: int = 512
+    """Approximate per-chunk temporary memory budget for auto-sized Megatron vocab entropy chunks."""
     fused_lm_head_logprob: bool = False
     """Megatron only. Fuse the LM-head projection into log-prob / entropy
     computation so the full ``[B, S, vocab//TP]`` logits tensor is never
@@ -1049,6 +1057,24 @@ class TrainerConfig(BaseConfig):
             raise ValueError(
                 "fused_lm_head_logprob_backend must be 'torch' or 'triton', "
                 f"got {self.fused_lm_head_logprob_backend!r}."
+            )
+        if self.vocab_entropy_chunk_size is not None and (
+            isinstance(self.vocab_entropy_chunk_size, bool)
+            or not isinstance(self.vocab_entropy_chunk_size, int)
+            or self.vocab_entropy_chunk_size < 0
+        ):
+            raise ValueError(
+                "vocab_entropy_chunk_size must be a non-negative integer or None, "
+                f"got {self.vocab_entropy_chunk_size!r}."
+            )
+        if (
+            isinstance(self.vocab_entropy_chunk_memory_mb, bool)
+            or not isinstance(self.vocab_entropy_chunk_memory_mb, int)
+            or self.vocab_entropy_chunk_memory_mb <= 0
+        ):
+            raise ValueError(
+                "vocab_entropy_chunk_memory_mb must be a positive integer, "
+                f"got {self.vocab_entropy_chunk_memory_mb!r}."
             )
 
 

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -372,8 +372,6 @@ class MegatronConfig(BaseConfig):
         default_factory=lambda: copy.deepcopy(DEFAULT_TRANSFORMER_CONFIG_KWARGS)
     )
     empty_cuda_cache: Optional[bool] = True
-    cpu_resident_microbatches: bool = False
-    """Keep policy batches on CPU and transfer each microbatch before its forward step."""
     model_config_kwargs: dict = field(default_factory=dict)
     dist_ckpt_optim_fully_reshardable: bool = False
     freeze_moe_router: bool = False

--- a/tests/backends/skyrl_train/distributed/test_vocab_entropy_chunking.py
+++ b/tests/backends/skyrl_train/distributed/test_vocab_entropy_chunking.py
@@ -62,6 +62,18 @@ def test_vocab_entropy_weighted_sum_chunking_matches_unchunked(monkeypatch):
     torch.testing.assert_close(actual, expected)
 
 
+@pytest.mark.parametrize("logits_shape", [(5, 7), (2, 5, 7)])
+def test_vocab_entropy_weighted_sum_supports_2d_and_batched_logits(monkeypatch, logits_shape):
+    monkeypatch.setattr(model_utils._VocabParallelEntropy, "apply", _local_entropy)
+    logits = torch.randn(*logits_shape, dtype=torch.float64)
+    weights = torch.linspace(0.25, 1.25, logits_shape[-2], dtype=torch.float64)
+    expected = (_local_entropy(logits) * weights).sum()
+
+    for chunk_size in (None, 1, 3):
+        actual = model_utils.vocab_parallel_entropy_weighted_sum(logits, weights, chunk_size=chunk_size)
+        torch.testing.assert_close(actual, expected)
+
+
 def test_vocab_entropy_weighted_sum_all_masked_keeps_zero_gradient(monkeypatch):
     monkeypatch.setattr(model_utils._VocabParallelEntropy, "apply", _local_entropy)
     logits = torch.randn(1, 7, 11, dtype=torch.float64, requires_grad=True)

--- a/tests/backends/skyrl_train/distributed/test_vocab_entropy_chunking.py
+++ b/tests/backends/skyrl_train/distributed/test_vocab_entropy_chunking.py
@@ -1,0 +1,86 @@
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+
+def _import_model_utils_without_megatron_extensions():
+    """Import the pure tensor helpers without loading optional TE binaries."""
+    module_names = ("megatron", "megatron.core", "megatron.core.parallel_state")
+    saved_modules = {name: sys.modules.get(name) for name in module_names}
+    megatron = ModuleType("megatron")
+    megatron.__path__ = []
+    core = ModuleType("megatron.core")
+    core.__path__ = []
+    parallel_state = ModuleType("megatron.core.parallel_state")
+    try:
+        sys.modules["megatron"] = megatron
+        sys.modules["megatron.core"] = core
+        sys.modules["megatron.core.parallel_state"] = parallel_state
+        return importlib.import_module("skyrl.backends.skyrl_train.distributed.megatron.model_utils")
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+model_utils = _import_model_utils_without_megatron_extensions()
+
+
+def _local_entropy(logits):
+    log_probs = torch.log_softmax(logits, dim=-1)
+    return -(log_probs.exp() * log_probs).sum(dim=-1)
+
+
+def test_vocab_entropy_chunking_matches_unchunked_output_and_gradient(monkeypatch):
+    monkeypatch.setattr(model_utils._VocabParallelEntropy, "apply", _local_entropy)
+    torch.manual_seed(3)
+    unchunked_logits = torch.randn(2, 11, 17, dtype=torch.float64, requires_grad=True)
+    chunked_logits = unchunked_logits.detach().clone().requires_grad_(True)
+
+    unchunked = model_utils.vocab_parallel_entropy(unchunked_logits, chunk_size=None)
+    chunked = model_utils.vocab_parallel_entropy(chunked_logits, chunk_size=3)
+    unchunked.sum().backward()
+    chunked.sum().backward()
+
+    torch.testing.assert_close(chunked, unchunked)
+    torch.testing.assert_close(chunked_logits.grad, unchunked_logits.grad)
+
+
+def test_vocab_entropy_weighted_sum_chunking_matches_unchunked(monkeypatch):
+    monkeypatch.setattr(model_utils._VocabParallelEntropy, "apply", _local_entropy)
+    logits = torch.randn(1, 9, 13, dtype=torch.float64)
+    weights = torch.tensor([1.0, 0.0, 0.5, 0.0, 2.0, 1.0, 0.0, 0.25, 0.0], dtype=torch.float64)
+
+    expected = model_utils.vocab_parallel_entropy_weighted_sum(logits, weights, chunk_size=None)
+    actual = model_utils.vocab_parallel_entropy_weighted_sum(logits, weights, chunk_size=2)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_vocab_entropy_weighted_sum_all_masked_keeps_zero_gradient(monkeypatch):
+    monkeypatch.setattr(model_utils._VocabParallelEntropy, "apply", _local_entropy)
+    logits = torch.randn(1, 7, 11, dtype=torch.float64, requires_grad=True)
+    weights = torch.zeros(7, dtype=torch.float64)
+
+    result = model_utils.vocab_parallel_entropy_weighted_sum(logits, weights, chunk_size=2)
+    result.backward()
+
+    assert result.item() == 0
+    torch.testing.assert_close(logits.grad, torch.zeros_like(logits))
+
+
+def test_vocab_entropy_auto_chunk_respects_memory_budget():
+    logits = torch.empty(1, 10, 65536, dtype=torch.bfloat16)
+
+    assert model_utils._resolve_vocab_entropy_chunk_size(logits, 0, 1) == 2
+
+
+@pytest.mark.parametrize(("chunk_size", "memory_mb"), [(-1, 1), (0, 0)])
+def test_vocab_entropy_chunk_resolver_rejects_invalid_values(chunk_size, memory_mb):
+    with pytest.raises(ValueError):
+        model_utils._resolve_vocab_entropy_chunk_size(torch.empty(1, 4, 8), chunk_size, memory_mb)

--- a/tests/backends/skyrl_train/distributed/test_vocab_entropy_chunking.py
+++ b/tests/backends/skyrl_train/distributed/test_vocab_entropy_chunking.py
@@ -92,6 +92,12 @@ def test_vocab_entropy_auto_chunk_respects_memory_budget():
     assert model_utils._resolve_vocab_entropy_chunk_size(logits, 0, 1) == 2
 
 
+def test_vocab_entropy_auto_chunk_accounts_for_leading_dimensions():
+    logits = torch.empty(2, 2, 10, 65536, dtype=torch.bfloat16)
+
+    assert model_utils._resolve_vocab_entropy_chunk_size(logits, 0, 4) == 2
+
+
 @pytest.mark.parametrize(("chunk_size", "memory_mb"), [(-1, 1), (0, 0)])
 def test_vocab_entropy_chunk_resolver_rejects_invalid_values(chunk_size, memory_mb):
     with pytest.raises(ValueError):

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -13,6 +13,7 @@ from omegaconf import OmegaConf
 from skyrl.train.config.config import (
     BaseConfig,
     SkyRLTrainConfig,
+    TrainerConfig,
     _resolve_class_type,
     build_nested_dataclass,
 )
@@ -126,6 +127,25 @@ def test_cli_overrides_empty_args():
     cfg = SkyRLTrainConfig.from_cli_overrides([])
     assert cfg.trainer.policy.model.path == "Qwen/Qwen2.5-1.5B-Instruct"
     assert cfg.trainer.seed == 42
+
+
+def test_cli_overrides_cpu_resident_megatron_microbatches():
+    cfg = SkyRLTrainConfig.from_cli_overrides(["trainer.policy.megatron_config.cpu_resident_microbatches=true"])
+    assert cfg.trainer.policy.megatron_config.cpu_resident_microbatches is True
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("vocab_entropy_chunk_size", -1),
+        ("vocab_entropy_chunk_size", True),
+        ("vocab_entropy_chunk_memory_mb", 0),
+        ("vocab_entropy_chunk_memory_mb", True),
+    ],
+)
+def test_trainer_config_rejects_invalid_vocab_entropy_chunking(field_name, value):
+    with pytest.raises(ValueError, match=field_name):
+        TrainerConfig(**{field_name: value})
 
 
 def test_cli_overrides_plus_prefix_rejected():

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -129,11 +129,6 @@ def test_cli_overrides_empty_args():
     assert cfg.trainer.seed == 42
 
 
-def test_cli_overrides_cpu_resident_megatron_microbatches():
-    cfg = SkyRLTrainConfig.from_cli_overrides(["trainer.policy.megatron_config.cpu_resident_microbatches=true"])
-    assert cfg.trainer.policy.megatron_config.cpu_resident_microbatches is True
-
-
 @pytest.mark.parametrize(
     ("field_name", "value"),
     [


### PR DESCRIPTION
# Bounded-Memory Megatron Training and Colocation

## Summary

This PR adds controls that bound temporary training memory and make colocated Megatron offload behavior complete.

## Changes

| Change | Explanation |
| --- | --- |
| CPU-resident policy microbatches | Keeps the DP-sharded policy batch on CPU and transfers one nested microbatch to CUDA immediately before its forward step. |
| Bounded vocabulary entropy | Chunks Megatron vocabulary entropy by an explicit size or an automatically calculated memory budget, and skips fully masked chunks. |

CPU-resident policy microbatches is opt-in; automatic vocabulary-entropy chunk sizing, which defaults to a 512 MiB temporary-memory budget.

## Memory Validation

| Variant | Memory Spike | Outcome |
| --- | ---: | --- |
| Earlier configuration | 9.3 GiB | OOM easily as the context/vocab size gets larger |
| Bounded-memory configuration | 0.5 GiB | All memory spikes are under control |
