### PR TITLE
[logging] Fix: RayGpuMonitor never ran on the fully async trainer

### DIFF
--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -456,6 +456,11 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         with Timer("sync_weights_to_inference_engines"):
             await self.dispatch.save_weights_for_sampler()
 
+        # Per-step GPU utilization to the tracker. The base loop starts, flushes, and stops the
+        # monitor itself. The async loop overrides train() and must wire it here.
+        if self._ray_gpu_monitor is not None:
+            self._ray_gpu_monitor.start()
+
         # Eval before training
         if self.cfg.trainer.eval_interval > 0 and self.cfg.trainer.eval_before_train:
             with Timer("eval", self.all_timings):
@@ -593,6 +598,8 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                                 await asyncio.to_thread(self.save_models)
 
                     timing_payload = {"timing/" + k: v for k, v in self.all_timings.items()}
+                    if self._ray_gpu_monitor is not None:
+                        timing_payload.update(self._ray_gpu_monitor.flush())
                     if self._vllm_metrics_scraper is not None:
                         timing_payload.update(await self._vllm_metrics_scraper.sample())
                     self.tracker.log(timing_payload, step=self.global_step, commit=True)
@@ -657,6 +664,8 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 # End of an epoch.
         finally:
             self._profiler_stop()
+            if self._ray_gpu_monitor is not None:
+                self._ray_gpu_monitor.stop()
 
         pbar.close()
 


### PR DESCRIPTION
## What does this PR do?

Fixes a wiring bug: `RayGpuMonitor` never ran on the fully async trainer.

`RayGpuMonitor` (#1712) is constructed in `RayPPOTrainer.__init__` and enabled by default with `trainer.enable_ray_gpu_monitor=True`. The base loop starts it, flushes it into the per-step log payload, and stops it. `FullyAsyncRayPPOTrainer` overrides `train()` and never called any of the three, so fully async runs logged no `ray/` GPU keys at all. Confirmed on real runs.

The async loop now starts the monitor at loop entry, flushes it into the per-step timing payload, and stops it in the `finally`, mirroring the base loop wiring.

## Tests

Wiring only, covered by lint and existing tests. Exercising it end to end needs a GPU cluster. A structural lifecycle test that catches any base-loop hook dropped by an overriding trainer is a planned follow-up.

Split out of #1900.
