### PR TITLE
[Tinker] Transfer LoRA adapters

### DIFF
--- a/skyrl/backends/backend.py
+++ b/skyrl/backends/backend.py
@@ -150,6 +150,14 @@ class AbstractBackend(ABC):
         """
         pass
 
+    def export_adapter(self, model_id: str, adapter_name: str) -> str:
+        """Export a named adapter and return its shared filesystem path."""
+        raise NotImplementedError(f"{type(self).__name__} does not support adapter export")
+
+    def load_adapter(self, adapter_name: str, adapter_path: str) -> None:
+        """Load a named adapter from a shared filesystem path."""
+        raise NotImplementedError(f"{type(self).__name__} does not support adapter loading")
+
     @abstractmethod
     def has_model(self, model_id: str) -> bool:
         """Check if a model is registered with the backend.

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -251,18 +251,33 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
             with io.open(os.path.join(lora_sync_path, "adapter_config.json"), "w", encoding="utf-8") as f:
                 json.dump(peft_config, f, ensure_ascii=False, indent=4)
 
-            # Send LoRA disk loading request to inference engine.
-            from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
-                RemoteInferenceClient,
-            )
+            if inference_engine_client is not None:
+                from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
+                    RemoteInferenceClient,
+                )
 
-            if isinstance(inference_engine_client, RemoteInferenceClient):
-                await inference_engine_client.load_lora_adapter(lora_name, lora_sync_path)
-            else:
-                lora_request = LoraLoadRequest(lora_path=lora_sync_path, lora_name=lora_name)
-                await inference_engine_client.update_named_weights(lora_request)
+                if isinstance(inference_engine_client, RemoteInferenceClient):
+                    await inference_engine_client.load_lora_adapter(lora_name, lora_sync_path)
+                else:
+                    lora_request = LoraLoadRequest(lora_path=lora_sync_path, lora_name=lora_name)
+                    await inference_engine_client.update_named_weights(lora_request)
 
         torch.distributed.barrier()
+
+    async def export_adapter(self, adapter_name: str) -> str:
+        if not self._is_lora:
+            raise RuntimeError("export_adapter requires LoRA training")
+        peft_model = getattr(self.model.model, "_fsdp_wrapped_module", self.model.model)
+        if not hasattr(peft_model, "peft_config"):
+            raise RuntimeError("LoRA model is missing its PEFT configuration")
+        lora_name, lora_sync_path = self._resolve_lora_sync_target(adapter_name)
+        await self._save_lora_adapters_and_sync(
+            peft_model,
+            lora_sync_path,
+            None,
+            lora_name=lora_name,
+        )
+        return lora_sync_path
 
     async def broadcast_to_inference_engines(
         self,

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1346,7 +1346,15 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
 
         adapter_state = {}
         for name, tensor in self.bridge.export_adapter_weights(self.actor_module, cpu=True, show_progress=False):
-            adapter_state[f"base_model.model.{name}"] = tensor.clone().float()
+            key = f"base_model.model.{name}"
+            if self.cfg.policy.language_model_only:
+                if any(part in key for part in (".visual.", ".mtp.", ".multi_token")):
+                    continue
+                key = key.replace(
+                    "base_model.model.model.language_model.",
+                    "base_model.model.language_model.model.",
+                )
+            adapter_state[key] = tensor.clone().float()
 
         if torch.distributed.get_rank() == 0:
             os.makedirs(lora_sync_path, exist_ok=True)

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1375,18 +1375,29 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             with open(os.path.join(lora_sync_path, "adapter_config.json"), "w", encoding="utf-8") as f:
                 json.dump(adapter_config, f, ensure_ascii=False, indent=4)
 
-            # Send LoRA disk loading request to inference engine.
-            from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
-                RemoteInferenceClient,
-            )
+            if inference_engine_client is not None:
+                from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
+                    RemoteInferenceClient,
+                )
 
-            if isinstance(inference_engine_client, RemoteInferenceClient):
-                await inference_engine_client.load_lora_adapter(lora_name, lora_sync_path)
-            else:
-                lora_request = LoraLoadRequest(lora_path=lora_sync_path, lora_name=lora_name)
-                await inference_engine_client.update_named_weights(lora_request)
+                if isinstance(inference_engine_client, RemoteInferenceClient):
+                    await inference_engine_client.load_lora_adapter(lora_name, lora_sync_path)
+                else:
+                    lora_request = LoraLoadRequest(lora_path=lora_sync_path, lora_name=lora_name)
+                    await inference_engine_client.update_named_weights(lora_request)
 
         torch.distributed.barrier()
+
+    async def export_adapter(self, adapter_name: str) -> str:
+        if not self._is_lora or self.cfg.policy.megatron_config.lora_config.merge_lora:
+            raise RuntimeError("export_adapter requires unmerged LoRA training")
+        lora_name, lora_sync_path = self._resolve_lora_sync_target(adapter_name)
+        await self._save_lora_adapters_and_sync(
+            lora_sync_path,
+            None,
+            lora_name=lora_name,
+        )
+        return lora_sync_path
 
     async def broadcast_to_inference_engines(
         self,

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -650,3 +650,22 @@ class WorkerDispatch:
         # Advance the policy version so prefix-cache salting isolates blocks from the previous weights
         # (see `GeneratorConfig.use_cache_salt`).
         self._inference_engine_client.increment_weight_version()
+
+    async def export_adapter(self, model_id: str, adapter_name: str) -> str:
+        """Export one policy adapter without creating inference engines."""
+        self._prepare_for_weight_sync()
+        try:
+            self.ensure_active_adapter("policy", model_id)
+            adapter_paths = ray.get(
+                self._actor_groups["policy"].async_run_ray_method(
+                    "pass_through",
+                    "export_adapter",
+                    adapter_name,
+                )
+            )
+        finally:
+            self._finish_weight_sync()
+        unique_paths = set(adapter_paths)
+        if len(unique_paths) != 1:
+            raise RuntimeError(f"Policy workers returned different adapter paths: {adapter_paths}")
+        return unique_paths.pop()

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -15,7 +15,7 @@ from ray.util.placement_group import placement_group
 from transformers import AutoTokenizer
 
 from skyrl.backends.backend import AbstractBackend
-from skyrl.backends.renderer import VLLMRenderer
+from skyrl.backends.renderer import VLLMRenderer, render_model_input
 from skyrl.backends.skyrl_train.inference_servers.utils import resolve_policy_model_name
 from skyrl.backends.skyrl_train.training_batch import (
     TensorList,
@@ -378,6 +378,8 @@ class SkyRLTrainBackend(AbstractBackend):
 
     def _ensure_inference_engines(self):
         """Lazily create inference engines and init weight sync on first sampling-related call."""
+        if not self._cfg.generator.inference_engine.enabled:
+            raise RuntimeError("Inference engines are disabled for this service")
         if self._inference_engines_initialized:
             return
 
@@ -539,10 +541,13 @@ class SkyRLTrainBackend(AbstractBackend):
         if not prepared_batch.all_model_inputs:
             return TrainingInputBatch({})
 
-        if self._renderer is None:
-            self._ensure_inference_engines()
-            self._renderer = VLLMRenderer(self._inference_engine_client, self._cfg.trainer.policy.model.path)
-        rendered_inputs = asyncio.run(self._renderer(prepared_batch.all_model_inputs))
+        if not self._cfg.generator.inference_engine.enabled:
+            rendered_inputs = render_model_input(prepared_batch.all_model_inputs)
+        else:
+            if self._renderer is None:
+                self._ensure_inference_engines()
+                self._renderer = VLLMRenderer(self._inference_engine_client, self._cfg.trainer.policy.model.path)
+            rendered_inputs = asyncio.run(self._renderer(prepared_batch.all_model_inputs))
 
         all_input_ids = [r.prompt_ids for r in rendered_inputs]
 
@@ -1200,6 +1205,7 @@ class SkyRLTrainBackend(AbstractBackend):
                 self._dispatch.save_hf_model(model="policy", export_dir=hf_dir, tokenizer=self._tokenizer)
                 self._create_tar_from_directory(hf_dir, output_path)
             logger.info(f"Saved sampler checkpoint for {model_id} to {output_path}")
+
         else:
             # Hot path: write a lightweight marker so the engine's checkpoint
             # bookkeeping stays consistent.  Actual weights live in GPU memory.
@@ -1210,3 +1216,16 @@ class SkyRLTrainBackend(AbstractBackend):
                 info.size = len(marker)
                 tar.addfile(info, io.BytesIO(marker))
             logger.info(f"Synced weights for {model_id} (disk save skipped)")
+
+    def export_adapter(self, model_id: str, adapter_name: str) -> str:
+        self._validate_model_state(model_id)
+        if self._get_role(model_id) != "policy":
+            raise ValueError("export_adapter is only supported for policy models")
+        if self._base_lora_signature is None:
+            raise ValueError("export_adapter requires LoRA training")
+        return asyncio.run(self._dispatch.export_adapter(model_id, adapter_name))
+
+    def load_adapter(self, adapter_name: str, adapter_path: str) -> None:
+        self._ensure_inference_engines()
+        asyncio.run(self._inference_engine_client.load_lora_adapter(adapter_name, adapter_path))
+        self._inference_engine_client.increment_weight_version()

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -524,12 +524,25 @@ class SaveWeightsForSamplerRequest(BaseModel):
     sampling_session_seq_id: int | None = None
     seq_id: int | None = None
     type: Literal["save_weights_for_sampler"] = "save_weights_for_sampler"
+    mode: Literal["sync", "export_adapter"] = "sync"
 
     @model_validator(mode="after")
     def check_path_or_ids(self):
+        if self.mode == "export_adapter":
+            if not self.path:
+                raise ValueError("'path' is required when mode='export_adapter'")
+            if self.sampling_session_seq_id is not None or self.seq_id is not None:
+                raise ValueError("sampling session IDs are not accepted when mode='export_adapter'")
+            return self
         if not self.path and (self.sampling_session_seq_id is None or self.seq_id is None):
             raise ValueError("Either 'path' or both 'sampling_session_seq_id' and 'seq_id' must be provided")
         return self
+
+
+class LoadAdapterRequest(BaseModel):
+    model_id: str
+    adapter_name: str = Field(pattern=ID_PATTERN, max_length=ID_MAX_LENGTH)
+    adapter_path: str
 
 
 class SamplingParams(BaseModel):
@@ -1030,7 +1043,10 @@ async def save_weights_for_sampler(request: SaveWeightsForSamplerRequest, sessio
 
     checkpoint_id = request.path or f"ss{request.sampling_session_seq_id}_seq{request.seq_id}"
     sampling_session_id = None
-    if request.sampling_session_seq_id is not None and request.seq_id is not None:
+    adapter_name = None
+    if request.mode == "export_adapter":
+        adapter_name = f"{request.model_id}_{checkpoint_id}"
+    elif request.sampling_session_seq_id is not None and request.seq_id is not None:
         # Create the sampling session using the model's session
         sampling_session_id = f"sampling_{uuid4().hex[:8]}"
         sampling_db = SamplingSessionDB(
@@ -1042,13 +1058,13 @@ async def save_weights_for_sampler(request: SaveWeightsForSamplerRequest, sessio
         )
         session.add(sampling_db)
 
-    # Create pending checkpoint entry
-    await create_checkpoint(
-        session=session,
-        model_id=request.model_id,
-        checkpoint_id=checkpoint_id,
-        checkpoint_type=types.CheckpointType.SAMPLER,
-    )
+    if request.mode == "sync":
+        await create_checkpoint(
+            session=session,
+            model_id=request.model_id,
+            checkpoint_id=checkpoint_id,
+            checkpoint_type=types.CheckpointType.SAMPLER,
+        )
 
     request_id = await create_future(
         session=session,
@@ -1059,11 +1075,30 @@ async def save_weights_for_sampler(request: SaveWeightsForSamplerRequest, sessio
             sampling_session_seq_id=request.sampling_session_seq_id,
             seq_id=request.seq_id,
             sampling_session_id=sampling_session_id,
+            mode=request.mode,
+            adapter_name=adapter_name,
         ),
     )
 
     await session.commit()
 
+    return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
+
+
+@app.post("/api/v1/load_adapter", response_model=FutureResponse)
+async def load_adapter(request: LoadAdapterRequest, session: AsyncSession = Depends(get_session)):
+    """Loads a LoRA adapter into this service's inference engines."""
+    await get_model(session, request.model_id)
+    request_id = await create_future(
+        session=session,
+        request_type=types.RequestType.LOAD_ADAPTER,
+        model_id=request.model_id,
+        request_data=types.LoadAdapterInput(
+            adapter_name=request.adapter_name,
+            adapter_path=request.adapter_path,
+        ),
+    )
+    await session.commit()
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -639,6 +639,16 @@ class TinkerEngine:
         if not self.backend.has_model(model_id):
             return _model_not_found_error(model_id)
 
+        if request_data.mode == "export_adapter":
+            if request_data.adapter_name is None:
+                raise ValueError("adapter_name is required for adapter export")
+            adapter_path = self.backend.export_adapter(model_id, request_data.adapter_name)
+            return types.SaveWeightsForSamplerOutput(
+                type="save_weights_for_sampler",
+                adapter_name=request_data.adapter_name,
+                adapter_path=adapter_path,
+            )
+
         # Make sure the user cannot store checkpoints in places like ../../<important file>
         checkpoint_id = Path(request_data.path).name
         output_path = self.config.checkpoints_base / model_id / "sampler_weights" / f"{checkpoint_id}.tar.gz"
@@ -662,6 +672,17 @@ class TinkerEngine:
             path=output_path_str,
             type="save_weights_for_sampler",
             sampling_session_id=request_data.sampling_session_id,
+        )
+
+    def process_load_adapter(
+        self, model_id: str, request_data: types.LoadAdapterInput
+    ) -> types.LoadAdapterOutput | types.ErrorResponse:
+        if not self.backend.has_model(model_id):
+            return _model_not_found_error(model_id)
+        self.backend.load_adapter(request_data.adapter_name, request_data.adapter_path)
+        return types.LoadAdapterOutput(
+            adapter_name=request_data.adapter_name,
+            adapter_path=request_data.adapter_path,
         )
 
     def _complete_futures(self, results: dict[str, BaseModel]):
@@ -695,6 +716,8 @@ class TinkerEngine:
                 return self.process_save_weights_for_sampler(
                     model_id, types.SaveWeightsForSamplerInput.model_validate(request_data)
                 )
+            case types.RequestType.LOAD_ADAPTER:
+                return self.process_load_adapter(model_id, types.LoadAdapterInput.model_validate(request_data))
             case types.RequestType.SAVE_WEIGHTS:
                 return self.process_save_weights(model_id, types.SaveWeightsInput.model_validate(request_data))
             case types.RequestType.LOAD_WEIGHTS:

--- a/skyrl/tinker/types.py
+++ b/skyrl/tinker/types.py
@@ -20,6 +20,7 @@ class RequestType(str, Enum):
     FORWARD = "forward"
     OPTIM_STEP = "optim_step"
     SAVE_WEIGHTS_FOR_SAMPLER = "save_weights_for_sampler"
+    LOAD_ADAPTER = "load_adapter"
     SAVE_WEIGHTS = "save_weights"
     LOAD_WEIGHTS = "load_weights"
     SAMPLE = "sample"
@@ -188,12 +189,27 @@ class SaveWeightsForSamplerInput(BaseModel):
     sampling_session_seq_id: int | None = None
     seq_id: int | None = None
     sampling_session_id: str | None = None
+    mode: Literal["sync", "export_adapter"] = "sync"
+    adapter_name: str | None = None
 
 
 class SaveWeightsForSamplerOutput(BaseModel):
     path: str | None = None
     type: str
     sampling_session_id: str | None = None
+    adapter_name: str | None = None
+    adapter_path: str | None = None
+
+
+class LoadAdapterInput(BaseModel):
+    adapter_name: str
+    adapter_path: str
+
+
+class LoadAdapterOutput(BaseModel):
+    adapter_name: str
+    adapter_path: str
+    type: str = "load_adapter"
 
 
 class SaveWeightsInput(BaseModel):

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -702,6 +702,7 @@ class InferenceEngineConfig(BaseConfig):
 
     model_dtype: str = "bfloat16"
     """Should match the dtype used by the inference engine."""
+    enabled: bool = True
     run_engines_locally: bool = True
     num_engines: int = 1
     backend: str = "vllm"

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -540,6 +540,18 @@ def _validate_new_inference_cfg(cfg: SkyRLTrainConfig):
     Raises:
         ValueError: If colocated mode is used with external URLs.
     """
+    if not cfg.generator.inference_engine.enabled:
+        if cfg.generator.inference_engine.run_engines_locally:
+            raise ValueError("generator.inference_engine.run_engines_locally must be false when inference is disabled")
+        if (
+            cfg.generator.inference_engine.external_proxy_url is not None
+            or cfg.generator.inference_engine.external_server_urls is not None
+        ):
+            raise ValueError("External inference URLs are not accepted when inference is disabled")
+        if cfg.trainer.placement.colocate_all:
+            raise ValueError("colocate_all must be false when inference is disabled")
+        return
+
     is_colocated = cfg.trainer.placement.colocate_all
     has_external_proxy = cfg.generator.inference_engine.external_proxy_url is not None
     has_external_servers = cfg.generator.inference_engine.external_server_urls is not None

--- a/tests/tinker/skyrl_train/test_adapter_transfer.py
+++ b/tests/tinker/skyrl_train/test_adapter_transfer.py
@@ -1,0 +1,37 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+skyrl_train_backend = pytest.importorskip("skyrl.backends.skyrl_train_backend")
+SkyRLTrainBackend = skyrl_train_backend.SkyRLTrainBackend
+
+
+def test_training_only_export_does_not_start_inference():
+    backend = object.__new__(SkyRLTrainBackend)
+    backend._validate_model_state = MagicMock()
+    backend._get_role = MagicMock(return_value="policy")
+    backend._base_lora_signature = (32, 32.0)
+    backend._dispatch = MagicMock()
+    backend._dispatch.export_adapter = AsyncMock(return_value="/shared/adapters/model_step_4")
+    backend._ensure_inference_engines = MagicMock()
+
+    adapter_path = backend.export_adapter("model", "model_step_4")
+
+    backend._dispatch.export_adapter.assert_awaited_once_with("model", "model_step_4")
+    backend._ensure_inference_engines.assert_not_called()
+    assert adapter_path == "/shared/adapters/model_step_4"
+
+
+def test_loading_adapter_advances_inference_weight_version():
+    backend = object.__new__(SkyRLTrainBackend)
+    backend._ensure_inference_engines = MagicMock()
+    backend._inference_engine_client = MagicMock()
+    backend._inference_engine_client.load_lora_adapter = AsyncMock()
+
+    backend.load_adapter("rollout_model", "/shared/adapters/model_step_4")
+
+    backend._ensure_inference_engines.assert_called_once_with()
+    backend._inference_engine_client.load_lora_adapter.assert_awaited_once_with(
+        "rollout_model", "/shared/adapters/model_step_4"
+    )
+    backend._inference_engine_client.increment_weight_version.assert_called_once_with()

--- a/tests/tinker/test_api_validation.py
+++ b/tests/tinker/test_api_validation.py
@@ -102,6 +102,22 @@ def test_datum_to_types_preserves_values_and_returns():
     assert datum.loss_fn_inputs.returns.data == [0.4, 0.5, 0.6]
 
 
+def test_adapter_export_requires_a_versioned_path():
+    with pytest.raises(ValidationError, match="path.*required"):
+        api.SaveWeightsForSamplerRequest(model_id="model", mode="export_adapter")
+
+
+def test_adapter_export_rejects_sampling_session_ids():
+    with pytest.raises(ValidationError, match="sampling session IDs"):
+        api.SaveWeightsForSamplerRequest(
+            model_id="model",
+            path="step_4",
+            mode="export_adapter",
+            sampling_session_seq_id=1,
+            seq_id=2,
+        )
+
+
 # --- ModelInputChunk discriminator tests (api) ---
 
 _api_adapter = TypeAdapter(api.ModelInputChunk)

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
 
 import pytest
 from cloudpathlib import AnyPath
@@ -35,6 +36,45 @@ def test_process_unload_model():
     result = engine.process_unload_model(model_id, types.UnloadModelInput())
     assert result.status == "unloaded"
     assert not engine.backend.has_model(model_id)
+
+
+def test_adapter_export_returns_backend_name_and_path():
+    engine = object.__new__(TinkerEngine)
+    engine.backend = MagicMock()
+    engine.backend.has_model.return_value = True
+    engine.backend.export_adapter.return_value = "/shared/adapters/model_step_4"
+
+    result = engine.process_save_weights_for_sampler(
+        "model",
+        types.SaveWeightsForSamplerInput(
+            path="step_4",
+            mode="export_adapter",
+            adapter_name="model_step_4",
+        ),
+    )
+
+    engine.backend.export_adapter.assert_called_once_with("model", "model_step_4")
+    engine.backend.save_sampler_checkpoint.assert_not_called()
+    assert result.adapter_name == "model_step_4"
+    assert result.adapter_path == "/shared/adapters/model_step_4"
+
+
+def test_adapter_load_uses_requested_name_and_path():
+    engine = object.__new__(TinkerEngine)
+    engine.backend = MagicMock()
+    engine.backend.has_model.return_value = True
+
+    result = engine.process_load_adapter(
+        "model",
+        types.LoadAdapterInput(
+            adapter_name="rollout_model",
+            adapter_path="/shared/adapters/model_step_4",
+        ),
+    )
+
+    engine.backend.load_adapter.assert_called_once_with("rollout_model", "/shared/adapters/model_step_4")
+    assert result.adapter_name == "rollout_model"
+    assert result.adapter_path == "/shared/adapters/model_step_4"
 
 
 def test_cleanup_stale_sessions():


### PR DESCRIPTION
## Summary

- allow a SkyRL Tinker service to train without starting inference engines
- export a versioned LoRA adapter and return the exact shared-filesystem path
- load a named adapter through the normal queued Tinker API
- preserve the existing combined training and inference behavior by default

This supports deployments where training and inference run in separate services. The training service no longer needs a list of inference endpoints, so it can be reused across different rollout layouts.

## Verification

- 33 Tinker API and engine tests
- 2 focused adapter transfer tests
- formatter and secret scan