### PR TITLE
FP8 RL Training and Rollout Weight Synchronization

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -421,12 +421,11 @@ def preprocess_packed_seqs(
       per row. This is the historical SkyRL behavior used by the RL path
       and the existing SFT path without mini-batch packing.
     - ``sub_seq_lengths is not None``: each row may contain multiple
-      sub-sequences concatenated end-to-end. ``sub_seq_lengths[r]`` lists
-      the per-sub-sequence valid token counts for row ``r``. Tokens
-      ``input_ids[r, :sum(sub_seq_lengths[r])]`` are assumed to be the
-      concatenated sub-sequences in order; any trailing tokens in the row
-      are pad. ``cu_seqlens`` enumerates every sub-sequence across every
-      row.
+      sub-sequences. ``sub_seq_lengths[r]`` lists their valid token counts.
+      Each sub-sequence begins at the next ``align_size`` boundary, so internal
+      alignment padding may separate adjacent sub-sequences; any remaining
+      trailing tokens are pad. ``cu_seqlens`` enumerates every sub-sequence
+      across every row.
 
     CP splits sequence into CP*2 chunks, and each GPU gets 2 chunks (GPU0
     gets first and last chunks, GPU1 gets second and second last chunks,

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -243,15 +243,10 @@ def offload_megatron_model_to_cpu(models):
                 # https://github.com/NVIDIA/Megatron-LM/blob/core_v0.16.0/megatron/core/distributed/param_and_grad_buffer.py#L964
                 buffer.offload_to_cpu(move_params=True, move_grads=False)
 
-            # LoRA-aware offloading: offload non-lora base weights that live
-            # outside the fused Megatron buffers (e.g. HF/bridge "to_wrap" weights).
+            # Offload parameters outside Megatron's fused buffers. Do not filter
+            # by requires_grad: reference parameters may retain it without an optimizer.
             for name, param in model_chunk.named_parameters():
-                if (
-                    param.is_cuda
-                    and not param.requires_grad
-                    and "adapter" not in name
-                    and param.data.storage().size() > 0
-                ):
+                if param.is_cuda and "adapter" not in name and param.data.storage().size() > 0:
                     cpu_tensor = param.data.detach().cpu().pin_memory()
                     param._offload_cpu_data = cpu_tensor
                     param._offload_cuda_numel = param.data.numel()
@@ -270,9 +265,9 @@ def load_megatron_model_to_gpu(models):
             for buffer in model_chunk.buffers + model_chunk.expert_parallel_buffers:
                 buffer.reload_from_cpu(move_params=True, move_grads=False)
 
-            # Restore any LoRA-frozen base weights that were offloaded above.
+            # Restore parameters held outside the fused buffers.
             device_id = torch.cuda.current_device()
-            for name, param in model_chunk.named_parameters():
+            for _, param in model_chunk.named_parameters():
                 if hasattr(param, "_offload_cpu_data") and param.data.storage().size() == 0:
                     restored = param._offload_cpu_data.to(device_id, non_blocking=True)
                     param.data = restored

--- a/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
@@ -1410,7 +1410,7 @@ def vocab_parallel_entropy_weighted_sum(
     """Compute ``sum(entropy * weights)`` with bounded temporary memory."""
     resolved_chunk_size = _resolve_vocab_entropy_chunk_size(vocab_parallel_logits, chunk_size, chunk_memory_mb)
     if resolved_chunk_size is None:
-        entropy_tokens = _VocabParallelEntropy.apply(vocab_parallel_logits).squeeze(0)
+        entropy_tokens = _VocabParallelEntropy.apply(vocab_parallel_logits)
         return (entropy_tokens * weights).sum()
 
     # Keep an autograd edge even when every chunk is masked out.
@@ -1421,6 +1421,6 @@ def vocab_parallel_entropy_weighted_sum(
         weight_chunk = weights[start:end]
         if torch.count_nonzero(weight_chunk).item() == 0:
             continue
-        entropy_chunk = _VocabParallelEntropy.apply(vocab_parallel_logits[..., start:end, :]).squeeze(0)
+        entropy_chunk = _VocabParallelEntropy.apply(vocab_parallel_logits[..., start:end, :])
         local_entropy_sum = local_entropy_sum + (entropy_chunk * weight_chunk).sum()
     return local_entropy_sum

--- a/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
@@ -1001,6 +1001,8 @@ def vocab_parallel_entropy_packed_sequences(
     loss_mask: Optional[torch.Tensor],
     cp_group: Optional[torch.distributed.ProcessGroup],
     sub_seq_lengths: Optional[list[list[int]]] = None,
+    chunk_size: Optional[int] = None,
+    chunk_memory_mb: int = 512,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Compute action-token entropy directly on TP+CP sharded packed logits.
 
@@ -1009,9 +1011,8 @@ def vocab_parallel_entropy_packed_sequences(
         local term is normalized by the global action-token count. Megatron's
         schedule already applies the CP loss scale for two-output loss funcs.
     """
-    entropy_tokens = vocab_parallel_entropy(vocab_parallel_logits).squeeze(0)
-    device = entropy_tokens.device
-    dtype = entropy_tokens.dtype
+    device = vocab_parallel_logits.device
+    dtype = vocab_parallel_logits.dtype
 
     attention_mask = attention_mask.to(device=device, dtype=torch.bool)
     cu_seqlens_padded = cu_seqlens_padded.to(device=device, dtype=torch.long)
@@ -1055,13 +1056,18 @@ def vocab_parallel_entropy_packed_sequences(
         cp_rank_for_token, local_indices = _packed_cp_rank_and_local_indices(
             cu_seqlens_padded, seq_indices, seq_offsets, seq_lens_padded, cp_size
         )
-        local_weights = torch.zeros_like(entropy_tokens)
+        local_weights = torch.zeros((int(vocab_parallel_logits.shape[-2]),), dtype=dtype, device=device)
         current_rank_mask = cp_rank_for_token == cp_rank
         local_weights[local_indices[current_rank_mask]] = packed_weights[current_rank_mask]
     else:
         local_weights = packed_weights
 
-    local_entropy_sum = (entropy_tokens * local_weights).sum()
+    local_entropy_sum = vocab_parallel_entropy_weighted_sum(
+        vocab_parallel_logits,
+        local_weights,
+        chunk_size=chunk_size,
+        chunk_memory_mb=chunk_memory_mb,
+    )
     local_count = local_weights.sum()
     global_count = local_count.detach().clone()
     global_entropy_sum = local_entropy_sum.detach().clone()
@@ -1333,7 +1339,48 @@ class _VocabParallelEntropy(torch.autograd.Function):
         return softmax_logits
 
 
-def vocab_parallel_entropy(vocab_parallel_logits: torch.Tensor) -> torch.Tensor:
+def _floor_power_of_two(value: int) -> int:
+    return 1 << (value.bit_length() - 1)
+
+
+def _resolve_vocab_entropy_chunk_size(
+    vocab_parallel_logits: torch.Tensor,
+    chunk_size: Optional[int],
+    chunk_memory_mb: int,
+    peak_factor: int = 4,
+) -> Optional[int]:
+    """Resolve the sequence chunk size for vocab entropy.
+
+    ``None`` disables chunking. ``0`` uses the runtime vocab shard and dtype to
+    choose a size. Positive values specify the number of tokens per chunk.
+    """
+    if chunk_size is None:
+        return None
+    if chunk_size < 0:
+        raise ValueError(f"chunk_size must be non-negative or None, got {chunk_size}")
+    if chunk_memory_mb <= 0:
+        raise ValueError(f"chunk_memory_mb must be positive, got {chunk_memory_mb}")
+    seq_len = int(vocab_parallel_logits.shape[-2])
+    if seq_len <= 0:
+        return None
+    if chunk_size > 0:
+        return chunk_size if chunk_size < seq_len else None
+
+    budget_bytes = int(chunk_memory_mb) * 1024 * 1024
+    bytes_per_token = int(vocab_parallel_logits.shape[-1]) * vocab_parallel_logits.element_size() * peak_factor
+    if bytes_per_token <= 0:
+        return None
+
+    auto_chunk = max(1, min(seq_len, budget_bytes // bytes_per_token))
+    auto_chunk = _floor_power_of_two(auto_chunk)
+    return auto_chunk if auto_chunk < seq_len else None
+
+
+def vocab_parallel_entropy(
+    vocab_parallel_logits: torch.Tensor,
+    chunk_size: Optional[int] = None,
+    chunk_memory_mb: int = 512,
+) -> torch.Tensor:
     """Compute entropy when the logits are sharded in tp ranks
 
     Args:
@@ -1342,4 +1389,38 @@ def vocab_parallel_entropy(vocab_parallel_logits: torch.Tensor) -> torch.Tensor:
     Returns: (total_nnz,)
 
     """
-    return _VocabParallelEntropy.apply(vocab_parallel_logits)
+    resolved_chunk_size = _resolve_vocab_entropy_chunk_size(vocab_parallel_logits, chunk_size, chunk_memory_mb)
+    if resolved_chunk_size is None:
+        return _VocabParallelEntropy.apply(vocab_parallel_logits)
+
+    entropy_chunks = []
+    seq_len = int(vocab_parallel_logits.shape[-2])
+    for start in range(0, seq_len, resolved_chunk_size):
+        end = min(start + resolved_chunk_size, seq_len)
+        entropy_chunks.append(_VocabParallelEntropy.apply(vocab_parallel_logits[..., start:end, :]))
+    return torch.cat(entropy_chunks, dim=-1)
+
+
+def vocab_parallel_entropy_weighted_sum(
+    vocab_parallel_logits: torch.Tensor,
+    weights: torch.Tensor,
+    chunk_size: Optional[int] = None,
+    chunk_memory_mb: int = 512,
+) -> torch.Tensor:
+    """Compute ``sum(entropy * weights)`` with bounded temporary memory."""
+    resolved_chunk_size = _resolve_vocab_entropy_chunk_size(vocab_parallel_logits, chunk_size, chunk_memory_mb)
+    if resolved_chunk_size is None:
+        entropy_tokens = _VocabParallelEntropy.apply(vocab_parallel_logits).squeeze(0)
+        return (entropy_tokens * weights).sum()
+
+    # Keep an autograd edge even when every chunk is masked out.
+    local_entropy_sum = vocab_parallel_logits[..., :0, :].sum()
+    seq_len = int(vocab_parallel_logits.shape[-2])
+    for start in range(0, seq_len, resolved_chunk_size):
+        end = min(start + resolved_chunk_size, seq_len)
+        weight_chunk = weights[start:end]
+        if torch.count_nonzero(weight_chunk).item() == 0:
+            continue
+        entropy_chunk = _VocabParallelEntropy.apply(vocab_parallel_logits[..., start:end, :]).squeeze(0)
+        local_entropy_sum = local_entropy_sum + (entropy_chunk * weight_chunk).sum()
+    return local_entropy_sum

--- a/skyrl/backends/skyrl_train/distributed/megatron/packing_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/packing_utils.py
@@ -5,23 +5,29 @@ from typing import Any
 def is_fp8_enabled(fp8: Any) -> bool:
     """Return whether a Megatron/TE fp8 config value enables FP8 execution."""
     if isinstance(fp8, str):
-        return fp8.strip().lower() not in {"", "0", "false", "none", "null", "no"}
+        return fp8.strip().lower() not in {"", "0", "false", "none", "null", "no", "off"}
     return bool(fp8)
 
 
 def get_packed_seq_align_size(tp_size: int, cp_size: int, fp8_enabled: bool = False) -> int:
-    """Return global per-subsequence padding needed for TP/CP layout."""
+    """Return the global alignment unit for packed TP/CP/FP8 sequences."""
+    if tp_size < 1 or cp_size < 1:
+        raise ValueError(f"tp_size and cp_size must be positive, got tp_size={tp_size}, cp_size={cp_size}")
     if cp_size > 1:
         layout_align = tp_size * cp_size * 2
     else:
         layout_align = tp_size
     if not fp8_enabled:
         return layout_align
-    return math.lcm(layout_align, 16 * cp_size)
+    fp8_token_align = 128 * tp_size * cp_size if tp_size > 1 else 16 * cp_size
+    return math.lcm(layout_align, fp8_token_align)
 
 
 def get_unpacked_seq_align_size(tp_size: int, fp8_enabled: bool = False) -> int:
-    """Return sequence padding needed when removing microbatch padding without CP."""
+    """Return the alignment unit for unpacked TP/FP8 sequences without CP."""
+    if tp_size < 1:
+        raise ValueError(f"tp_size must be positive, got {tp_size}")
     if not fp8_enabled:
         return tp_size
-    return math.lcm(tp_size, 16)
+    fp8_token_align = 128 * tp_size if tp_size > 1 else 16
+    return math.lcm(tp_size, fp8_token_align)

--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -29,6 +29,7 @@ import torch
 from skyrl.backends.skyrl_train.inference_servers.layerwise_reload import (
     LayerwiseReloadWorkerMixin,
 )
+from skyrl.backends.skyrl_train.weight_sync.base import cuda_uuid_to_str
 
 VLLM_NEW_INFERENCE_WORKER_EXTENSION_CLS = f"{__name__}.NewInferenceWorkerWrap"
 
@@ -86,7 +87,7 @@ class NewInferenceWorkerWrap(LayerwiseReloadWorkerMixin):
         handles = pickle.loads(base64.b64decode(pickled))
 
         device_index = torch.cuda.current_device()
-        physical_gpu_id = str(torch.cuda.get_device_properties(device_index).uuid)
+        physical_gpu_id = cuda_uuid_to_str(torch.cuda.get_device_properties(device_index).uuid)
         if physical_gpu_id not in handles:
             raise ValueError(f"IPC handle not found for GPU UUID {physical_gpu_id}. " f"Available: {list(handles)}")
         func, args = handles[physical_gpu_id]

--- a/skyrl/backends/skyrl_train/inference_servers/utils.py
+++ b/skyrl/backends/skyrl_train/inference_servers/utils.py
@@ -11,6 +11,13 @@ from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import
     SKYRL_LORA_ADAPTER_NAME,
 )
 from skyrl.backends.skyrl_train.weight_sync import get_transfer_strategy
+from skyrl.backends.skyrl_train.weight_sync.serialized_fp8 import (
+    SERIALIZED_BLOCKWISE_FP8,
+    get_qwen35_fp8_ignored_layers,
+    get_serialized_fp8_quantization_config,
+    is_qwen35_config,
+    should_use_serialized_fp8,
+)
 from skyrl.train.config import (
     InferenceEngineConfig,
     SkyRLTrainConfig,
@@ -18,6 +25,88 @@ from skyrl.train.config import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _serialized_fp8_ignored_layers(model_path: Optional[str]) -> list[str]:
+    if not model_path:
+        raise ValueError("A model path is required when serialized FP8 weight sync is enabled")
+    try:
+        from transformers import AutoConfig
+
+        hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    except Exception as exc:
+        raise RuntimeError(
+            "Could not inspect the model config required to derive serialized FP8 ignored layers: "
+            f"model_path={model_path!r}"
+        ) from exc
+    if not is_qwen35_config(hf_config):
+        raise ValueError(
+            "Serialized FP8 weight sync currently supports only Qwen3.5 checkpoint layouts; "
+            f"model_path={model_path!r}"
+        )
+    return get_qwen35_fp8_ignored_layers(hf_config)
+
+
+def _set_or_validate(mapping: Dict[str, Any], key: str, expected: Any, *, context: str) -> None:
+    if key in mapping and mapping[key] != expected:
+        raise ValueError(
+            f"{context}.{key} must be {expected!r} when serialized FP8 weight sync is enabled, " f"got {mapping[key]!r}"
+        )
+    mapping[key] = copy.deepcopy(expected)
+
+
+def _apply_serialized_fp8_weight_sync_defaults(
+    ie_cfg: InferenceEngineConfig,
+    engine_kwargs: Dict[str, Any],
+    model_path: Optional[str] = None,
+) -> None:
+    """Configure vLLM for checkpoint-format blockwise FP8 weight reloads."""
+
+    mode = ie_cfg.fp8_weight_sync_mode
+    if mode is None:
+        return
+    if not should_use_serialized_fp8(mode):
+        raise ValueError(
+            f"Unsupported fp8_weight_sync_mode={mode!r}. " f"Supported value: {SERIALIZED_BLOCKWISE_FP8!r}."
+        )
+
+    _set_or_validate(engine_kwargs, "quantization", "fp8", context="engine_init_kwargs")
+    # Build FP8 modules without a bootstrap checkpoint; the first full-weight
+    # sync replaces the dummy values.
+    _set_or_validate(engine_kwargs, "load_format", "dummy", context="engine_init_kwargs")
+
+    hf_overrides_value = engine_kwargs.get("hf_overrides")
+    hf_overrides = {} if hf_overrides_value is None else copy.deepcopy(hf_overrides_value)
+    if not isinstance(hf_overrides, dict):
+        raise ValueError("engine_init_kwargs.hf_overrides must be a dict when serialized FP8 weight sync is enabled")
+
+    qcfg_value = hf_overrides.get("quantization_config")
+    qcfg = {} if qcfg_value is None else copy.deepcopy(qcfg_value)
+    if not isinstance(qcfg, dict):
+        raise ValueError(
+            "engine_init_kwargs.hf_overrides.quantization_config must be a dict "
+            "when serialized FP8 weight sync is enabled"
+        )
+
+    ignored_layers = _serialized_fp8_ignored_layers(model_path)
+    if ignored_layers:
+        logger.info(
+            "Serialized FP8 weight sync will leave %d vLLM modules unquantized "
+            "to match the Qwen3.5 serialized FP8 policy.",
+            len(ignored_layers),
+        )
+
+    for key, value in get_serialized_fp8_quantization_config(
+        ignored_layers=ignored_layers,
+    ).items():
+        _set_or_validate(
+            qcfg,
+            key,
+            value,
+            context="engine_init_kwargs.hf_overrides.quantization_config",
+        )
+    hf_overrides["quantization_config"] = qcfg
+    engine_kwargs["hf_overrides"] = hf_overrides
 
 
 def _uses_lora_weight_sync(cfg: SkyRLTrainConfig) -> bool:
@@ -145,6 +234,11 @@ def build_vllm_cli_args(cfg: SkyRLTrainConfig) -> Namespace:
 
     # Add any extra engine_init_kwargs
     engine_kwargs = get_config_as_dict(ie_cfg.engine_init_kwargs)
+    _apply_serialized_fp8_weight_sync_defaults(
+        ie_cfg,
+        engine_kwargs,
+        cfg.trainer.policy.model.path,
+    )
     for key, value in engine_kwargs.items():
         setattr(args, key, value)
 

--- a/skyrl/backends/skyrl_train/weight_sync/base.py
+++ b/skyrl/backends/skyrl_train/weight_sync/base.py
@@ -2,7 +2,7 @@
 
 from dataclasses import asdict, dataclass, field
 from functools import cached_property
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List
 
 import torch
 
@@ -104,3 +104,53 @@ class WeightChunk:
     def total_size_bytes(self) -> int:
         """Calculate total memory footprint in bytes."""
         return sum(t.numel() * t.element_size() for t in self.tensors)
+
+
+def torch_dtype_name(dtype: torch.dtype) -> str:
+    """Return the dtype spelling expected by vLLM weight-transfer metadata."""
+    return str(dtype).split(".")[-1]
+
+
+def cuda_uuid_to_str(uuid: str | bytes) -> str:
+    """Normalize CUDA UUIDs identically on both sides of an IPC transfer."""
+    return uuid.decode("ascii") if isinstance(uuid, bytes) else str(uuid)
+
+
+def iter_single_dtype_chunks(chunk: WeightChunk) -> Iterator[WeightChunk]:
+    """Yield dtype-homogeneous subchunks in first-seen dtype order.
+
+    CUDA IPC packs tensors into a typed buffer, while serialized FP8 chunks mix
+    FP8 weights, FP32 scales, and unquantized BF16 tensors. vLLM's NCCL path
+    byte-packs mixed dtypes and does not require this split.
+    """
+    by_dtype: Dict[torch.dtype, Dict[str, list]] = {}
+    dtype_order: List[torch.dtype] = []
+
+    for name, tensor in zip(chunk.names, chunk.tensors):
+        dtype = tensor.dtype
+        if dtype not in by_dtype:
+            dtype_order.append(dtype)
+            by_dtype[dtype] = {"names": [], "dtypes": [], "shapes": [], "tensors": []}
+        group = by_dtype[dtype]
+        group["names"].append(name)
+        group["dtypes"].append(str(dtype))
+        group["shapes"].append(list(tensor.shape))
+        group["tensors"].append(tensor)
+
+    for dtype in dtype_order:
+        group = by_dtype[dtype]
+        yield WeightChunk(
+            names=group["names"],
+            dtypes=group["dtypes"],
+            shapes=group["shapes"],
+            tensors=group["tensors"],
+        )
+
+
+def get_weight_chunk_metadata(chunk: WeightChunk) -> Dict[str, List]:
+    """Return vLLM metadata for the tensors in a transfer chunk."""
+    return {
+        "names": list(chunk.names),
+        "dtype_names": [torch_dtype_name(tensor.dtype) for tensor in chunk.tensors],
+        "shapes": [list(tensor.shape) for tensor in chunk.tensors],
+    }

--- a/skyrl/backends/skyrl_train/weight_sync/broadcast_strategy.py
+++ b/skyrl/backends/skyrl_train/weight_sync/broadcast_strategy.py
@@ -18,7 +18,11 @@ if TYPE_CHECKING:
 import ray
 import torch
 
-from skyrl.backends.skyrl_train.weight_sync.base import WeightChunk, WeightUpdateRequest
+from skyrl.backends.skyrl_train.weight_sync.base import (
+    WeightChunk,
+    WeightUpdateRequest,
+    get_weight_chunk_metadata,
+)
 from skyrl.backends.skyrl_train.weight_sync.transfer_strategy import (
     WeightSyncInitInfo,
     WeightTransferSender,
@@ -117,32 +121,35 @@ class BroadcastWeightTransferSender(WeightTransferSender):
         self,
         chunks: Iterable[WeightChunk],
         weight_metadata: Optional[Dict[str, list]] = None,
+        derive_metadata_from_chunks: bool = False,
     ) -> None:
         """Send chunks via broadcast or vLLM native NCCL.
 
         Args:
             chunks: Iterable of WeightChunk objects to send.
-            weight_metadata: Pre-computed metadata dict with "names", "dtype_names",
-                "shapes". Avoids materializing all chunks to collect metadata.
+            weight_metadata: Complete metadata for the batched update path.
+            derive_metadata_from_chunks: Send each chunk with derived metadata.
         """
-        await self._send_chunks_vllm_native(chunks, weight_metadata)
+        if derive_metadata_from_chunks:
+            if weight_metadata is not None:
+                raise ValueError("weight_metadata must be omitted when deriving metadata from chunks")
+            await self._send_serialized_fp8_chunks_vllm_native(chunks)
+        else:
+            await self._send_chunks_vllm_native(chunks, weight_metadata)
 
     async def _send_chunks_vllm_native(
         self,
         chunks: Iterable[WeightChunk],
-        weight_metadata: Optional[Dict[str, list]] = None,
+        weight_metadata: Optional[Dict[str, list]],
     ) -> None:
-        """Batched path: one update_weights call + trainer_send_weights (vLLM native).
+        """Send one metadata-declared update through vLLM's native NCCL path.
 
         All ranks must evaluate the chunks iterator (extract_weights uses
         collective all-gather internally). Only rank 0 sends the gathered
         tensors to vLLM via the NCCL weight transfer engine.
         """
         if weight_metadata is None:
-            raise ValueError(
-                "weight_metadata is required for vLLM native path. "
-                "Call weight_extractor.get_weight_metadata() and pass it to send_chunks."
-            )
+            raise ValueError("weight_metadata is required unless derive_metadata_from_chunks=true")
 
         def weight_iterator() -> Iterator[Tuple[str, torch.Tensor]]:
             for chunk in chunks:
@@ -165,7 +172,7 @@ class BroadcastWeightTransferSender(WeightTransferSender):
             update_info = {**weight_metadata, "packed": True}
             update_task = asyncio.create_task(self._inference_client.update_weights_nccl(update_info))
 
-            # Run in thread so the HTTP update_task can progress concurrently
+            # Run in a thread so the HTTP update task can progress concurrently.
             await asyncio.to_thread(
                 NCCLWeightTransferEngine.trainer_send_weights,
                 iterator=weight_iterator(),
@@ -175,11 +182,45 @@ class BroadcastWeightTransferSender(WeightTransferSender):
 
             await self._inference_client.finish_weight_update()
         else:
-            # Non-rank-0 still needs to participate in the all-gather
+            # Non-rank-0 still needs to participate in extractor collectives.
             for _ in weight_iterator():
                 pass
 
         torch.distributed.barrier()
+
+    async def _send_serialized_fp8_chunks_vllm_native(
+        self,
+        chunks: Iterable[WeightChunk],
+    ) -> None:
+        """Send lazy mixed-dtype serialized-FP8 chunks through vLLM NCCL."""
+        if torch.distributed.get_rank() == 0:
+            await self._inference_client.start_weight_update(is_checkpoint_format=True)
+
+        for chunk in chunks:
+            if torch.distributed.get_rank() == 0:
+                await self._send_chunk_vllm_native(chunk)
+
+        if torch.distributed.get_rank() == 0:
+            await self._inference_client.finish_weight_update()
+
+        torch.distributed.barrier()
+
+    async def _send_chunk_vllm_native(self, chunk: WeightChunk) -> None:
+        """Send one logical chunk through vLLM's byte-packed NCCL path."""
+        from vllm.distributed.weight_transfer.nccl_engine import (
+            NCCLWeightTransferEngine,
+        )
+
+        update_info = {**get_weight_chunk_metadata(chunk), "packed": True}
+        update_task = asyncio.create_task(self._inference_client.update_weights_nccl(update_info))
+
+        # Let the receiver enter its collective while the trainer broadcasts.
+        await asyncio.to_thread(
+            NCCLWeightTransferEngine.trainer_send_weights,
+            iterator=iter(zip(chunk.names, chunk.tensors)),
+            trainer_args={"group": self._model_update_group, "packed": True},
+        )
+        await update_task
 
     def teardown(self) -> None:
         """Destroy the process group used for weight transfer."""

--- a/skyrl/backends/skyrl_train/weight_sync/cuda_ipc_strategy.py
+++ b/skyrl/backends/skyrl_train/weight_sync/cuda_ipc_strategy.py
@@ -28,13 +28,18 @@ if TYPE_CHECKING:
 import torch
 from torch.multiprocessing.reductions import reduce_tensor
 
-from skyrl.backends.skyrl_train.weight_sync.base import WeightChunk, WeightUpdateRequest
+from skyrl.backends.skyrl_train.weight_sync.base import (
+    WeightChunk,
+    WeightUpdateRequest,
+    cuda_uuid_to_str,
+    iter_single_dtype_chunks,
+    torch_dtype_name,
+)
 from skyrl.backends.skyrl_train.weight_sync.transfer_strategy import (
     WeightSyncInitInfo,
     WeightTransferSender,
     WeightTransferStrategy,
 )
-from skyrl.train.utils.utils import str_to_torch_dtype
 
 # IPC handle type: (rebuild_func, args) returned by reduce_tensor
 IpcHandle = Tuple[Callable[..., torch.Tensor], Tuple[Any, ...]]
@@ -148,14 +153,14 @@ class CudaIpcWeightTransferSender(WeightTransferSender):
         self,
         chunks: Iterable[WeightChunk],
         weight_metadata: Optional[Dict[str, list]] = None,
+        derive_metadata_from_chunks: bool = False,
     ) -> None:
         """Send chunks via CUDA IPC.
 
         Args:
             chunks: Iterable of WeightChunk objects to send.
-            weight_metadata: Unused for IPC (metadata is derived from chunks
-                directly to avoid ordering mismatches). Kept for interface
-                compatibility with the base class.
+            weight_metadata: Unused; IPC derives metadata from each tensor.
+            derive_metadata_from_chunks: Accepted for sender interface compatibility.
         """
         await self._send_chunks_vllm_native(chunks, weight_metadata)
 
@@ -185,76 +190,90 @@ class CudaIpcWeightTransferSender(WeightTransferSender):
         rank = torch.distributed.get_rank()
         world_size = torch.distributed.get_world_size()
         device = torch.cuda.current_device()
-        gpu_uuid = str(torch.cuda.get_device_properties(device).uuid)
-        dtype = str_to_torch_dtype(self._init_info.model_dtype_str)
-        dtype_name = self._init_info.model_dtype_str.split(".")[-1]
-
+        gpu_uuid = cuda_uuid_to_str(torch.cuda.get_device_properties(device).uuid)
         if rank == 0:
             await self._inference_client.start_weight_update(is_checkpoint_format=True)
         torch.distributed.barrier()
 
-        for chunk in chunks:
-            # --- pack all tensors in this chunk into one contiguous buffer ---
-            # Chunk tensors share a single dtype by construction (see
-            # weight_extractor_utils.py), so offsets in element units are safe.
-            names: List[str] = []
-            dtype_names: List[str] = []
-            shapes: List[List[int]] = []
-            sizes: List[int] = []
-
-            total_numel = sum(t.numel() for t in chunk.tensors)
-            packed_tensor = torch.empty(
-                total_numel,
-                device=device,
-                dtype=dtype,
-                requires_grad=False,
-            )
-
-            offset = 0
-            for name, tensor, shape in zip(chunk.names, chunk.tensors, chunk.shapes):
-                size = tensor.numel()
-                packed_tensor[offset : offset + size].copy_(tensor.detach().reshape(-1))
-                offset += size
-                names.append(name)
-                dtype_names.append(dtype_name)
-                shapes.append(list(shape) if not isinstance(shape, list) else shape)
-                sizes.append(size)
-
-            # --- one IPC handle per rank for the packed buffer ---
-            ipc_handle: IpcHandle = reduce_tensor(packed_tensor)
-            local_handle_dict: Dict[str, IpcHandle] = {gpu_uuid: ipc_handle}
-            gathered: List[Optional[Dict[str, IpcHandle]]] = [None] * world_size
-            torch.distributed.all_gather_object(gathered, local_handle_dict)
-
-            torch.distributed.barrier()
-            torch.cuda.synchronize()
-
-            if rank == 0:
-                merged_handles: Dict[str, IpcHandle] = {}
-                for d in gathered:
-                    if d is not None:
-                        merged_handles.update(d)
-
-                pickled = base64.b64encode(pickle.dumps(merged_handles)).decode("utf-8")
-                chunk_update_info: Dict[str, Any] = {
-                    "names": names,
-                    "dtype_names": dtype_names,
-                    "shapes": shapes,
-                    "sizes": sizes,
-                    "ipc_handles_pickled": pickled,
-                }
-                await self._inference_client.update_weights_ipc(chunk_update_info)
-
-            # Keep packed_tensor alive past the barrier so the receiver's
-            # rebuilt view has valid backing storage while it copies into
-            # the model. Post-barrier drops the local ref safely.
-            torch.distributed.barrier()
-            torch.cuda.ipc_collect()
-            torch.cuda.synchronize()
+        for logical_chunk in chunks:
+            for chunk in iter_single_dtype_chunks(logical_chunk):
+                await self._send_single_dtype_chunk_vllm_native(
+                    chunk=chunk,
+                    device=device,
+                    gpu_uuid=gpu_uuid,
+                    world_size=world_size,
+                    rank=rank,
+                )
 
         if rank == 0:
             await self._inference_client.finish_weight_update()
         torch.distributed.barrier()
+
+    async def _send_single_dtype_chunk_vllm_native(
+        self,
+        *,
+        chunk: WeightChunk,
+        device: int,
+        gpu_uuid: str,
+        world_size: int,
+        rank: int,
+    ) -> None:
+        dtype = chunk.tensors[0].dtype
+        dtype_name = torch_dtype_name(dtype)
+        if any(tensor.dtype != dtype for tensor in chunk.tensors):
+            raise ValueError("CUDA IPC packed chunks must contain a single tensor dtype")
+
+        names: List[str] = []
+        dtype_names: List[str] = []
+        shapes: List[List[int]] = []
+        sizes: List[int] = []
+
+        total_numel = sum(t.numel() for t in chunk.tensors)
+        packed_tensor = torch.empty(
+            total_numel,
+            device=device,
+            dtype=dtype,
+            requires_grad=False,
+        )
+
+        offset = 0
+        for name, tensor in zip(chunk.names, chunk.tensors):
+            size = tensor.numel()
+            packed_tensor[offset : offset + size].copy_(tensor.detach().reshape(-1))
+            offset += size
+            names.append(name)
+            dtype_names.append(dtype_name)
+            shapes.append(list(tensor.shape))
+            sizes.append(size)
+
+        ipc_handle: IpcHandle = reduce_tensor(packed_tensor)
+        local_handle_dict: Dict[str, IpcHandle] = {gpu_uuid: ipc_handle}
+        gathered: List[Optional[Dict[str, IpcHandle]]] = [None] * world_size
+        torch.distributed.all_gather_object(gathered, local_handle_dict)
+
+        torch.distributed.barrier()
+        torch.cuda.synchronize()
+
+        if rank == 0:
+            merged_handles: Dict[str, IpcHandle] = {}
+            for d in gathered:
+                if d is not None:
+                    merged_handles.update(d)
+
+            pickled = base64.b64encode(pickle.dumps(merged_handles)).decode("utf-8")
+            chunk_update_info: Dict[str, Any] = {
+                "names": names,
+                "dtype_names": dtype_names,
+                "shapes": shapes,
+                "sizes": sizes,
+                "ipc_handles_pickled": pickled,
+            }
+            await self._inference_client.update_weights_ipc(chunk_update_info)
+
+        # Keep the backing tensor alive until the receiver copies from its IPC view.
+        torch.distributed.barrier()
+        torch.cuda.ipc_collect()
+        torch.cuda.synchronize()
 
     def teardown(self) -> None:
         """No-op for CUDA IPC sender (no custom process group to clean up)."""

--- a/skyrl/backends/skyrl_train/weight_sync/serialized_fp8.py
+++ b/skyrl/backends/skyrl_train/weight_sync/serialized_fp8.py
@@ -1,0 +1,321 @@
+"""Convert Megatron-exported tensors to vLLM's blockwise FP8 checkpoint format."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from math import isfinite
+from operator import index
+from typing import Any, Iterator, Sequence
+
+import torch
+
+SERIALIZED_BLOCKWISE_FP8 = "serialized_blockwise"
+
+
+def use_power_2_scales_default() -> bool:
+    """Return whether rollout weights use power-of-two block scales.
+
+    The setting must match Transformer Engine. Hopper defaults to FP32 scales;
+    Blackwell launchers select power-of-two scales by setting
+    ``NVTE_FP8_BLOCK_SCALING_FP32_SCALES=0``.
+    """
+
+    scale_mode = os.getenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "1")
+    if scale_mode not in {"0", "1"}:
+        raise ValueError(
+            "NVTE_FP8_BLOCK_SCALING_FP32_SCALES must be '0' (power-of-2) " f"or '1' (FP32 scales), got {scale_mode!r}"
+        )
+    return scale_mode == "0"
+
+
+def use_amax_epsilon_default() -> float:
+    """Read the TE blockwise amax floor used by the training weight quantizer."""
+
+    raw_value = os.getenv("NVTE_FP8_BLOCK_AMAX_EPSILON", "0")
+    try:
+        epsilon = float(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"NVTE_FP8_BLOCK_AMAX_EPSILON must be a float, got {raw_value!r}") from exc
+    if not isfinite(epsilon) or epsilon < 0:
+        raise ValueError(f"NVTE_FP8_BLOCK_AMAX_EPSILON must be finite and non-negative, got {epsilon}")
+    return epsilon
+
+
+_QWEN35_FP8_WEIGHT_SUFFIXES = (
+    ".self_attn.q_proj.weight",
+    ".self_attn.k_proj.weight",
+    ".self_attn.v_proj.weight",
+    ".self_attn.o_proj.weight",
+    ".mlp.gate_proj.weight",
+    ".mlp.up_proj.weight",
+    ".mlp.down_proj.weight",
+    ".linear_attn.in_proj_qkv.weight",
+    ".linear_attn.in_proj_z.weight",
+    ".linear_attn.out_proj.weight",
+    # Shared-expert linears use FP8; router and shared-expert gates remain BF16.
+    ".mlp.shared_expert.gate_proj.weight",
+    ".mlp.shared_expert.up_proj.weight",
+    ".mlp.shared_expert.down_proj.weight",
+)
+# Megatron Bridge exports routed experts in batched tensors. Emit vLLM's
+# per-expert projection layout so its loader can assemble fused MoE parameters.
+_QWEN35_MOE_GATE_UP_SUFFIX = ".mlp.experts.gate_up_proj"
+_QWEN35_MOE_DOWN_SUFFIX = ".mlp.experts.down_proj"
+_QWEN35_UNQUANTIZED_LINEAR_SUFFIXES = (
+    ".in_proj_b",
+    ".in_proj_a",
+)
+_QWEN35_LINEAR_ATTN_PREFIX_TEMPLATES = (
+    "{model_prefix}.layers.{layer_idx}.linear_attn",
+    "{model_prefix}.language_model.layers.{layer_idx}.linear_attn",
+)
+_QWEN35_VISION_ATTN_PROJ_PREFIX_TEMPLATES = ("{model_prefix}.visual.blocks.{block_idx}.attn.proj",)
+
+
+def _normalize_block_size(block_size: Sequence[int]) -> tuple[int, int]:
+    try:
+        raw_values = tuple(block_size)
+        if any(isinstance(value, bool) for value in raw_values):
+            raise TypeError
+        values = tuple(index(value) for value in raw_values)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"weight_block_size must contain exactly two positive integers, got {block_size!r}") from exc
+    if len(values) != 2 or any(value <= 0 for value in values):
+        raise ValueError(f"weight_block_size must contain exactly two positive integers, got {block_size!r}")
+    return values
+
+
+@dataclass(frozen=True)
+class SerializedFp8Config:
+    """Configuration for serialized FP8 rollout weight sync."""
+
+    weight_block_size: tuple[int, int] = (128, 128)
+    power_2_scale: bool = field(default_factory=use_power_2_scales_default)
+    amax_epsilon: float = field(default_factory=use_amax_epsilon_default)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "weight_block_size", _normalize_block_size(self.weight_block_size))
+        if type(self.power_2_scale) is not bool:
+            raise ValueError(f"power_2_scale must be a bool, got {self.power_2_scale!r}")
+        if not isfinite(self.amax_epsilon) or self.amax_epsilon < 0:
+            raise ValueError(f"amax_epsilon must be finite and non-negative, got {self.amax_epsilon}")
+
+
+def get_serialized_fp8_quantization_config(
+    weight_block_size: Sequence[int] = (128, 128),
+    ignored_layers: Sequence[str] | None = None,
+) -> dict:
+    """Return vLLM's Hugging Face quantization config for serialized FP8."""
+
+    block_m, block_n = _normalize_block_size(weight_block_size)
+    qconfig = {
+        "quant_method": "fp8",
+        "activation_scheme": "dynamic",
+        "weight_block_size": [block_m, block_n],
+    }
+    if ignored_layers:
+        qconfig["ignored_layers"] = list(ignored_layers)
+    return qconfig
+
+
+def is_qwen35_config(hf_config: Any) -> bool:
+    """Return whether an HF config uses the supported Qwen3.5 text layout."""
+
+    text_config = getattr(hf_config, "text_config", None) or getattr(hf_config, "language_config", None) or hf_config
+    model_type = str(getattr(text_config, "model_type", "") or getattr(hf_config, "model_type", ""))
+    return model_type in {"qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text"}
+
+
+def get_qwen35_fp8_ignored_layers(hf_config: Any, model_prefix: str = "model") -> list[str]:
+    """Return Qwen3.5 vLLM module prefixes excluded from serialized FP8.
+
+    Serialized sync excludes GDN ``in_proj_a`` and ``in_proj_b``. vLLM requires
+    every shard of the fused module to share a quantization scheme, so both
+    prefixes are ignored for text-only and conditional-generation checkpoints.
+    """
+
+    text_config = getattr(hf_config, "text_config", None) or getattr(hf_config, "language_config", None) or hf_config
+    if not is_qwen35_config(hf_config):
+        return []
+
+    layer_types = list(getattr(text_config, "layer_types", []) or [])
+    ignored: list[str] = []
+    for layer_idx, layer_type in enumerate(layer_types):
+        if layer_type != "linear_attention":
+            continue
+        layer_prefixes = []
+        for template in _QWEN35_LINEAR_ATTN_PREFIX_TEMPLATES:
+            prefix = template.format(model_prefix=model_prefix, layer_idx=layer_idx)
+            if prefix not in layer_prefixes:
+                layer_prefixes.append(prefix)
+
+        for layer_prefix in layer_prefixes:
+            for suffix in _QWEN35_UNQUANTIZED_LINEAR_SUFFIXES:
+                ignored.append(f"{layer_prefix}{suffix}")
+
+    # vLLM 0.23 may instantiate the vision tower for text-only runs. Its TP2
+    # attention output is incompatible with 128-wide blocks, and ignore matching
+    # requires each block's exact module prefix.
+    vision_config = getattr(hf_config, "vision_config", None) or getattr(hf_config, "visual_config", None)
+    vision_depth = 0
+    if vision_config is not None:
+        for attr in ("depth", "num_hidden_layers", "num_layers"):
+            value = getattr(vision_config, attr, None)
+            if isinstance(value, int) and value > 0:
+                vision_depth = value
+                break
+    for block_idx in range(vision_depth):
+        for template in _QWEN35_VISION_ATTN_PROJ_PREFIX_TEMPLATES:
+            ignored.append(template.format(model_prefix=model_prefix, block_idx=block_idx))
+    return ignored
+
+
+def should_use_serialized_fp8(mode: str | None) -> bool:
+    return mode == SERIALIZED_BLOCKWISE_FP8
+
+
+def is_quantizable_weight(name: str, tensor: torch.Tensor) -> bool:
+    """Return whether an exported HF tensor should be serialized as FP8.
+
+    vLLM's FP8 config applies to Linear modules. HF checkpoints also contain 2D
+    embedding/output weights, so keep known non-Linear weight tables unquantized.
+    """
+
+    if not name.endswith(".weight") or tensor.ndim != 2:
+        return False
+
+    return is_quantizable_weight_shape(name, tensor.shape)
+
+
+def is_quantizable_weight_shape(name: str, shape: Sequence[int]) -> bool:
+    if not name.endswith(".weight") or len(shape) != 2:
+        return False
+    return name.endswith(_QWEN35_FP8_WEIGHT_SUFFIXES)
+
+
+def scale_name_for_weight(name: str) -> str:
+    if not name.endswith(".weight"):
+        raise ValueError(f"FP8 scale can only be derived from .weight tensors: {name}")
+    return name[: -len(".weight")] + ".weight_scale_inv"
+
+
+def blockwise_cast_to_fp8(
+    weight: torch.Tensor,
+    block_size: Sequence[int],
+    power_2_scale: bool = False,
+    amax_epsilon: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a 2D tensor to vLLM's blockwise E4M3 checkpoint format.
+
+    Returns ``weight_scale_inv`` such that
+    ``weight ~= qweight.float() * scale``. Power-of-two mode rounds scales up
+    to match Transformer Engine's UE8M0 rule.
+    """
+
+    if weight.ndim != 2:
+        raise ValueError(f"Blockwise FP8 expects a 2D tensor, got shape={tuple(weight.shape)}")
+    if not isfinite(amax_epsilon) or amax_epsilon < 0:
+        raise ValueError(f"amax_epsilon must be finite and non-negative, got {amax_epsilon}")
+
+    block_m, block_n = _normalize_block_size(block_size)
+    rows, cols = weight.shape
+    padded_rows = ((rows + block_m - 1) // block_m) * block_m
+    padded_cols = ((cols + block_n - 1) // block_n) * block_n
+
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    weight_fp32 = weight.detach().to(torch.float32)
+    if padded_rows != rows or padded_cols != cols:
+        padded = weight_fp32.new_zeros((padded_rows, padded_cols))
+        padded[:rows, :cols].copy_(weight_fp32)
+    else:
+        padded = weight_fp32
+
+    blocks = padded.view(padded_rows // block_m, block_m, padded_cols // block_n, block_n)
+    blocks = blocks.permute(0, 2, 1, 3)
+    # Match TE's amax floor, with a nonzero fallback for all-zero blocks.
+    scale = blocks.abs().amax(dim=(2, 3)).clamp(min=max(amax_epsilon, 1e-10)) / fp8_info.max
+    if power_2_scale:
+        # Rounding up preserves range and matches TE's power-of-two scale rule.
+        scale = torch.pow(2.0, torch.ceil(torch.log2(scale)))
+    q_blocks = (blocks / scale[:, :, None, None]).clamp(min=fp8_info.min, max=fp8_info.max)
+    q_blocks = q_blocks.to(torch.float8_e4m3fn)
+    q_padded = q_blocks.permute(0, 2, 1, 3).contiguous().view(padded_rows, padded_cols)
+    q_weight = q_padded[:rows, :cols].contiguous()
+    return q_weight, scale.to(torch.float32).contiguous()
+
+
+def batched_moe_expert_spec(name: str) -> tuple[str, tuple[str, ...], bool] | None:
+    """Parse a Megatron Bridge batched Qwen3.5 MoE tensor name.
+
+    Returns ``(experts_base, projection_names, split_gate_up)`` or ``None``.
+    """
+
+    if name.endswith(_QWEN35_MOE_GATE_UP_SUFFIX):
+        return name[: -len(".gate_up_proj")], ("gate_proj", "up_proj"), True
+    if name.endswith(_QWEN35_MOE_DOWN_SUFFIX):
+        return name[: -len(".down_proj")], ("down_proj",), False
+    return None
+
+
+def _per_expert_2d_slices(mat: torch.Tensor, is_gate_up: bool) -> list[torch.Tensor]:
+    """Split fused gate/up weights; return other expert weights unchanged."""
+    if is_gate_up:
+        if mat.shape[0] % 2 != 0:
+            raise ValueError("Batched MoE gate_up_proj output dimension must be even, " f"got shape={tuple(mat.shape)}")
+        half = mat.shape[0] // 2
+        return [mat[:half], mat[half:]]
+    return [mat]
+
+
+def iter_batched_moe_expert_fp8_tensors(
+    name: str,
+    tensor: torch.Tensor,
+    config: SerializedFp8Config,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Convert a batched expert tensor to per-expert FP8 weights and scales."""
+    spec = batched_moe_expert_spec(name)
+    if spec is None:
+        raise ValueError(f"Not a batched MoE expert tensor: {name}")
+    if tensor.ndim != 3:
+        raise ValueError(f"Batched MoE expert tensor must be 3D, got shape={tuple(tensor.shape)}")
+    experts_base, proj_names, is_gate_up = spec
+    num_experts = tensor.shape[0]
+    for expert_idx in range(num_experts):
+        mat = tensor[expert_idx]
+        for proj, sub in zip(proj_names, _per_expert_2d_slices(mat, is_gate_up)):
+            weight_name = f"{experts_base}.{expert_idx}.{proj}.weight"
+            q_weight, scale = blockwise_cast_to_fp8(
+                sub.contiguous(),
+                config.weight_block_size,
+                config.power_2_scale,
+                config.amax_epsilon,
+            )
+            yield weight_name, q_weight
+            yield scale_name_for_weight(weight_name), scale
+
+
+def iter_serialized_fp8_tensors(
+    name: str,
+    tensor: torch.Tensor,
+    target_dtype: torch.dtype,
+    config: SerializedFp8Config,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Yield vLLM checkpoint tensors for one Megatron-exported weight."""
+
+    if batched_moe_expert_spec(name) is not None:
+        yield from iter_batched_moe_expert_fp8_tensors(name, tensor, config)
+        return
+
+    if is_quantizable_weight(name, tensor):
+        q_weight, scale = blockwise_cast_to_fp8(
+            tensor,
+            config.weight_block_size,
+            config.power_2_scale,
+            config.amax_epsilon,
+        )
+        yield name, q_weight
+        yield scale_name_for_weight(name), scale
+        return
+
+    yield name, tensor.to(dtype=target_dtype)

--- a/skyrl/backends/skyrl_train/weight_sync/transfer_strategy.py
+++ b/skyrl/backends/skyrl_train/weight_sync/transfer_strategy.py
@@ -38,6 +38,7 @@ class WeightTransferSender(ABC):
         self,
         chunks: Iterable[WeightChunk],
         weight_metadata: Optional[Dict[str, list]] = None,
+        derive_metadata_from_chunks: bool = False,
     ) -> None:
         """Send chunks using this transfer strategy.
 
@@ -47,8 +48,7 @@ class WeightTransferSender(ABC):
         Args:
             chunks: Iterable of WeightChunk objects to send.
             weight_metadata: Optional pre-computed metadata (names, dtype_names, shapes).
-                When provided, allows the sender to avoid materializing all chunks
-                to collect metadata upfront.
+            derive_metadata_from_chunks: Derive metadata from each transferred chunk.
         """
         ...
 

--- a/skyrl/backends/skyrl_train/workers/megatron/_fp8_block_amax_epsilon_patch.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/_fp8_block_amax_epsilon_patch.py
@@ -1,0 +1,76 @@
+"""Apply an optional amax floor to Transformer Engine blockwise FP8 recipes."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from math import isfinite
+
+from loguru import logger
+
+_ENV_VAR = "NVTE_FP8_BLOCK_AMAX_EPSILON"
+_PATCH_FLAG = "_skyrl_amax_epsilon_patched"
+_QPARAM_FIELDS = ("fp8_quant_fwd_inp", "fp8_quant_fwd_weight", "fp8_quant_bwd_grad")
+_MISSING = object()
+
+
+def _configured_amax_epsilon() -> float | None:
+    raw_value = os.getenv(_ENV_VAR)
+    if raw_value is None or not raw_value.strip():
+        return None
+    try:
+        epsilon = float(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{_ENV_VAR} must be a float, got {raw_value!r}") from exc
+    if not isfinite(epsilon) or epsilon < 0:
+        raise ValueError(f"{_ENV_VAR} must be finite and non-negative, got {epsilon}")
+    return epsilon or None
+
+
+def apply_fp8_block_amax_epsilon_patch() -> None:
+    """Idempotently set ``amax_epsilon`` on TE 2.11 blockwise QParams.
+
+    Once configured, fail if the TE API cannot be patched and verified; rollout
+    and training quantizers must use the same amax floor.
+    """
+
+    epsilon = _configured_amax_epsilon()
+    if epsilon is None:
+        return
+
+    try:
+        from transformer_engine.common.recipe import Float8BlockScaling, Format
+    except Exception as exc:
+        raise RuntimeError(
+            f"{_ENV_VAR} is set, but Transformer Engine's Float8BlockScaling recipe is unavailable"
+        ) from exc
+
+    if getattr(Float8BlockScaling, _PATCH_FLAG, None) == epsilon:
+        return
+
+    original_qparams = {}
+    original_flag = getattr(Float8BlockScaling, _PATCH_FLAG, _MISSING)
+    try:
+        original_qparams = {name: getattr(Float8BlockScaling, name) for name in _QPARAM_FIELDS}
+        patched_qparams = {name: replace(qparams, amax_epsilon=epsilon) for name, qparams in original_qparams.items()}
+        for name, qparams in patched_qparams.items():
+            setattr(Float8BlockScaling, name, qparams)
+        setattr(Float8BlockScaling, _PATCH_FLAG, epsilon)
+
+        probe = Float8BlockScaling(fp8_format=Format.E4M3)
+        observed = {name: getattr(probe, name).amax_epsilon for name in _QPARAM_FIELDS}
+        if any(value != epsilon for value in observed.values()):
+            raise RuntimeError(f"fresh Float8BlockScaling instance reported {observed}")
+    except Exception as exc:
+        for name, qparams in original_qparams.items():
+            setattr(Float8BlockScaling, name, qparams)
+        if original_flag is _MISSING:
+            try:
+                delattr(Float8BlockScaling, _PATCH_FLAG)
+            except AttributeError:
+                pass
+        else:
+            setattr(Float8BlockScaling, _PATCH_FLAG, original_flag)
+        raise RuntimeError(f"Failed to apply {_ENV_VAR}={epsilon} to Transformer Engine") from exc
+
+    logger.info("Applied {}={} to TE Float8BlockScaling blockwise quantizers", _ENV_VAR, epsilon)

--- a/skyrl/backends/skyrl_train/workers/megatron/fp8_param.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/fp8_param.py
@@ -1,0 +1,148 @@
+"""Initialize optimizer state for persistent Transformer Engine FP8 parameters."""
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+
+from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import is_fp8_enabled
+
+
+def is_fp8_param_enabled(transformer_config_kwargs: Mapping[str, Any]) -> bool:
+    """Return whether dictionary config enables persistent FP8 parameters."""
+    return is_fp8_enabled(transformer_config_kwargs.get("fp8_param", False))
+
+
+def _copy_model_shards_to_main_params(
+    megatron_optimizer: Any,
+    state_dict: Mapping[str, Any],
+) -> int:
+    """Reload MCore FP32 master shards from converted checkpoint tensors.
+
+    HybridDeviceOptimizer bypasses Megatron's state-dict-aware reload path.
+    Copying from ``state_dict`` preserves unquantized values for persistent FP8
+    parameters and refreshes ordinary BF16 parameters.
+    """
+    model_groups = getattr(megatron_optimizer, "model_float16_groups", None)
+    main_groups = getattr(megatron_optimizer, "shard_fp32_from_float16_groups", None)
+    model_fp32_groups = getattr(megatron_optimizer, "model_fp32_groups", None)
+    main_fp32_groups = getattr(megatron_optimizer, "shard_fp32_groups", None)
+    get_range = getattr(megatron_optimizer, "_get_model_param_range_map", None)
+    if model_groups is None or main_groups is None or not callable(get_range):
+        raise TypeError(
+            "Persistent FP8 parameter training with CPU optimizer offload requires "
+            "Megatron DistributedOptimizer shard metadata."
+        )
+
+    build_state_dict_map = getattr(megatron_optimizer, "_build_model_param_to_state_dict_param_map", None)
+    if not callable(build_state_dict_map):
+        raise TypeError(
+            "Persistent FP8 parameter training requires Megatron's "
+            "_build_model_param_to_state_dict_param_map() to reload exact checkpoint masters."
+        )
+    state_dict_params = build_state_dict_map(state_dict)
+
+    group_pairs = [(model_groups, main_groups)]
+    if model_fp32_groups is not None and main_fp32_groups is not None:
+        group_pairs.append((model_fp32_groups, main_fp32_groups))
+
+    copied = 0
+    for grouped_model_params, grouped_main_params in group_pairs:
+        for model_group, main_group in zip(grouped_model_params, grouped_main_params):
+            for model_param, main_param in zip(model_group, main_group):
+                if main_param is None:
+                    continue
+
+                param_range = get_range(model_param)["param"]
+                if param_range.size != main_param.numel():
+                    raise RuntimeError(
+                        "Persistent FP8 master-shard range does not match its FP32 master tensor: "
+                        f"{param_range.size=} {main_param.numel()=}."
+                    )
+
+                source_param = state_dict_params[model_param]
+                source = source_param.detach().reshape(-1)[param_range.start : param_range.end]
+                main_param.data.copy_(source.to(device=main_param.device, dtype=main_param.dtype))
+                copied += 1
+    return copied
+
+
+def _sync_hybrid_device_optimizer_masters(hybrid_optimizer: Any) -> int:
+    """Refresh HybridDeviceOptimizer's secondary masters after checkpoint import.
+
+    CPU copies are created before checkpoint import and are not refreshed by
+    MCore's public reload helper. Stale copies would overwrite weights on the
+    first optimizer step.
+    """
+    copied = 0
+    for cpu_param, gpu_param in getattr(hybrid_optimizer, "cpu_copys_map_gpu_param", {}).items():
+        cpu_param.data.copy_(
+            gpu_param.detach().to(device=cpu_param.device, dtype=cpu_param.dtype),
+            non_blocking=False,
+        )
+        copied += 1
+
+    for param, fp32_param in getattr(hybrid_optimizer, "param_to_fp32_param", {}).items():
+        fp32_param.data.copy_(
+            param.detach().to(device=fp32_param.device, dtype=fp32_param.dtype),
+            non_blocking=False,
+        )
+        copied += 1
+    return copied
+
+
+def _uses_hybrid_device_optimizer(megatron_optimizer: Any) -> bool:
+    """Identify MCore's CPU-offload optimizer without importing it eagerly."""
+    optimizer = getattr(megatron_optimizer, "optimizer", None)
+    return hasattr(optimizer, "cpu_copys_map_gpu_param") and hasattr(optimizer, "param_to_fp32_param")
+
+
+def initialize_fp8_param_optimizer_masters(
+    optimizer: Any,
+    *,
+    fp8_param: bool,
+    fp8_param_gather: bool,
+    state_dict: Mapping[str, Any] | None = None,
+) -> int:
+    """Initialize optimizer masters from unquantized checkpoint shards.
+
+    Persistent FP8 parameters cannot seed exact FP32 masters. For CPU offload,
+    refresh both distributed shards and HybridDeviceOptimizer's secondary copies.
+    """
+    if not fp8_param:
+        return 0
+    if not fp8_param_gather:
+        raise ValueError(
+            "Persistent FP8 parameters require ddp_config.fp8_param_gather=true "
+            "so updated FP32 master weights are requantized into FP8 compute weights."
+        )
+    if state_dict is None:
+        raise ValueError(
+            "Persistent FP8 optimizer masters require Megatron-Bridge's exact unquantized checkpoint state."
+        )
+
+    optimizers = getattr(optimizer, "chained_optimizers", None)
+    if optimizers is None:
+        optimizers = [optimizer]
+
+    initialized = 0
+    with torch.no_grad():
+        for megatron_optimizer in optimizers:
+            if _uses_hybrid_device_optimizer(megatron_optimizer):
+                copied = _copy_model_shards_to_main_params(megatron_optimizer, state_dict)
+                if copied == 0:
+                    raise RuntimeError(
+                        "Persistent FP8 parameter training did not find any model shards "
+                        "to seed into CPU-offloaded optimizer masters."
+                    )
+                _sync_hybrid_device_optimizer_masters(megatron_optimizer.optimizer)
+            else:
+                reload_main_params = getattr(megatron_optimizer, "_copy_model_params_to_main_params", None)
+                if not callable(reload_main_params):
+                    raise TypeError(
+                        "Persistent FP8 parameter training requires a Megatron optimizer "
+                        "with _copy_model_params_to_main_params()."
+                    )
+                reload_main_params(state_dict=state_dict)
+            initialized += 1
+    return initialized

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -29,6 +29,7 @@ from skyrl.backends.skyrl_train.distributed.megatron.model_utils import (
     vocab_parallel_entropy_packed_sequences,
 )
 from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import is_fp8_enabled
+from skyrl.backends.skyrl_train.training_batch import TensorList
 from skyrl.backends.skyrl_train.utils.ppo_utils import (
     PolicyLossRegistry,
     compute_approx_kl,
@@ -82,6 +83,23 @@ def _build_packed_targets(
     return targets.unsqueeze(0)
 
 
+def _copy_tensor_tree_to_device(value: Any, device: int) -> Any:
+    """Move all tensors in a nested microbatch to a CUDA device."""
+    if torch.is_tensor(value) or isinstance(value, TensorList):
+        return value.to(device=device, non_blocking=True)
+    if isinstance(value, dict):
+        return {key: _copy_tensor_tree_to_device(item, device) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_copy_tensor_tree_to_device(item, device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_copy_tensor_tree_to_device(item, device) for item in value)
+    return value
+
+
+def _copy_tensor_dict_to_device(batch: Dict[str, Any], device: int) -> Dict[str, Any]:
+    return {key: _copy_tensor_tree_to_device(value, device) for key, value in batch.items()}
+
+
 def _fused_lm_head_output_processor(**kwargs):
     """GPTModel ``output_processor`` hook for the fused LM-head log-prob path.
 
@@ -119,6 +137,7 @@ class MegatronModelWrapper:
         actor_optimizer: Optional[torch.optim.Optimizer] = None,
         policy_loss_fn: Optional[Callable] = None,
         is_vlm: bool = False,
+        cpu_resident_microbatches: bool = False,
     ):
         self.cfg = config
         self.actor_module = actor_module
@@ -126,6 +145,7 @@ class MegatronModelWrapper:
         self.policy_loss_fn = policy_loss_fn
         self.remove_microbatch_padding = self.cfg.remove_microbatch_padding
         self.is_vlm = is_vlm
+        self.cpu_resident_microbatches = cpu_resident_microbatches
         # Fuse the LM-head projection into the chunked log-prob/entropy via the
         # GPTModel output_processor hook (avoids materializing the full
         # [B, S, vocab//TP] logits + its fp32 grad). See model_utils.
@@ -282,6 +302,8 @@ class MegatronModelWrapper:
 
         def forward_step(batch_iter, model):
             batch = next(batch_iter)
+            if self.cpu_resident_microbatches:
+                batch = _copy_tensor_dict_to_device(batch, torch.cuda.current_device())
 
             model_config = get_model_config(model)
             fp8_enabled = is_fp8_enabled(getattr(model_config, "fp8", None))
@@ -645,10 +667,16 @@ class MegatronModelWrapper:
                         loss_mask,
                         mpu.get_context_parallel_group(),
                         sub_seq_lengths=data.get("sub_seq_lengths_list"),
+                        chunk_size=self.cfg.vocab_entropy_chunk_size,
+                        chunk_memory_mb=self.cfg.vocab_entropy_chunk_memory_mb,
                     )
                 else:
                     action_logits = logits[:, -num_actions - 1 : -1, :]
-                    entropy_BS = vocab_parallel_entropy(action_logits)
+                    entropy_BS = vocab_parallel_entropy(
+                        action_logits,
+                        chunk_size=self.cfg.vocab_entropy_chunk_size,
+                        chunk_memory_mb=self.cfg.vocab_entropy_chunk_memory_mb,
+                    )
                     entropy = masked_mean(entropy_BS, loss_mask)
                     entropy_for_loss = entropy
 
@@ -735,6 +763,8 @@ class MegatronModelWrapper:
             # for recover_left_padding and setup_per_microbatch_replay_forward. Especially relevant
             # after this PR https://github.com/NovaSky-AI/SkyRL/pull/1285.
             batch = next(batch_iter)
+            if self.cpu_resident_microbatches:
+                batch = _copy_tensor_dict_to_device(batch, torch.cuda.current_device())
 
             model_config = get_model_config(model)
             fp8_enabled = is_fp8_enabled(getattr(model_config, "fp8", None))

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -610,7 +610,6 @@ class MegatronWorker:
 
         # Build micro-batch dicts expected by policy.forward_mini_batch
         micro_dicts = []
-        device = torch.cuda.current_device()
 
         if microbatch_iterator is not None:
             micro_batches = microbatch_iterator
@@ -618,7 +617,8 @@ class MegatronWorker:
             micro_batches = data.chunk(self.cfg.micro_forward_batch_size_per_gpu)
 
         for micro in micro_batches:
-            micro.to(device)
+            if not self.model.cpu_resident_microbatches:
+                micro.to(torch.cuda.current_device())
             attention_mask = micro["attention_mask"]
             position_ids = attention_mask.long().cumsum(-1) - 1
             position_ids.masked_fill_(attention_mask == 0, 0)
@@ -930,6 +930,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             actor_optimizer=self.optimizer,
             policy_loss_fn=self.policy_loss_fn,
             is_vlm=self.is_vlm,
+            cpu_resident_microbatches=self.cfg.policy.megatron_config.cpu_resident_microbatches,
         )
 
         self.empty_cuda_cache = self.cfg.policy.megatron_config.empty_cuda_cache
@@ -971,8 +972,8 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         all_loss_fn_outputs: List[Dict[str, Any]] = []
 
         self._drop_pixel_values_on_non_first_pp_stage(data)
-        # Move data to GPU
-        data.to(torch.cuda.current_device())
+        if not self.cfg.policy.megatron_config.cpu_resident_microbatches:
+            data.to(torch.cuda.current_device())
 
         # Build micro-batch dicts expected by forward_backward_mini_batch
         micro_buffer = []
@@ -1084,8 +1085,8 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         all_metrics = defaultdict(list)
 
         self._drop_pixel_values_on_non_first_pp_stage(data)
-        # Move data to GPU
-        data.to(torch.cuda.current_device())
+        if not self.cfg.policy.megatron_config.cpu_resident_microbatches:
+            data.to(torch.cuda.current_device())
 
         use_token_batching = self.cfg.max_tokens_per_microbatch > 0
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import shutil
 from collections import defaultdict
@@ -49,10 +50,22 @@ from skyrl.backends.skyrl_train.weight_sync import (
     WeightChunk,
     WeightExtractor,
 )
+from skyrl.backends.skyrl_train.weight_sync.serialized_fp8 import (
+    SerializedFp8Config,
+    iter_serialized_fp8_tensors,
+    should_use_serialized_fp8,
+)
+from skyrl.backends.skyrl_train.workers.megatron._fp8_block_amax_epsilon_patch import (
+    apply_fp8_block_amax_epsilon_patch,
+)
 from skyrl.backends.skyrl_train.workers.megatron.adapter_store import (
     AdapterStore,
     LoraSignature,
     iter_opts,
+)
+from skyrl.backends.skyrl_train.workers.megatron.fp8_param import (
+    initialize_fp8_param_optimizer_masters,
+    is_fp8_param_enabled,
 )
 from skyrl.backends.skyrl_train.workers.megatron.megatron_model_wrapper import (
     MegatronModelWrapper,
@@ -107,12 +120,19 @@ class MegatronWeightExtractor(WeightExtractor):
         enable_bucketing: bool = False,
         bucket_size_threshold_GB: float = 1.0,
         training_dtype: torch.dtype = torch.bfloat16,
+        fp8_weight_sync_mode: Optional[str] = None,
     ):
         self.bridge = bridge
         self.actor_module = actor_module
         self.enable_bucketing = enable_bucketing
         self.bucket_size_threshold_GB = bucket_size_threshold_GB
         self.training_dtype = training_dtype
+        if fp8_weight_sync_mode is None:
+            self.serialized_fp8_config = None
+        elif should_use_serialized_fp8(fp8_weight_sync_mode):
+            self.serialized_fp8_config = SerializedFp8Config()
+        else:
+            raise ValueError(f"Unsupported fp8_weight_sync_mode={fp8_weight_sync_mode!r}")
 
         # Defer bucket init to first extract_weights call.
         # At __init__ time the model may be CPU-offloaded (colocate_all),
@@ -210,6 +230,11 @@ class MegatronWeightExtractor(WeightExtractor):
         (tensors are discarded immediately). Result is cached for subsequent calls.
         TODO (aaron): find a better way to get all metadata without materializing tensors.
         """
+        if self.serialized_fp8_config is not None:
+            raise RuntimeError(
+                "Serialized FP8 metadata depends on quantized tensor contents; "
+                "consume extract_weights() chunks instead."
+            )
         if hasattr(self, "_weight_metadata_cache"):
             return self._weight_metadata_cache
 
@@ -257,6 +282,18 @@ class MegatronWeightExtractor(WeightExtractor):
             self._init_param_buckets()
         self._buckets_initialized = True
 
+    def _iter_sync_tensors(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        dtype: torch.dtype,
+        device: int,
+    ):
+        if self.serialized_fp8_config is not None:
+            tensor = tensor.to(device=device, non_blocking=True)
+            return iter_serialized_fp8_tensors(name, tensor, dtype, self.serialized_fp8_config)
+        return [(name, tensor.to(device=device, dtype=dtype, non_blocking=True))]
+
     def extract_weights(self, dtype: torch.dtype):
         """Extract weights from Megatron model.
 
@@ -278,14 +315,21 @@ class MegatronWeightExtractor(WeightExtractor):
             )
 
             for name, tensor in hf_params_generator:
-                tensor = tensor.to(device=device, dtype=dtype, non_blocking=True)
+                tensor_iter = self._iter_sync_tensors(name, tensor, dtype, device)
 
-                yield WeightChunk(
-                    names=[name],
-                    dtypes=[str(dtype)],
-                    shapes=[list(tensor.shape)],
-                    tensors=[tensor],
-                )
+                names = []
+                dtypes = []
+                shapes = []
+                tensors = []
+                for out_name, out_tensor in tensor_iter:
+                    out_tensor = out_tensor.contiguous()
+                    names.append(out_name)
+                    dtypes.append(str(out_tensor.dtype))
+                    shapes.append(list(out_tensor.shape))
+                    tensors.append(out_tensor)
+
+                if tensors:
+                    yield WeightChunk(names=names, dtypes=dtypes, shapes=shapes, tensors=tensors)
         else:
             # Build fresh tasks each sync so mapping objects have clean
             # PP-collective caches; reuse the pre-computed bucket structure.
@@ -306,13 +350,14 @@ class MegatronWeightExtractor(WeightExtractor):
                 tensors = []
 
                 for name, tensor in hf_params_generator:
-                    # Move to device and convert dtype
-                    tensor = tensor.to(device=device, dtype=dtype, non_blocking=True)
+                    tensor_iter = self._iter_sync_tensors(name, tensor, dtype, device)
 
-                    names.append(name)
-                    dtypes_list.append(str(dtype))
-                    shapes.append(list(tensor.shape))
-                    tensors.append(tensor)
+                    for out_name, out_tensor in tensor_iter:
+                        out_tensor = out_tensor.contiguous()
+                        names.append(out_name)
+                        dtypes_list.append(str(out_tensor.dtype))
+                        shapes.append(list(out_tensor.shape))
+                        tensors.append(out_tensor)
 
                 # Yield one chunk containing all parameters in this bucket
                 if tensors:
@@ -392,6 +437,7 @@ class MegatronWorker:
         masters and fake-quantizes them in the forward pass. Tokenizer + HF config
         (the logical model identity) still come from ``model_path``.
         """
+        apply_fp8_block_amax_epsilon_patch()
         tokenizer = get_tokenizer(model_path, trust_remote_code=True)
         hf_config_original = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
 
@@ -421,6 +467,7 @@ class MegatronWorker:
             for key in ("recompute_granularity", "recompute_method", "recompute_num_layers"):
                 transformer_config_kwargs[key] = None
 
+        fp8_param_enabled = is_fp8_param_enabled(transformer_config_kwargs)
         bridge_source = bridge_weights_path or model_path
         if bridge_weights_path:
             logger.info(
@@ -438,7 +485,11 @@ class MegatronWorker:
                 "(native GDN thd packing path; vision tower dropped)"
             )
 
-        provider = bridge.to_megatron_provider()
+        # Defer persistent-FP8 checkpoint import until the bridge can expose
+        # unquantized converted shards for optimizer-master initialization.
+        provider = bridge.to_megatron_provider(load_weights=not fp8_param_enabled)
+        if fp8_param_enabled:
+            provider.perform_initialization = False
 
         # Disable MTP for training: its aux loss is unused, and under full
         # recompute its checkpointed forward passes packed_seq_params positionally
@@ -499,6 +550,8 @@ class MegatronWorker:
         # the bridge weights path only under fake-INT4 QAT (INT4 model.path, BF16
         # bridge weights); used so saved LoRA adapters reference the INT4 base.
         self._logical_model_path = model_path
+        self._deferred_fp8_param_weight_load = fp8_param_enabled
+        self._fp8_param_unquantized_state_dict = None
 
         # strategy.hf_config is the on-disk source-of-truth used by
         # save_hf_configs and must NOT carry runtime overrides like
@@ -506,6 +559,40 @@ class MegatronWorker:
         self.strategy.hf_config = hf_config_original
         self.tokenizer = tokenizer
         self.enable_router_replay = megatron_config.moe_enable_routing_replay
+
+    def _load_deferred_fp8_param_weights(self, *, retain_unquantized_state: bool = False) -> None:
+        """Load deferred FP8 weights and optionally retain exact master tensors."""
+        if not self._deferred_fp8_param_weight_load:
+            return
+
+        original_export_dtype = self.bridge.export_weight_dtype
+        try:
+            # The FP8 export path retains converted, unquantized local shards.
+            # Only policy workers with an optimizer keep this additional copy.
+            if retain_unquantized_state:
+                self.bridge.export_weight_dtype = "fp8"
+            self.bridge.load_hf_weights(self.actor_module)
+            state_dict = getattr(self.bridge, "unquantized_state_dict", None)
+            if retain_unquantized_state and not state_dict:
+                raise RuntimeError(
+                    "Megatron-Bridge did not capture unquantized checkpoint shards "
+                    "for persistent FP8 optimizer initialization."
+                )
+            self._fp8_param_unquantized_state_dict = state_dict if retain_unquantized_state else None
+        finally:
+            self.bridge.export_weight_dtype = original_export_dtype
+
+    def _release_fp8_param_unquantized_state(self) -> None:
+        """Release temporary checkpoint shards after deferred weight import."""
+        if not self._deferred_fp8_param_weight_load:
+            return
+        self._fp8_param_unquantized_state_dict = None
+        if self.bridge is not None:
+            # Clear both owners; either reference keeps the unquantized shard in HBM.
+            self.bridge.unquantized_state_dict = None
+        self._deferred_fp8_param_weight_load = False
+        gc.collect()
+        torch.cuda.empty_cache()
 
     def configure_lora(self, lora_config, lora_type: Optional[str] = "lora"):
         if lora_type == "lora":
@@ -898,6 +985,8 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             snapshot_download(model_path)  # will be no-op if already downloaded
         torch.distributed.barrier()
 
+        self._load_deferred_fp8_param_weights(retain_unquantized_state=not self.cfg.policy.inference_only_init)
+
         if self._rank == 0:
             print_model_size(self.actor_module[0])
 
@@ -915,13 +1004,25 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
                 self.cfg.policy.optimizer_config, self.cfg.policy.megatron_config.optimizer_config_kwargs
             )
             self.optimizer = get_megatron_optimizer(self.actor_module, optim_config)
-
+            fp8_param_masters = initialize_fp8_param_optimizer_masters(
+                self.optimizer,
+                fp8_param=is_fp8_param_enabled(self.cfg.policy.megatron_config.transformer_config_kwargs),
+                fp8_param_gather=self.cfg.policy.megatron_config.ddp_config.fp8_param_gather,
+                state_dict=self._fp8_param_unquantized_state_dict,
+            )
+            if fp8_param_masters:
+                logger.info(
+                    "Initialized {} persistent-FP8 optimizer master shard group(s) from exact checkpoint shards.",
+                    fp8_param_masters,
+                )
             # create scheduler
             self.scheduler = get_megatron_optimizer_param_scheduler(
                 optimizer=self.optimizer,
                 config=self.cfg.policy.optimizer_config,
                 num_training_steps=num_training_steps,
             )
+
+        self._release_fp8_param_unquantized_state()
 
         # create worker model
         self.model = MegatronModelWrapper(
@@ -1326,6 +1427,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             enable_bucketing=True,
             bucket_size_threshold_GB=inference_engine_cfg.weight_transfer_threshold_cuda_ipc_GB,
             training_dtype=torch.bfloat16 if self.cfg.bf16 else torch.float32,
+            fp8_weight_sync_mode=inference_engine_cfg.fp8_weight_sync_mode,
         )
 
     async def _save_lora_adapters_and_sync(
@@ -1423,10 +1525,15 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             # CUDA-IPC path calls cudaIpcGetMemHandle, which is incompatible with the
             # VMM addresses expandable segments uses.
             with self._expandable_segments_disabled_for_sync():
-                weight_metadata = self.weight_extractor.get_weight_metadata(generator_dtype)
+                weight_iterator = self.weight_extractor.extract_weights(generator_dtype)
+                derive_metadata_from_chunks = self.weight_extractor.serialized_fp8_config is not None
+                weight_metadata = (
+                    None if derive_metadata_from_chunks else self.weight_extractor.get_weight_metadata(generator_dtype)
+                )
                 await self._weight_transfer_sender.send_chunks(
-                    self.weight_extractor.extract_weights(generator_dtype),
+                    weight_iterator,
                     weight_metadata=weight_metadata,
+                    derive_metadata_from_chunks=derive_metadata_from_chunks,
                 )
 
         if cache_reset_task is not None:
@@ -1604,6 +1711,9 @@ class MegatronRefWorkerBase(MegatronWorker, RefWorkerBase):
         ):  # if not local path, try downloading model weights from huggingface
             snapshot_download(model_path)  # will be no-op if already downloaded
         torch.distributed.barrier()
+
+        self._load_deferred_fp8_param_weights()
+        self._release_fp8_param_unquantized_state()
 
         # load weights
         if self._rank == 0:

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -258,11 +258,25 @@ class Worker(DistributedTorchRayActor):
                 gpu_uuid = str(raw_gpu_uuid) if raw_gpu_uuid else None
             pynvml.nvmlInit()
             try:
-                handle = (
-                    pynvml.nvmlDeviceGetHandleByUUID(gpu_uuid)
-                    if gpu_uuid
-                    else pynvml.nvmlDeviceGetHandleByIndex(device)
-                )
+                if gpu_uuid:
+                    handle = pynvml.nvmlDeviceGetHandleByUUID(gpu_uuid)
+                else:
+                    visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+                    nvml_identifier = str(device)
+                    if visible_devices is not None:
+                        identifiers = [value.strip() for value in visible_devices.split(",") if value.strip()]
+                        if device >= len(identifiers):
+                            raise RuntimeError(
+                                f"CUDA device {device} is absent from CUDA_VISIBLE_DEVICES={visible_devices!r}"
+                            )
+                        nvml_identifier = identifiers[device]
+
+                    try:
+                        physical_device = int(nvml_identifier)
+                    except ValueError:
+                        handle = pynvml.nvmlDeviceGetHandleByUUID(nvml_identifier)
+                    else:
+                        handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device)
                 processes = pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
                 current_pid = os.getpid()
                 for proc in processes:

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -1,9 +1,11 @@
 import asyncio
+import gc
 import logging
 import os
 import socket
+import time
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from ctypes import CDLL, POINTER, Structure, c_char_p, c_int, c_ulong, c_void_p
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type
@@ -243,9 +245,86 @@ class Worker(DistributedTorchRayActor):
         """Initialize worker state (model, and optimizer if applicable) on worker."""
         raise NotImplementedError()
 
+    def _get_own_nvml_used_bytes(self, device: int) -> Dict[str, Any]:
+        """Return this process's NVML-reported memory for the selected GPU."""
+        try:
+            import pynvml
+
+            props = torch.cuda.get_device_properties(device)
+            raw_gpu_uuid = getattr(props, "uuid", None)
+            if isinstance(raw_gpu_uuid, bytes):
+                gpu_uuid = raw_gpu_uuid.decode("ascii")
+            else:
+                gpu_uuid = str(raw_gpu_uuid) if raw_gpu_uuid else None
+            pynvml.nvmlInit()
+            try:
+                handle = (
+                    pynvml.nvmlDeviceGetHandleByUUID(gpu_uuid)
+                    if gpu_uuid
+                    else pynvml.nvmlDeviceGetHandleByIndex(device)
+                )
+                processes = pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
+                current_pid = os.getpid()
+                for proc in processes:
+                    if int(proc.pid) == current_pid:
+                        return {"nvml_used_bytes": int(getattr(proc, "usedGpuMemory", 0) or 0)}
+                return {"nvml_error": f"PID {current_pid} was not present in NVML's compute-process list"}
+            finally:
+                with suppress(Exception):
+                    pynvml.nvmlShutdown()
+        except Exception as exc:
+            return {"nvml_error": repr(exc)}
+
+    def cuda_memory_stats(self) -> Dict[str, Any]:
+        """Return best-effort CUDA/NVML memory stats for this worker process."""
+        record: Dict[str, Any] = {
+            "hostname": socket.gethostname(),
+            "pid": os.getpid(),
+            "cuda_available": torch.cuda.is_available(),
+        }
+        if not torch.cuda.is_available():
+            return record
+
+        device = torch.cuda.current_device()
+        props = torch.cuda.get_device_properties(device)
+        raw_gpu_uuid = getattr(props, "uuid", None)
+        if isinstance(raw_gpu_uuid, bytes):
+            gpu_uuid = raw_gpu_uuid.decode("ascii")
+        else:
+            gpu_uuid = str(raw_gpu_uuid) if raw_gpu_uuid else None
+        torch.cuda.synchronize(device)
+        free_bytes, total_bytes = torch.cuda.mem_get_info(device)
+        record.update(
+            {
+                "device": device,
+                "gpu_name": getattr(props, "name", None),
+                "gpu_uuid": gpu_uuid,
+                "allocated_bytes": torch.cuda.memory_allocated(device),
+                "reserved_bytes": torch.cuda.memory_reserved(device),
+                "free_bytes": free_bytes,
+                "total_bytes": total_bytes,
+            }
+        )
+        record.update(self._get_own_nvml_used_bytes(device))
+        return record
+
     def empty_cache(self) -> None:
-        """Empty GPU memory cache on Worker's CUDA device"""
-        torch.cuda.empty_cache()
+        """Empty this worker's CUDA allocator cache."""
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    def release_cuda_memory(self) -> Dict[str, Any]:
+        """Release Python/CUDA caches and return process-level HBM statistics."""
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+            try:
+                torch.cuda.ipc_collect()
+            except RuntimeError:
+                pass
+            torch.cuda.synchronize()
+        return self.cuda_memory_stats()
 
     def _set_expandable_segments(self, enabled: bool) -> None:
         """Toggle PyTorch's CUDA ``expandable_segments`` allocator at runtime.
@@ -567,6 +646,11 @@ class PPORayActorGroup:
         self.colocate_all = colocate_all
         self.sequence_parallel_size = sequence_parallel_size
         self.record_memory = record_memory
+        self._pg = pg
+        self._num_gpus_per_actor = num_gpus_per_actor
+        self._last_init_model_args = None
+        self._last_init_model_kwargs = None
+        self._last_dp_size: Optional[int] = None
         self._initiate_actors(pg, num_gpus_per_actor)
 
     def _initiate_actors(self, pg: Optional[ResolvedPlacementGroup], num_gpus_per_actor: float):
@@ -678,6 +762,8 @@ class PPORayActorGroup:
         ray.get([actor.init_worker_process_group.remote() for actor in self._actor_handlers])
         logger.info("Initialized process group for RayActorGroup")
         self.actor_infos = [ActorInfo(actor, ray.get(actor.get_mesh_rank.remote())) for actor in self._actor_handlers]
+        if self.actor_infos:
+            self._last_dp_size = self.actor_infos[0].rank.dp_size
         logger.info(f"Mesh Ranks: {[actor_info.rank for actor_info in self.actor_infos]}")
 
     def async_init_model(
@@ -691,7 +777,60 @@ class PPORayActorGroup:
         Returns:
             A list of ray object refs.
         """
+        self._last_init_model_args = args
+        self._last_init_model_kwargs = dict(kwargs)
         return [actor.init_model.remote(*args, **kwargs) for actor in self._actor_handlers]
+
+    @property
+    def is_shutdown(self) -> bool:
+        """Return True when this group has no live Ray actor handles."""
+        return len(getattr(self, "_actor_handlers", [])) == 0
+
+    def can_restore_init_model(self) -> bool:
+        """Return whether the actor group can be restarted and reinitialized."""
+        return self._last_init_model_args is not None
+
+    def get_dp_size(self) -> int:
+        """Return the current or last-known data-parallel size for this actor group."""
+        if self.actor_infos:
+            self._last_dp_size = self.actor_infos[0].rank.dp_size
+            return self._last_dp_size
+        if self._last_dp_size is None:
+            raise RuntimeError("Cannot determine data-parallel size before actor group initialization.")
+        return self._last_dp_size
+
+    def shutdown(self) -> None:
+        """Terminate all actors in this group so process-owned CUDA memory is released."""
+        if self.actor_infos:
+            self._last_dp_size = self.actor_infos[0].rank.dp_size
+        actors = list(getattr(self, "_actor_handlers", []))
+        for actor in actors:
+            ray.kill(actor, no_restart=True)
+        for actor in actors:
+            deadline = time.monotonic() + 30.0
+            while True:
+                try:
+                    ray.get(actor.get_mesh_rank.remote(), timeout=1.0)
+                except ray.exceptions.RayActorError:
+                    break
+                except ray.exceptions.GetTimeoutError:
+                    pass
+                if time.monotonic() >= deadline:
+                    raise RuntimeError("Timed out waiting for a hard-evicted Ray actor to terminate")
+        self._actor_handlers = []
+        self.actor_infos = []
+
+    def restart_actors(self) -> None:
+        """Recreate the Ray actors and distributed process group for this actor group."""
+        if not self.is_shutdown:
+            self.shutdown()
+        self._initiate_actors(self._pg, self._num_gpus_per_actor)
+
+    def restore_init_model(self) -> None:
+        """Reinitialize actors with the last init_model arguments."""
+        if not self.can_restore_init_model():
+            raise RuntimeError("Cannot restore actor group: last init_model path is unavailable.")
+        ray.get(self.async_init_model(*self._last_init_model_args, **(self._last_init_model_kwargs or {})))
 
     def offload_to_cpu(self, nonblocking=False, offload_optimizer=True, offload_model=True):
         """Offload all worker state to CPU.

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -110,16 +110,16 @@ class WorkerDispatch:
         """Get LCM of all models' dp_size."""
         import math
 
-        dp_size = self._actor_groups["policy"].actor_infos[0].rank.dp_size
+        dp_size = self._actor_groups["policy"].get_dp_size()
         if "critic" in self._actor_groups:
-            dp_size = math.lcm(dp_size, self._actor_groups["critic"].actor_infos[0].rank.dp_size)
+            dp_size = math.lcm(dp_size, self._actor_groups["critic"].get_dp_size())
         if "ref" in self._actor_groups:
-            dp_size = math.lcm(dp_size, self._actor_groups["ref"].actor_infos[0].rank.dp_size)
+            dp_size = math.lcm(dp_size, self._actor_groups["ref"].get_dp_size())
         return dp_size
 
     def dp_size(self, model: str) -> int:
         """Return the data-parallel size for ``model`` (e.g. "policy")."""
-        return self._actor_groups[model].actor_infos[0].rank.dp_size
+        return self._actor_groups[model].get_dp_size()
 
     def _should_manage_offload(self, model: str) -> bool:
         """Check if we need to manage offload for this model."""
@@ -137,6 +137,84 @@ class WorkerDispatch:
             return [m for m in ["policy", "ref"] if m in self._actor_groups]
         return [model]
 
+    @staticmethod
+    def _worker_residual_hbm_bytes(stats: Dict[str, Any]) -> Optional[int]:
+        """Best-effort residual HBM for a worker process after offload."""
+        if stats.get("nvml_used_bytes") is None:
+            return None
+        measurements = [
+            int(stats[key])
+            for key in ("nvml_used_bytes", "reserved_bytes", "allocated_bytes")
+            if stats.get(key) is not None
+        ]
+        return max(measurements) if measurements else None
+
+    def _enforce_inactive_worker_memory_barrier(self, model: str, stats: List[Dict[str, Any]]) -> None:
+        """Enforce the residual-HBM policy after CPU offload."""
+        placement = self.cfg.trainer.placement
+        if not placement.colocated_worker_memory_barrier:
+            return
+        if not stats:
+            raise RuntimeError(f"Inactive colocated worker barrier for {model} received no memory statistics")
+
+        threshold = placement.colocated_worker_residual_hbm_threshold_gb * (1024**3)
+        measurements = [self._worker_residual_hbm_bytes(record) for record in stats]
+        missing_measurements = sum(value is None for value in measurements)
+        available_measurements = [value for value in measurements if value is not None]
+        max_residual = max(available_measurements) if available_measurements else None
+        if missing_measurements == 0 and max_residual is not None:
+            logger.info(
+                f"Inactive colocated worker barrier model={model} "
+                f"max_residual={max_residual / (1024**3):.2f} GiB "
+                f"threshold={threshold / (1024**3):.2f} GiB"
+            )
+            if max_residual <= threshold:
+                return
+
+        if model != "ref" or not placement.colocated_ref_hard_evict_on_breach:
+            detail = (
+                f"still holds {max_residual / (1024**3):.2f} GiB HBM"
+                if max_residual is not None and missing_measurements == 0
+                else f"has {missing_measurements} missing memory measurement(s)"
+            )
+            raise RuntimeError(f"Inactive colocated worker model={model} {detail} after CPU offload")
+
+        group = self._actor_groups[model]
+        if not group.can_restore_init_model():
+            raise RuntimeError(
+                f"Cannot hard-evict inactive colocated {model} worker because init_model arguments were not captured"
+            )
+
+        reason = (
+            f"residual HBM was {max_residual / (1024**3):.2f} GiB"
+            if max_residual is not None and missing_measurements == 0
+            else f"{missing_measurements} memory measurement(s) were unavailable"
+        )
+        logger.warning(f"Hard-evicting inactive colocated {model} workers because {reason}.")
+        group.shutdown()
+        self._gpu_state[model] = GPUState()
+
+    def _offload_inactive_model(self, model: str) -> None:
+        """Offload an inactive colocated model and enforce its residual-HBM policy."""
+        group = self._actor_groups[model]
+        if group.is_shutdown:
+            self._gpu_state[model] = GPUState()
+            return
+        group.offload_to_cpu()
+        self._gpu_state[model] = GPUState()
+        if self.cfg.trainer.placement.colocated_worker_memory_barrier:
+            self._enforce_inactive_worker_memory_barrier(model, self.release_cuda_memory(model))
+
+    def _ensure_actor_group_ready(self, model: str) -> None:
+        """Restart a hard-evicted actor group before the model is used again."""
+        group = self._actor_groups[model]
+        if not group.is_shutdown:
+            return
+        logger.info(f"Restarting hard-evicted colocated {model} actors.")
+        group.restart_actors()
+        group.restore_init_model()
+        self._gpu_state[model] = GPUState(model_on_gpu=True, optimizer_on_gpu=(model != "ref"))
+
     def _ensure_on_gpu(self, model: str, need_optimizer: bool = True, need_model: bool = True) -> None:
         """Ensure model is on GPU, offloading others in same colocation group if needed."""
         if not self._should_manage_offload(model):
@@ -147,26 +225,30 @@ class WorkerDispatch:
 
         group = self._get_colocation_group(model)
 
-        # Offload others in the same colocation group
+        # Offload peers before restarting an evicted group to avoid a transient
+        # overlap during model initialization.
         for other in group:
             if other != model and other in self._actor_groups:
                 state = self._gpu_state[other]
                 if state.model_on_gpu or state.optimizer_on_gpu:
-                    self._actor_groups[other].offload_to_cpu()
-                    self._gpu_state[other] = GPUState()
+                    self._offload_inactive_model(other)
 
-        # Backload requested model
+        self._ensure_actor_group_ready(model)
+
+        # Reload only missing state; model weights may remain resident while the
+        # optimizer is offloaded.
         state = self._gpu_state[model]
-        needs_backload = (need_model and not state.model_on_gpu) or (need_optimizer and not state.optimizer_on_gpu)
+        backload_model = need_model and not state.model_on_gpu
+        backload_optimizer = need_optimizer and not state.optimizer_on_gpu
 
-        if needs_backload:
+        if backload_model or backload_optimizer:
             self._actor_groups[model].backload_to_gpu(
-                backload_optimizer=need_optimizer,
-                backload_model=need_model,
+                backload_optimizer=backload_optimizer,
+                backload_model=backload_model,
             )
-            if need_model:
+            if backload_model:
                 self._gpu_state[model].model_on_gpu = True
-            if need_optimizer:
+            if backload_optimizer:
                 self._gpu_state[model].optimizer_on_gpu = True
 
     def _offload(self, model: str, offload_optimizer: bool = True, offload_model: bool = True) -> None:
@@ -516,8 +598,7 @@ class WorkerDispatch:
                 if other != model and other in self._actor_groups:
                     state = self._gpu_state[other]
                     if state.model_on_gpu or state.optimizer_on_gpu:
-                        self._actor_groups[other].offload_to_cpu()
-                        self._gpu_state[other] = GPUState()
+                        self._offload_inactive_model(other)
 
         kwargs = {"model_path": model_path}
         if num_training_steps is not None:
@@ -545,6 +626,10 @@ class WorkerDispatch:
             for group in self._actor_groups.values():
                 refs.extend(group.async_run_ray_method("pass_through", "empty_cache"))
             ray.get(refs)
+
+    def release_cuda_memory(self, model: str) -> List[Dict[str, Any]]:
+        """Release worker caches and collect process-level HBM measurements."""
+        return ray.get(self._actor_groups[model].async_run_ray_method("pass_through", "release_cuda_memory"))
 
     def get_node_ids(self) -> List[str]:
         """Get unique node IDs from all actor groups."""

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -197,6 +197,7 @@ class MegatronDDPConfig(BaseConfig):
     grad_reduce_in_fp32: bool = True
     overlap_grad_reduce: bool = False
     overlap_param_gather: bool = False
+    fp8_param_gather: bool = False
     average_in_collective: bool = True
 
 
@@ -715,6 +716,9 @@ class InferenceEngineConfig(BaseConfig):
 
     model_dtype: str = "bfloat16"
     """Should match the dtype used by the inference engine."""
+    fp8_weight_sync_mode: Optional[str] = None
+    """Optional rollout weight format. ``"serialized_blockwise"`` sends FP8
+    checkpoint weights and scales instead of ``model_dtype`` tensors."""
     run_engines_locally: bool = True
     num_engines: int = 1
     backend: str = "vllm"

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -7,6 +7,7 @@ can be constructed from a Hydra DictConfig via SkyRLTrainConfig.from_dict_config
 
 import copy
 import dataclasses
+import math
 import os
 import typing
 from abc import ABC
@@ -353,6 +354,8 @@ class MegatronConfig(BaseConfig):
         default_factory=lambda: copy.deepcopy(DEFAULT_TRANSFORMER_CONFIG_KWARGS)
     )
     empty_cuda_cache: Optional[bool] = True
+    cpu_resident_microbatches: bool = False
+    """Keep policy batches on CPU and transfer each microbatch before its forward step."""
     model_config_kwargs: dict = field(default_factory=dict)
     dist_ckpt_optim_fully_reshardable: bool = False
     freeze_moe_router: bool = False
@@ -392,6 +395,16 @@ class PlacementConfig(BaseConfig):
     critic_num_gpus_per_node: int = 1
     ref_num_nodes: int = 1
     ref_num_gpus_per_node: int = 1
+    colocated_worker_memory_barrier: bool = False
+    """Check inactive colocated worker residual HBM after CPU offload."""
+    colocated_worker_residual_hbm_threshold_gb: float = 2.0
+    colocated_ref_hard_evict_on_breach: bool = False
+    """Hard-evict and later restart reference workers that breach the threshold."""
+
+    def __post_init__(self) -> None:
+        value = self.colocated_worker_residual_hbm_threshold_gb
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value < 0:
+            raise ValueError("colocated_worker_residual_hbm_threshold_gb must be finite and non-negative")
 
 
 # ---------------------------------------------------------------------------
@@ -927,6 +940,12 @@ class TrainerConfig(BaseConfig):
     This lowers peak GPU memory at the cost of ~2x wall-clock time.
     ``None`` disables chunking (Megatron backend only; FSDP requires a positive int).
     See https://github.com/NovaSky-AI/SkyRL/pull/1610 for more details."""
+    vocab_entropy_chunk_size: Optional[int] = 0
+    """Chunk size along the sequence dimension when computing Megatron vocab entropy.
+    ``0`` auto-sizes from the local vocab shard size and ``vocab_entropy_chunk_memory_mb``.
+    ``None`` disables chunking."""
+    vocab_entropy_chunk_memory_mb: int = 512
+    """Approximate per-chunk temporary memory budget for auto-sized Megatron vocab entropy chunks."""
     fused_lm_head_logprob: bool = False
     """Megatron only. Fuse the LM-head projection into log-prob / entropy
     computation so the full ``[B, S, vocab//TP]`` logits tensor is never
@@ -971,6 +990,24 @@ class TrainerConfig(BaseConfig):
             raise ValueError(
                 "fused_lm_head_logprob_backend must be 'torch' or 'triton', "
                 f"got {self.fused_lm_head_logprob_backend!r}."
+            )
+        if self.vocab_entropy_chunk_size is not None and (
+            isinstance(self.vocab_entropy_chunk_size, bool)
+            or not isinstance(self.vocab_entropy_chunk_size, int)
+            or self.vocab_entropy_chunk_size < 0
+        ):
+            raise ValueError(
+                "vocab_entropy_chunk_size must be a non-negative integer or None, "
+                f"got {self.vocab_entropy_chunk_size!r}."
+            )
+        if (
+            isinstance(self.vocab_entropy_chunk_memory_mb, bool)
+            or not isinstance(self.vocab_entropy_chunk_memory_mb, int)
+            or self.vocab_entropy_chunk_memory_mb <= 0
+        ):
+            raise ValueError(
+                "vocab_entropy_chunk_memory_mb must be a positive integer, "
+                f"got {self.vocab_entropy_chunk_memory_mb!r}."
             )
 
 

--- a/skyrl/train/dataset/collators.py
+++ b/skyrl/train/dataset/collators.py
@@ -74,7 +74,8 @@ class PackedDataCollator:
     Flow:
 
     1. Compute per-example sequence lengths.
-    2. FFD-pack with ``bin_capacity = max_tokens_per_microbatch``,
+    2. FFD-pack using each sequence's alignment-padded footprint and
+       ``bin_capacity = max(max_tokens_per_microbatch, align_size)``,
        ``min_bin_count = dp_size``, ``bin_count_multiple = dp_size``.
     3. Round-robin assign bins to DP shards (this happens implicitly inside
        ``MeshDispatch.dispatch`` because the rows are laid out in shard-major
@@ -135,19 +136,22 @@ class PackedDataCollator:
         pp_size = self.pp_size
         cp_size = self.cp_size
         # Each sub-seq's padded length must satisfy these divisibility
-        # constraints, which is why ``align_size`` carries all factors:
+        # constraints, which is why ``align_size`` carries all required factors:
         #   - Sequence Parallelism (auto-on when tp>1) shards along the seq
         #     dim, so each segment must be divisible by ``tp_size``.
         #   - Context Parallelism splits each segment into ``2*cp_size`` equal
         #     load-balanced causal chunks, so each segment must be divisible by
         #     ``2*cp_size``.
-        #   - When FP8 is enabled, Transformer Engine GEMMs require each CP
-        #     rank's local token slab to be 16-aligned; globally this means
-        #     ``16*cp_size``.
+        #   - FP8 requires 16-token local slabs for TP=1. With sequence
+        #     parallelism, TE quantizes all-gather inputs in 128-token blocks,
+        #     so the global segment includes the TP and CP shard factors.
         # This MUST stay in lockstep with the worker's preprocess_packed_seqs
         # (megatron_utils.py): if the divisors drift, the per-rank CP/SP
         # gather/scatter offsets silently corrupt loss/grads (no crash).
         align_size = get_packed_seq_align_size(tp_size, cp_size, fp8_enabled=self.fp8_enabled)
+
+        def _round_up(x: int, multiple: int) -> int:
+            return ((x + multiple - 1) // multiple) * multiple
 
         dp_size = self.dp_size
 
@@ -177,14 +181,18 @@ class PackedDataCollator:
         # same number of micro-batches. Forcing the global bin count to a
         # multiple of ``dp_size`` makes the per-DP-rank bin count (and thus
         # ``num_microbatches``) identical across ranks.
+        # Pack aligned footprints so per-sequence padding cannot exceed the row
+        # budget. Allow at least one alignment unit per bin.
+        packing_lengths = [_round_up(length, align_size) for length in seq_lengths]
+        packing_capacity = max(bin_capacity, align_size)
         bin_count_multiple = dp_size
         packer = make_seq_packer(
             "first_fit_decreasing",
-            bin_capacity=bin_capacity,
+            bin_capacity=packing_capacity,
             min_bin_count=bin_count_multiple,
             bin_count_multiple=bin_count_multiple,
         )
-        bins: List[List[int]] = packer.pack(seq_lengths)
+        bins: List[List[int]] = packer.pack(packing_lengths)
 
         # Assign bins to DP shards via round-robin (bin_idx % shards).
         # Concretely we want the resulting layout to be shard-major:
@@ -204,9 +212,6 @@ class PackedDataCollator:
         # 3. Compute packed-row lengths (with align_size padding per sub-seq)
         #    and the global max packed length (for PP > 1 uniform padding).
         # ------------------------------------------------------------------
-        def _round_up(x: int, m: int) -> int:
-            return ((x + m - 1) // m) * m
-
         bin_packed_lengths: List[int] = []
         bin_subseq_lengths: List[List[int]] = []  # one list per bin row
         for bin_indices in flat_bins:
@@ -242,7 +247,7 @@ class PackedDataCollator:
         n_samples = len(examples)
         logger.info(
             f"sequence packing | packed {n_samples} samples into {num_bins} bins "
-            f"(~{num_bins // dp_size}/DP rank, bin_capacity={bin_capacity} tokens)"
+            f"(~{num_bins // dp_size}/DP rank, bin_capacity={packing_capacity} aligned tokens)"
         )
 
         sequences = torch.full((num_bins, max_packed_len), pad_token_id, dtype=torch.long)
@@ -282,8 +287,7 @@ class PackedDataCollator:
                 # p_local = s - 1 (last token of sub-seq): mask = 0.
                 # Already zero by initialization.
 
-                # Advance row_offset, padding sub-seq to the TP/CP layout
-                # multiple, plus FP8's 16-token local-rank multiple when active.
+                # Match the aligned footprint consumed by preprocess_packed_seqs.
                 row_offset += _round_up(s, align_size)
 
         # The total_nonpad we just counted matches sum(loss_mask). Verify in

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -20,6 +20,10 @@ from ray.util.placement_group import (
 )
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
+from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import is_fp8_enabled
+from skyrl.backends.skyrl_train.weight_sync.serialized_fp8 import (
+    SERIALIZED_BLOCKWISE_FP8,
+)
 from skyrl.env_vars import (
     SKYRL_DUMP_INFRA_LOG_TO_STDOUT,
     SKYRL_LD_LIBRARY_PATH_EXPORT,
@@ -197,6 +201,18 @@ def validate_megatron_cfg(cfg: SkyRLTrainConfig):
     assert ie_cfg.weight_sync_backend == "nccl", "only nccl is supported for megatron weight sync"
     assert ie_cfg.backend == "vllm", "only vllm is supported for with megatron"
     assert cfg.trainer.critic.model.path is None, "only GRPO training is currently supported for megatron"
+
+    policy_cfg = cfg.trainer.policy
+    policy_fp8_param = is_fp8_enabled(policy_cfg.megatron_config.transformer_config_kwargs.get("fp8_param"))
+    if (
+        policy_fp8_param
+        and not policy_cfg.inference_only_init
+        and not policy_cfg.megatron_config.ddp_config.fp8_param_gather
+    ):
+        raise ValueError(
+            "Persistent policy fp8_param training requires "
+            "trainer.policy.megatron_config.ddp_config.fp8_param_gather=true"
+        )
 
     if cfg.trainer.policy.megatron_config.moe_enable_routing_replay:
         assert (
@@ -492,6 +508,21 @@ def validate_inference_engine_cfg(cfg: SkyRLTrainConfig):
     """
     ie_cfg = cfg.generator.inference_engine
 
+    if ie_cfg.fp8_weight_sync_mode not in (None, SERIALIZED_BLOCKWISE_FP8):
+        raise ValueError(
+            f"Unsupported fp8_weight_sync_mode={ie_cfg.fp8_weight_sync_mode!r}; "
+            f"expected {SERIALIZED_BLOCKWISE_FP8!r} or None"
+        )
+    if ie_cfg.fp8_weight_sync_mode == SERIALIZED_BLOCKWISE_FP8:
+        if cfg.trainer.strategy != "megatron":
+            raise ValueError("serialized_blockwise FP8 weight sync requires trainer.strategy='megatron'")
+        lora_cfg = cfg.trainer.policy.model.lora
+        if lora_cfg.rank > 0 and not cfg.trainer.policy.megatron_config.lora_config.merge_lora:
+            raise ValueError(
+                "serialized_blockwise FP8 weight sync requires full-weight updates; "
+                "Megatron LoRA with merge_lora=false syncs adapters only"
+            )
+
     if ie_cfg.enable_pd:
         assert ie_cfg.num_prefill > 0, "num_prefill must be > 0 when enable_pd=True"
         assert (
@@ -747,6 +778,52 @@ def prepare_runtime_environment(cfg: SkyRLTrainConfig) -> dict[str, str]:
             f"Exporting `SKYRL_WAIT_UNTIL_INFERENCE_SERVER_HEALTHY_TIMEOUT_S` to ray runtime env: {health_timeout}"
         )
         env_vars["SKYRL_WAIT_UNTIL_INFERENCE_SERVER_HEALTHY_TIMEOUT_S"] = health_timeout
+
+    # Forward one block-scale contract to all Ray actors. Hopper defaults to FP32;
+    # Blackwell launchers explicitly select power-of-two scales.
+    serialized_fp8 = cfg.generator.inference_engine.fp8_weight_sync_mode == SERIALIZED_BLOCKWISE_FP8
+    use_ref_model = cfg.trainer.algorithm.use_kl_loss or cfg.trainer.algorithm.use_kl_in_reward
+    policy_transformer_kwargs = cfg.trainer.policy.megatron_config.transformer_config_kwargs
+    ref_transformer_kwargs = cfg.trainer.ref.megatron_config.transformer_config_kwargs
+    policy_fp8_param = is_fp8_enabled(policy_transformer_kwargs.get("fp8_param"))
+    ref_fp8_param = use_ref_model and is_fp8_enabled(ref_transformer_kwargs.get("fp8_param"))
+    fp8_compute = is_fp8_enabled(policy_transformer_kwargs.get("fp8")) or (
+        use_ref_model and is_fp8_enabled(ref_transformer_kwargs.get("fp8"))
+    )
+    fp8_contract_enabled = serialized_fp8 or fp8_compute or policy_fp8_param or ref_fp8_param
+
+    fp8_env_defaults: dict[str, str] = {}
+    configured_scale_mode = os.environ.get("NVTE_FP8_BLOCK_SCALING_FP32_SCALES")
+    if fp8_contract_enabled or configured_scale_mode is not None:
+        scale_mode = configured_scale_mode or "1"
+        if scale_mode not in {"0", "1"}:
+            raise ValueError("NVTE_FP8_BLOCK_SCALING_FP32_SCALES must be '0' (power-of-2) " "or '1' (FP32 scales).")
+
+        if scale_mode == "0" and (policy_fp8_param or ref_fp8_param):
+            raise ValueError(
+                "Persistent fp8_param requires FP32 block scales. Blackwell only supports "
+                "power-of-2 block scales, so use fp8_param=false on Blackwell."
+            )
+
+        if fp8_contract_enabled:
+            fp8_env_defaults["NVTE_FP8_BLOCK_SCALING_FP32_SCALES"] = scale_mode
+        if serialized_fp8 and scale_mode == "1":
+            e8m0_mode = os.environ.get("VLLM_USE_DEEP_GEMM_E8M0", "0")
+            if e8m0_mode != "0":
+                raise ValueError(
+                    "FP32 block scales require VLLM_USE_DEEP_GEMM_E8M0=0 so vLLM "
+                    "does not requantize them to power-of-2 scales."
+                )
+            fp8_env_defaults["VLLM_USE_DEEP_GEMM_E8M0"] = e8m0_mode
+
+    for var_name in (
+        "NVTE_FP8_BLOCK_SCALING_FP32_SCALES",
+        "NVTE_FP8_BLOCK_AMAX_EPSILON",
+        "VLLM_USE_DEEP_GEMM_E8M0",
+    ):
+        if value := os.environ.get(var_name, fp8_env_defaults.get(var_name)):
+            logger.info(f"Exporting `{var_name}` to ray runtime env: {value}")
+            env_vars[var_name] = value
 
     return env_vars
 

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -256,6 +256,22 @@ def validate_cfg(cfg: SkyRLTrainConfig):
     ), "use_kl_in_reward and use_kl_loss should be mutually exclusive"
     use_ref_model = cfg.trainer.algorithm.use_kl_loss or cfg.trainer.algorithm.use_kl_in_reward
 
+    placement = cfg.trainer.placement
+    if placement.colocated_worker_memory_barrier and not (placement.colocate_all or placement.colocate_policy_ref):
+        raise ValueError("colocated_worker_memory_barrier=true requires colocate_all=true or colocate_policy_ref=true")
+    if placement.colocated_ref_hard_evict_on_breach:
+        if not placement.colocated_worker_memory_barrier:
+            raise ValueError("colocated_ref_hard_evict_on_breach=true requires colocated_worker_memory_barrier=true")
+        if not use_ref_model:
+            raise ValueError("colocated_ref_hard_evict_on_breach=true requires an enabled reference model")
+        if not (placement.colocate_all or placement.colocate_policy_ref):
+            raise ValueError("colocated_ref_hard_evict_on_breach=true requires the reference model to be colocated")
+        if cfg.trainer.update_ref_every_epoch:
+            raise ValueError(
+                "colocated_ref_hard_evict_on_breach is incompatible with update_ref_every_epoch: "
+                "restarting the ref actor reloads the original checkpoint"
+            )
+
     if cfg.trainer.policy.language_model_only:
         assert (
             cfg.generator.inference_engine.language_model_only

--- a/tests/backends/skyrl_train/distributed/test_packing_utils.py
+++ b/tests/backends/skyrl_train/distributed/test_packing_utils.py
@@ -30,10 +30,25 @@ def test_packed_alignment_uses_layout_only_without_fp8():
 
 
 def test_packed_alignment_adds_fp8_local_rank_multiple():
-    assert get_packed_seq_align_size(tp_size=4, cp_size=1, fp8_enabled=True) == 16
+    assert get_packed_seq_align_size(tp_size=4, cp_size=1, fp8_enabled=True) == 512
     assert get_packed_seq_align_size(tp_size=1, cp_size=2, fp8_enabled=True) == 32
+    assert get_packed_seq_align_size(tp_size=2, cp_size=1, fp8_enabled=True) == 256
+    assert get_packed_seq_align_size(tp_size=2, cp_size=2, fp8_enabled=True) == 512
 
 
 def test_unpacked_alignment_adds_fp8_multiple_only_when_enabled():
     assert get_unpacked_seq_align_size(tp_size=4) == 4
-    assert get_unpacked_seq_align_size(tp_size=4, fp8_enabled=True) == 16
+    assert get_unpacked_seq_align_size(tp_size=1, fp8_enabled=True) == 16
+    assert get_unpacked_seq_align_size(tp_size=2, fp8_enabled=True) == 256
+    assert get_unpacked_seq_align_size(tp_size=4, fp8_enabled=True) == 512
+
+
+@pytest.mark.parametrize(("tp_size", "cp_size"), [(0, 1), (1, 0), (-1, 1)])
+def test_packed_alignment_rejects_nonpositive_parallel_sizes(tp_size, cp_size):
+    with pytest.raises(ValueError, match="must be positive"):
+        get_packed_seq_align_size(tp_size, cp_size, fp8_enabled=True)
+
+
+def test_unpacked_alignment_rejects_nonpositive_tp_size():
+    with pytest.raises(ValueError, match="must be positive"):
+        get_unpacked_seq_align_size(0, fp8_enabled=True)

--- a/tests/backends/skyrl_train/distributed/test_preprocess_packed_seqs_cp.py
+++ b/tests/backends/skyrl_train/distributed/test_preprocess_packed_seqs_cp.py
@@ -142,3 +142,47 @@ class TestPreprocessPackedSeqsShortSequencesCP:
                 assert result_ids.shape[1] % 16 == 0
                 assert packed_params.max_seqlen_q % (16 * cp_size) == 0
                 assert packed_params.qkv_format == "thd"
+
+    def test_remove_left_padding_tp1_aligns_only_for_fp8(self):
+        """TP1 applies 16-token alignment only when FP8 is enabled."""
+        from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
+            remove_left_padding,
+        )
+
+        input_ids = torch.arange(7000).unsqueeze(0)
+        attention_mask = torch.zeros((1, 7000), dtype=torch.bool)
+        attention_mask[0, :6541] = True
+        position_ids = torch.arange(7000).unsqueeze(0)
+
+        with patch("skyrl.backends.skyrl_train.distributed.megatron.megatron_utils.mpu") as mock_mpu:
+            mock_mpu.get_tensor_model_parallel_world_size.return_value = 1
+            mock_mpu.get_context_parallel_world_size.return_value = 1
+
+            bf16_ids, bf16_mask, _ = remove_left_padding(input_ids, attention_mask, position_ids, fp8_enabled=False)
+            fp8_ids, fp8_mask, _ = remove_left_padding(input_ids, attention_mask, position_ids, fp8_enabled=True)
+
+        assert bf16_ids.shape == (1, 6541)
+        assert int(bf16_mask.sum().item()) == 6541
+        assert fp8_ids.shape == (1, 6544)
+        assert int(fp8_mask.sum().item()) == 6541
+
+    def test_remove_left_padding_tp_gt_1_fp8_uses_local_128_alignment(self):
+        """TP2 rounds 8,552 tokens to the 8,704-token global alignment."""
+        from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
+            remove_left_padding,
+        )
+
+        input_ids = torch.arange(9000).unsqueeze(0)
+        attention_mask = torch.zeros((1, 9000), dtype=torch.bool)
+        attention_mask[0, :8552] = True
+        position_ids = torch.arange(9000).unsqueeze(0)
+
+        with patch("skyrl.backends.skyrl_train.distributed.megatron.megatron_utils.mpu") as mock_mpu:
+            mock_mpu.get_tensor_model_parallel_world_size.return_value = 2
+            mock_mpu.get_context_parallel_world_size.return_value = 1
+
+            fp8_ids, fp8_mask, _ = remove_left_padding(input_ids, attention_mask, position_ids, fp8_enabled=True)
+
+        assert fp8_ids.shape == (1, 8704)
+        assert int(fp8_mask.sum().item()) == 8552
+        assert fp8_ids.shape[1] % (128 * 2) == 0

--- a/tests/backends/skyrl_train/distributed/test_preprocess_packed_seqs_multiseq.py
+++ b/tests/backends/skyrl_train/distributed/test_preprocess_packed_seqs_multiseq.py
@@ -185,24 +185,24 @@ class TestSubSeqLengths:
         The intra-row offsets read by preprocess must match the
         collator's row layout, which advances ``row_offset += round_up(s,
         align_size)`` between sub-seqs. So with sub-seqs of length 3 and
-        5 and tp_size=4, the collator places sub-seq 1 at row column 16
-        (after the FP8/TP alignment pad gap), NOT row column 3.
+        5 and tp_size=4, the collator places sub-seq 1 at row column
+        ``align_size`` after the FP8/TP alignment gap, not row column 3.
         """
         from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
             preprocess_packed_seqs,
         )
 
-        seq_len = 48
         batch_size = 1
 
-        # Two sub-seqs of length 3 and 5; tp_size=4 still pads each to 16
-        # for Transformer Engine FP8 compatibility.
+        # Each sequence uses a global footprint that leaves TP-local inputs
+        # aligned to 128 tokens.
         align_size = _get_align_size(tp_size=4, cp_size=1, fp8_enabled=True)
+        seq_len = 2 * align_size
         # Row layout mirrors what PackedDataCollator produces:
-        # row[0:3]   = sub-seq 0 tokens
-        # row[3:16]  = alignment pad (zero)
-        # row[16:21] = sub-seq 1 tokens
-        # row[21:32] = alignment pad (zero)
+        # row[0:3]                         = sub-seq 0 tokens
+        # row[3:align_size]                = alignment pad (zero)
+        # row[align_size:align_size + 5]   = sub-seq 1 tokens
+        # row[align_size + 5:2*align_size] = alignment pad (zero)
         input_ids = torch.zeros(batch_size, seq_len, dtype=torch.long)
         input_ids[0, :3] = torch.tensor([1, 2, 3])
         input_ids[0, align_size : align_size + 5] = torch.tensor([10, 11, 12, 13, 14])
@@ -222,11 +222,11 @@ class TestSubSeqLengths:
                 fp8_enabled=True,
             )
 
-        assert params.cu_seqlens_q.tolist() == [0, 16, 32]
-        assert packed.shape == (1, 32)
+        assert params.cu_seqlens_q.tolist() == [0, align_size, 2 * align_size]
+        assert packed.shape == (1, 2 * align_size)
         assert packed[0, :3].tolist() == [1, 2, 3]
-        assert packed[0, 3:16].tolist() == [0] * 13
-        assert packed[0, 16:21].tolist() == [10, 11, 12, 13, 14]
+        assert packed[0, 3:align_size].tolist() == [0] * (align_size - 3)
+        assert packed[0, align_size : align_size + 5].tolist() == [10, 11, 12, 13, 14]
 
     def test_multiple_bin_rows(self):
         """Two bin rows, each with two sub-seqs, produce 4+1 cu_seqlens entries."""

--- a/tests/backends/skyrl_train/distributed/test_vocab_entropy_chunking.py
+++ b/tests/backends/skyrl_train/distributed/test_vocab_entropy_chunking.py
@@ -62,6 +62,18 @@ def test_vocab_entropy_weighted_sum_chunking_matches_unchunked(monkeypatch):
     torch.testing.assert_close(actual, expected)
 
 
+@pytest.mark.parametrize("logits_shape", [(5, 7), (2, 5, 7)])
+def test_vocab_entropy_weighted_sum_supports_2d_and_batched_logits(monkeypatch, logits_shape):
+    monkeypatch.setattr(model_utils._VocabParallelEntropy, "apply", _local_entropy)
+    logits = torch.randn(*logits_shape, dtype=torch.float64)
+    weights = torch.linspace(0.25, 1.25, logits_shape[-2], dtype=torch.float64)
+    expected = (_local_entropy(logits) * weights).sum()
+
+    for chunk_size in (None, 1, 3):
+        actual = model_utils.vocab_parallel_entropy_weighted_sum(logits, weights, chunk_size=chunk_size)
+        torch.testing.assert_close(actual, expected)
+
+
 def test_vocab_entropy_weighted_sum_all_masked_keeps_zero_gradient(monkeypatch):
     monkeypatch.setattr(model_utils._VocabParallelEntropy, "apply", _local_entropy)
     logits = torch.randn(1, 7, 11, dtype=torch.float64, requires_grad=True)

--- a/tests/backends/skyrl_train/distributed/test_vocab_entropy_chunking.py
+++ b/tests/backends/skyrl_train/distributed/test_vocab_entropy_chunking.py
@@ -1,0 +1,86 @@
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+
+def _import_model_utils_without_megatron_extensions():
+    """Import the pure tensor helpers without loading optional TE binaries."""
+    module_names = ("megatron", "megatron.core", "megatron.core.parallel_state")
+    saved_modules = {name: sys.modules.get(name) for name in module_names}
+    megatron = ModuleType("megatron")
+    megatron.__path__ = []
+    core = ModuleType("megatron.core")
+    core.__path__ = []
+    parallel_state = ModuleType("megatron.core.parallel_state")
+    try:
+        sys.modules["megatron"] = megatron
+        sys.modules["megatron.core"] = core
+        sys.modules["megatron.core.parallel_state"] = parallel_state
+        return importlib.import_module("skyrl.backends.skyrl_train.distributed.megatron.model_utils")
+    finally:
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+model_utils = _import_model_utils_without_megatron_extensions()
+
+
+def _local_entropy(logits):
+    log_probs = torch.log_softmax(logits, dim=-1)
+    return -(log_probs.exp() * log_probs).sum(dim=-1)
+
+
+def test_vocab_entropy_chunking_matches_unchunked_output_and_gradient(monkeypatch):
+    monkeypatch.setattr(model_utils._VocabParallelEntropy, "apply", _local_entropy)
+    torch.manual_seed(3)
+    unchunked_logits = torch.randn(2, 11, 17, dtype=torch.float64, requires_grad=True)
+    chunked_logits = unchunked_logits.detach().clone().requires_grad_(True)
+
+    unchunked = model_utils.vocab_parallel_entropy(unchunked_logits, chunk_size=None)
+    chunked = model_utils.vocab_parallel_entropy(chunked_logits, chunk_size=3)
+    unchunked.sum().backward()
+    chunked.sum().backward()
+
+    torch.testing.assert_close(chunked, unchunked)
+    torch.testing.assert_close(chunked_logits.grad, unchunked_logits.grad)
+
+
+def test_vocab_entropy_weighted_sum_chunking_matches_unchunked(monkeypatch):
+    monkeypatch.setattr(model_utils._VocabParallelEntropy, "apply", _local_entropy)
+    logits = torch.randn(1, 9, 13, dtype=torch.float64)
+    weights = torch.tensor([1.0, 0.0, 0.5, 0.0, 2.0, 1.0, 0.0, 0.25, 0.0], dtype=torch.float64)
+
+    expected = model_utils.vocab_parallel_entropy_weighted_sum(logits, weights, chunk_size=None)
+    actual = model_utils.vocab_parallel_entropy_weighted_sum(logits, weights, chunk_size=2)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_vocab_entropy_weighted_sum_all_masked_keeps_zero_gradient(monkeypatch):
+    monkeypatch.setattr(model_utils._VocabParallelEntropy, "apply", _local_entropy)
+    logits = torch.randn(1, 7, 11, dtype=torch.float64, requires_grad=True)
+    weights = torch.zeros(7, dtype=torch.float64)
+
+    result = model_utils.vocab_parallel_entropy_weighted_sum(logits, weights, chunk_size=2)
+    result.backward()
+
+    assert result.item() == 0
+    torch.testing.assert_close(logits.grad, torch.zeros_like(logits))
+
+
+def test_vocab_entropy_auto_chunk_respects_memory_budget():
+    logits = torch.empty(1, 10, 65536, dtype=torch.bfloat16)
+
+    assert model_utils._resolve_vocab_entropy_chunk_size(logits, 0, 1) == 2
+
+
+@pytest.mark.parametrize(("chunk_size", "memory_mb"), [(-1, 1), (0, 0)])
+def test_vocab_entropy_chunk_resolver_rejects_invalid_values(chunk_size, memory_mb):
+    with pytest.raises(ValueError):
+        model_utils._resolve_vocab_entropy_chunk_size(torch.empty(1, 4, 8), chunk_size, memory_mb)

--- a/tests/backends/skyrl_train/inference_servers/test_build_vllm_cli_args.py
+++ b/tests/backends/skyrl_train/inference_servers/test_build_vllm_cli_args.py
@@ -1,12 +1,123 @@
 """Tests for build_vllm_cli_args on GPU-less hosts."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from skyrl.backends.skyrl_train.inference_servers.utils import (
+    _apply_serialized_fp8_weight_sync_defaults,
     build_vllm_cli_args,
     resolve_policy_model_name,
 )
 from skyrl.train.config import SkyRLTrainConfig
+
+
+def test_serialized_fp8_weight_sync_defaults_configure_vllm_checkpoint_fp8(monkeypatch):
+    import skyrl.backends.skyrl_train.inference_servers.utils as inference_utils
+
+    monkeypatch.setattr(inference_utils, "_serialized_fp8_ignored_layers", lambda _model_path: [])
+    cfg = SkyRLTrainConfig()
+    ie_cfg = cfg.generator.inference_engine
+    ie_cfg.fp8_weight_sync_mode = "serialized_blockwise"
+    engine_kwargs = {"hf_overrides": {"rope_theta": 10000.0}}
+
+    _apply_serialized_fp8_weight_sync_defaults(ie_cfg, engine_kwargs, model_path="qwen35-test")
+
+    assert engine_kwargs["quantization"] == "fp8"
+    assert engine_kwargs["load_format"] == "dummy"
+    assert engine_kwargs["hf_overrides"]["rope_theta"] == 10000.0
+    assert engine_kwargs["hf_overrides"]["quantization_config"] == {
+        "quant_method": "fp8",
+        "activation_scheme": "dynamic",
+        "weight_block_size": [128, 128],
+    }
+
+
+@pytest.mark.parametrize(
+    "engine_kwargs",
+    [
+        {"quantization": "awq"},
+        {"load_format": "safetensors"},
+        {"hf_overrides": {"quantization_config": {"weight_block_size": [64, 128]}}},
+    ],
+)
+def test_serialized_fp8_weight_sync_rejects_conflicting_vllm_settings(engine_kwargs, monkeypatch):
+    import skyrl.backends.skyrl_train.inference_servers.utils as inference_utils
+
+    monkeypatch.setattr(inference_utils, "_serialized_fp8_ignored_layers", lambda _model_path: [])
+    cfg = SkyRLTrainConfig()
+    cfg.generator.inference_engine.fp8_weight_sync_mode = "serialized_blockwise"
+
+    with pytest.raises(ValueError, match="serialized FP8 weight sync"):
+        _apply_serialized_fp8_weight_sync_defaults(
+            cfg.generator.inference_engine,
+            engine_kwargs,
+            model_path="qwen35-test",
+        )
+
+
+@pytest.mark.parametrize(
+    "engine_kwargs",
+    [
+        {"hf_overrides": []},
+        {"hf_overrides": {"quantization_config": []}},
+    ],
+)
+def test_serialized_fp8_weight_sync_rejects_non_mapping_overrides(engine_kwargs):
+    cfg = SkyRLTrainConfig()
+    cfg.generator.inference_engine.fp8_weight_sync_mode = "serialized_blockwise"
+
+    with pytest.raises(ValueError, match="must be a dict"):
+        _apply_serialized_fp8_weight_sync_defaults(
+            cfg.generator.inference_engine,
+            engine_kwargs,
+            model_path="qwen35-test",
+        )
+
+
+def test_serialized_fp8_requires_model_path():
+    cfg = SkyRLTrainConfig()
+    cfg.generator.inference_engine.fp8_weight_sync_mode = "serialized_blockwise"
+
+    with pytest.raises(ValueError, match="model path is required"):
+        _apply_serialized_fp8_weight_sync_defaults(cfg.generator.inference_engine, {})
+
+
+def test_serialized_fp8_fails_when_model_config_cannot_be_inspected(monkeypatch):
+    import transformers
+
+    cfg = SkyRLTrainConfig()
+    cfg.generator.inference_engine.fp8_weight_sync_mode = "serialized_blockwise"
+
+    def fail_config_load(*_args, **_kwargs):
+        raise OSError("missing config")
+
+    monkeypatch.setattr(transformers.AutoConfig, "from_pretrained", fail_config_load)
+    with pytest.raises(RuntimeError, match="Could not inspect the model config"):
+        _apply_serialized_fp8_weight_sync_defaults(
+            cfg.generator.inference_engine,
+            {},
+            model_path="missing-model",
+        )
+
+
+def test_serialized_fp8_rejects_unsupported_model_layout(monkeypatch):
+    import transformers
+
+    cfg = SkyRLTrainConfig()
+    cfg.generator.inference_engine.fp8_weight_sync_mode = "serialized_blockwise"
+    monkeypatch.setattr(
+        transformers.AutoConfig,
+        "from_pretrained",
+        lambda *_args, **_kwargs: SimpleNamespace(model_type="llama"),
+    )
+
+    with pytest.raises(ValueError, match="only Qwen3.5"):
+        _apply_serialized_fp8_weight_sync_defaults(
+            cfg.generator.inference_engine,
+            {},
+            model_path="unsupported-model",
+        )
 
 
 @pytest.mark.vllm

--- a/tests/backends/skyrl_train/weight_sync/test_serialized_fp8.py
+++ b/tests/backends/skyrl_train/weight_sync/test_serialized_fp8.py
@@ -1,0 +1,234 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from skyrl.backends.skyrl_train.weight_sync.serialized_fp8 import (
+    SerializedFp8Config,
+    batched_moe_expert_spec,
+    blockwise_cast_to_fp8,
+    get_qwen35_fp8_ignored_layers,
+    get_serialized_fp8_quantization_config,
+    is_quantizable_weight,
+    is_quantizable_weight_shape,
+    iter_serialized_fp8_tensors,
+)
+
+
+def test_blockwise_cast_to_fp8_emits_weight_and_fp32_scale():
+    weight = torch.arange(257 * 129, dtype=torch.float32).reshape(257, 129) / 1000
+
+    q_weight, scale = blockwise_cast_to_fp8(weight, [128, 128])
+
+    assert q_weight.shape == weight.shape
+    assert q_weight.dtype == torch.float8_e4m3fn
+    assert scale.shape == (3, 2)
+    assert scale.dtype == torch.float32
+
+
+def test_blockwise_cast_defaults_to_exact_fp32_scales():
+    torch.manual_seed(7)
+    weight = torch.randn(256, 256, dtype=torch.float32)
+
+    default_weight, default_scale = blockwise_cast_to_fp8(weight, [128, 128])
+    exact_weight, exact_scale = blockwise_cast_to_fp8(weight, [128, 128], power_2_scale=False)
+
+    assert torch.equal(default_weight.view(torch.uint8), exact_weight.view(torch.uint8))
+    assert torch.equal(default_scale, exact_scale)
+
+
+def test_blockwise_cast_uses_training_amax_epsilon_for_near_zero_blocks(monkeypatch):
+    monkeypatch.setenv("NVTE_FP8_BLOCK_AMAX_EPSILON", "1e-4")
+    monkeypatch.setenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "1")
+    config = SerializedFp8Config()
+    weight = torch.full((128, 128), 1e-8, dtype=torch.float32)
+
+    _, scale = blockwise_cast_to_fp8(
+        weight,
+        config.weight_block_size,
+        config.power_2_scale,
+        config.amax_epsilon,
+    )
+
+    assert scale.item() == pytest.approx(config.amax_epsilon / torch.finfo(torch.float8_e4m3fn).max)
+
+
+def test_blockwise_cast_pow2_scales_match_te_ue8m0_rule():
+    # TE's UE8M0 mode rounds dequantization scales up to powers of two.
+    torch.manual_seed(0)
+    weight = torch.randn(256, 384, dtype=torch.float32)
+
+    _, pow2_scale = blockwise_cast_to_fp8(weight, [128, 128], power_2_scale=True)
+    _, exact_scale = blockwise_cast_to_fp8(weight, [128, 128], power_2_scale=False)
+
+    log2 = torch.log2(pow2_scale)
+    assert torch.allclose(log2, log2.round(), atol=0.0)
+    expected = torch.pow(2.0, torch.ceil(torch.log2(exact_scale)))
+    assert torch.allclose(pow2_scale, expected)
+    assert torch.all(pow2_scale >= exact_scale)
+
+
+def test_serialized_config_power_2_scale_follows_te_env(monkeypatch):
+    monkeypatch.delenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", raising=False)
+    assert SerializedFp8Config().power_2_scale is False
+
+    monkeypatch.setenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "1")
+    assert SerializedFp8Config().power_2_scale is False
+
+    monkeypatch.setenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "0")
+    assert SerializedFp8Config().power_2_scale is True
+
+    monkeypatch.setenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "invalid")
+    with pytest.raises(ValueError, match="must be '0'.*or '1'"):
+        SerializedFp8Config()
+
+
+@pytest.mark.parametrize("block_size", [[], [128], [128, 128, 128], [128, 0], [128, 1.5], [True, 128]])
+def test_blockwise_cast_rejects_invalid_block_size(block_size):
+    with pytest.raises(ValueError, match="exactly two positive integers"):
+        blockwise_cast_to_fp8(torch.ones((2, 2)), block_size)
+
+
+def test_quantizable_weight_filter_keeps_embeddings_in_target_dtype():
+    config = SerializedFp8Config()
+    linear = torch.ones((256, 256), dtype=torch.bfloat16)
+    embedding = torch.ones((32000, 256), dtype=torch.bfloat16)
+
+    assert is_quantizable_weight("model.layers.0.mlp.down_proj.weight", linear)
+    assert is_quantizable_weight("model.layers.0.linear_attn.in_proj_qkv.weight", linear)
+    assert is_quantizable_weight("model.layers.0.linear_attn.in_proj_z.weight", linear)
+    assert is_quantizable_weight("model.layers.0.linear_attn.out_proj.weight", linear)
+    assert not is_quantizable_weight("model.layers.0.linear_attn.conv1d.weight", linear)
+    assert not is_quantizable_weight("model.layers.0.linear_attn.in_proj_b.weight", linear)
+    assert not is_quantizable_weight("model.layers.0.linear_attn.in_proj_a.weight", linear)
+    assert not is_quantizable_weight("model.embed_tokens.weight", embedding)
+
+    tensors = list(
+        iter_serialized_fp8_tensors(
+            "model.embed_tokens.weight",
+            embedding,
+            torch.bfloat16,
+            config,
+        )
+    )
+    assert [(name, tensor.dtype) for name, tensor in tensors] == [("model.embed_tokens.weight", torch.bfloat16)]
+
+
+def test_vllm_serialized_fp8_quantization_config():
+    assert get_serialized_fp8_quantization_config() == {
+        "quant_method": "fp8",
+        "activation_scheme": "dynamic",
+        "weight_block_size": [128, 128],
+    }
+    assert get_serialized_fp8_quantization_config(ignored_layers=["model.layers.0.linear_attn.in_proj_b"]) == {
+        "quant_method": "fp8",
+        "activation_scheme": "dynamic",
+        "weight_block_size": [128, 128],
+        "ignored_layers": ["model.layers.0.linear_attn.in_proj_b"],
+    }
+
+
+def test_qwen35_fp8_ignored_layers_use_linear_attention_layers():
+    hf_config = SimpleNamespace(
+        model_type="qwen3_5_text",
+        layer_types=[
+            "linear_attention",
+            "full_attention",
+            "linear_attention",
+        ],
+    )
+
+    assert get_qwen35_fp8_ignored_layers(hf_config) == [
+        "model.layers.0.linear_attn.in_proj_b",
+        "model.layers.0.linear_attn.in_proj_a",
+        "model.language_model.layers.0.linear_attn.in_proj_b",
+        "model.language_model.layers.0.linear_attn.in_proj_a",
+        "model.layers.2.linear_attn.in_proj_b",
+        "model.layers.2.linear_attn.in_proj_a",
+        "model.language_model.layers.2.linear_attn.in_proj_b",
+        "model.language_model.layers.2.linear_attn.in_proj_a",
+    ]
+
+
+def test_qwen35_ignored_layers_include_only_checkpoint_vision_prefixes():
+    hf_config = SimpleNamespace(
+        model_type="qwen3_5",
+        text_config=SimpleNamespace(model_type="qwen3_5_text", layer_types=[]),
+        vision_config=SimpleNamespace(depth=2),
+    )
+
+    assert get_qwen35_fp8_ignored_layers(hf_config) == [
+        "model.visual.blocks.0.attn.proj",
+        "model.visual.blocks.1.attn.proj",
+    ]
+
+
+def test_qwen35_ignored_layers_are_not_inferred_from_unrelated_hybrid_config():
+    hf_config = SimpleNamespace(model_type="unrelated_hybrid", layer_types=["linear_attention"])
+
+    assert get_qwen35_fp8_ignored_layers(hf_config) == []
+
+
+def test_moe_batched_expert_spec_recognizes_and_splits_gate_up():
+    base = "model.language_model.layers.5.mlp.experts"
+    assert batched_moe_expert_spec(f"{base}.gate_up_proj") == (base, ("gate_proj", "up_proj"), True)
+    assert batched_moe_expert_spec(f"{base}.down_proj") == (base, ("down_proj",), False)
+    assert batched_moe_expert_spec("model.layers.5.mlp.gate.weight") is None
+    assert batched_moe_expert_spec("model.layers.5.self_attn.q_proj.weight") is None
+
+
+def test_moe_shared_expert_quantized_router_and_gate_bf16():
+    lin = (256, 256)
+    assert is_quantizable_weight_shape("model.layers.3.mlp.shared_expert.gate_proj.weight", lin)
+    assert is_quantizable_weight_shape("model.layers.3.mlp.shared_expert.up_proj.weight", lin)
+    assert is_quantizable_weight_shape("model.layers.3.mlp.shared_expert.down_proj.weight", lin)
+    assert not is_quantizable_weight_shape("model.layers.3.mlp.gate.weight", (256, 8))
+    assert not is_quantizable_weight_shape("model.layers.3.mlp.shared_expert_gate.weight", (256, 1))
+
+
+def test_batched_moe_experts_unbatch_to_per_expert_fp8_with_pow2_scales():
+    num_experts, moe_inter, hidden = 3, 128, 256
+    config = SerializedFp8Config(weight_block_size=(128, 128), power_2_scale=True)
+    base = "model.language_model.layers.7.mlp.experts"
+
+    torch.manual_seed(0)
+    gate_up = torch.randn(num_experts, 2 * moe_inter, hidden, dtype=torch.bfloat16)
+    emitted = list(iter_serialized_fp8_tensors(f"{base}.gate_up_proj", gate_up, torch.bfloat16, config))
+    by_name = dict(emitted)
+    # Names must match vLLM's per-expert parameter mapping.
+    for e in range(num_experts):
+        for proj in ("gate_proj", "up_proj"):
+            w = by_name[f"{base}.{e}.{proj}.weight"]
+            s = by_name[f"{base}.{e}.{proj}.weight_scale_inv"]
+            assert w.dtype == torch.float8_e4m3fn and tuple(w.shape) == (moe_inter, hidden)
+            assert s.dtype == torch.float32 and tuple(s.shape) == (1, 2)
+            log2 = torch.log2(s)
+            assert torch.allclose(log2, log2.round(), atol=0.0)
+
+    down = torch.randn(num_experts, hidden, moe_inter, dtype=torch.bfloat16)
+    emitted_d = dict(iter_serialized_fp8_tensors(f"{base}.down_proj", down, torch.bfloat16, config))
+    for e in range(num_experts):
+        w = emitted_d[f"{base}.{e}.down_proj.weight"]
+        assert w.dtype == torch.float8_e4m3fn and tuple(w.shape) == (hidden, moe_inter)
+        assert f"{base}.{e}.down_proj.weight_scale_inv" in emitted_d
+
+
+def test_batched_moe_gate_up_rejects_odd_output_dimension():
+    name = "model.layers.0.mlp.experts.gate_up_proj"
+    tensor = torch.randn(2, 255, 128, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="output dimension must be even"):
+        list(iter_serialized_fp8_tensors(name, tensor, torch.bfloat16, SerializedFp8Config()))
+
+
+def test_batched_moe_expert_iterator_rejects_non_3d_input():
+    name = "model.layers.0.mlp.experts.down_proj"
+    with pytest.raises(ValueError, match="must be 3D"):
+        list(
+            iter_serialized_fp8_tensors(
+                name,
+                torch.ones((128, 128)),
+                torch.bfloat16,
+                SerializedFp8Config(),
+            )
+        )

--- a/tests/backends/skyrl_train/weight_sync/test_transfer_strategies.py
+++ b/tests/backends/skyrl_train/weight_sync/test_transfer_strategies.py
@@ -1,4 +1,7 @@
+import asyncio
+
 import pytest
+import torch
 
 from skyrl.backends.skyrl_train.weight_sync import (
     BroadcastInitInfo,
@@ -9,6 +12,10 @@ from skyrl.backends.skyrl_train.weight_sync import (
     CudaIpcWeightUpdateRequest,
     LoraLoadRequest,
     get_transfer_strategy_cls,
+)
+from skyrl.backends.skyrl_train.weight_sync.base import WeightChunk
+from skyrl.backends.skyrl_train.weight_sync.broadcast_strategy import (
+    BroadcastWeightTransferSender,
 )
 from skyrl.train.config import InferenceEngineConfig
 
@@ -55,7 +62,7 @@ class TestCreateInitInfo:
         )
 
     def test_cuda_ipc_create_init_info(self):
-        """CudaIpcTransferStrategy.create_init_info should create CudaIpcInitInfo with model_dtype_str."""
+        """Preserve model-dtype metadata in CUDA IPC initialization."""
         ie_cfg = self._make_ie_cfg(model_dtype="torch.float32")
         init_info = CudaIpcTransferStrategy.create_init_info(ie_cfg)
 
@@ -120,6 +127,89 @@ class TestBroadcastWeightUpdateRequest:
                 dtypes=["bfloat16"],
                 shapes=[[4096, 4096]],
             )
+
+
+def test_broadcast_sender_preserves_mixed_dtype_logical_chunk(monkeypatch):
+    """vLLM's byte-packed NCCL path accepts one mixed-dtype logical update."""
+    import skyrl.backends.skyrl_train.weight_sync.broadcast_strategy as broadcast_module
+
+    class FakeInferenceClient:
+        def __init__(self):
+            self.events = []
+
+        async def start_weight_update(self, is_checkpoint_format):
+            self.events.append(("start", is_checkpoint_format))
+
+        async def finish_weight_update(self):
+            self.events.append(("finish",))
+
+    client = FakeInferenceClient()
+    sender = BroadcastWeightTransferSender(
+        init_info=BroadcastInitInfo(
+            master_addr="127.0.0.1",
+            master_port=12345,
+            rank_offset=1,
+            world_size=2,
+            override_existing_receiver=False,
+        ),
+        model_update_group=object(),
+        inference_client=client,
+    )
+    sent_chunks = []
+
+    async def record_chunk(chunk):
+        sent_chunks.append((list(chunk.names), [tensor.dtype for tensor in chunk.tensors]))
+
+    monkeypatch.setattr(sender, "_send_chunk_vllm_native", record_chunk)
+    monkeypatch.setattr(broadcast_module.torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(broadcast_module.torch.distributed, "barrier", lambda: None)
+
+    mixed_chunk = WeightChunk(
+        names=["w0", "scale", "w1", "norm"],
+        dtypes=["ignored"] * 4,
+        shapes=[[4], [1], [8], [2]],
+        tensors=[
+            torch.empty((4,), dtype=torch.float8_e4m3fn),
+            torch.empty((1,), dtype=torch.float32),
+            torch.empty((8,), dtype=torch.float8_e4m3fn),
+            torch.empty((2,), dtype=torch.bfloat16),
+        ],
+    )
+
+    asyncio.run(sender.send_chunks(iter([mixed_chunk]), derive_metadata_from_chunks=True))
+
+    assert client.events == [("start", True), ("finish",)]
+    assert sent_chunks == [
+        (
+            ["w0", "scale", "w1", "norm"],
+            [torch.float8_e4m3fn, torch.float32, torch.float8_e4m3fn, torch.bfloat16],
+        )
+    ]
+
+
+def test_broadcast_sender_retains_precomputed_metadata_path(monkeypatch):
+    sender = BroadcastWeightTransferSender(
+        init_info=BroadcastInitInfo(
+            master_addr="127.0.0.1",
+            master_port=12345,
+            rank_offset=1,
+            world_size=2,
+            override_existing_receiver=False,
+        ),
+        model_update_group=object(),
+        inference_client=object(),
+    )
+    calls = []
+
+    async def record_batched(chunks, weight_metadata):
+        calls.append((list(chunks), weight_metadata))
+
+    monkeypatch.setattr(sender, "_send_chunks_vllm_native", record_batched)
+    metadata = {"names": ["w"], "dtype_names": ["bfloat16"], "shapes": [[1]]}
+
+    asyncio.run(sender.send_chunks(iter([]), weight_metadata=metadata))
+
+    assert calls == [([], metadata)]
 
 
 class TestCudaIpcWeightUpdateRequest:

--- a/tests/backends/skyrl_train/weight_sync/test_weight_chunk.py
+++ b/tests/backends/skyrl_train/weight_sync/test_weight_chunk.py
@@ -2,6 +2,11 @@ import pytest
 import torch
 
 from skyrl.backends.skyrl_train.weight_sync import WeightChunk
+from skyrl.backends.skyrl_train.weight_sync.base import (
+    cuda_uuid_to_str,
+    get_weight_chunk_metadata,
+    iter_single_dtype_chunks,
+)
 
 
 class TestWeightChunk:
@@ -95,3 +100,50 @@ class TestWeightChunk:
         )
 
         assert chunk.total_size_bytes == 40 + 20
+
+
+def test_single_dtype_chunk_partition_preserves_first_seen_dtype_order():
+    chunk = WeightChunk(
+        names=["w0", "s0", "w1", "b0"],
+        dtypes=["ignored"] * 4,
+        shapes=[[4], [1], [8], [2]],
+        tensors=[
+            torch.empty((4,), dtype=torch.float8_e4m3fn),
+            torch.ones((1,), dtype=torch.float32),
+            torch.empty((8,), dtype=torch.float8_e4m3fn),
+            torch.ones((2,), dtype=torch.bfloat16),
+        ],
+    )
+
+    chunks = list(iter_single_dtype_chunks(chunk))
+
+    assert [subchunk.names for subchunk in chunks] == [["w0", "w1"], ["s0"], ["b0"]]
+    assert [[tensor.dtype for tensor in subchunk.tensors] for subchunk in chunks] == [
+        [torch.float8_e4m3fn, torch.float8_e4m3fn],
+        [torch.float32],
+        [torch.bfloat16],
+    ]
+
+
+def test_weight_chunk_metadata_uses_actual_tensor_dtypes():
+    chunk = WeightChunk(
+        names=["w", "scale", "norm"],
+        dtypes=["stale"] * 3,
+        shapes=[[999], [999], [999]],
+        tensors=[
+            torch.empty((4,), dtype=torch.float8_e4m3fn),
+            torch.empty((1,), dtype=torch.float32),
+            torch.empty((2,), dtype=torch.bfloat16),
+        ],
+    )
+
+    assert get_weight_chunk_metadata(chunk) == {
+        "names": ["w", "scale", "norm"],
+        "dtype_names": ["float8_e4m3fn", "float32", "bfloat16"],
+        "shapes": [[4], [1], [2]],
+    }
+
+
+@pytest.mark.parametrize("uuid", ["GPU-123", b"GPU-123"])
+def test_cuda_uuid_to_str_normalizes_string_and_bytes(uuid):
+    assert cuda_uuid_to_str(uuid) == "GPU-123"

--- a/tests/backends/skyrl_train/workers/megatron/test_fp8_block_amax_epsilon_patch.py
+++ b/tests/backends/skyrl_train/workers/megatron/test_fp8_block_amax_epsilon_patch.py
@@ -1,0 +1,64 @@
+import sys
+from dataclasses import dataclass
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from skyrl.backends.skyrl_train.workers.megatron._fp8_block_amax_epsilon_patch import (
+    apply_fp8_block_amax_epsilon_patch,
+)
+
+
+def _install_fake_te_recipe(monkeypatch):
+    @dataclass(frozen=True)
+    class QParams:
+        power_2_scale: bool
+        amax_epsilon: float = 0.0
+        random_hadamard_transform: bool = False
+        stochastic_rounding: bool = False
+        fp4_2d_quantization: bool = False
+
+    class Float8BlockScaling:
+        fp8_quant_fwd_inp = QParams(power_2_scale=False)
+        fp8_quant_fwd_weight = QParams(power_2_scale=True)
+        fp8_quant_bwd_grad = QParams(power_2_scale=True)
+
+        def __init__(self, fp8_format):
+            self.fp8_format = fp8_format
+
+    transformer_engine = ModuleType("transformer_engine")
+    transformer_engine.__path__ = []
+    common = ModuleType("transformer_engine.common")
+    common.__path__ = []
+    recipe = ModuleType("transformer_engine.common.recipe")
+    recipe.Float8BlockScaling = Float8BlockScaling
+    recipe.Format = SimpleNamespace(E4M3="e4m3")
+    transformer_engine.common = common
+    common.recipe = recipe
+
+    monkeypatch.setitem(sys.modules, "transformer_engine", transformer_engine)
+    monkeypatch.setitem(sys.modules, "transformer_engine.common", common)
+    monkeypatch.setitem(sys.modules, "transformer_engine.common.recipe", recipe)
+    return Float8BlockScaling
+
+
+def test_fp8_block_amax_patch_updates_all_qparams_and_preserves_scale_modes(monkeypatch):
+    recipe_cls = _install_fake_te_recipe(monkeypatch)
+    monkeypatch.setenv("NVTE_FP8_BLOCK_AMAX_EPSILON", "1e-4")
+
+    apply_fp8_block_amax_epsilon_patch()
+    apply_fp8_block_amax_epsilon_patch()
+
+    assert recipe_cls.fp8_quant_fwd_inp.amax_epsilon == 1e-4
+    assert recipe_cls.fp8_quant_fwd_weight.amax_epsilon == 1e-4
+    assert recipe_cls.fp8_quant_bwd_grad.amax_epsilon == 1e-4
+    assert recipe_cls.fp8_quant_fwd_inp.power_2_scale is False
+    assert recipe_cls.fp8_quant_fwd_weight.power_2_scale is True
+
+
+@pytest.mark.parametrize("value", ["invalid", "-0.1", "nan", "inf"])
+def test_fp8_block_amax_patch_rejects_invalid_explicit_values(monkeypatch, value):
+    monkeypatch.setenv("NVTE_FP8_BLOCK_AMAX_EPSILON", value)
+
+    with pytest.raises(ValueError, match="NVTE_FP8_BLOCK_AMAX_EPSILON"):
+        apply_fp8_block_amax_epsilon_patch()

--- a/tests/backends/skyrl_train/workers/megatron/test_fp8_param.py
+++ b/tests/backends/skyrl_train/workers/megatron/test_fp8_param.py
@@ -1,0 +1,171 @@
+import pytest
+import torch
+
+from skyrl.backends.skyrl_train.workers.megatron.fp8_param import (
+    initialize_fp8_param_optimizer_masters,
+    is_fp8_param_enabled,
+)
+
+
+class _FakeOptimizer:
+    def __init__(self):
+        self.calls = 0
+        self.state_dict = None
+
+    def _copy_model_params_to_main_params(self, state_dict=None):
+        self.calls += 1
+        self.state_dict = state_dict
+
+
+class _Range:
+    def __init__(self, start: int, end: int):
+        self.start = start
+        self.end = end
+        self.size = end - start
+
+
+class _FakeQuantizedParam:
+    def __init__(self, values):
+        self._values = torch.tensor(values, dtype=torch.float32)
+
+    def dequantize(self):
+        return self._values
+
+
+class _FakeHybridDeviceOptimizer:
+    def __init__(self, cpu_masters, gpu_masters):
+        self.cpu_copys_map_gpu_param = dict(zip(cpu_masters, gpu_masters))
+        self.param_to_fp32_param = {}
+
+
+class _FakeHybridMegatronOptimizer:
+    def __init__(self):
+        self.model = _FakeQuantizedParam([2.0, 4.0, 6.0, 8.0])
+        self.unquantized_model = torch.tensor([10.0, 20.0, 30.0, 40.0])
+        self.gpu_master = torch.full((2,), -1.0)
+        self.gpu_master_unquantized = torch.full((2,), -3.0)
+        self.cpu_master = torch.full((2,), -2.0)
+        self.cpu_master_unquantized = torch.full((2,), -4.0)
+        self.optimizer = _FakeHybridDeviceOptimizer(
+            [self.cpu_master, self.cpu_master_unquantized],
+            [self.gpu_master, self.gpu_master_unquantized],
+        )
+        self.model_float16_groups = [[self.model, self.unquantized_model]]
+        self.shard_fp32_from_float16_groups = [[self.gpu_master, self.gpu_master_unquantized]]
+        self.model_fp32_groups = []
+        self.shard_fp32_groups = []
+        self.loaded_quantized_model = torch.tensor([100.0, 200.0, 300.0, 400.0])
+        self.loaded_unquantized_model = torch.tensor([50.0, 60.0, 70.0, 80.0])
+        self.exact_state_dict = {"model": {"ignored": torch.tensor(0.0)}}
+
+    def _is_distopt_quantized_param(self, param):
+        return param is self.model
+
+    def _get_model_param_range_map(self, param):
+        assert param is self.model or param is self.unquantized_model
+        return {"param": _Range(1, 3)}
+
+    def _build_model_param_to_state_dict_param_map(self, state_dict):
+        assert state_dict is self.exact_state_dict
+        return {
+            self.model: self.loaded_quantized_model,
+            self.unquantized_model: self.loaded_unquantized_model,
+        }
+
+    def _copy_model_params_to_main_params(self):
+        raise AssertionError("Hybrid CPU-offload path must seed both master copies directly")
+
+
+def test_fp8_param_enablement_reads_skyrl_transformer_config_mapping():
+    assert is_fp8_param_enabled({"fp8_param": True})
+    assert not is_fp8_param_enabled({"fp8_param": False})
+    assert not is_fp8_param_enabled({"fp8_param": "false"})
+    assert not is_fp8_param_enabled({})
+
+
+def test_fp8_param_master_initialization_reloads_each_chained_optimizer():
+    first = _FakeOptimizer()
+    second = _FakeOptimizer()
+    chained = type("FakeChainedOptimizer", (), {"chained_optimizers": [first, second]})()
+
+    initialized = initialize_fp8_param_optimizer_masters(
+        chained,
+        fp8_param=True,
+        fp8_param_gather=True,
+        state_dict={"model": {}},
+    )
+
+    assert initialized == 2
+    assert first.calls == 1
+    assert second.calls == 1
+
+
+def test_fp8_param_cpu_offload_uses_exact_checkpoint_state_for_all_masters():
+    optimizer = _FakeHybridMegatronOptimizer()
+
+    initialized = initialize_fp8_param_optimizer_masters(
+        optimizer,
+        fp8_param=True,
+        fp8_param_gather=True,
+        state_dict=optimizer.exact_state_dict,
+    )
+
+    assert initialized == 1
+    torch.testing.assert_close(optimizer.gpu_master, torch.tensor([200.0, 300.0]))
+    torch.testing.assert_close(optimizer.cpu_master, torch.tensor([200.0, 300.0]))
+    torch.testing.assert_close(optimizer.gpu_master_unquantized, torch.tensor([60.0, 70.0]))
+    torch.testing.assert_close(optimizer.cpu_master_unquantized, torch.tensor([60.0, 70.0]))
+
+
+def test_fp8_param_master_initialization_passes_exact_state_to_normal_optimizer():
+    optimizer = _FakeOptimizer()
+    state_dict = {"model": {"weight": torch.tensor([1.0])}}
+
+    initialized = initialize_fp8_param_optimizer_masters(
+        optimizer,
+        fp8_param=True,
+        fp8_param_gather=True,
+        state_dict=state_dict,
+    )
+
+    assert initialized == 1
+    assert optimizer.state_dict is state_dict
+
+
+def test_fp8_param_master_initialization_requires_fp8_param_gather():
+    optimizer = _FakeOptimizer()
+
+    with pytest.raises(ValueError, match="fp8_param_gather=true"):
+        initialize_fp8_param_optimizer_masters(
+            optimizer,
+            fp8_param=True,
+            fp8_param_gather=False,
+        )
+
+    assert optimizer.calls == 0
+
+
+def test_fp8_param_master_initialization_requires_exact_checkpoint_state():
+    optimizer = _FakeOptimizer()
+
+    with pytest.raises(ValueError, match="exact unquantized checkpoint state"):
+        initialize_fp8_param_optimizer_masters(
+            optimizer,
+            fp8_param=True,
+            fp8_param_gather=True,
+        )
+
+    assert optimizer.calls == 0
+
+
+def test_non_persistent_fp8_does_not_touch_optimizer_masters():
+    optimizer = _FakeOptimizer()
+
+    initialized = initialize_fp8_param_optimizer_masters(
+        optimizer,
+        fp8_param=False,
+        fp8_param_gather=False,
+    )
+
+    assert initialized == 0
+    assert optimizer.calls == 0

--- a/tests/backends/skyrl_train/workers/test_worker_dispatch_memory.py
+++ b/tests/backends/skyrl_train/workers/test_worker_dispatch_memory.py
@@ -1,0 +1,162 @@
+from types import SimpleNamespace
+
+import pytest
+import ray
+
+from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
+from skyrl.backends.skyrl_train.workers.worker_dispatch import GPUState, WorkerDispatch
+
+
+class _FakeActorGroup:
+    def __init__(self):
+        self.shutdown_called = False
+        self.offload_called = False
+
+    @property
+    def is_shutdown(self):
+        return False
+
+    def offload_to_cpu(self):
+        self.offload_called = True
+
+    def can_restore_init_model(self):
+        return True
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+
+def _dispatch(*, hard_evict: bool = False, barrier: bool = True):
+    placement = SimpleNamespace(
+        colocated_worker_memory_barrier=barrier,
+        colocated_worker_residual_hbm_threshold_gb=1.0,
+        colocated_ref_hard_evict_on_breach=hard_evict,
+    )
+    dispatch = object.__new__(WorkerDispatch)
+    dispatch.cfg = SimpleNamespace(trainer=SimpleNamespace(placement=placement))
+    dispatch._actor_groups = {"ref": _FakeActorGroup()}
+    dispatch._gpu_state = {"ref": GPUState(model_on_gpu=True)}
+    return dispatch
+
+
+def test_inactive_offload_skips_extra_stats_call_when_barrier_is_disabled():
+    dispatch = _dispatch(barrier=False)
+    dispatch.release_cuda_memory = lambda _model: pytest.fail("release_cuda_memory should not be called")
+
+    dispatch._offload_inactive_model("ref")
+
+    assert dispatch._actor_groups["ref"].offload_called
+    assert dispatch._gpu_state["ref"] == GPUState()
+
+
+def test_inactive_offload_collects_stats_only_for_enabled_barrier():
+    dispatch = _dispatch()
+    calls = []
+    dispatch.release_cuda_memory = lambda model: calls.append(model) or [{"nvml_used_bytes": 0}]
+
+    dispatch._offload_inactive_model("ref")
+
+    assert calls == ["ref"]
+    assert dispatch._actor_groups["ref"].offload_called
+    assert dispatch._gpu_state["ref"] == GPUState()
+
+
+def test_worker_residual_hbm_uses_largest_available_metric():
+    assert (
+        WorkerDispatch._worker_residual_hbm_bytes({"nvml_used_bytes": 0, "reserved_bytes": 123, "allocated_bytes": 45})
+        == 123
+    )
+    assert WorkerDispatch._worker_residual_hbm_bytes({"nvml_error": "unavailable"}) is None
+    assert WorkerDispatch._worker_residual_hbm_bytes({"nvml_error": "unavailable", "reserved_bytes": 123}) is None
+
+
+def test_worker_memory_barrier_rejects_unknown_measurement():
+    dispatch = _dispatch()
+
+    with pytest.raises(RuntimeError, match="missing memory measurement"):
+        dispatch._enforce_inactive_worker_memory_barrier("ref", [{"nvml_error": "unavailable"}])
+
+
+def test_worker_memory_barrier_hard_evicts_restorable_ref_on_breach():
+    dispatch = _dispatch(hard_evict=True)
+
+    dispatch._enforce_inactive_worker_memory_barrier(
+        "ref",
+        [{"nvml_used_bytes": 2 * 1024**3, "reserved_bytes": 2 * 1024**3}],
+    )
+
+    assert dispatch._actor_groups["ref"].shutdown_called
+    assert dispatch._gpu_state["ref"] == GPUState()
+
+
+def test_hard_evicted_group_restarts_only_after_colocated_model_is_offloaded():
+    events = []
+
+    class _ResidentPolicyGroup:
+        is_shutdown = False
+
+        def offload_to_cpu(self):
+            events.append("offload_policy")
+
+    class _EvictedRefGroup:
+        is_shutdown = True
+
+        def restart_actors(self):
+            events.append("restart_ref")
+            self.is_shutdown = False
+
+        def restore_init_model(self):
+            events.append("init_ref")
+
+    dispatch = object.__new__(WorkerDispatch)
+    dispatch.colocate_all = True
+    dispatch.colocate_policy_ref = False
+    dispatch.cfg = SimpleNamespace(
+        trainer=SimpleNamespace(placement=SimpleNamespace(colocated_worker_memory_barrier=False))
+    )
+    dispatch._actor_groups = {
+        "policy": _ResidentPolicyGroup(),
+        "ref": _EvictedRefGroup(),
+    }
+    dispatch._gpu_state = {
+        "policy": GPUState(model_on_gpu=True, optimizer_on_gpu=True),
+        "ref": GPUState(),
+    }
+
+    dispatch._ensure_on_gpu("ref", need_optimizer=False, need_model=True)
+
+    assert events == ["offload_policy", "restart_ref", "init_ref"]
+    assert dispatch._gpu_state["policy"] == GPUState()
+    assert dispatch._gpu_state["ref"] == GPUState(model_on_gpu=True, optimizer_on_gpu=False)
+
+
+def test_actor_group_shutdown_waits_for_actor_death(monkeypatch):
+    events = []
+
+    class _RemoteProbe:
+        def remote(self):
+            events.append("probe")
+            return object()
+
+    class _ActorDead(ray.exceptions.RayActorError):
+        def __init__(self):
+            Exception.__init__(self)
+
+    actor = SimpleNamespace(get_mesh_rank=_RemoteProbe())
+    group = object.__new__(PPORayActorGroup)
+    group.actor_infos = []
+    group._actor_handlers = [actor]
+
+    monkeypatch.setattr(ray, "kill", lambda handle, no_restart: events.append(("kill", handle, no_restart)))
+
+    def _dead_actor(_ref, timeout):
+        events.append(("wait", timeout))
+        raise _ActorDead()
+
+    monkeypatch.setattr(ray, "get", _dead_actor)
+
+    group.shutdown()
+
+    assert events == [("kill", actor, True), "probe", ("wait", 1.0)]
+    assert group._actor_handlers == []
+    assert group.actor_infos == []

--- a/tests/backends/skyrl_train/workers/test_worker_dispatch_memory.py
+++ b/tests/backends/skyrl_train/workers/test_worker_dispatch_memory.py
@@ -1,9 +1,12 @@
+import os
+import sys
 from types import SimpleNamespace
 
 import pytest
 import ray
+import torch
 
-from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
+from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup, Worker
 from skyrl.backends.skyrl_train.workers.worker_dispatch import GPUState, WorkerDispatch
 
 
@@ -24,6 +27,34 @@ class _FakeActorGroup:
 
     def shutdown(self):
         self.shutdown_called = True
+
+
+@pytest.mark.parametrize(
+    ("visible_devices", "expected_handle"),
+    [("3,7", ("index", 3)), ("GPU-first,GPU-second", ("uuid", "GPU-first"))],
+)
+def test_nvml_memory_maps_cuda_visible_device(monkeypatch, visible_devices, expected_handle):
+    requested_handles = []
+
+    def get_handle(kind, identifier):
+        requested_handles.append((kind, identifier))
+        return object()
+
+    pynvml = SimpleNamespace(
+        nvmlInit=lambda: None,
+        nvmlShutdown=lambda: None,
+        nvmlDeviceGetHandleByIndex=lambda index: get_handle("index", index),
+        nvmlDeviceGetHandleByUUID=lambda uuid: get_handle("uuid", uuid),
+        nvmlDeviceGetComputeRunningProcesses=lambda _handle: [SimpleNamespace(pid=os.getpid(), usedGpuMemory=123)],
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", pynvml)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", visible_devices)
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _device: SimpleNamespace(uuid=None))
+
+    result = Worker._get_own_nvml_used_bytes(object(), 0)
+
+    assert result == {"nvml_used_bytes": 123}
+    assert requested_handles == [expected_handle]
 
 
 def _dispatch(*, hard_evict: bool = False, barrier: bool = True):

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -12,7 +12,9 @@ from omegaconf import OmegaConf
 
 from skyrl.train.config.config import (
     BaseConfig,
+    PlacementConfig,
     SkyRLTrainConfig,
+    TrainerConfig,
     _resolve_class_type,
     build_nested_dataclass,
 )
@@ -126,6 +128,65 @@ def test_cli_overrides_empty_args():
     cfg = SkyRLTrainConfig.from_cli_overrides([])
     assert cfg.trainer.policy.model.path == "Qwen/Qwen2.5-1.5B-Instruct"
     assert cfg.trainer.seed == 42
+
+
+def test_cli_overrides_cpu_resident_megatron_microbatches():
+    cfg = SkyRLTrainConfig.from_cli_overrides(["trainer.policy.megatron_config.cpu_resident_microbatches=true"])
+    assert cfg.trainer.policy.megatron_config.cpu_resident_microbatches is True
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("colocated_worker_residual_hbm_threshold_gb", -1),
+        ("colocated_worker_residual_hbm_threshold_gb", float("inf")),
+    ],
+)
+def test_placement_config_rejects_invalid_worker_memory_barrier_values(field_name, value):
+    with pytest.raises(ValueError, match=field_name):
+        PlacementConfig(**{field_name: value})
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("vocab_entropy_chunk_size", -1),
+        ("vocab_entropy_chunk_size", True),
+        ("vocab_entropy_chunk_memory_mb", 0),
+        ("vocab_entropy_chunk_memory_mb", True),
+    ],
+)
+def test_trainer_config_rejects_invalid_vocab_entropy_chunking(field_name, value):
+    with pytest.raises(ValueError, match=field_name):
+        TrainerConfig(**{field_name: value})
+
+
+def test_hard_ref_evict_requires_worker_memory_barrier():
+    cfg = _make_validated_test_config()
+    cfg.trainer.placement.colocated_ref_hard_evict_on_breach = True
+
+    with pytest.raises(ValueError, match="requires colocated_worker_memory_barrier=true"):
+        validate_cfg(cfg)
+
+
+def test_worker_memory_barrier_requires_colocated_workers():
+    cfg = _make_validated_test_config()
+    cfg.trainer.placement.colocate_all = False
+    cfg.trainer.placement.colocate_policy_ref = False
+    cfg.trainer.placement.colocated_worker_memory_barrier = True
+
+    with pytest.raises(ValueError, match="requires colocate_all=true or colocate_policy_ref=true"):
+        validate_cfg(cfg)
+
+
+def test_hard_ref_evict_rejects_mutable_reference_model():
+    cfg = _make_validated_test_config()
+    cfg.trainer.placement.colocated_worker_memory_barrier = True
+    cfg.trainer.placement.colocated_ref_hard_evict_on_breach = True
+    cfg.trainer.update_ref_every_epoch = True
+
+    with pytest.raises(ValueError, match="incompatible with update_ref_every_epoch"):
+        validate_cfg(cfg)
 
 
 def test_cli_overrides_plus_prefix_rejected():

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -18,7 +18,12 @@ from skyrl.train.config.config import (
     _resolve_class_type,
     build_nested_dataclass,
 )
-from skyrl.train.utils.utils import validate_cfg, validate_inference_engine_cfg
+from skyrl.train.utils import utils as train_utils
+from skyrl.train.utils.utils import (
+    prepare_runtime_environment,
+    validate_cfg,
+    validate_inference_engine_cfg,
+)
 from tests.train.util import example_dummy_config
 
 
@@ -130,6 +135,11 @@ def test_cli_overrides_empty_args():
     assert cfg.trainer.seed == 42
 
 
+def test_cli_overrides_fp8_param_gather():
+    cfg = SkyRLTrainConfig.from_cli_overrides(["trainer.policy.megatron_config.ddp_config.fp8_param_gather=true"])
+    assert cfg.trainer.policy.megatron_config.ddp_config.fp8_param_gather is True
+
+
 def test_cli_overrides_cpu_resident_megatron_microbatches():
     cfg = SkyRLTrainConfig.from_cli_overrides(["trainer.policy.megatron_config.cpu_resident_microbatches=true"])
     assert cfg.trainer.policy.megatron_config.cpu_resident_microbatches is True
@@ -161,6 +171,89 @@ def test_trainer_config_rejects_invalid_vocab_entropy_chunking(field_name, value
         TrainerConfig(**{field_name: value})
 
 
+def test_runtime_env_forwards_te_block_scale_mode(monkeypatch):
+    monkeypatch.setenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "1")
+    monkeypatch.setattr(train_utils, "peer_access_supported", lambda **_kwargs: True)
+
+    env_vars = prepare_runtime_environment(example_dummy_config())
+
+    assert env_vars["NVTE_FP8_BLOCK_SCALING_FP32_SCALES"] == "1"
+
+
+def test_serialized_fp8_runtime_defaults_to_fp32_scales(monkeypatch):
+    monkeypatch.delenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", raising=False)
+    monkeypatch.delenv("VLLM_USE_DEEP_GEMM_E8M0", raising=False)
+    monkeypatch.setattr(train_utils, "peer_access_supported", lambda **_kwargs: True)
+    cfg = example_dummy_config()
+    cfg.generator.inference_engine.fp8_weight_sync_mode = "serialized_blockwise"
+
+    env_vars = prepare_runtime_environment(cfg)
+
+    assert env_vars["NVTE_FP8_BLOCK_SCALING_FP32_SCALES"] == "1"
+    assert env_vars["VLLM_USE_DEEP_GEMM_E8M0"] == "0"
+
+
+def test_serialized_fp8_weight_sync_requires_megatron():
+    cfg = _make_validated_test_config()
+    cfg.trainer.strategy = "fsdp"
+    cfg.generator.inference_engine.fp8_weight_sync_mode = "serialized_blockwise"
+
+    with pytest.raises(ValueError, match="requires trainer.strategy='megatron'"):
+        validate_inference_engine_cfg(cfg)
+
+
+def test_serialized_fp8_weight_sync_rejects_adapter_only_megatron_lora():
+    cfg = _make_validated_test_config()
+    cfg.trainer.strategy = "megatron"
+    cfg.generator.inference_engine.fp8_weight_sync_mode = "serialized_blockwise"
+    cfg.trainer.policy.model.lora.rank = 8
+    cfg.trainer.policy.megatron_config.lora_config.merge_lora = False
+
+    with pytest.raises(ValueError, match="requires full-weight updates"):
+        validate_inference_engine_cfg(cfg)
+
+
+def test_megatron_fp8_compute_defaults_to_fp32_scales_without_serialized_sync(monkeypatch):
+    monkeypatch.delenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", raising=False)
+    monkeypatch.setattr(train_utils, "peer_access_supported", lambda **_kwargs: True)
+    cfg = example_dummy_config()
+    cfg.trainer.policy.megatron_config.transformer_config_kwargs["fp8"] = "hybrid"
+
+    env_vars = prepare_runtime_environment(cfg)
+
+    assert env_vars["NVTE_FP8_BLOCK_SCALING_FP32_SCALES"] == "1"
+
+
+def test_power_2_mode_rejects_persistent_fp8_without_serialized_sync(monkeypatch):
+    monkeypatch.setenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "0")
+    monkeypatch.setattr(train_utils, "peer_access_supported", lambda **_kwargs: True)
+    cfg = example_dummy_config()
+    cfg.trainer.policy.megatron_config.transformer_config_kwargs["fp8_param"] = True
+
+    with pytest.raises(ValueError, match="fp8_param=false on Blackwell"):
+        prepare_runtime_environment(cfg)
+
+
+def test_megatron_validation_requires_fp8_param_gather_for_training():
+    cfg = _make_validated_test_config()
+    cfg.trainer.strategy = "megatron"
+    cfg.trainer.policy.megatron_config.transformer_config_kwargs["fp8_param"] = True
+    cfg.trainer.policy.megatron_config.ddp_config.fp8_param_gather = False
+
+    with pytest.raises(ValueError, match="fp8_param_gather=true"):
+        train_utils.validate_megatron_cfg(cfg)
+
+
+def test_megatron_validation_allows_inference_only_fp8_param_without_gather():
+    cfg = _make_validated_test_config()
+    cfg.trainer.strategy = "megatron"
+    cfg.trainer.policy.inference_only_init = True
+    cfg.trainer.policy.megatron_config.transformer_config_kwargs["fp8_param"] = True
+    cfg.trainer.policy.megatron_config.ddp_config.fp8_param_gather = False
+
+    train_utils.validate_megatron_cfg(cfg)
+
+
 def test_hard_ref_evict_requires_worker_memory_barrier():
     cfg = _make_validated_test_config()
     cfg.trainer.placement.colocated_ref_hard_evict_on_breach = True
@@ -187,6 +280,17 @@ def test_hard_ref_evict_rejects_mutable_reference_model():
 
     with pytest.raises(ValueError, match="incompatible with update_ref_every_epoch"):
         validate_cfg(cfg)
+
+
+def test_serialized_fp8_fp32_scales_reject_vllm_e8m0(monkeypatch):
+    monkeypatch.setenv("NVTE_FP8_BLOCK_SCALING_FP32_SCALES", "1")
+    monkeypatch.setenv("VLLM_USE_DEEP_GEMM_E8M0", "1")
+    monkeypatch.setattr(train_utils, "peer_access_supported", lambda **_kwargs: True)
+    cfg = example_dummy_config()
+    cfg.generator.inference_engine.fp8_weight_sync_mode = "serialized_blockwise"
+
+    with pytest.raises(ValueError, match="VLLM_USE_DEEP_GEMM_E8M0=0"):
+        prepare_runtime_environment(cfg)
 
 
 def test_cli_overrides_plus_prefix_rejected():

--- a/tests/train/test_packing_round_trip.py
+++ b/tests/train/test_packing_round_trip.py
@@ -155,9 +155,8 @@ class TestPreprocessPackedRows:
         - ``mbs = 2`` so the THD offset stride matters per micro-batch row.
         - ``tp_size = 4`` so the TP-alignment padding inside rows kicks in.
         - Multi-subseq rows ``[(7, 5)]`` and ``[(3, 11)]`` to expose offset
-          mismatches in both directions (sub-seq 0 length 7 is NOT a multiple
-          of 4, sub-seq 1 length 5 is also not; row 1's sub-seq 0 length 3 is
-          shorter than its sub-seq 1 length 11).
+          mismatches in both directions (none of the lengths are alignment
+          multiples, and row 1's first sub-seq is shorter than its second).
         """
         from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
             preprocess_packed_seqs,
@@ -177,17 +176,15 @@ class TestPreprocessPackedRows:
         )
 
         # Sanity: collator layout matches what PackedDataCollator does.
-        #   row 0: [101..107] + pad-to-16 + [201..205] + pad-to-16 => 32 slots
-        #   row 1: [301..303] + pad-to-16 + [401..411] + pad-to-16 => 32 slots
-        assert sequences.shape == (2, 32)
+        assert sequences.shape == (2, 2 * align_size)
         assert sequences[0, :7].tolist() == row_0_sub_0
-        assert sequences[0, 7:16].tolist() == [0] * 9
-        assert sequences[0, 16:21].tolist() == row_0_sub_1
+        assert sequences[0, 7:align_size].tolist() == [0] * (align_size - 7)
+        assert sequences[0, align_size : align_size + 5].tolist() == row_0_sub_1
         assert sequences[1, :3].tolist() == row_1_sub_0
-        assert sequences[1, 3:16].tolist() == [0] * 13
-        assert sequences[1, 16:27].tolist() == row_1_sub_1
+        assert sequences[1, 3:align_size].tolist() == [0] * (align_size - 3)
+        assert sequences[1, align_size : align_size + 11].tolist() == row_1_sub_1
         # attention_mask is True ONLY at valid slots (NOT at TP-alignment gaps).
-        assert attention_mask[0, 7:16].any().item() is False
+        assert attention_mask[0, 7:align_size].any().item() is False
         assert attention_mask[0].sum().item() == 7 + 5
         assert attention_mask[1].sum().item() == 3 + 11
 
@@ -207,19 +204,14 @@ class TestPreprocessPackedRows:
             )
 
         # cu_seqlens_q (== cu_seqlens_q_padded for THD) enumerates 4 sub-seqs:
-        assert params.cu_seqlens_q.tolist() == [0, 16, 32, 48, 64]
-        # Packed slab is 64 tokens. Verify each sub-seq's *valid* tokens were
-        # read from the *correct intra-row offset* — i.e. preprocess respected
-        # the TP-alignment gap that the collator inserted.
-        assert packed.shape == (1, 64)
-        assert packed[0, :7].tolist() == row_0_sub_0  # row 0 sub 0
-        assert packed[0, 7:16].tolist() == [0] * 9  # alignment pad
-        assert packed[0, 16:21].tolist() == row_0_sub_1  # row 0 sub 1
-        assert packed[0, 21:32].tolist() == [0] * 11  # alignment pad
-        assert packed[0, 32:35].tolist() == row_1_sub_0  # row 1 sub 0
-        assert packed[0, 35:48].tolist() == [0] * 13  # alignment pad
-        assert packed[0, 48:59].tolist() == row_1_sub_1  # row 1 sub 1
-        assert packed[0, 59:64].tolist() == [0] * 5  # alignment pad
+        assert params.cu_seqlens_q.tolist() == [i * align_size for i in range(5)]
+        # Verify valid tokens are read from offsets produced by alignment padding.
+        assert packed.shape == (1, 4 * align_size)
+        assert packed[0, :7].tolist() == row_0_sub_0
+        assert packed[0, 7:align_size].tolist() == [0] * (align_size - 7)
+        assert packed[0, align_size : align_size + 5].tolist() == row_0_sub_1
+        assert packed[0, 2 * align_size : 2 * align_size + 3].tolist() == row_1_sub_0
+        assert packed[0, 3 * align_size : 3 * align_size + 11].tolist() == row_1_sub_1
 
     def test_mbs2_tp1_singlesubseq_rows_match_legacy_preprocess_path(self):
         """No regression in the legacy path: when each row has 1 sub-seq and tp_size=1."""

--- a/tests/train/test_sft_packing_collate.py
+++ b/tests/train/test_sft_packing_collate.py
@@ -212,17 +212,18 @@ class TestPackingCollator:
         subseq_lengths = batch["sub_seq_lengths"][0].tolist()
         assert sum(subseq_lengths) == 12  # raw, un-padded
 
-    def test_fp8_tp_alignment_pads_each_sub_seq_to_16(self):
-        """When FP8 is enabled, TP-only packed subseqs are also 16-aligned."""
+    def test_fp8_tp_alignment_cost_prevents_overpacking(self):
+        """Packing uses each sequence's aligned FP8/TP footprint."""
         collator = _make_collator(num_gpus=4, batch_size=2, max_length=128, tp=4, fp8="hybrid")
         examples = [
             _make_example(7, 3),
             _make_example(5, 3),
         ]
         batch = collator(examples, batch_size=2)
-        assert batch["sequences"].shape[1] >= 32
-        subseq_lengths = batch["sub_seq_lengths"][0].tolist()
-        assert sum(subseq_lengths) == 12
+        # TP4 gives each sequence a 512-token footprint, so the 128-token budget
+        # expands to one footprint without packing both sequences together.
+        assert batch["sequences"].shape == (2, 512)
+        assert sorted(lengths.tolist() for lengths in batch["sub_seq_lengths"]) == [[5], [7]]
 
     def test_bf16_cp_alignment_does_not_apply_fp8_padding(self):
         """With CP>1 and BF16, keep only TP/CP layout padding."""
@@ -255,6 +256,38 @@ class TestPackingCollator:
         for s in subseq_lengths:
             padded = ((s + 31) // 32) * 32
             assert (padded // 2) % 16 == 0
+
+    def test_fp8_alignment_is_conditional(self):
+        examples = [
+            _make_example(3, 1, base_token=100),
+            _make_example(3, 1, base_token=200),
+        ]
+
+        bf16 = _make_collator(num_gpus=1, batch_size=2, max_length=64, fp8=False)
+        bf16_batch = bf16(examples, batch_size=2)
+        assert bf16_batch["sequences"].shape[1] == 6
+        bf16_chunks = [bf16_batch["sequences"][0, :3].tolist(), bf16_batch["sequences"][0, 3:6].tolist()]
+        assert sorted(bf16_chunks) == [[100, 101, 102], [200, 201, 202]]
+
+        fp8 = _make_collator(num_gpus=1, batch_size=2, max_length=64, fp8=True)
+        fp8_batch = fp8(examples, batch_size=2)
+        assert fp8_batch["sequences"].shape[1] == 32
+        fp8_chunks = [fp8_batch["sequences"][0, :3].tolist(), fp8_batch["sequences"][0, 16:19].tolist()]
+        assert sorted(fp8_chunks) == [[100, 101, 102], [200, 201, 202]]
+
+    def test_tp_gt_1_fp8_alignment_uses_local_128(self):
+        """TP>1 FP8 row layout must satisfy TE blockwise input all-gather."""
+        examples = [
+            _make_example(3, 1, base_token=100),
+            _make_example(3, 1, base_token=200),
+        ]
+
+        fp8 = _make_collator(num_gpus=2, batch_size=2, max_length=512, tp=2, fp8=True)
+        fp8_batch = fp8(examples, batch_size=2)
+
+        assert fp8_batch["sequences"].shape[1] == 512
+        fp8_chunks = [fp8_batch["sequences"][0, :3].tolist(), fp8_batch["sequences"][0, 256:259].tolist()]
+        assert sorted(fp8_chunks) == [[100, 101, 102], [200, 201, 202]]
 
     def test_eval_path_falls_back_to_super(self):
         """When batch_size != self.sft_cfg.batch_size (eval), no packing happens."""


### PR DESCRIPTION
This PR adds end-to-end FP8 training and rollout support. It covers persistent Megatron FP8 parameters, serialized blockwise weight synchronization, mixed-dtype transport, and FP8 vLLM execution. 

## Changes

| Change | Explanation |
| --- | --- |
| Serialized blockwise FP8 sync | `fp8_weight_sync_mode=serialized_blockwise` converts eligible Qwen3.5 weights to E4M3 and sends matching FP32 `weight_scale_inv` tensors in vLLM checkpoint format. |
| FP8 vLLM execution | Builds the rollout model with `quantization=fp8`, `load_format=dummy`, and a matching 128 x 128 block quantization configuration; the first full sync replaces the dummy weights. |
| Qwen3.5 mapping | Handles dense attention and MLP linears, GDN projections, shared experts, and routed MoE experts while keeping incompatible GDN and vision projections in BF16. |
| Mixed-dtype transport | Preserves mixed-dtype logical chunks over NCCL and partitions CUDA IPC buffers by their actual tensor dtype. |
| Persistent FP8 parameters | Keeps eligible Megatron primary parameters in E4M3, reducing the required HBM in Megatron. |
| Exact optimizer initialization | Initializes FP32 masters and hybrid CPU copies from unquantized checkpoint shards before the first optimizer step. |
| FP8 parameter gather | Exposes `fp8_param_gather`, which refreshes persistent FP8 parameters from updated FP32 masters. |
| FP8-safe packed sequences | Uses one TP/CP-aware alignment rule in collation, packed-sequence preprocessing, and MoE replay. |

## Scale Support

Without persistent `fp8_param`, serialized FP8 synchronization supports both FP32 and power-of-two block scales. Hopper supports both modes and defaults to FP32 scales; the current Blackwell path requires power-of-two scales.

Persistent `fp8_param` is supported only with FP32 scales. The main reason is that at a `1e-6` learning rate, 99.97-99.999% of sampled FP32 master values changed per update, no power-of-two block scale changed. The configuration therefore rejects power-of-two scales with `fp8_param`. Because Blackwell currently requires power-of-two scales, persistent FP8 parameters are not enabled there.

## Performance

### vLLM Rollout Throughput

On `Qwen/Qwen3.5-9B-Base`, NVIDIA H100 80GB, TP1, vLLM 0.23.0, using DAPO recipe dataset.

| Concurrent requests | BF16 output tok/s | FP8 output tok/s | Gain |
| ---: | ---: | ---: | ---: |
| 1 | 140.5 | 198.6 | +41.4% |
| 16 | 1,940.3 | 2,599.4 | +34.0% |
| 32 | 3,418.9 | 4,361.0 | +27.6% |
| 128 | 7,897.7 | 8,989.2 | +13.8% |
| 256 | 9,223.3 | 10,791.0 | +17.0% |

This gain comes from FP8 vLLM execution and does not require persistent FP8 Megatron parameters.

### Persistent FP8 Policy HBM

| Megatron primary storage | HBM/GPU | Change at highest sample |
| --- | ---: | ---: |
| BF16 | 59,676-63,638 MiB | Baseline |
| Persistent E4M3 | 56,850-57,810 MiB | -5,828 MiB (-5.69 GiB, -9.2%) |

## Quality Checks
The following WANDB runs log the metrics. All FP8 runs aligns well with the BF16 baseline.
Qwen3.5-4B runs: https://wandb.ai/sky-posttraining-uc-berkeley/qwen35_4b_dapo_mainclean_fp8align_fastbatch_bf16_fp8_20260630?nw=nwuserjinghanyao1

Qwen3.5-9B runs: https://wandb.ai/sky-posttraining-uc-berkeley/qwen35_9b_h100_tp2_bf16_fp8_prready_20260709?nw=nwuserjinghanyao1

Qwen3.5-35B-A3B runs: https://wandb.ai/sky-posttraining-uc-berkeley/qwen35_35b_a3b_fp8_amaxeps_20260705?nw=nwuserjinghanyao1
