### PR TITLE
Add AMD ROCm Docker image and Tinker training examples

### DIFF
--- a/docker/Dockerfile.amd
+++ b/docker/Dockerfile.amd
@@ -41,7 +41,7 @@ RUN if ! command -v uv >/dev/null 2>&1; then \
 # runtime pieces that are not provided by the base image.
 RUN python -m pip install --no-cache-dir "ray[default]==${RAY_VERSION}" \
     && python -m pip install --no-cache-dir "flash-linear-attention[rocm]" orjson torchdata \
-    && python -m pip install --no-cache-dir --no-deps boto3==1.43.0 s3transfer==0.17.1 \
+    && python -m pip install --no-cache-dir boto3==1.43.0 botocore==1.43.0 s3transfer==0.17.1 \
     && python -m pip install --no-cache-dir "pyOpenSSL<26" "cryptography<49,>=2.5" \
     && python -m pip install --no-cache-dir --upgrade "importlib-metadata>=6.0,<8.8.0"
 

--- a/docker/Dockerfile.amd
+++ b/docker/Dockerfile.amd
@@ -1,0 +1,58 @@
+FROM vllm/vllm-openai-rocm:v0.20.2
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG RAY_VERSION=2.51.1
+ARG UV_VERSION=0.11.11
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV HF_HUB_ENABLE_HF_TRANSFER=1 \
+    PATH=/root/.local/bin:${PATH} \
+    RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook \
+    UV_FIND_LINKS=/opt/wheels \
+    UV_PROJECT_ENVIRONMENT=/usr
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        iproute2 \
+        iputils-ping \
+        kmod \
+        libnuma-dev \
+        libxml2 \
+        net-tools \
+        netcat-openbsd \
+        openssh-server \
+        traceroute \
+        tzdata \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN if ! command -v uv >/dev/null 2>&1; then \
+        curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh; \
+    fi \
+    && mkdir -p /opt/wheels \
+    && uv --version
+
+# The base vLLM ROCm image supplies ROCm builds of torch, vLLM, and flash-attn.
+# Keep those packages in the system environment and install only the SkyRL
+# runtime pieces that are not provided by the base image.
+RUN python -m pip install --no-cache-dir "ray[default]==${RAY_VERSION}" \
+    && python -m pip install --no-cache-dir "flash-linear-attention[rocm]" orjson torchdata \
+    && python -m pip install --no-cache-dir --no-deps boto3==1.43.0 s3transfer==0.17.1 \
+    && python -m pip install --no-cache-dir "pyOpenSSL<26" "cryptography<49,>=2.5" \
+    && python -m pip install --no-cache-dir --upgrade "importlib-metadata>=6.0,<8.8.0"
+
+WORKDIR /workspace/SkyRL
+COPY . /workspace/SkyRL
+
+# Use an AMD dependency view that omits GPU-specific CUDA packages. The ROCm
+# variants of torch/vLLM/flash-attn come from the base image instead.
+RUN cp docker/pyproject.amd.toml pyproject.toml \
+    && uv pip install --system --no-cache-dir -e ".[fsdp,tinker]" \
+    && python -c "import ray, torch, vllm; print('ray', ray.__version__); print('vllm', vllm.__version__); print('torch', torch.__version__, 'hip', torch.version.hip)"
+
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.amd
+++ b/docker/Dockerfile.amd
@@ -1,7 +1,7 @@
 FROM vllm/vllm-openai-rocm:v0.20.2
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG RAY_VERSION=2.51.1
+ARG RAY_VERSION=2.56.0
 ARG UV_VERSION=0.11.11
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/Dockerfile.amd
+++ b/docker/Dockerfile.amd
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai-rocm:v0.20.2
+FROM vllm/vllm-openai-rocm:v0.23.0
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG RAY_VERSION=2.56.0
@@ -36,9 +36,9 @@ RUN if ! command -v uv >/dev/null 2>&1; then \
     && mkdir -p /opt/wheels \
     && uv --version
 
-# The base vLLM ROCm image supplies ROCm builds of torch, vLLM, and flash-attn.
+# The parent vLLM ROCm image supplies ROCm builds of torch, vLLM, and flash-attn.
 # Keep those packages in the system environment and install only the SkyRL
-# runtime pieces that are not provided by the base image.
+# runtime pieces that are not provided by the parent image.
 RUN python -m pip install --no-cache-dir "ray[default]==${RAY_VERSION}" \
     && python -m pip install --no-cache-dir "flash-linear-attention[rocm]" orjson torchdata \
     && python -m pip install --no-cache-dir boto3==1.43.0 botocore==1.43.0 s3transfer==0.17.1 \
@@ -49,7 +49,7 @@ WORKDIR /workspace/SkyRL
 COPY . /workspace/SkyRL
 
 # Use an AMD dependency view that omits GPU-specific CUDA packages. The ROCm
-# variants of torch/vLLM/flash-attn come from the base image instead.
+# variants of torch/vLLM/flash-attn come from the parent image instead.
 RUN cp docker/pyproject.amd.toml pyproject.toml \
     && uv pip install --system --no-cache-dir -e ".[fsdp,tinker]" \
     && python -c "import ray, torch, vllm; print('ray', ray.__version__); print('vllm', vllm.__version__); print('torch', torch.__version__, 'hip', torch.version.hip)"

--- a/docker/pyproject.amd.toml
+++ b/docker/pyproject.amd.toml
@@ -1,0 +1,86 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["skyrl*"]
+
+[project]
+name = "skyrl"
+dynamic = ["version"]
+description = "Unified API for training and inference"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "datasets>=4.0.0",
+    "pillow>=11.3.0",
+    "rich>=14.1.0",
+    "safetensors>=0.6.2",
+    "tokenizers>=0.21.2",
+    "transformers>=5.6.1,<=5.8.0",
+    "typer>=0.17.4",
+    "peft==0.18.1",
+    "hf_transfer",
+    "cloudpathlib>=0.23.0",
+]
+
+[project.optional-dependencies]
+tinker = [
+    "tinker==0.16.1",
+    "fastapi[standard]",
+    "sqlmodel",
+    "sqlalchemy[asyncio]",
+    "aiosqlite",
+    "asyncpg",
+    "psycopg2-binary",
+]
+
+skyrl-train = [
+    "loguru",
+    "tqdm",
+    "ninja",
+    "tensorboard",
+    "func_timeout",
+    "hydra-core==1.3.2",
+    "accelerate",
+    "omegaconf",
+    "peft==0.18.1",
+    "debugpy==1.8.0",
+    "hf_transfer",
+    "wandb",
+    "datasets>=4.0.0",
+    "tensordict",
+    "jaxtyping",
+    "skyrl-gym",
+    "polars",
+    "s3fs",
+    "fastapi",
+    "uvicorn",
+    "vllm-router; sys_platform == 'linux'",
+    "pybind11",
+    "setuptools",
+]
+
+fsdp = [
+    "skyrl[skyrl-train]",
+]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.dynamic]
+version = {attr = "skyrl.__version__"}
+
+[tool.uv]
+required-environments = [
+    "sys_platform == 'linux'",
+    "sys_platform == 'darwin' and platform_machine == 'arm64'",
+]
+
+[tool.uv.sources]
+skyrl-gym = { path = "./skyrl-gym", editable = true }
+
+vllm-router = [
+    { url = "https://github.com/SumanthRH/router/releases/download/0.1.14.post1/vllm_router-0.1.14-cp38-abi3-manylinux_2_35_x86_64.whl", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
+    { url = "https://github.com/SumanthRH/router/releases/download/0.1.14.post1/vllm_router-0.1.14-cp38-abi3-linux_aarch64.whl", marker = "sys_platform == 'linux' and platform_machine == 'aarch64'" },
+]

--- a/docs/content/docs/examples/amd.mdx
+++ b/docs/content/docs/examples/amd.mdx
@@ -1,0 +1,141 @@
+---
+title: "AMD ROCm Tinker"
+---
+
+<Callout type="info">
+This example uses the `fsdp` backend with vLLM ROCm inference.
+</Callout>
+
+This example shows how to run SkyRL's Tinker-compatible API on AMD GPUs. It
+uses the AMD Docker image in `docker/Dockerfile.amd` and the client scripts in
+`examples/train/amd`.
+
+The Docker image builds from `vllm/vllm-openai-rocm:v0.20.2`, installs Ray and
+SkyRL's non-GPU runtime dependencies, and relies on the base image for ROCm
+builds of PyTorch, vLLM, and flash-attn.
+
+## Build The Image
+
+From the repository root:
+
+```bash
+docker build -f docker/Dockerfile.amd -t skyrl-amd-rocm .
+```
+
+## Run The Container
+
+Use the ROCm devices and host IPC. `--network host` is convenient for Ray and
+for reaching the Tinker API from another shell.
+
+```bash
+docker run --rm -it \
+  --network host \
+  --ipc=host \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  skyrl-amd-rocm
+```
+
+## Start The Tinker Server
+
+Inside the container:
+
+```bash
+cd /workspace/SkyRL/examples/train/amd
+bash run_tinker_server_amd.sh
+```
+
+The default server binds to `0.0.0.0:9000` and uses:
+
+- `BASE_MODEL=Qwen/Qwen3-4B-Instruct-2507`
+- `BACKEND=fsdp`
+- `POLICY_NUM_GPUS_PER_NODE=1`
+- `INFERENCE_NUM_ENGINES=6`
+
+This default targets an 8-GPU AMD node with one GPU for the FSDP policy worker,
+six vLLM inference engines, and one GPU left for headroom. For smaller nodes or
+faster local debugging, reduce the inference engine count:
+
+```bash
+INFERENCE_NUM_ENGINES=1 \
+bash run_tinker_server_amd.sh
+```
+
+All server arguments can still be overridden through environment variables or
+by passing flags directly:
+
+```bash
+bash run_tinker_server_amd.sh --help
+```
+
+## Run The Client Smoke Test
+
+In a second shell inside the container:
+
+```bash
+cd /workspace/SkyRL/examples/train/amd
+TINKER_BASE_URL=http://localhost:9000 TINKER_API_KEY=tml-dummy \
+python tinker_hello_world.py
+```
+
+The client creates a rank-32 LoRA training client, builds 16 tiny
+cross-entropy datums, samples once before training, runs four
+`forward_backward` + `optim_step` iterations, syncs trained weights to the
+sampler, samples once more, and prints `PASS` on success.
+
+## Run The GSM8K GRPO Client
+
+For a fuller Tinker client, run the GRPO-style GSM8K example against the same
+server:
+
+```bash
+cd /workspace/SkyRL/examples/train/amd
+TINKER_BASE_URL=http://localhost:9000 TINKER_API_KEY=tml-dummy \
+python grpo_client.py
+```
+
+The GRPO client samples groups of responses, computes group-relative advantages
+from rule-based rewards, and trains a rank-32 LoRA policy with the public
+Tinker `ppo` loss. SkyRL maps this to its standard PPO-style policy loss
+internally.
+
+If `--data-dir` does not already contain `train.parquet` and
+`validation.parquet`, the client prepares a small GSM8K subset automatically
+under `/tmp/skyrl-tinker-grpo/gsm8k`. Prepared subsets are shuffled before
+truncation, and each training step samples a fresh random prompt batch from the
+loaded train pool.
+
+The default client run uses:
+
+- `--max-train-steps 5`
+- `--num-prompts 64`
+- `--group-size 8`
+- `--max-tokens 512`
+- `--max-train-examples 1024`
+- `--max-val-examples 128`
+
+To force regeneration of the shuffled GSM8K subset:
+
+```bash
+TINKER_BASE_URL=http://localhost:9000 TINKER_API_KEY=tml-dummy \
+python grpo_client.py \
+  --reprepare-data
+```
+
+For a faster single-step smoke:
+
+```bash
+TINKER_BASE_URL=http://localhost:9000 TINKER_API_KEY=tml-dummy \
+python grpo_client.py \
+  --max-train-steps 1 \
+  --num-prompts 2 \
+  --group-size 2 \
+  --max-tokens 64 \
+  --max-train-examples 32 \
+  --max-val-examples 8 \
+  --reprepare-data
+```
+

--- a/docs/content/docs/examples/amd.mdx
+++ b/docs/content/docs/examples/amd.mdx
@@ -10,8 +10,8 @@ This example shows how to run SkyRL's Tinker-compatible API on AMD GPUs. It
 uses the AMD Docker image in `docker/Dockerfile.amd` and the client scripts in
 `examples/train/amd`.
 
-The Docker image builds from `vllm/vllm-openai-rocm:v0.20.2`, installs Ray and
-SkyRL's non-GPU runtime dependencies, and relies on the base image for ROCm
+The Docker image builds from `vllm/vllm-openai-rocm:v0.23.0`, installs Ray and
+SkyRL's non-GPU runtime dependencies, and relies on the parent image for ROCm
 builds of PyTorch, vLLM, and flash-attn.
 
 ## Build The Image
@@ -138,4 +138,3 @@ python grpo_client.py \
   --max-val-examples 8 \
   --reprepare-data
 ```
-

--- a/docs/content/docs/examples/meta.json
+++ b/docs/content/docs/examples/meta.json
@@ -4,6 +4,7 @@
     "megatron",
     "ppo",
     "lora",
+    "amd",
     "llm_as_a_judge",
     "remote_server",
     "training_backends",

--- a/examples/train/amd/README.md
+++ b/examples/train/amd/README.md
@@ -1,0 +1,147 @@
+# AMD ROCm Tinker Example
+
+This example is a starting point for running SkyRL's Tinker-compatible API on AMD GPUs with the FSDP backend and vLLM ROCm inference.
+
+The runtime path is intentionally split from the image path:
+
+- `docker/Dockerfile.amd` builds a SkyRL AMD image from `vllm/vllm-openai-rocm:v0.20.2`.
+- This directory contains commands to run inside that image.
+
+The Docker image bakes in Ray and the non-GPU SkyRL dependencies. It relies on the base vLLM ROCm image for ROCm builds of PyTorch, vLLM, and flash-attn.
+
+## Build
+
+From the repository root:
+
+```bash
+docker build -f docker/Dockerfile.amd -t skyrl-amd-rocm .
+```
+
+## Run The Container
+
+Use the ROCm devices and host IPC. `--network host` is convenient for Ray and for reaching the Tinker API from another shell.
+
+```bash
+docker run --rm -it \
+  --network host \
+  --ipc=host \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  skyrl-amd-rocm
+```
+
+## Start The Tinker Server
+
+Inside the container:
+
+```bash
+cd /workspace/SkyRL/examples/train/amd
+bash run_tinker_server_amd.sh
+```
+
+The default server binds to `0.0.0.0:9000` and uses:
+
+- `BASE_MODEL=Qwen/Qwen3-4B-Instruct-2507`
+- `BACKEND=fsdp`
+- `POLICY_NUM_GPUS_PER_NODE=1`
+- `INFERENCE_NUM_ENGINES=6`
+
+This default targets an 8-GPU AMD node with one GPU for the FSDP policy worker,
+six vLLM inference engines, and one GPU left for headroom. For smaller nodes or
+faster local debugging, reduce the inference engine count:
+
+```bash
+INFERENCE_NUM_ENGINES=1 \
+bash run_tinker_server_amd.sh
+```
+
+All server arguments can still be overridden through environment variables or by passing flags directly:
+
+```bash
+bash run_tinker_server_amd.sh --help
+```
+
+## Run The Client Smoke Test
+
+In a second shell inside the container:
+
+```bash
+cd /workspace/SkyRL/examples/train/amd
+TINKER_BASE_URL=http://localhost:9000 TINKER_API_KEY=tml-dummy \
+python tinker_hello_world.py
+```
+
+The client is a fixed Tinker smoke test. It creates a rank-32 LoRA training
+client, builds 16 tiny cross-entropy datums, samples once before training, runs
+four `forward_backward` + `optim_step` iterations, syncs trained weights to the
+sampler, samples once more, and prints `PASS` on success.
+
+## Run The GRPO Client
+
+For a fuller Tinker client, run the GRPO-style GSM8K example against the same
+server:
+
+```bash
+cd /workspace/SkyRL/examples/train/amd
+TINKER_BASE_URL=http://localhost:9000 TINKER_API_KEY=tml-dummy \
+python grpo_client.py
+```
+
+The GRPO client samples groups of responses, computes group-relative advantages
+from rule-based rewards, and trains a rank-32 LoRA policy with the public Tinker
+`ppo` loss. SkyRL maps this to its standard PPO-style policy loss internally. If
+`--data-dir` does not already contain
+`train.parquet` and `validation.parquet`, the client prepares a small GSM8K
+subset automatically under `/tmp/skyrl-tinker-grpo/gsm8k`. Prepared subsets are
+shuffled before truncation, and each training step samples a fresh random prompt
+batch from the loaded train pool.
+
+The default client run uses:
+
+- `--max-train-steps 5`
+- `--num-prompts 64`
+- `--group-size 8`
+- `--max-tokens 512`
+- `--max-train-examples 1024`
+- `--max-val-examples 128`
+
+To force regeneration of the shuffled GSM8K subset:
+
+```bash
+TINKER_BASE_URL=http://localhost:9000 TINKER_API_KEY=tml-dummy \
+python grpo_client.py \
+  --reprepare-data
+```
+
+For a faster single-step smoke:
+
+```bash
+TINKER_BASE_URL=http://localhost:9000 TINKER_API_KEY=tml-dummy \
+python grpo_client.py \
+  --max-train-steps 1 \
+  --num-prompts 2 \
+  --group-size 2 \
+  --max-tokens 64 \
+  --max-train-examples 32 \
+  --max-val-examples 8 \
+  --reprepare-data
+```
+
+## Multi-Node Note
+
+Ray is installed in the image so cluster setup can be handled by normal Ray commands or a platform launcher.
+
+Head node:
+
+```bash
+ray start --head --port=6379
+```
+
+Worker nodes:
+
+```bash
+ray start --address="$HEAD_NODE_IP:6379"
+```

--- a/examples/train/amd/README.md
+++ b/examples/train/amd/README.md
@@ -4,10 +4,10 @@ This example is a starting point for running SkyRL's Tinker-compatible API on AM
 
 The runtime path is intentionally split from the image path:
 
-- `docker/Dockerfile.amd` builds a SkyRL AMD image from `vllm/vllm-openai-rocm:v0.20.2`.
+- `docker/Dockerfile.amd` builds a SkyRL AMD image from `vllm/vllm-openai-rocm:v0.23.0`.
 - This directory contains commands to run inside that image.
 
-The Docker image bakes in Ray and the non-GPU SkyRL dependencies. It relies on the base vLLM ROCm image for ROCm builds of PyTorch, vLLM, and flash-attn.
+The Docker image bakes in Ray and the non-GPU SkyRL dependencies. It relies on the parent vLLM ROCm image for ROCm builds of PyTorch, vLLM, and flash-attn.
 
 ## Build
 

--- a/examples/train/amd/README.md
+++ b/examples/train/amd/README.md
@@ -129,19 +129,3 @@ python grpo_client.py \
   --max-val-examples 8 \
   --reprepare-data
 ```
-
-## Multi-Node Note
-
-Ray is installed in the image so cluster setup can be handled by normal Ray commands or a platform launcher.
-
-Head node:
-
-```bash
-ray start --head --port=6379
-```
-
-Worker nodes:
-
-```bash
-ray start --address="$HEAD_NODE_IP:6379"
-```

--- a/examples/train/amd/grpo_client.py
+++ b/examples/train/amd/grpo_client.py
@@ -187,7 +187,9 @@ def ensure_gsm8k_data(args: argparse.Namespace) -> tuple[Path, Path]:
     return train_path, val_path
 
 
-def prompt_tokens_for_messages(tokenizer: Any, messages: list[dict[str, str]], max_prompt_length: int) -> list[int] | None:
+def prompt_tokens_for_messages(
+    tokenizer: Any, messages: list[dict[str, str]], max_prompt_length: int
+) -> list[int] | None:
     tokens = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_dict=False, tokenize=True)
     token_list = list(tokens["input_ids"] if isinstance(tokens, Mapping) else tokens)
     if len(token_list) > max_prompt_length:

--- a/examples/train/amd/grpo_client.py
+++ b/examples/train/amd/grpo_client.py
@@ -1,0 +1,451 @@
+"""GRPO-style GSM8K AMD Tinker client using the public Tinker SDK.
+
+The client prepares or loads GSM8K-style parquet data, samples groups of
+responses, computes group-relative advantages from exact-match rewards, and
+trains the policy with the public Tinker ``ppo`` loss.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import random
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+import datasets
+import torch
+import tinker
+from tinker import types
+
+
+DEFAULT_BASE_URL = "http://localhost:9000"
+DEFAULT_API_KEY = "tml-dummy"
+DEFAULT_MODEL_NAME = "Qwen/Qwen3-4B-Instruct-2507"
+DEFAULT_OUTPUT_DIR = "/tmp/skyrl-tinker-grpo"
+DEFAULT_DATA_DIR = "/tmp/skyrl-tinker-grpo/gsm8k"
+
+LORA_RANK = 32
+LEARNING_RATE = 3.0e-5
+POLICY_LOSS = "ppo"
+GSM8K_SOURCE = "openai/gsm8k"
+GSM8K_CONFIG = "main"
+GSM8K_INSTRUCTION = 'Let\'s think step by step and output the final answer after "####".'
+STRICT_ANSWER_RE = re.compile(r"####\s*(-?[0-9\.,]+)")
+FALLBACK_NUMBER_RE = re.compile(r"(-?[0-9\.,]+)")
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GSM8KRecord:
+    prompt_messages: list[dict[str, str]]
+    prompt_tokens: list[int]
+    question: str
+    answer: str
+    dataset_index: int
+
+
+@dataclass
+class Trajectory:
+    prompt_tokens: list[int]
+    response_tokens: list[int]
+    old_logprobs: list[float]
+    reward: float
+    advantage: float
+    prompt_group: int
+    question: str
+    answer: str
+    response_text: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--base-url", default=os.environ.get("TINKER_BASE_URL", DEFAULT_BASE_URL))
+    parser.add_argument("--api-key", default=os.environ.get("TINKER_API_KEY", DEFAULT_API_KEY))
+    parser.add_argument("--base-model", default=os.environ.get("TINKER_GRPO_BASE_MODEL", DEFAULT_MODEL_NAME))
+    parser.add_argument("--data-dir", default=os.environ.get("GSM8K_DATA_DIR", DEFAULT_DATA_DIR))
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--max-train-steps", type=int, default=5)
+    parser.add_argument("--num-prompts", type=int, default=64)
+    parser.add_argument("--group-size", type=int, default=8)
+    parser.add_argument("--max-tokens", type=int, default=512)
+    parser.add_argument("--max-prompt-length", type=int, default=512)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--max-train-examples", type=int, default=1024)
+    parser.add_argument("--max-val-examples", type=int, default=128)
+    parser.add_argument("--reprepare-data", action="store_true")
+    parser.add_argument("--no-auto-prepare-data", action="store_true")
+    return parser.parse_args()
+
+
+def chunked(items: Sequence[Any], size: int) -> Iterable[Sequence[Any]]:
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def write_jsonl(output_dir: str, payload: Mapping[str, Any]) -> None:
+    path = Path(output_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    with (path / "metrics.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def extract_solution(solution_str: str) -> str:
+    match = STRICT_ANSWER_RE.search(solution_str)
+    if match is None:
+        raise ValueError(f"Could not extract GSM8K answer from: {solution_str!r}")
+    return match.group(1).replace(",", "")
+
+
+def process_gsm8k_row(example: dict[str, Any], split: str, index: int) -> dict[str, Any]:
+    question_raw = example["question"]
+    answer_raw = example["answer"]
+    return {
+        "data_source": GSM8K_SOURCE,
+        "prompt": [
+            {
+                "role": "user",
+                "content": f"{question_raw} {GSM8K_INSTRUCTION}",
+            }
+        ],
+        "env_class": "gsm8k",
+        "reward_spec": {
+            "method": "rule",
+            "ground_truth": extract_solution(answer_raw),
+        },
+        "extra_info": {
+            "split": split,
+            "index": index,
+            "answer": answer_raw,
+            "question": question_raw,
+        },
+    }
+
+
+def write_split(dataset: datasets.Dataset, path: Path, split: str, max_examples: int, seed: int) -> None:
+    dataset = dataset.shuffle(seed=seed)
+    if max_examples > 0:
+        dataset = dataset.select(range(min(max_examples, len(dataset))))
+    processed = dataset.map(lambda example, idx: process_gsm8k_row(example, split, idx), with_indices=True)
+    processed.to_parquet(str(path))
+    logger.info("Prepared %s GSM8K records at %s", len(processed), path)
+
+
+def ensure_gsm8k_data(args: argparse.Namespace) -> tuple[Path, Path]:
+    data_dir = Path(os.path.expanduser(args.data_dir))
+    train_path = data_dir / "train.parquet"
+    val_path = data_dir / "validation.parquet"
+    if train_path.exists() and val_path.exists() and not args.reprepare_data:
+        return train_path, val_path
+
+    if args.no_auto_prepare_data:
+        raise FileNotFoundError(
+            f"Missing {train_path} or {val_path}. Run without --no-auto-prepare-data to create a small GSM8K subset."
+        )
+
+    logger.info("Preparing GSM8K parquet data in %s", data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    dataset = datasets.load_dataset(GSM8K_SOURCE, GSM8K_CONFIG)
+    write_split(dataset["train"], train_path, "train", args.max_train_examples, seed=args.seed)
+    write_split(dataset["test"], val_path, "test", args.max_val_examples, seed=args.seed + 1)
+    return train_path, val_path
+
+
+def prompt_tokens_for_messages(tokenizer: Any, messages: list[dict[str, str]], max_prompt_length: int) -> list[int] | None:
+    tokens = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_dict=False, tokenize=True)
+    token_list = list(tokens["input_ids"] if isinstance(tokens, Mapping) else tokens)
+    if len(token_list) > max_prompt_length:
+        return None
+    return token_list
+
+
+def load_split(path: Path, tokenizer: Any, max_prompt_length: int, limit: int | None = None) -> list[GSM8KRecord]:
+    dataset = datasets.load_dataset("parquet", data_files=str(path), keep_in_memory=True)["train"]
+    if limit is not None and limit > 0:
+        dataset = dataset.select(range(min(limit, len(dataset))))
+
+    records = []
+    filtered = 0
+    for idx, row in enumerate(dataset):
+        prompt_tokens = prompt_tokens_for_messages(tokenizer, row["prompt"], max_prompt_length=max_prompt_length)
+        if prompt_tokens is None:
+            filtered += 1
+            continue
+        records.append(
+            GSM8KRecord(
+                prompt_messages=row["prompt"],
+                prompt_tokens=prompt_tokens,
+                question=row.get("extra_info", {}).get("question", ""),
+                answer=str(row["reward_spec"]["ground_truth"]).strip(),
+                dataset_index=idx,
+            )
+        )
+    logger.info("Loaded %s records from %s (filtered %s long prompts)", len(records), path, filtered)
+    return records
+
+
+def sample_train_records(records: Sequence[GSM8KRecord], num_prompts: int, seed: int, step: int) -> list[GSM8KRecord]:
+    if num_prompts <= 0:
+        raise ValueError("--num-prompts must be positive")
+    if len(records) < num_prompts:
+        raise ValueError(
+            f"Requested {num_prompts} prompts, but only loaded {len(records)} records. "
+            "Increase --max-train-examples or lower --num-prompts."
+        )
+    rng = random.Random(seed + step * 1_000_003)
+    return rng.sample(list(records), num_prompts)
+
+
+def extract_answer(text: str) -> str | None:
+    match = STRICT_ANSWER_RE.search(text)
+    if match is not None:
+        return match.group(1).replace(",", "")
+    matches = FALLBACK_NUMBER_RE.findall(text)
+    for candidate in reversed(matches):
+        candidate = candidate.replace(",", "")
+        if candidate not in {"", "."}:
+            return candidate
+    return None
+
+
+def reward_response(text: str, answer: str) -> float:
+    return 1.0 if extract_answer(text) == answer else 0.0
+
+
+def tensor_i64(values: list[int]) -> types.TensorData:
+    return types.TensorData.from_torch(torch.tensor(values, dtype=torch.int64))
+
+
+def tensor_f32(values: list[float]) -> types.TensorData:
+    return types.TensorData.from_torch(torch.tensor(values, dtype=torch.float32))
+
+
+def model_input_for_rollout(prompt_tokens: list[int], response_tokens: list[int]) -> types.ModelInput:
+    return types.ModelInput.from_ints(prompt_tokens + response_tokens[:-1])
+
+
+def build_policy_datum(trajectory: Trajectory) -> types.Datum:
+    token_count = len(trajectory.response_tokens)
+    return types.Datum(
+        model_input=model_input_for_rollout(trajectory.prompt_tokens, trajectory.response_tokens),
+        loss_fn_inputs={
+            "target_tokens": tensor_i64(trajectory.response_tokens),
+            "weights": tensor_f32([1.0] * token_count),
+            "logprobs": tensor_f32(trajectory.old_logprobs),
+            "advantages": tensor_f32([trajectory.advantage] * token_count),
+        },
+    )
+
+
+def normalise_logprobs(logprobs: Sequence[float] | None, token_count: int) -> list[float]:
+    values = [float(value or 0.0) for value in (logprobs or [])]
+    if len(values) < token_count:
+        values.extend([0.0] * (token_count - len(values)))
+    return values[:token_count]
+
+
+def assign_group_advantages(trajectories: list[Trajectory]) -> int:
+    zero_variance_groups = 0
+    by_group: dict[int, list[Trajectory]] = {}
+    for trajectory in trajectories:
+        by_group.setdefault(trajectory.prompt_group, []).append(trajectory)
+
+    for group in by_group.values():
+        rewards = torch.tensor([trajectory.reward for trajectory in group], dtype=torch.float32)
+        mean = rewards.mean()
+        std = rewards.std(unbiased=False)
+        if float(std) <= 1.0e-8:
+            zero_variance_groups += 1
+            advantages = rewards - mean
+        else:
+            advantages = (rewards - mean) / (std + 1.0e-8)
+        for trajectory, advantage in zip(group, advantages.tolist(), strict=True):
+            trajectory.advantage = float(advantage)
+    return zero_variance_groups
+
+
+def collect_rollouts(
+    sampling_client: Any,
+    tokenizer: Any,
+    records: Sequence[GSM8KRecord],
+    args: argparse.Namespace,
+    step: int,
+) -> tuple[list[Trajectory], dict[str, float]]:
+    pending = []
+    for index, record in enumerate(records):
+        params = types.SamplingParams(
+            max_tokens=args.max_tokens,
+            seed=args.seed + step * 10_000 + index,
+            temperature=args.temperature,
+            top_p=1.0,
+            top_k=-1,
+        )
+        future = sampling_client.sample(
+            prompt=types.ModelInput.from_ints(record.prompt_tokens),
+            num_samples=args.group_size,
+            sampling_params=params,
+        )
+        pending.append((index, record, future))
+
+    trajectories: list[Trajectory] = []
+    rewards_by_group: list[list[float]] = []
+    for prompt_group, record, future in pending:
+        result = future.result()
+        rewards_for_group = []
+        for sequence in result.sequences:
+            response_tokens = list(sequence.tokens)
+            if not response_tokens:
+                continue
+            response_text = tokenizer.decode(response_tokens, skip_special_tokens=True)
+            reward = reward_response(response_text, record.answer)
+            rewards_for_group.append(reward)
+            trajectories.append(
+                Trajectory(
+                    prompt_tokens=list(record.prompt_tokens),
+                    response_tokens=response_tokens,
+                    old_logprobs=normalise_logprobs(sequence.logprobs, len(response_tokens)),
+                    reward=reward,
+                    advantage=0.0,
+                    prompt_group=prompt_group,
+                    question=record.question,
+                    answer=record.answer,
+                    response_text=response_text,
+                )
+            )
+        rewards_by_group.append(rewards_for_group)
+
+    zero_variance_groups = assign_group_advantages(trajectories)
+    flat_rewards = [reward for group in rewards_by_group for reward in group]
+    pass_at_group = (
+        sum(1 for group in rewards_by_group if any(reward > 0.0 for reward in group)) / len(rewards_by_group)
+        if rewards_by_group
+        else 0.0
+    )
+    metrics = {
+        "num_prompts": float(len(records)),
+        "num_trajectories": float(len(trajectories)),
+        "avg_reward": float(sum(flat_rewards) / len(flat_rewards)) if flat_rewards else 0.0,
+        "pass_at_group": float(pass_at_group),
+        "zero_variance_groups": float(zero_variance_groups),
+    }
+    return trajectories, metrics
+
+
+def average_metrics(metrics_list: Sequence[Mapping[str, Any]]) -> dict[str, float]:
+    totals: dict[str, float] = {}
+    counts: dict[str, int] = {}
+    for metrics in metrics_list:
+        for key, value in metrics.items():
+            totals[key] = totals.get(key, 0.0) + float(value)
+            counts[key] = counts.get(key, 0) + 1
+    return {key: totals[key] / counts[key] for key in totals}
+
+
+def train_policy(
+    training_client: tinker.TrainingClient,
+    trajectories: Sequence[Trajectory],
+    learning_rate: float,
+) -> dict[str, float]:
+    all_metrics = []
+    optimizer = types.AdamParams(
+        learning_rate=learning_rate,
+        beta1=0.9,
+        beta2=0.999,
+        eps=1.0e-8,
+    )
+    for minibatch in chunked(list(trajectories), 32):
+        data = [build_policy_datum(trajectory) for trajectory in minibatch]
+        forward_result = training_client.forward_backward(data, POLICY_LOSS).result()
+        optim_result = training_client.optim_step(optimizer).result()
+        metrics = dict(forward_result.metrics)
+        metrics.update(optim_result.metrics or {})
+        all_metrics.append(metrics)
+    return average_metrics(all_metrics)
+
+
+def sample_preview(sampling_client: Any, tokenizer: Any, record: GSM8KRecord, args: argparse.Namespace) -> str:
+    params = types.SamplingParams(
+        max_tokens=args.max_tokens,
+        seed=args.seed + 999_999,
+        temperature=0.0,
+        top_p=1.0,
+        top_k=-1,
+    )
+    result = sampling_client.sample(
+        prompt=types.ModelInput.from_ints(record.prompt_tokens),
+        num_samples=1,
+        sampling_params=params,
+    ).result()
+    return tokenizer.decode(result.sequences[0].tokens, skip_special_tokens=True)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = parse_args()
+    random.seed(args.seed)
+
+    logger.info("base_url=%s model=%s data_dir=%s", args.base_url, args.base_model, args.data_dir)
+    train_path, val_path = ensure_gsm8k_data(args)
+
+    service_client = tinker.ServiceClient(base_url=args.base_url.rstrip("/"), api_key=args.api_key)
+    training_client = service_client.create_lora_training_client(
+        base_model=args.base_model,
+        rank=LORA_RANK,
+        seed=args.seed,
+        train_mlp=True,
+        train_attn=True,
+        train_unembed=True,
+        user_metadata={"example": "skyrl-amd-tinker-grpo-gsm8k"},
+    )
+    tokenizer = training_client.get_tokenizer()
+    train_records = load_split(train_path, tokenizer, args.max_prompt_length, limit=args.max_train_examples)
+    val_records = load_split(val_path, tokenizer, args.max_prompt_length, limit=args.max_val_examples)
+    if not train_records:
+        raise RuntimeError("No train records were loaded")
+
+    try:
+        for step in range(1, args.max_train_steps + 1):
+            step_start = time.time()
+            step_records = sample_train_records(train_records, args.num_prompts, args.seed, step)
+            sampling_client = training_client.save_weights_and_get_sampling_client()
+            trajectories, rollout_metrics = collect_rollouts(
+                sampling_client,
+                tokenizer,
+                step_records,
+                args,
+                step,
+            )
+            if not trajectories:
+                raise RuntimeError("No trajectories were produced")
+
+            train_metrics = train_policy(training_client, trajectories, LEARNING_RATE)
+            elapsed = time.time() - step_start
+            payload = {
+                "step": step,
+                "time/step_seconds": elapsed,
+                **{f"rollout/{key}": value for key, value in rollout_metrics.items()},
+                **{f"train/{key}": value for key, value in train_metrics.items()},
+            }
+            write_jsonl(args.output_dir, payload)
+            logger.info("Train step %s: %s", step, payload)
+
+        sampling_client = training_client.save_weights_and_get_sampling_client()
+        preview_record = val_records[0] if val_records else train_records[0]
+        preview = sample_preview(sampling_client, tokenizer, preview_record, args)
+        logger.info("Final sample question: %s", preview_record.question)
+        logger.info("Final sample expected answer: %s", preview_record.answer)
+        logger.info("Final sample response: %r", preview)
+        logger.info("PASS")
+    finally:
+        service_client.holder.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/train/amd/grpo_client.py
+++ b/examples/train/amd/grpo_client.py
@@ -17,6 +17,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 import datasets
 import torch
@@ -95,6 +97,33 @@ def write_jsonl(output_dir: str, payload: Mapping[str, Any]) -> None:
     path.mkdir(parents=True, exist_ok=True)
     with (path / "metrics.jsonl").open("a", encoding="utf-8") as f:
         f.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def post_json(base_url: str, path: str, payload: dict[str, Any], timeout: float = 300.0) -> dict[str, Any]:
+    data = json.dumps(payload).encode("utf-8")
+    request = Request(
+        f"{base_url}{path}",
+        data=data,
+        headers={"accept": "application/json", "content-type": "application/json"},
+        method="POST",
+    )
+    with urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def unload_training_model(base_url: str, training_client: tinker.TrainingClient | None) -> None:
+    if training_client is None:
+        return
+    model_id = getattr(training_client, "model_id", None)
+    if not model_id:
+        return
+    try:
+        response = post_json(base_url, "/api/v1/unload_model", {"model_id": model_id}, timeout=10.0)
+        request_id = response["request_id"]
+        post_json(base_url, "/api/v1/retrieve_future", {"request_id": request_id}, timeout=300.0)
+        logger.info("Unloaded model %s", model_id)
+    except (HTTPError, URLError, TimeoutError, KeyError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to unload model %s: %s", model_id, exc)
 
 
 def extract_solution(solution_str: str) -> str:
@@ -390,27 +419,30 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     args = parse_args()
     random.seed(args.seed)
+    base_url = args.base_url.rstrip("/")
 
     logger.info("base_url=%s model=%s data_dir=%s", args.base_url, args.base_model, args.data_dir)
     train_path, val_path = ensure_gsm8k_data(args)
 
-    service_client = tinker.ServiceClient(base_url=args.base_url.rstrip("/"), api_key=args.api_key)
-    training_client = service_client.create_lora_training_client(
-        base_model=args.base_model,
-        rank=LORA_RANK,
-        seed=args.seed,
-        train_mlp=True,
-        train_attn=True,
-        train_unembed=True,
-        user_metadata={"example": "skyrl-amd-tinker-grpo-gsm8k"},
-    )
-    tokenizer = training_client.get_tokenizer()
-    train_records = load_split(train_path, tokenizer, args.max_prompt_length, limit=args.max_train_examples)
-    val_records = load_split(val_path, tokenizer, args.max_prompt_length, limit=args.max_val_examples)
-    if not train_records:
-        raise RuntimeError("No train records were loaded")
-
+    service_client = None
+    training_client = None
     try:
+        service_client = tinker.ServiceClient(base_url=base_url, api_key=args.api_key)
+        training_client = service_client.create_lora_training_client(
+            base_model=args.base_model,
+            rank=LORA_RANK,
+            seed=args.seed,
+            train_mlp=True,
+            train_attn=True,
+            train_unembed=True,
+            user_metadata={"example": "skyrl-amd-tinker-grpo-gsm8k"},
+        )
+        tokenizer = training_client.get_tokenizer()
+        train_records = load_split(train_path, tokenizer, args.max_prompt_length, limit=args.max_train_examples)
+        val_records = load_split(val_path, tokenizer, args.max_prompt_length, limit=args.max_val_examples)
+        if not train_records:
+            raise RuntimeError("No train records were loaded")
+
         for step in range(1, args.max_train_steps + 1):
             step_start = time.time()
             step_records = sample_train_records(train_records, args.num_prompts, args.seed, step)
@@ -444,7 +476,9 @@ def main() -> None:
         logger.info("Final sample response: %r", preview)
         logger.info("PASS")
     finally:
-        service_client.holder.close()
+        unload_training_model(base_url, training_client)
+        if service_client is not None:
+            service_client.holder.close()
 
 
 if __name__ == "__main__":

--- a/examples/train/amd/run_tinker_server_amd.sh
+++ b/examples/train/amd/run_tinker_server_amd.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+export HOME="${SKYRL_HOME:-/tmp}"
+export SKYRL_RAY_NUM_CPUS="${SKYRL_RAY_NUM_CPUS:-64}"
+export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-/usr}"
+
+UV_ARGS=(--active --no-sync --extra tinker --extra fsdp)
+
+LOG_DIR="${TINKER_API_LOG_DIR:-logs/tinker-api}"
+if [[ -n "${TINKER_API_LOG_FILE:-}" ]]; then
+    LOG_FILE="${TINKER_API_LOG_FILE}"
+    mkdir -p "$(dirname "${LOG_FILE}")"
+else
+    mkdir -p "${LOG_DIR}"
+    LOG_FILE="${LOG_DIR}/tinker-api-amd-$(date +%Y%m%d-%H%M%S).log"
+fi
+
+write_log_header() {
+    {
+        printf 'SkyRL AMD Tinker API log\n'
+        printf 'started_at=%s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)"
+        printf 'cwd=%s\n' "$(pwd)"
+        printf 'HOME=%s\n' "${HOME}"
+        printf 'SKYRL_RAY_NUM_CPUS=%s\n' "${SKYRL_RAY_NUM_CPUS}"
+        printf 'UV_PROJECT_ENVIRONMENT=%s\n' "${UV_PROJECT_ENVIRONMENT}"
+        printf 'log_file=%s\n' "${LOG_FILE}"
+        printf 'command=uv run'
+        printf ' %q' "${UV_ARGS[@]}" -m skyrl.tinker.api "$@"
+        printf '\n\n'
+    } | tee "${LOG_FILE}"
+}
+
+run_api() {
+    write_log_header "$@"
+
+    set +e
+    uv run "${UV_ARGS[@]}" -m skyrl.tinker.api "$@" 2>&1 | tee -a "${LOG_FILE}"
+    status=${PIPESTATUS[0]}
+
+    {
+        printf '\nfinished_at=%s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)"
+        printf 'exit_status=%s\n' "${status}"
+    } | tee -a "${LOG_FILE}"
+
+    set -e
+    return "${status}"
+}
+
+if [[ "$#" -gt 0 ]]; then
+    run_api "$@"
+    exit "$?"
+fi
+
+BASE_MODEL="${BASE_MODEL:-Qwen/Qwen3-4B-Instruct-2507}"
+BACKEND="${BACKEND:-fsdp}"
+HOST="${HOST:-0.0.0.0}"
+PORT="${PORT:-9000}"
+
+POLICY_NUM_NODES="${POLICY_NUM_NODES:-1}"
+POLICY_NUM_GPUS_PER_NODE="${POLICY_NUM_GPUS_PER_NODE:-1}"
+COLOCATE_ALL="${COLOCATE_ALL:-false}"
+MICRO_TRAIN_BATCH_SIZE_PER_GPU="${MICRO_TRAIN_BATCH_SIZE_PER_GPU:-32}"
+MICRO_FORWARD_BATCH_SIZE_PER_GPU="${MICRO_FORWARD_BATCH_SIZE_PER_GPU:-32}"
+
+INFERENCE_NUM_ENGINES="${INFERENCE_NUM_ENGINES:-6}"
+INFERENCE_TENSOR_PARALLEL_SIZE="${INFERENCE_TENSOR_PARALLEL_SIZE:-1}"
+INFERENCE_MAX_NUM_BATCHED_TOKENS="${INFERENCE_MAX_NUM_BATCHED_TOKENS:-32768}"
+INFERENCE_MAX_NUM_SEQS="${INFERENCE_MAX_NUM_SEQS:-256}"
+INFERENCE_MAX_MODEL_LEN="${INFERENCE_MAX_MODEL_LEN:-32768}"
+INFERENCE_GPU_MEMORY_UTILIZATION="${INFERENCE_GPU_MEMORY_UTILIZATION:-0.8}"
+INFERENCE_ENABLE_RAY_PROMETHEUS_STATS="${INFERENCE_ENABLE_RAY_PROMETHEUS_STATS:-false}"
+
+BACKEND_CONFIG="${BACKEND_CONFIG:-$(cat <<JSON
+{
+    "trainer.placement.colocate_all": ${COLOCATE_ALL},
+    "trainer.placement.policy_num_nodes": ${POLICY_NUM_NODES},
+    "trainer.placement.policy_num_gpus_per_node": ${POLICY_NUM_GPUS_PER_NODE},
+    "trainer.micro_train_batch_size_per_gpu": ${MICRO_TRAIN_BATCH_SIZE_PER_GPU},
+    "trainer.micro_forward_batch_size_per_gpu": ${MICRO_FORWARD_BATCH_SIZE_PER_GPU},
+
+    "generator.inference_engine.num_engines": ${INFERENCE_NUM_ENGINES},
+    "generator.inference_engine.tensor_parallel_size": ${INFERENCE_TENSOR_PARALLEL_SIZE},
+    "generator.inference_engine.max_num_batched_tokens": ${INFERENCE_MAX_NUM_BATCHED_TOKENS},
+    "generator.inference_engine.enable_ray_prometheus_stats": ${INFERENCE_ENABLE_RAY_PROMETHEUS_STATS},
+    "generator.inference_engine.gpu_memory_utilization": ${INFERENCE_GPU_MEMORY_UTILIZATION},
+    "generator.inference_engine.max_num_seqs": ${INFERENCE_MAX_NUM_SEQS},
+    "generator.inference_engine.engine_init_kwargs.max_model_len": ${INFERENCE_MAX_MODEL_LEN}
+}
+JSON
+)}"
+
+run_api \
+    --base-model "${BASE_MODEL}" \
+    --backend "${BACKEND}" \
+    --host "${HOST}" \
+    --port "${PORT}" \
+    --backend-config "${BACKEND_CONFIG}"

--- a/examples/train/amd/tinker_hello_world.py
+++ b/examples/train/amd/tinker_hello_world.py
@@ -1,0 +1,289 @@
+"""Direct Tinker smoke client for SkyRL's AMD Tinker server example.
+
+Run this in a separate shell from this directory after starting
+``run_tinker_server_amd.sh``. The script intentionally avoids task frameworks
+and exercises the public Tinker SDK directly against SkyRL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import tinker
+from tinker import types
+
+
+DEFAULT_BASE_URL = "http://localhost:9000"
+DEFAULT_API_KEY = "tml-dummy"
+SMOKE_LORA_RANK = 32
+SMOKE_STEPS = 4
+SMOKE_LEARNING_RATE = 3.0e-5
+SMOKE_SAMPLE_TOKENS = 32
+SMOKE_TEMPERATURE = 0.0
+
+SMOKE_EXAMPLES = [
+    ("Reply with only this word: amber", "amber"),
+    ("Reply with only this word: basalt", "basalt"),
+    ("Reply with only this word: cobalt", "cobalt"),
+    ("Reply with only this word: delta", "delta"),
+    ("Reply with only this word: ember", "ember"),
+    ("Reply with only this word: forest", "forest"),
+    ("Reply with only this word: granite", "granite"),
+    ("Reply with only this word: harbor", "harbor"),
+    ("Reply with only this word: indigo", "indigo"),
+    ("Reply with only this word: jasmine", "jasmine"),
+    ("Reply with only this word: kernel", "kernel"),
+    ("Reply with only this word: lantern", "lantern"),
+    ("Reply with only this word: marble", "marble"),
+    ("Reply with only this word: nickel", "nickel"),
+    ("Reply with only this word: orchid", "orchid"),
+    ("Reply with only this word: prism", "prism"),
+]
+
+
+@dataclass(frozen=True)
+class EncodedDatum:
+    prompt: str
+    target: str
+    prompt_tokens: list[int]
+    target_tokens: list[int]
+    datum: types.Datum
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a fixed AMD Tinker LoRA smoke test against a SkyRL server.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--base-url", default=os.environ.get("TINKER_BASE_URL", DEFAULT_BASE_URL))
+    parser.add_argument("--api-key", default=os.environ.get("TINKER_API_KEY", DEFAULT_API_KEY))
+    parser.add_argument(
+        "--base-model",
+        default=os.environ.get("TINKER_HELLO_BASE_MODEL"),
+        help="Base model to request. Defaults to the first model advertised by the server.",
+    )
+    return parser.parse_args()
+
+
+def normalize_base_url(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
+def fetch_json(url: str, timeout: float = 5.0) -> dict[str, Any]:
+    request = Request(url, headers={"accept": "application/json"})
+    with urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def check_health(base_url: str) -> None:
+    health_url = f"{base_url}/api/v1/healthz"
+    try:
+        payload = fetch_json(health_url)
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"SkyRL Tinker health check failed at {health_url}: {exc}") from exc
+
+    if payload.get("status") != "ok":
+        raise RuntimeError(f"Unexpected health response from {health_url}: {payload}")
+    print(f"[1/7] health ok ({health_url})", flush=True)
+
+
+def discover_base_model(client: tinker.ServiceClient, requested: str | None) -> str:
+    capabilities = client.get_server_capabilities()
+    supported = [model.model_name for model in capabilities.supported_models if model.model_name]
+
+    if requested:
+        if supported and requested not in supported:
+            print(
+                f"      warning: requested {requested!r}, but server advertised {supported!r}",
+                flush=True,
+            )
+        base_model = requested
+    else:
+        if not supported:
+            raise RuntimeError("Server did not advertise any supported base models")
+        base_model = supported[0]
+
+    print(f"[2/7] model {base_model}", flush=True)
+    return base_model
+
+
+def encode_prompt(tokenizer: Any, user_message: str) -> list[int]:
+    messages = [{"role": "user", "content": user_message}]
+    apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+    if apply_chat_template is not None:
+        try:
+            tokens = apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+                return_dict=False,
+            )
+            if isinstance(tokens, Mapping):
+                tokens = tokens["input_ids"]
+            return list(tokens)
+        except Exception as exc:
+            print(f"      warning: chat template failed, falling back to plain text: {exc}", flush=True)
+
+    return list(tokenizer.encode(f"User: {user_message}\nAssistant:", add_special_tokens=False))
+
+
+def encode_text(tokenizer: Any, text: str) -> list[int]:
+    tokens = list(tokenizer.encode(text, add_special_tokens=False))
+    if not tokens:
+        raise ValueError(f"text produced no tokens: {text!r}")
+    return tokens
+
+
+def tensor_i64(values: list[int]) -> types.TensorData:
+    return types.TensorData(data=values, dtype="int64", shape=[len(values)])
+
+
+def tensor_f32(values: list[float]) -> types.TensorData:
+    return types.TensorData(data=values, dtype="float32", shape=[len(values)])
+
+
+def make_cross_entropy_datum(prompt_tokens: list[int], target_tokens: list[int]) -> types.Datum:
+    model_input_tokens = prompt_tokens + target_tokens[:-1]
+    return types.Datum(
+        model_input=types.ModelInput.from_ints(model_input_tokens),
+        loss_fn_inputs={
+            "target_tokens": tensor_i64(target_tokens),
+            "weights": tensor_f32([1.0] * len(target_tokens)),
+        },
+    )
+
+
+def build_datums(tokenizer: Any) -> list[EncodedDatum]:
+    encoded = []
+    for prompt, target in SMOKE_EXAMPLES:
+        prompt_tokens = encode_prompt(tokenizer, prompt)
+        target_tokens = encode_text(tokenizer, target)
+        encoded.append(
+            EncodedDatum(
+                prompt=prompt,
+                target=target,
+                prompt_tokens=prompt_tokens,
+                target_tokens=target_tokens,
+                datum=make_cross_entropy_datum(prompt_tokens, target_tokens),
+            )
+        )
+    return encoded
+
+
+def metric_value(metrics: Mapping[str, Any], key: str) -> str:
+    value = metrics.get(key)
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def sample_once(
+    sampling_client: Any,
+    tokenizer: Any,
+    prompt_tokens: list[int],
+    label: str,
+) -> None:
+    sampling_params = types.SamplingParams(
+        max_tokens=SMOKE_SAMPLE_TOKENS,
+        seed=1,
+        temperature=SMOKE_TEMPERATURE,
+        top_p=1.0,
+        top_k=-1,
+    )
+    sample_result = sampling_client.sample(
+        prompt=types.ModelInput.from_ints(prompt_tokens),
+        num_samples=1,
+        sampling_params=sampling_params,
+    ).result()
+
+    sequence = sample_result.sequences[0]
+    completion = tokenizer.decode(sequence.tokens, skip_special_tokens=True)
+    print(f"      {label}.stop_reason={sequence.stop_reason}", flush=True)
+    print(f"      {label}.text={completion!r}", flush=True)
+
+
+def run() -> int:
+    args = parse_args()
+    base_url = normalize_base_url(args.base_url)
+
+    check_health(base_url)
+
+    service_client = tinker.ServiceClient(base_url=base_url, api_key=args.api_key)
+    base_model = discover_base_model(service_client, args.base_model)
+
+    print(f"[3/7] creating LoRA training client rank={SMOKE_LORA_RANK}", flush=True)
+    training_client = service_client.create_lora_training_client(
+        base_model=base_model,
+        rank=SMOKE_LORA_RANK,
+        seed=1,
+        train_mlp=True,
+        train_attn=True,
+        train_unembed=True,
+        user_metadata={"example": "skyrl-amd-tinker-smoke"},
+    )
+    tokenizer = training_client.get_tokenizer()
+
+    encoded_datums = build_datums(tokenizer)
+    datums = [item.datum for item in encoded_datums]
+    total_prompt_tokens = sum(len(item.prompt_tokens) for item in encoded_datums)
+    total_target_tokens = sum(len(item.target_tokens) for item in encoded_datums)
+    print(
+        "[4/7] built smoke batch "
+        f"examples={len(datums)} prompt_tokens={total_prompt_tokens} target_tokens={total_target_tokens}",
+        flush=True,
+    )
+
+    print("[5/7] syncing initial weights and sampling once", flush=True)
+    sampling_client = training_client.save_weights_and_get_sampling_client()
+    sample_once(sampling_client, tokenizer, encoded_datums[0].prompt_tokens, "pre_train_sample")
+
+    print(
+        f"[6/7] training steps={SMOKE_STEPS} loss=cross_entropy lr={SMOKE_LEARNING_RATE}",
+        flush=True,
+    )
+    for step in range(1, SMOKE_STEPS + 1):
+        forward_backward_future = training_client.forward_backward(datums, "cross_entropy")
+        optim_future = training_client.optim_step(types.AdamParams(learning_rate=SMOKE_LEARNING_RATE))
+
+        forward_backward_result = forward_backward_future.result()
+        optim_result = optim_future.result()
+        fb_metrics = forward_backward_result.metrics
+        optim_metrics = optim_result.metrics
+        print(
+            f"      step {step}/{SMOKE_STEPS} "
+            f"tokens={metric_value(fb_metrics, 'num_tokens:sum')} "
+            f"loss={metric_value(fb_metrics, 'total_loss:sum')} "
+            f"grad_norm={metric_value(optim_metrics, 'skyrl.ai/grad_norm')} "
+            f"lr={metric_value(optim_metrics, 'skyrl.ai/learning_rate')}",
+            flush=True,
+        )
+
+    print("[7/7] syncing trained weights and sampling once", flush=True)
+    sampling_client = training_client.save_weights_and_get_sampling_client()
+    sample_once(sampling_client, tokenizer, encoded_datums[0].prompt_tokens, "post_train_sample")
+
+    print("PASS", flush=True)
+    return 0
+
+
+def main() -> int:
+    try:
+        return run()
+    except KeyboardInterrupt:
+        print("Interrupted", file=sys.stderr)
+        return 130
+    except Exception as exc:
+        print(f"tinker_hello_world failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/train/amd/tinker_hello_world.py
+++ b/examples/train/amd/tinker_hello_world.py
@@ -83,6 +83,33 @@ def fetch_json(url: str, timeout: float = 5.0) -> dict[str, Any]:
         return json.loads(response.read().decode("utf-8"))
 
 
+def post_json(base_url: str, path: str, payload: dict[str, Any], timeout: float = 300.0) -> dict[str, Any]:
+    data = json.dumps(payload).encode("utf-8")
+    request = Request(
+        f"{base_url}{path}",
+        data=data,
+        headers={"accept": "application/json", "content-type": "application/json"},
+        method="POST",
+    )
+    with urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def unload_training_model(base_url: str, training_client: tinker.TrainingClient | None) -> None:
+    if training_client is None:
+        return
+    model_id = getattr(training_client, "model_id", None)
+    if not model_id:
+        return
+    try:
+        response = post_json(base_url, "/api/v1/unload_model", {"model_id": model_id}, timeout=10.0)
+        request_id = response["request_id"]
+        post_json(base_url, "/api/v1/retrieve_future", {"request_id": request_id}, timeout=300.0)
+        print(f"      unloaded model {model_id}", flush=True)
+    except (HTTPError, URLError, TimeoutError, KeyError, json.JSONDecodeError) as exc:
+        print(f"      warning: failed to unload model {model_id}: {exc}", file=sys.stderr, flush=True)
+
+
 def check_health(base_url: str) -> None:
     health_url = f"{base_url}/api/v1/healthz"
     try:
@@ -216,62 +243,69 @@ def run() -> int:
 
     check_health(base_url)
 
-    service_client = tinker.ServiceClient(base_url=base_url, api_key=args.api_key)
-    base_model = discover_base_model(service_client, args.base_model)
+    service_client = None
+    training_client = None
+    try:
+        service_client = tinker.ServiceClient(base_url=base_url, api_key=args.api_key)
+        base_model = discover_base_model(service_client, args.base_model)
 
-    print(f"[3/7] creating LoRA training client rank={SMOKE_LORA_RANK}", flush=True)
-    training_client = service_client.create_lora_training_client(
-        base_model=base_model,
-        rank=SMOKE_LORA_RANK,
-        seed=1,
-        train_mlp=True,
-        train_attn=True,
-        train_unembed=True,
-        user_metadata={"example": "skyrl-amd-tinker-smoke"},
-    )
-    tokenizer = training_client.get_tokenizer()
+        print(f"[3/7] creating LoRA training client rank={SMOKE_LORA_RANK}", flush=True)
+        training_client = service_client.create_lora_training_client(
+            base_model=base_model,
+            rank=SMOKE_LORA_RANK,
+            seed=1,
+            train_mlp=True,
+            train_attn=True,
+            train_unembed=True,
+            user_metadata={"example": "skyrl-amd-tinker-smoke"},
+        )
+        tokenizer = training_client.get_tokenizer()
 
-    encoded_datums = build_datums(tokenizer)
-    datums = [item.datum for item in encoded_datums]
-    total_prompt_tokens = sum(len(item.prompt_tokens) for item in encoded_datums)
-    total_target_tokens = sum(len(item.target_tokens) for item in encoded_datums)
-    print(
-        "[4/7] built smoke batch "
-        f"examples={len(datums)} prompt_tokens={total_prompt_tokens} target_tokens={total_target_tokens}",
-        flush=True,
-    )
-
-    print("[5/7] syncing initial weights and sampling once", flush=True)
-    sampling_client = training_client.save_weights_and_get_sampling_client()
-    sample_once(sampling_client, tokenizer, encoded_datums[0].prompt_tokens, "pre_train_sample")
-
-    print(
-        f"[6/7] training steps={SMOKE_STEPS} loss=cross_entropy lr={SMOKE_LEARNING_RATE}",
-        flush=True,
-    )
-    for step in range(1, SMOKE_STEPS + 1):
-        forward_backward_future = training_client.forward_backward(datums, "cross_entropy")
-        optim_future = training_client.optim_step(types.AdamParams(learning_rate=SMOKE_LEARNING_RATE))
-
-        forward_backward_result = forward_backward_future.result()
-        optim_result = optim_future.result()
-        fb_metrics = forward_backward_result.metrics
-        optim_metrics = optim_result.metrics
+        encoded_datums = build_datums(tokenizer)
+        datums = [item.datum for item in encoded_datums]
+        total_prompt_tokens = sum(len(item.prompt_tokens) for item in encoded_datums)
+        total_target_tokens = sum(len(item.target_tokens) for item in encoded_datums)
         print(
-            f"      step {step}/{SMOKE_STEPS} "
-            f"tokens={metric_value(fb_metrics, 'num_tokens:sum')} "
-            f"loss={metric_value(fb_metrics, 'total_loss:sum')} "
-            f"grad_norm={metric_value(optim_metrics, 'skyrl.ai/grad_norm')} "
-            f"lr={metric_value(optim_metrics, 'skyrl.ai/learning_rate')}",
+            "[4/7] built smoke batch "
+            f"examples={len(datums)} prompt_tokens={total_prompt_tokens} target_tokens={total_target_tokens}",
             flush=True,
         )
 
-    print("[7/7] syncing trained weights and sampling once", flush=True)
-    sampling_client = training_client.save_weights_and_get_sampling_client()
-    sample_once(sampling_client, tokenizer, encoded_datums[0].prompt_tokens, "post_train_sample")
+        print("[5/7] syncing initial weights and sampling once", flush=True)
+        sampling_client = training_client.save_weights_and_get_sampling_client()
+        sample_once(sampling_client, tokenizer, encoded_datums[0].prompt_tokens, "pre_train_sample")
 
-    print("PASS", flush=True)
-    return 0
+        print(
+            f"[6/7] training steps={SMOKE_STEPS} loss=cross_entropy lr={SMOKE_LEARNING_RATE}",
+            flush=True,
+        )
+        for step in range(1, SMOKE_STEPS + 1):
+            forward_backward_future = training_client.forward_backward(datums, "cross_entropy")
+            optim_future = training_client.optim_step(types.AdamParams(learning_rate=SMOKE_LEARNING_RATE))
+
+            forward_backward_result = forward_backward_future.result()
+            optim_result = optim_future.result()
+            fb_metrics = forward_backward_result.metrics
+            optim_metrics = optim_result.metrics
+            print(
+                f"      step {step}/{SMOKE_STEPS} "
+                f"tokens={metric_value(fb_metrics, 'num_tokens:sum')} "
+                f"loss={metric_value(fb_metrics, 'total_loss:sum')} "
+                f"grad_norm={metric_value(optim_metrics, 'skyrl.ai/grad_norm')} "
+                f"lr={metric_value(optim_metrics, 'skyrl.ai/learning_rate')}",
+                flush=True,
+            )
+
+        print("[7/7] syncing trained weights and sampling once", flush=True)
+        sampling_client = training_client.save_weights_and_get_sampling_client()
+        sample_once(sampling_client, tokenizer, encoded_datums[0].prompt_tokens, "post_train_sample")
+
+        print("PASS", flush=True)
+        return 0
+    finally:
+        unload_training_model(base_url, training_client)
+        if service_client is not None:
+            service_client.holder.close()
 
 
 def main() -> int:

--- a/skyrl/backends/skyrl_train/inference_servers/layerwise_reload.py
+++ b/skyrl/backends/skyrl_train/inference_servers/layerwise_reload.py
@@ -65,6 +65,18 @@ def patch_numel_loaded():
 _PATCHED_LAYERWISE_NUMEL_LOADED = False
 
 
+def _empty_cuda_cache_rocm() -> None:
+    """Release unused ROCm cached blocks after full-weight sync."""
+    is_rocm = torch.version.hip is not None
+    if not torch.cuda.is_available() or not is_rocm:
+        return
+
+    device = torch.cuda.current_device()
+    torch.cuda.synchronize(device)
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize(device)
+
+
 class LayerwiseReloadWorkerMixin:
     """Bracket a multi-chunk weight sync with one vLLM layerwise-reload init/finalize.
 
@@ -153,3 +165,4 @@ class LayerwiseReloadWorkerMixin:
 
         self._skyrl_weight_update_active = False
         self._skyrl_is_checkpoint_format = True
+        _empty_cuda_cache_rocm()

--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -32,8 +32,18 @@ from skyrl.backends.skyrl_train.inference_servers.layerwise_reload import (
 
 VLLM_NEW_INFERENCE_WORKER_EXTENSION_CLS = f"{__name__}.NewInferenceWorkerWrap"
 
+def _empty_cuda_cache() -> None:
+    """Release unused CUDA/ROCm cached blocks after full-weight sync."""
+    if not torch.cuda.is_available():
+        return
 
-class NewInferenceWorkerWrap(LayerwiseReloadWorkerMixin):
+    device = torch.cuda.current_device()
+    torch.cuda.synchronize(device)
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize(device)
+
+
+class NewInferenceWorkerWrap:
     """
     vLLM worker extension for chunked weight sync (new inference path).
 
@@ -158,3 +168,29 @@ class NewInferenceWorkerWrap(LayerwiseReloadWorkerMixin):
             )
 
         torch.accelerator.synchronize()
+        _empty_cuda_cache()
+
+    def finish_weight_update(self) -> None:
+        """
+        Finalize the current weight update.
+
+        For checkpoint-format weights, runs layerwise postprocessing
+        (quantization repacking, attention weight processing, etc.).
+        Must be called after all update_weights_ipc calls are done.
+        """
+        if not getattr(self, "_skyrl_weight_update_active", False):
+            raise RuntimeError("start_weight_update must be called before finish_weight_update.")
+
+        if self._skyrl_is_checkpoint_format:
+            from vllm.config import set_current_vllm_config
+            from vllm.model_executor.model_loader.reload import (
+                finalize_layerwise_reload,
+            )
+
+            model = self.model_runner.model
+            with set_current_vllm_config(self.vllm_config), torch.device(self.device):
+                finalize_layerwise_reload(model, self.model_config)
+
+        self._skyrl_weight_update_active = False
+        self._skyrl_is_checkpoint_format = True
+        _empty_cuda_cache()

--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -28,20 +28,10 @@ import torch
 
 from skyrl.backends.skyrl_train.inference_servers.layerwise_reload import (
     LayerwiseReloadWorkerMixin,
+    _empty_cuda_cache_rocm,
 )
 
 VLLM_NEW_INFERENCE_WORKER_EXTENSION_CLS = f"{__name__}.NewInferenceWorkerWrap"
-
-
-def _empty_cuda_cache() -> None:
-    """Release unused CUDA/ROCm cached blocks after full-weight sync."""
-    if not torch.cuda.is_available():
-        return
-
-    device = torch.cuda.current_device()
-    torch.cuda.synchronize(device)
-    torch.cuda.empty_cache()
-    torch.cuda.synchronize(device)
 
 
 class NewInferenceWorkerWrap(LayerwiseReloadWorkerMixin):
@@ -169,18 +159,4 @@ class NewInferenceWorkerWrap(LayerwiseReloadWorkerMixin):
             )
 
         torch.accelerator.synchronize()
-        _empty_cuda_cache()
-
-    def skyrl_finish_weight_update(self) -> None:
-        """
-        Finalize the current weight update.
-
-        For checkpoint-format weights, runs layerwise postprocessing
-        (quantization repacking, attention weight processing, etc.).
-        Must be called after all update_weights_* calls are done.
-
-        Keep the SkyRL-prefixed name to avoid colliding with vLLM Worker
-        methods such as finish_weight_update.
-        """
-        super().skyrl_finish_weight_update()
-        _empty_cuda_cache()
+        _empty_cuda_cache_rocm()

--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -43,7 +43,7 @@ def _empty_cuda_cache() -> None:
     torch.cuda.synchronize(device)
 
 
-class NewInferenceWorkerWrap:
+class NewInferenceWorkerWrap(LayerwiseReloadWorkerMixin):
     """
     vLLM worker extension for chunked weight sync (new inference path).
 
@@ -170,27 +170,16 @@ class NewInferenceWorkerWrap:
         torch.accelerator.synchronize()
         _empty_cuda_cache()
 
-    def finish_weight_update(self) -> None:
+    def skyrl_finish_weight_update(self) -> None:
         """
         Finalize the current weight update.
 
         For checkpoint-format weights, runs layerwise postprocessing
         (quantization repacking, attention weight processing, etc.).
-        Must be called after all update_weights_ipc calls are done.
+        Must be called after all update_weights_* calls are done.
+
+        Keep the SkyRL-prefixed name to avoid colliding with vLLM Worker
+        methods such as finish_weight_update.
         """
-        if not getattr(self, "_skyrl_weight_update_active", False):
-            raise RuntimeError("start_weight_update must be called before finish_weight_update.")
-
-        if self._skyrl_is_checkpoint_format:
-            from vllm.config import set_current_vllm_config
-            from vllm.model_executor.model_loader.reload import (
-                finalize_layerwise_reload,
-            )
-
-            model = self.model_runner.model
-            with set_current_vllm_config(self.vllm_config), torch.device(self.device):
-                finalize_layerwise_reload(model, self.model_config)
-
-        self._skyrl_weight_update_active = False
-        self._skyrl_is_checkpoint_format = True
+        super().skyrl_finish_weight_update()
         _empty_cuda_cache()

--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -32,6 +32,7 @@ from skyrl.backends.skyrl_train.inference_servers.layerwise_reload import (
 
 VLLM_NEW_INFERENCE_WORKER_EXTENSION_CLS = f"{__name__}.NewInferenceWorkerWrap"
 
+
 def _empty_cuda_cache() -> None:
     """Release unused CUDA/ROCm cached blocks after full-weight sync."""
     if not torch.cuda.is_available():


### PR DESCRIPTION
This PR adds an AMD ROCm path for running SkyRL’s Tinker-compatible API with FSDP training and vLLM ROCm inference.

  Changes

  - Add `docker/Dockerfile.amd` for a ROCm-based SkyRL image.
  - Add `docker/pyproject.amd.toml` to avoid CUDA-specific dependencies in the AMD image.
  - Add `examples/train/amd/run_tinker_server_amd.sh` to launch the Tinker API on AMD nodes.
  - Add AMD example clients:
      - `tinker_hello_world.py`: small LoRA smoke test.
      - `grpo_client.py`: GSM8K GRPO/PPO training example.
  - Add `examples/train/amd/README.md` with build/run instructions.