### PR TITLE
[fix] Log evaluation metrics with the same step in `FullyAsyncRayPPOTrainer`

### DIFF
--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -567,6 +567,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                     # 5. Set logs for this training step.
                     logger.info(status)
                     self.all_metrics.update({"trainer/epoch": epoch, "trainer/global_step": self.global_step})
+                    pbar.update(1)
 
                     # 6. Eval. At interval and at the last step.
                     # NOTE(Charlie): eval does not overlap with training, but overlaps with generation.
@@ -581,7 +582,6 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                     # Log metrics for this step after evaluation
                     self.tracker.log(self.all_metrics, step=self.global_step, commit=False)
                     self.all_metrics = {}
-                    pbar.update(1)
 
                     # 7. Checkpointing. At interval and at the last step of each epoch.
                     is_epoch_end = trained_steps_this_epoch == self.num_steps_per_epoch

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -567,9 +567,6 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                     # 5. Set logs for this training step.
                     logger.info(status)
                     self.all_metrics.update({"trainer/epoch": epoch, "trainer/global_step": self.global_step})
-                    self.tracker.log(self.all_metrics, step=self.global_step, commit=False)
-                    self.all_metrics = {}
-                    pbar.update(1)
 
                     # 6. Eval. At interval and at the last step.
                     # NOTE(Charlie): eval does not overlap with training, but overlaps with generation.
@@ -580,6 +577,11 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                         with Timer("eval", self.all_timings):
                             eval_metrics = await self.eval()
                             self.all_metrics.update(eval_metrics)
+
+                    # Log metrics for this step after evaluation
+                    self.tracker.log(self.all_metrics, step=self.global_step, commit=False)
+                    self.all_metrics = {}
+                    pbar.update(1)
 
                     # 7. Checkpointing. At interval and at the last step of each epoch.
                     is_epoch_end = trained_steps_this_epoch == self.num_steps_per_epoch


### PR DESCRIPTION
# What does this PR do?

Fixes an issue with logging for evaluation metrics in `FullyAsyncRayPPOTrainer`. 

Currently, we finalize and log the metrics to `Tracking` (WandB, MLFlow, etc) before running evaluation for that step. 

This means that the evaluation metrics will appear in the logs for the next step. 

This PR fixes the issue by finalizing and logging the metrics after evaluation runs.