### PR TITLE
[fix] Use the right CISPO epsilon defaults following ScaleRL

### DIFF
--- a/docs/content/docs/configuration/config.mdx
+++ b/docs/content/docs/configuration/config.mdx
@@ -469,8 +469,8 @@ algorithm:
 
   # cispo parameters (only used when policy_loss_type: "cispo")
   cispo:
-    cispo_eps_clip_low: 0  # offset for lower bound of importance sampling ratio clipping (as opposed to PPO token update clipping)
-    cispo_eps_clip_high: 5 # offset for upper bound of importance sampling ratio clipping (as opposed to PPO token update clipping)
+    cispo_eps_clip_low: 1  # offset for lower bound of importance sampling ratio clipping (as opposed to PPO token update clipping)
+    cispo_eps_clip_high: 4 # offset for upper bound of importance sampling ratio clipping (as opposed to PPO token update clipping)
 
   # value loss parameters
   value_clip: 0.2

--- a/examples/train/algorithms/cispo/run_cispo_gsm8k.sh
+++ b/examples/train/algorithms/cispo/run_cispo_gsm8k.sh
@@ -15,8 +15,8 @@ LOGGER="wandb"  # change to "console" to print to stdout
 
 # Configure CISPO parameters
 POLICY_LOSS="cispo"
-CISPO_EPS_CLIP_LOW=0
-CISPO_EPS_CLIP_HIGH=5
+CISPO_EPS_CLIP_LOW=1
+CISPO_EPS_CLIP_HIGH=4
 USE_KL_LOSS=false
 
 uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -540,10 +540,16 @@ class KLCovConfig(BaseConfig):
 @dataclass
 class CISPOConfig(BaseConfig):
 
-    cispo_eps_clip_low: float = 0.0
-    """Offset for lower bound of importance sampling ratio clipping (as opposed to PPO token update clipping)."""
-    cispo_eps_clip_high: float = 5.0
-    """Offset for upper bound of importance sampling ratio clipping (as opposed to PPO token update clipping)."""
+    cispo_eps_clip_low: float = 1
+    """Offset for lower bound of importance sampling ratio clipping (as opposed to PPO token update clipping).
+    
+    The lower bound used is ``1-cispo_eps_clip_low``. The default lower bound is 0 following the ScaleRL recipe: https://arxiv.org/abs/2510.13786
+    """
+    cispo_eps_clip_high: float = 4.0
+    """Offset for upper bound of importance sampling ratio clipping (as opposed to PPO token update clipping).
+    
+    The upper bound used is ``1+cispo_eps_clip_high``. The default upper bound is 5 following the ScaleRL recipe: https://arxiv.org/abs/2510.13786
+    """
 
 
 # DPPO parameters (only used when policy_loss_type="dppo")

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -540,7 +540,7 @@ class KLCovConfig(BaseConfig):
 @dataclass
 class CISPOConfig(BaseConfig):
 
-    cispo_eps_clip_low: float = 1
+    cispo_eps_clip_low: float = 1.0
     """Offset for lower bound of importance sampling ratio clipping (as opposed to PPO token update clipping).
     
     The lower bound used is ``1-cispo_eps_clip_low``. The default lower bound is 0 following the ScaleRL recipe: https://arxiv.org/abs/2510.13786


### PR DESCRIPTION
# What does this PR do?

Fixes the default upper and lower bounds for CISPO.

The ScaleRL paper uses a lower bound of 0 and an upper bound of 5. 

In our formulation of the loss, the lower bound is `1 - cispo_eps_clip_low` and `1 + cispo_eps_clip_high`. So the values for `cispo_eps_clip_low` and `cispo_eps_clip_high` should be 1 and 4. 