### PR TITLE
[fix] Make FSDP HF export atomic on local paths

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -3,7 +3,10 @@ import gc
 import json
 import os
 import random
+import shutil
+import tempfile
 from collections import defaultdict
+from contextlib import contextmanager
 from typing import List, Optional, Union
 
 import numpy as np
@@ -572,7 +575,7 @@ class FSDPStrategy(DistributedStrategy):
 
         # Step 4: Save on rank 0 only
         if self.is_rank_0():
-            with io.local_work_dir(output_dir) as work_dir:
+            with self._atomic_local_export_dir(output_dir) as work_dir:
                 # Save the model in HuggingFace format using safetensors
                 model_to_save.save_pretrained(work_dir, state_dict=output_state_dict, safe_serialization=True, **kwargs)
 
@@ -597,3 +600,31 @@ class FSDPStrategy(DistributedStrategy):
             self.print(f"[rank-0]: Successfully saved model to {output_dir}")
 
         dist.barrier()
+
+    @contextmanager
+    def _atomic_local_export_dir(self, output_dir: str):
+        """Rank-0 HF export dir that appears at ``output_dir`` only once complete.
+
+        HF ``save_pretrained`` writes ``config.json`` before the safetensors
+        shards, so an in-place write lets a reader that polls for ``config.json``
+        (e.g. an eval watcher) pick up a half-written export. For local paths,
+        stage in a sibling temp dir and atomically swap it in. Cloud paths already
+        stage-then-upload via ``io.local_work_dir``.
+        """
+        if io.is_cloud_path(output_dir):
+            with io.local_work_dir(output_dir) as work_dir:
+                yield work_dir
+            return
+
+        parent = os.path.dirname(os.path.abspath(output_dir)) or "."
+        io.makedirs(parent, exist_ok=True)
+        staging_dir = tempfile.mkdtemp(prefix=".tmp-hf-export-", dir=parent)
+        try:
+            yield staging_dir
+            # os.replace can't overwrite a non-empty dir, so clear a prior export first.
+            shutil.rmtree(output_dir, ignore_errors=True)
+            os.replace(staging_dir, output_dir)
+            staging_dir = None
+        finally:
+            if staging_dir is not None:
+                shutil.rmtree(staging_dir, ignore_errors=True)

--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -605,9 +605,9 @@ class FSDPStrategy(DistributedStrategy):
     def _atomic_local_export_dir(self, output_dir: str):
         """Rank-0 HF export dir that appears at ``output_dir`` only once complete.
 
-         Atomic write to the local export path provides a consistent way to signal export
-         finish. Ex: An asynchronous watcher can watch for ``config.json`` file to populate
-         in the export directory. 
+        Atomic write to the local export path provides a consistent way to signal export
+        finish. Ex: An asynchronous watcher can watch for ``config.json`` file to populate
+        in the export directory.
         """
         if io.is_cloud_path(output_dir):
             with io.local_work_dir(output_dir) as work_dir:

--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -605,11 +605,9 @@ class FSDPStrategy(DistributedStrategy):
     def _atomic_local_export_dir(self, output_dir: str):
         """Rank-0 HF export dir that appears at ``output_dir`` only once complete.
 
-        HF ``save_pretrained`` writes ``config.json`` before the safetensors
-        shards, so an in-place write lets a reader that polls for ``config.json``
-        (e.g. an eval watcher) pick up a half-written export. For local paths,
-        stage in a sibling temp dir and atomically swap it in. Cloud paths already
-        stage-then-upload via ``io.local_work_dir``.
+         Atomic write to the local export path provides a consistent way to signal export
+         finish. Ex: An asynchronous watcher can watch for ``config.json`` file to populate
+         in the export directory. 
         """
         if io.is_cloud_path(output_dir):
             with io.local_work_dir(output_dir) as work_dir:

--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -619,12 +619,19 @@ class FSDPStrategy(DistributedStrategy):
         parent = os.path.dirname(os.path.abspath(output_dir)) or "."
         io.makedirs(parent, exist_ok=True)
         staging_dir = tempfile.mkdtemp(prefix=".tmp-hf-export-", dir=parent)
+        old_dir = None
         try:
             yield staging_dir
-            # os.replace can't overwrite a non-empty dir, so clear a prior export first.
-            shutil.rmtree(output_dir, ignore_errors=True)
+            # Swap via renames only (each atomic on the same filesystem) so a reader
+            # never sees output_dir mid-delete: move any prior export aside, move the
+            # new one in, then rmtree the old one afterwards.
+            if os.path.lexists(output_dir):
+                old_dir = tempfile.mktemp(prefix=".old-hf-export-", dir=parent)
+                os.replace(output_dir, old_dir)
             os.replace(staging_dir, output_dir)
             staging_dir = None
         finally:
             if staging_dir is not None:
                 shutil.rmtree(staging_dir, ignore_errors=True)
+            if old_dir is not None:
+                shutil.rmtree(old_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

`FSDPStrategy.save_hf_model` writes the HF export in place: `save_pretrained` emits `config.json` before the safetensors shards. A reader that treats `config.json` as the "export complete" signal (e.g. an async eval watcher polling the export dir) can therefore pick up a half-written checkpoint, and a crash mid-write leaves a partial export with a valid-looking `config.json` behind.

This stages the rank-0 export in a sibling temp dir on the same filesystem and atomically swaps it into place, so the final path only ever contains a complete export.

## Scope

- Local paths only get the stage-and-swap; cloud paths keep using `io.local_work_dir` (already stage-then-upload).
- The multi-writer megatron `distributed_save` path is intentionally untouched — all ranks write into one shared dir there, so a per-call atomic swap would be incorrect.

## Test plan

- [ ] FSDP SFT/RL run exports to a local `export_path`; confirm `global_step_*/policy` contains complete weights + `config.json` and no leftover `.tmp-hf-export-*` dirs.
- [ ] Resume/overwrite: re-export the same step and confirm the prior export is replaced cleanly.
- [ ] Cloud (`s3://`) export still works unchanged.