### PR TITLE
[feat][SFT] Cloud-path (S3/GCS) dataset ingestion for pretokenized and text datasets

### DIFF
--- a/examples/train/sft/README.md
+++ b/examples/train/sft/README.md
@@ -6,24 +6,26 @@ This example demonstrates supervised fine-tuning using SkyRL, with support for b
 
 By default, the example uses the [Alpaca-Cleaned](https://huggingface.co/datasets/yahma/alpaca-cleaned) dataset (`yahma/alpaca-cleaned`). No manual download is required -- the dataset is loaded automatically via HuggingFace `datasets`.
 
-You can switch to a different dataset by overriding `train_datasets` and `train_dataset_splits` on the command line, or train on a weighted mixture of several datasets (see [Multi-dataset training](#multi-dataset-training-and-evaluation)). The singular `dataset_name`/`dataset_split` (and `eval_dataset_name`/`eval_dataset_split`) fields are deprecated: they still work but emit a `DeprecationWarning` and are translated to the list form internally.
+You can switch to a different dataset by overriding `train_datasets` and `train_dataset_splits` on the command line, or train on a weighted mixture of several datasets (see [Multi-dataset training](#multi-dataset-training-and-evaluation)). Entries may be HuggingFace dataset names, local paths, or cloud URIs (`s3://`, `gs://`, `gcs://`) — cloud-hosted raw datasets are downloaded once and cached under `cache_dir`. The singular `dataset_name`/`dataset_split` (and `eval_dataset_name`/`eval_dataset_split`) fields are deprecated: they still work but emit a `DeprecationWarning` and are translated to the list form internally.
 
-### Pretokenized datasets
+### Pretokenized datasets (local or S3/GCS)
 
 If your data pipeline tokenizes offline, point the trainer directly at the pretokenized store to skip
 online tokenization (`tokenize_chat_example` / `tokenize_sft_example`) entirely:
 
 ```bash
 bash examples/train/sft/run_sft_megatron.sh \
-    "pretokenized_dataset_paths=['$HOME/data/tokenized-train']" \
-    "eval_pretokenized_dataset_paths=['$HOME/data/tokenized-eval']"  # optional
+    "pretokenized_dataset_paths=['s3://my-bucket/datasets/tokenized-train']" \
+    "eval_pretokenized_dataset_paths=['s3://my-bucket/datasets/tokenized-eval']"  # optional
 ```
 
-Each entry of `pretokenized_dataset_paths` is a local path to a file or directory in any of these formats
-(auto-detected): Parquet, JSON-lines, raw Arrow IPC files, or a HuggingFace `Dataset.save_to_disk` directory.
-Like `train_datasets`, multiple stores are concatenated and mixed per `train_dataset_weights`; multiple eval
-stores are evaluated separately under `eval/{name}/`, with names from `eval_dataset_names` (defaulting to each
-path's basename).
+Each entry of `pretokenized_dataset_paths` is a local path, `s3://`, `gs://`, or `gcs://` URI pointing at a
+file or directory in any of these formats (auto-detected): Parquet, JSON-lines, raw Arrow IPC files, or a
+HuggingFace `Dataset.save_to_disk` directory. Cloud paths are downloaded once and cached under `cache_dir`
+(set `disable_cache=true` to download to a temporary directory instead, or `force_recache=true` to
+re-download). Like `train_datasets`, multiple stores are concatenated and mixed per `train_dataset_weights`;
+multiple eval stores are evaluated separately under `eval/{name}/`, with names from `eval_dataset_names`
+(defaulting to each path's basename).
 
 Each row must contain:
 
@@ -125,7 +127,7 @@ All SFT configuration is defined in [`skyrl/train/config/sft_config.py`](../../.
 | `train_datasets` | `[yahma/alpaca-cleaned]` | List of HuggingFace dataset names to train on; multiple entries are mixed per `train_dataset_weights` |
 | `train_dataset_splits` | `[train[:100]]` | Split/slice per training dataset (same length as `train_datasets`) |
 | `train_dataset_weights` | equal (`1/N`) | Per-dataset sampling ratios within a batch, independent of dataset sizes; `sampler=random` only |
-| `pretokenized_dataset_paths` | `None` | List of local paths to pretokenized datasets (Parquet/JSONL/Arrow/`save_to_disk`); skips tokenization, mixed per `train_dataset_weights`; exclusive with `train_datasets` |
+| `pretokenized_dataset_paths` | `None` | List of local paths or `s3://`/`gs://` URIs to pretokenized datasets (Parquet/JSONL/Arrow/`save_to_disk`); skips tokenization, mixed per `train_dataset_weights`; exclusive with `train_datasets` |
 | `eval_datasets` | `None` | List of eval dataset names; `None` disables eval. Metrics logged under `eval/{name}/` |
 | `eval_dataset_splits` | `None` | Split per eval dataset (same length as `eval_datasets`) |
 | `eval_dataset_names` | dataset names | Shorthand names used only for logging (`eval/{name}/loss`); must be unique |

--- a/skyrl/train/config/sft_config.py
+++ b/skyrl/train/config/sft_config.py
@@ -153,8 +153,10 @@ class SFTConfig(BaseConfig):
     dataset_split: Optional[str] = None
     """Deprecated: use ``train_dataset_splits`` instead."""
     train_datasets: Optional[List[str]] = None
-    """HuggingFace dataset names (or paths) to train on. With multiple datasets, batches are
-    mixed per-source by :class:`~skyrl.train.dataset.samplers.DataMixingSampler` according to
+    """HuggingFace dataset names, local paths, or cloud URIs (``s3://``, ``gs://``, ``gcs://``)
+    to train on. Cloud URIs are downloaded once and cached under ``cache_dir``. With multiple
+    datasets, batches are mixed per-source by
+    :class:`~skyrl.train.dataset.samplers.DataMixingSampler` according to
     ``train_dataset_weights``. Defaults to ``["yahma/alpaca-cleaned"]``. All datasets must share
     the same ``messages_key``/``tools_key``/``system_key`` columns and modality."""
     train_dataset_splits: Optional[List[str]] = None
@@ -165,15 +167,17 @@ class SFTConfig(BaseConfig):
     dataset, independent of dataset sizes. Only supported with ``sampler="random"`` (custom
     samplers receive ratios via ``sampler_kwargs``). Defaults to equal mixing (``1/N`` each)."""
     pretokenized_dataset_paths: Optional[List[str]] = None
-    """Local paths to *pretokenized* training datasets, each a file or
-    directory holding parquet/JSONL/arrow files or a HF
-    ``Dataset.save_to_disk`` directory. Rows must carry unpadded
-    ``input_ids`` and a full-sequence 0/1 ``loss_mask`` (``num_actions`` is
-    inferred); VLM rows additionally carry ``pixel_values`` /
-    ``image_grid_thw``. See ``skyrl.train.dataset.pretokenized``. When set,
-    online tokenization is skipped; cannot be combined with ``train_datasets``.
-    Multiple stores are concatenated and mixed per ``train_dataset_weights``
-    (like ``train_datasets``)."""
+    """Paths to *pretokenized* training datasets: local paths, ``s3://``,
+    ``gs://``, or ``gcs://`` URIs, each a file or directory holding
+    parquet/JSONL/arrow files or a HF ``Dataset.save_to_disk`` directory.
+    Cloud URIs are downloaded once and cached under ``cache_dir``. Rows must
+    carry unpadded ``input_ids`` and a full-sequence 0/1 ``loss_mask``
+    (``num_actions`` is inferred); VLM rows additionally carry
+    ``pixel_values`` / ``image_grid_thw``. See
+    ``skyrl.train.dataset.pretokenized``. When set, online tokenization is
+    skipped; cannot be combined with ``train_datasets``. Multiple stores are
+    concatenated and mixed per ``train_dataset_weights`` (like
+    ``train_datasets``)."""
     messages_key: str = "messages"  # column name for chat-format datasets
     tools_key: str = "tools"
     """Column name holding per-row tool/function schemas for tool-calling datasets

--- a/skyrl/train/dataset/pretokenized.py
+++ b/skyrl/train/dataset/pretokenized.py
@@ -1,9 +1,12 @@
-"""Loading of pretokenized SFT datasets.
+"""Loading of pretokenized SFT datasets from local or cloud storage.
 
-Some data pipelines tokenize offline (e.g. on a Spark/Ray data cluster). This
-module lets the SFT trainer ingest such a dataset directly from a local file
-or directory -- skipping online tokenization (``tokenize_chat_example`` and
-``tokenize_sft_example`` in ``skyrl.train.sft_trainer``) entirely.
+Some data pipelines tokenize offline (e.g. on a Spark/Ray data cluster) and
+publish the result to an object store. This module lets the SFT trainer ingest
+such a dataset directly -- skipping online tokenization (``tokenize_chat_example``
+and ``tokenize_sft_example`` in ``skyrl.train.sft_trainer``) entirely -- from a
+local file or directory, or an ``s3://``, ``gs://``, or ``gcs://`` URI. Cloud
+paths are materialized locally through
+:mod:`skyrl.train.dataset.remote_storage` before loading.
 
 Supported on-disk formats (auto-detected):
 
@@ -34,6 +37,8 @@ from typing import Any, Optional
 
 from datasets import Dataset, concatenate_datasets, load_dataset
 from loguru import logger
+
+from skyrl.train.dataset.remote_storage import materialize_local
 
 # Keys consumed (and re-emitted in normalized form) by ``_normalize_row``.
 # ``num_actions`` and ``labels`` are consumed-but-dropped: ``num_actions`` is
@@ -233,48 +238,56 @@ def _normalize_row(row: dict, row_idx: int, max_length: Optional[int]) -> Option
 def load_from_pretokenized(
     path: str,
     max_length: Optional[int] = None,
+    cache_dir: Optional[str] = None,
+    force_redownload: bool = False,
 ) -> list[dict[str, Any]]:
-    """Load a pretokenized SFT dataset from a local file or directory.
+    """Load a pretokenized SFT dataset from a local path or object store.
 
     The pretokenized counterpart of ``SFTTrainer._load_and_tokenize``: returns
     the same ``list[dict]`` representation the trainer's dataloaders and
     collators consume.
 
     Args:
-        path: Local path to a file or directory in one of the supported
-            formats (see module docstring).
+        path: Local path, ``s3://``, ``gs://``, or ``gcs://`` URI pointing to a
+            file or directory in one of the supported formats (see module
+            docstring).
         max_length: Optional sequence-length cap. Longer text rows are
             truncated (keeping the prompt prefix) and dropped if no loss tokens
             survive; longer VLM rows are always dropped with a warning,
             matching the online tokenization path.
+        cache_dir: Base directory for caching cloud downloads. ``None``
+            downloads to a temporary directory instead (no reuse across runs).
+        force_redownload: Re-download a cloud path even if a cached copy
+            exists.
 
     Returns:
         List of normalized examples (``input_ids`` / ``attention_mask`` /
         ``num_actions`` / window ``loss_mask``, plus pass-through columns like
         ``pixel_values`` / ``image_grid_thw``) ready for the SFT collators.
     """
-    if not os.path.exists(path):
-        raise FileNotFoundError(f"Pretokenized dataset path does not exist: {path}")
+    # The dataset is arrow-backed (memory-mapped from the store's files), so
+    # rows must be materialized before the context exits and an uncached
+    # temporary download is removed.
+    with materialize_local(path, cache_dir, force_redownload) as local_path:
+        dataset = _load_as_hf_dataset(local_path)
+        logger.info(f"Loaded pretokenized dataset from '{path}': {len(dataset)} rows, columns={dataset.column_names}")
 
-    dataset = _load_as_hf_dataset(path)
-    logger.info(f"Loaded pretokenized dataset from '{path}': {len(dataset)} rows, columns={dataset.column_names}")
+        global _warned_attention_mask_dropped
+        if "attention_mask" in dataset.column_names and not _warned_attention_mask_dropped:
+            _warned_attention_mask_dropped = True
+            logger.warning(
+                "Pretokenized dataset carries an 'attention_mask' column; its values are dropped and "
+                "regenerated as all-ones (rows must be stored unpadded; padding is applied at collation time)."
+            )
 
-    global _warned_attention_mask_dropped
-    if "attention_mask" in dataset.column_names and not _warned_attention_mask_dropped:
-        _warned_attention_mask_dropped = True
-        logger.warning(
-            "Pretokenized dataset carries an 'attention_mask' column; its values are dropped and "
-            "regenerated as all-ones (rows must be stored unpadded; padding is applied at collation time)."
-        )
-
-    normalized: list[dict] = []
-    num_dropped = 0
-    for row_idx, row in enumerate(dataset):
-        example = _normalize_row(row, row_idx, max_length)
-        if example is None:
-            num_dropped += 1
-        else:
-            normalized.append(example)
+        normalized: list[dict] = []
+        num_dropped = 0
+        for row_idx, row in enumerate(dataset):
+            example = _normalize_row(row, row_idx, max_length)
+            if example is None:
+                num_dropped += 1
+            else:
+                normalized.append(example)
 
     if num_dropped:
         logger.warning(

--- a/skyrl/train/dataset/remote_storage.py
+++ b/skyrl/train/dataset/remote_storage.py
@@ -1,0 +1,109 @@
+"""Materialize cloud-hosted (S3/GCS) datasets to local storage.
+
+Shared by the SFT data paths: pretokenized stores
+(:mod:`skyrl.train.dataset.pretokenized`) and text-format datasets
+(``SFTTrainer._load_and_tokenize``) both accept ``s3://``, ``gs://``, and
+``gcs://`` URIs, resolved through
+:mod:`skyrl.backends.skyrl_train.utils.io` (fsspec-backed, with the
+project's S3 retry/credential-refresh handling).
+
+Downloads are cached under ``cache_dir`` keyed by the remote path (atomic
+tmp-dir-then-rename, so concurrent readers -- e.g. multi-node runs sharing an
+NFS cache -- never see a partial download). The cache is keyed by remote path
+only: replacing a store's contents in place requires ``force_redownload``.
+"""
+
+import hashlib
+import os
+import shutil
+import tempfile
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+from loguru import logger
+
+from skyrl.backends.skyrl_train.utils.io import io
+
+
+def _cache_dir_for_path(cache_dir: str, path: str) -> str:
+    """Local cache directory for a downloaded cloud dataset path."""
+    key = hashlib.sha256(path.encode()).hexdigest()[:16]
+    return os.path.join(cache_dir, "remote_datasets", key)
+
+
+def _download_to(path: str, target_dir: str) -> None:
+    """Download a cloud file or directory into ``target_dir``.
+
+    A cloud directory's contents land directly in ``target_dir``; a single
+    cloud file lands at ``target_dir/<basename>``. The download goes to a
+    sibling ``<target_dir>.tmp`` first and is atomically renamed so concurrent
+    readers never see a partial download.
+    """
+    temp_dir = target_dir + ".tmp"
+    if os.path.isdir(temp_dir):
+        shutil.rmtree(temp_dir)
+    os.makedirs(temp_dir, exist_ok=True)
+
+    if io.isdir(path):
+        io.download_directory(path, temp_dir)
+    else:
+        io.download_file(path, os.path.join(temp_dir, os.path.basename(path.rstrip("/"))))
+
+    if os.path.isdir(target_dir):
+        shutil.rmtree(target_dir)
+    os.makedirs(os.path.dirname(target_dir), exist_ok=True)
+    os.rename(temp_dir, target_dir)
+
+
+def materialize_remote_dataset(
+    path: str,
+    cache_dir: Optional[str] = None,
+    force_redownload: bool = False,
+) -> str:
+    """Return a *persistent* local copy of the dataset at ``path``.
+
+    Local paths pass through unchanged (after an existence check). Cloud paths
+    are downloaded into ``cache_dir`` (reused across runs), or into a
+    process-lifetime temporary directory when ``cache_dir`` is ``None``.
+
+    Use this when the resolved path outlives the caller -- e.g. the text
+    tokenization path, whose worker subprocesses re-open the dataset by path.
+    """
+    if not io.is_cloud_path(path):
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Dataset path does not exist: {path}")
+        return path
+
+    if cache_dir is not None:
+        local_dir = _cache_dir_for_path(cache_dir, path)
+        if os.path.isdir(local_dir) and not force_redownload:
+            logger.info(f"Using cached download of '{path}' at {local_dir}")
+        else:
+            logger.info(f"Downloading dataset '{path}' to {local_dir} ...")
+            _download_to(path, local_dir)
+        return local_dir
+
+    local_dir = os.path.join(tempfile.mkdtemp(prefix="skyrl_remote_dataset_"), "data")
+    logger.info(f"Downloading dataset '{path}' to temporary directory ...")
+    _download_to(path, local_dir)
+    return local_dir
+
+
+@contextmanager
+def materialize_local(path: str, cache_dir: Optional[str], force_redownload: bool) -> Iterator[str]:
+    """Yield a local path holding the dataset at ``path``.
+
+    Like :func:`materialize_remote_dataset`, but when ``cache_dir`` is ``None``
+    the temporary download is removed at context exit. Use this when the data
+    is fully consumed within the context (e.g. the pretokenized loader, which
+    materializes rows in memory).
+    """
+    if not io.is_cloud_path(path) or cache_dir is not None:
+        yield materialize_remote_dataset(path, cache_dir, force_redownload)
+        return
+
+    with tempfile.TemporaryDirectory(prefix="skyrl_remote_dataset_") as temp_dir:
+        local_dir = os.path.join(temp_dir, "data")
+        logger.info(f"Downloading dataset '{path}' to temporary directory ...")
+        _download_to(path, local_dir)
+        yield local_dir

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -53,6 +53,7 @@ from skyrl.train.config.sft_config import (
     build_skyrl_config_for_sft,
 )
 from skyrl.train.dataset.pretokenized import load_from_pretokenized
+from skyrl.train.dataset.remote_storage import materialize_remote_dataset
 from skyrl.train.generators.utils import (
     get_response_ids_and_loss_mask_from_messages,
 )
@@ -1043,7 +1044,10 @@ class SFTTrainer:
         - Set ``disable_cache=True`` to disable caching entirely.
 
         Args:
-            dataset_name: HuggingFace dataset name (e.g. ``"yahma/alpaca-cleaned"``).
+            dataset_name: HuggingFace dataset name (e.g. ``"yahma/alpaca-cleaned"``),
+                local path, or cloud URI (``s3://``, ``gs://``, ``gcs://``) of a
+                raw dataset directory. Cloud URIs are downloaded once and cached
+                under ``cache_dir``.
             dataset_split: Dataset split (e.g. ``"train[:100]"`` or ``"test"``).
 
         Returns a list of tokenized examples (dicts with ``input_ids``,
@@ -1076,6 +1080,17 @@ class SFTTrainer:
 
             logger.info("Cache miss or force_recache=True, tokenizing dataset...")
             logger.info(f"Cache key: {cache_key}")
+
+        # Cloud-hosted (s3://, gs://) raw datasets are materialized to a
+        # persistent local copy before loading -- persistent because the
+        # parallel tokenization workers re-open the dataset by path. The
+        # original URI (not the resolved local path) is the cache key above,
+        # so tokenization caches stay stable across nodes and runs.
+        dataset_name = materialize_remote_dataset(
+            dataset_name,
+            cache_dir=None if self.sft_cfg.disable_cache else self.sft_cfg.cache_dir,
+            force_redownload=self.sft_cfg.force_recache,
+        )
 
         logger.info(f"Loading dataset '{dataset_name}' split='{dataset_split}'...")
         dataset = load_dataset(dataset_name, split=dataset_split)
@@ -1249,7 +1264,12 @@ class SFTTrainer:
         if self.sft_cfg.pretokenized_dataset_paths:
             for path in self.sft_cfg.pretokenized_dataset_paths:
                 # The loader raises on 0 usable rows, so no empty-source check.
-                source = load_from_pretokenized(path, max_length=self.sft_cfg.max_length)
+                source = load_from_pretokenized(
+                    path,
+                    max_length=self.sft_cfg.max_length,
+                    cache_dir=None if self.sft_cfg.disable_cache else self.sft_cfg.cache_dir,
+                    force_redownload=self.sft_cfg.force_recache,
+                )
                 tokenized.extend(source)
                 dataset_lengths.append(len(source))
             if len(dataset_lengths) > 1:
@@ -1286,7 +1306,15 @@ class SFTTrainer:
         """
         if self.sft_cfg.eval_pretokenized_dataset_paths:
             return [
-                (name, load_from_pretokenized(path, max_length=self.sft_cfg.max_length))
+                (
+                    name,
+                    load_from_pretokenized(
+                        path,
+                        max_length=self.sft_cfg.max_length,
+                        cache_dir=None if self.sft_cfg.disable_cache else self.sft_cfg.cache_dir,
+                        force_redownload=self.sft_cfg.force_recache,
+                    ),
+                )
                 for name, path in zip(self.sft_cfg.eval_dataset_names, self.sft_cfg.eval_pretokenized_dataset_paths)
             ]
         if not self.sft_cfg.eval_datasets:

--- a/tests/train/test_sft_pretokenized.py
+++ b/tests/train/test_sft_pretokenized.py
@@ -12,8 +12,10 @@ import pytest
 import torch
 from datasets import Dataset
 
+from skyrl.backends.skyrl_train.utils.io import io
 from skyrl.train.config.sft_config import SFTConfig, validate_sft_cfg
 from skyrl.train.dataset.pretokenized import load_from_pretokenized
+from skyrl.train.dataset.remote_storage import materialize_remote_dataset
 from skyrl.train.sft_trainer import SFTTrainer, collate_sft_batch
 
 
@@ -373,6 +375,90 @@ def test_mixed_text_and_vlm_store_drops_null_image_columns(tmp_path):
     assert len(rows) == 3
     text_rows = [r for r in rows if "pixel_values" not in r]
     assert len(text_rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cloud (S3) paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_s3(tmp_path, monkeypatch):
+    """Route the io module's cloud calls at a local directory acting as S3."""
+    remote_dir = tmp_path / "remote"
+    remote_dir.mkdir()
+    Dataset.from_list(_rows()).to_parquet(str(remote_dir / "data.parquet"))
+    calls = {"downloads": 0}
+
+    def fake_isdir(path):
+        assert path.startswith("s3://")
+        return True
+
+    def fake_download_directory(path, local_path):
+        assert path.startswith("s3://")
+        calls["downloads"] += 1
+        shutil.copytree(remote_dir, local_path, dirs_exist_ok=True)
+
+    monkeypatch.setattr(io, "isdir", fake_isdir)
+    monkeypatch.setattr(io, "download_directory", fake_download_directory)
+    return calls
+
+
+def test_s3_path_download(tmp_path, fake_s3):
+    rows = load_from_pretokenized("s3://bucket/prefix/data", cache_dir=None)
+    assert len(rows) == 2
+    assert fake_s3["downloads"] == 1
+    _assert_normalized(rows)
+
+
+def test_s3_download_cached_across_calls(tmp_path, fake_s3):
+    cache_dir = str(tmp_path / "cache")
+    rows = load_from_pretokenized("s3://bucket/prefix/data", cache_dir=cache_dir)
+    assert len(rows) == 2
+    assert fake_s3["downloads"] == 1
+
+    # Second load reuses the cached download.
+    rows = load_from_pretokenized("s3://bucket/prefix/data", cache_dir=cache_dir)
+    assert len(rows) == 2
+    assert fake_s3["downloads"] == 1
+
+    # force_redownload bypasses the cache.
+    rows = load_from_pretokenized("s3://bucket/prefix/data", cache_dir=cache_dir, force_redownload=True)
+    assert len(rows) == 2
+    assert fake_s3["downloads"] == 2
+
+
+def test_s3_single_file_download(tmp_path, monkeypatch):
+    remote_file = tmp_path / "data.parquet"
+    Dataset.from_list(_rows()).to_parquet(str(remote_file))
+
+    monkeypatch.setattr(io, "isdir", lambda path: False)
+    monkeypatch.setattr(io, "download_file", lambda path, local: shutil.copy(remote_file, local))
+
+    rows = load_from_pretokenized("s3://bucket/data.parquet", cache_dir=None)
+    assert len(rows) == 2
+
+
+def test_materialize_remote_dataset_local_passthrough(tmp_path):
+    local = tmp_path / "data.parquet"
+    Dataset.from_list(_rows()).to_parquet(str(local))
+    assert materialize_remote_dataset(str(local)) == str(local)
+
+    with pytest.raises(FileNotFoundError):
+        materialize_remote_dataset(str(tmp_path / "missing"))
+
+
+def test_materialize_remote_dataset_downloads_and_caches(tmp_path, fake_s3):
+    cache_dir = str(tmp_path / "cache")
+    local_a = materialize_remote_dataset("s3://bucket/rawdata", cache_dir=cache_dir)
+    assert os.path.isdir(local_a)
+    assert fake_s3["downloads"] == 1
+
+    # Second resolution reuses the cached download; force bypasses it.
+    assert materialize_remote_dataset("s3://bucket/rawdata", cache_dir=cache_dir) == local_a
+    assert fake_s3["downloads"] == 1
+    materialize_remote_dataset("s3://bucket/rawdata", cache_dir=cache_dir, force_redownload=True)
+    assert fake_s3["downloads"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Follow-up to #1927 (now merged and rebased onto — this PR is a single commit on top of main), per review: cloud-path support was split out of the pretokenized PR so it can land once for *both* SFT data paths.

After this PR, `s3://`, `gs://`, and `gcs://` URIs are accepted by:

- `pretokenized_dataset_paths` / `eval_pretokenized_dataset_paths` (pretokenized stores), and
- `train_datasets` / `eval_datasets` (raw text-format datasets fed to online tokenization).

## How

New shared module `skyrl/train/dataset/remote_storage.py`, built on the existing fsspec io layer (`skyrl.backends.skyrl_train.utils.io`, with its S3 retry/credential-refresh handling):

- `materialize_local(...)` — context-managed download for the pretokenized loader (rows are materialized in memory inside the context, so an uncached temp download is cleaned up at context exit).
- `materialize_remote_dataset(...)` — persistent resolution for the text tokenization path: the parallel tokenization workers re-open the dataset by path, so the local copy must outlive the call. The **original URI** (not the resolved local path) remains the tokenization cache key, keeping caches stable across nodes/runs.
- Downloads cache under `cache_dir` keyed by remote path, with atomic tmp-dir-then-rename (NFS-safe for multi-node runs); `disable_cache` / `force_recache` are honored. Note the cache is keyed by remote path only — replacing a store's contents in place requires `force_recache=true` once.

## Testing

- CPU: S3 download/cache/force-redownload tests for the pretokenized path (monkeypatched io) plus unit tests for `materialize_remote_dataset` (local passthrough, missing-path error, cache reuse). 148 passed across the pretokenized + SFT config/dataloader suites.
- GPU e2e on 1×L4 (Qwen2.5-0.5B-Instruct, FSDP), covering **both** routes:
  - **Text-format dataset from S3** (raw alpaca JSONL; download → 8-worker online tokenization from the persistent local copy; eval from the same store via a split slice, with a download-cache hit on the second resolution): **https://wandb.ai/sky-posttraining-uc-berkeley/skyrl_sft/runs/si3o19i3**
  - Pretokenized stores from S3 — two stores concatenated + S3 eval store: https://wandb.ai/sky-posttraining-uc-berkeley/skyrl_sft/runs/gx6a6xny; single store, fresh download: https://wandb.ai/sky-posttraining-uc-berkeley/skyrl_sft/runs/cpsetz30
  - Loss parity: the S3-text run reproduces the pretokenized runs' curves at the same seed (step-5 train loss 1.0812 vs 1.0803–1.0840), i.e. online-tokenized-from-cloud and pretokenized ingestion train identically on the same data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)