### PR TITLE
[fix] Render multimodal sample prompts under the base model (#1860)

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -524,7 +524,6 @@ class RemoteInferenceClient(InferenceEngineInterface):
         self,
         prompt: Dict[str, Any],
         session_id: Optional[str],
-        model: str,
     ) -> Tuple[List[int], Optional[MultiModalFeatures]]:
         """Build token_ids and optional multi-modal features from a Tinker prompt.
 
@@ -532,6 +531,11 @@ class RemoteInferenceClient(InferenceEngineInterface):
         When image chunks are present, calls /v1/chat/completions/render to
         process images, then splices the resulting placeholder tokens into the
         pre-tokenized text stream and adjusts placeholder offsets.
+
+        The render request always targets the base model (``self.model_name``):
+        rendering (chat-template application, tokenization, and multimodal
+        preprocessing) is adapter-independent, and vLLM's render endpoint does
+        not resolve LoRA adapter names, so passing one returns 404 (#1860).
 
         Returns:
             (token_ids, features) where features is None for text-only prompts.
@@ -558,7 +562,7 @@ class RemoteInferenceClient(InferenceEngineInterface):
 
         render_payload: Dict[str, Any] = {
             "json": {
-                "model": model,
+                "model": self.model_name,
                 "messages": [{"role": "user", "content": content_parts}],
             }
         }
@@ -645,7 +649,7 @@ class RemoteInferenceClient(InferenceEngineInterface):
 
         # Render prompt: flatten text tokens and, if images are present,
         # call the render endpoint to get placeholder tokens + features.
-        token_ids, mm_features = await self._render_for_sample(prompt, session_id, model=model)
+        token_ids, mm_features = await self._render_for_sample(prompt, session_id)
 
         # Map Tinker SamplingParams → vLLM format
         sampling_params: Dict[str, Any] = {
@@ -776,8 +780,11 @@ class RemoteInferenceClient(InferenceEngineInterface):
             request_payload: Dict with {"json": <request-body>}.
                 The request body should be OpenAI-compatible chat completion
                 request. ``model`` is optional and resolved via
-                ``_resolve_model``. session_id can be included in json for
-                consistent routing.
+                ``_resolve_model``; note that vLLM's render endpoint only
+                resolves base model names, so under LoRA pass the base model
+                explicitly (adapter names return 404, #1860; see
+                ``_render_for_sample``). session_id can be included in json
+                for consistent routing.
 
         Returns:
             Rendered chat completion response (template-applied prompt and token IDs).

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -1024,6 +1024,10 @@ class TestExplicitModelRequired:
       ``client.model_name``.
     - If no model is supplied and LoRA **is** in use, the call raises
       ``ValueError`` so requests don't silently target the base model.
+
+    One exception: ``sample`` threads the resolved model to the generate
+    endpoint, but its internal render sub-request for image prompts always
+    targets the base model (see ``_render_for_sample``).
     """
 
     @pytest.mark.asyncio
@@ -1270,6 +1274,44 @@ class TestExplicitModelRequired:
             await client.sample(request_payload)
             captured = await _get_last_models(mock_servers["server_urls"])
             assert captured[0]["generate"] == "lora-sample"
+        finally:
+            await client.teardown()
+
+    @pytest.mark.asyncio
+    async def test_sample_with_image_renders_under_base_model(self, mock_servers):
+        """With LoRA, sample's render sub-request targets the base model while
+        generate targets the adapter (#1860); see ``_render_for_sample``.
+        """
+        import base64
+
+        client = RemoteInferenceClient(
+            proxy_url=mock_servers["proxy_url"],
+            server_urls=mock_servers["server_urls"],
+            model_name="base-model",
+            uses_lora_weight_sync=True,
+            data_parallel_size=1,
+        )
+        try:
+            image_bytes = base64.b64encode(b"fake-jpeg-data").decode("ascii")
+            request_payload = {
+                "json": {
+                    "model": "lora-adapter",
+                    "prompt": {
+                        "chunks": [
+                            {"type": "encoded_text", "tokens": [100, 101, 102]},
+                            {"type": "image", "data": image_bytes, "format": "jpeg"},
+                            {"type": "encoded_text", "tokens": [200, 201]},
+                        ]
+                    },
+                    "num_samples": 1,
+                    "sampling_params": {"temperature": 0.7, "max_tokens": 16},
+                }
+            }
+            result = await client.sample(request_payload)
+            assert result["type"] == "sample"
+            captured = await _get_last_models(mock_servers["server_urls"])
+            assert captured[0]["render"] == "base-model"
+            assert captured[0]["generate"] == "lora-adapter"
         finally:
             await client.teardown()
 


### PR DESCRIPTION
# What does this PR do?

Fixes #1860.

`_render_for_sample` posts the resolved model to `/v1/chat/completions/render`. Under `uses_lora_weight_sync=True` the resolved model is the LoRA adapter name, which the render endpoint does not resolve, so every image-bearing Tinker sample request 404s. Following @benrhodes26's diagnosis in #1860, the render request now always targets the base model (`self.model_name`): rendering (chat-template application, tokenization, multimodal preprocessing) is adapter-independent. Generation still targets the adapter on `/inference/v1/generate`.

The `model` parameter of `_render_for_sample` becomes unused and is removed.

## Tests

New `test_sample_with_image_renders_under_base_model`: image chunks + `uses_lora_weight_sync=True` + explicit adapter model, asserts the render sub-request targets the base model while generate targets the adapter. On main it fails with `AssertionError: assert 'lora-adapter' == 'base-model'`; with this fix the full file passes (57 passed, `pytest tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py -m "not vllm"`).

Also verified live against vLLM 0.23.0 (the version pinned in `pyproject.toml`) on an L40S, serving `Qwen/Qwen2.5-VL-3B-Instruct` with a LoRA adapter via `--enable-lora --lora-modules`:

- `POST /v1/chat/completions/render` with the adapter name returns 404 (`The model 'lora-test' does not exist`), even though `/v1/models` lists the adapter.
- The same request with the base model name returns 200 with prompt token ids and image placeholder features.
- `POST /v1/chat/completions` with an image under the adapter name returns 200, confirming generation resolves adapters while render does not.

On the parity point raised in #1860 (base-model render output matching what the adapter would produce): in vLLM 0.23.0 this holds by construction. The render module (`vllm/entrypoints/serve/render/`) has no LoRA code path, and its model check goes through `OpenAIModelRegistry`, documented as having "no engine client and no LoRA support". Adapters also cannot alter tokenization in this version (`LoRAConfig` has no extra-vocab field), so there is no adapter-dependent render output to diverge from.
