### PR TITLE
Keep prewarmed inference alive after model unload

### DIFF
--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -706,6 +706,13 @@ class PPORayActorGroup:
             raise RuntimeError("Cannot determine data-parallel size before actor group initialization.")
         return self._last_dp_size
 
+    def shutdown(self) -> None:
+        """Terminate all workers in this training actor group."""
+        for actor in self._actor_handlers:
+            ray.kill(actor, no_restart=True)
+        self._actor_handlers = []
+        self.actor_infos = []
+
     def offload_to_cpu(self, nonblocking=False, offload_optimizer=True, offload_model=True):
         """Offload all worker state to CPU.
 

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -76,6 +76,13 @@ class WorkerDispatch:
         self._actor_groups[model] = actor_group
         self._gpu_state[model] = GPUState()
 
+    def shutdown(self) -> None:
+        """Stop training workers without affecting shared inference actors."""
+        for group in self._actor_groups.values():
+            group.shutdown()
+        self._actor_groups.clear()
+        self._gpu_state.clear()
+
     # ------------------------------------------------------------------
     # Multi-LoRA: per-model adapter swap orchestration.
     # ------------------------------------------------------------------

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -135,6 +135,7 @@ class SkyRLTrainBackend(AbstractBackend):
         self._tokenizer: AutoTokenizer = get_tokenizer(self.base_model)
         self._inference_engine_client = None
         self._inference_engines_initialized = False
+        self._keep_inference_warm = False
         self._renderer = None
         # CPU-only render server for multi-modal preprocessing; started
         # lazily on the first image-bearing training batch.
@@ -437,6 +438,7 @@ class SkyRLTrainBackend(AbstractBackend):
         """Start base-model inference before a Tinker adapter is created."""
         if self._inference_engines_initialized:
             return
+        self._keep_inference_warm = True
         self._cfg = _build_skyrl_train_config(self.base_model, self.config)
         if not ray.is_initialized():
             initialize_ray(self._cfg)
@@ -568,6 +570,20 @@ class SkyRLTrainBackend(AbstractBackend):
                 logger.info(f"Removed LoRA adapter '{model_id}'")
                 return
             # Fall through to teardown for non-LoRA roles or unexpected mixes.
+
+        if self._keep_inference_warm:
+            # A service-level prewarm owns the vLLM/router actors. A short-lived
+            # adapter must not tear them down when its client session ends.
+            self._dispatch.shutdown()
+            self._model_ids_to_role = {}
+            self._model_metadata = {}
+            self._cfg = None
+            self._dispatch = None
+            self._renderer = None
+            self._colocate_pg = None
+            self._base_lora_signature = None
+            logger.info(f"Deleted model {model_id}; kept prewarmed inference runtime")
+            return
 
         # Last model (or non-LoRA path): tear down the shared Ray runtime.
         # The Tinker engine will rebuild on the next create_model().

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -433,6 +433,17 @@ class SkyRLTrainBackend(AbstractBackend):
             self._render_server.shutdown()
             self._render_server = None
 
+    def prewarm_inference(self) -> None:
+        """Start base-model inference before a Tinker adapter is created."""
+        if self._inference_engines_initialized:
+            return
+        self._cfg = _build_skyrl_train_config(self.base_model, self.config)
+        if not ray.is_initialized():
+            initialize_ray(self._cfg)
+        self._colocate_pg = self._create_colocate_pg() if self._cfg.trainer.placement.colocate_all else None
+        self._create_new_inference_client()
+        self._inference_engines_initialized = True
+
     def _lora_signature_from(self, lora_config: types.LoraConfig) -> tuple:
         # Tinker's public LoraConfig only exposes rank + alpha (plus
         # seed/train_attn/train_mlp/train_unembed) - pending support https://github.com/NovaSky-AI/SkyRL/issues/1632.
@@ -501,6 +512,9 @@ class SkyRLTrainBackend(AbstractBackend):
 
             logger.info("Building models.")
             self._build_policy(PolicyWorker, model_id=model_id)
+            if self._inference_engines_initialized:
+                self._dispatch.set_inference_engine_client(self._inference_engine_client)
+                self.init_weight_sync_state()
             if is_lora:
                 self._base_lora_signature = self._lora_signature_from(lora_config)
         elif model_role == "critic":

--- a/skyrl/tinker/config.py
+++ b/skyrl/tinker/config.py
@@ -58,6 +58,10 @@ class EngineConfig(BaseModel):
         ),
         json_schema_extra={"argparse_type": lambda v: None if v == "None" else int(v)},
     )
+    prewarm_inference: bool = Field(
+        default=False,
+        description="Start the base inference engines before the first model is created.",
+    )
     session_cleanup_interval_sec: int = Field(
         default=60,
         description="How often to check for stale sessions (seconds). Set to -1 to disable cleanup.",

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -264,6 +264,8 @@ class TinkerEngine:
         # DB-free; only the engine owns the connection.
         if hasattr(self.backend, "set_inference_state_publisher"):
             self.backend.set_inference_state_publisher(self._write_inference_state_to_db)
+        if config.prewarm_inference:
+            self.backend.prewarm_inference()
 
         # Track last cleanup time for periodic stale session cleanup
         self._last_cleanup_time: float = time.time()

--- a/tests/tinker/skyrl_train/test_prewarm_lifecycle.py
+++ b/tests/tinker/skyrl_train/test_prewarm_lifecycle.py
@@ -1,0 +1,36 @@
+"""Regression coverage for retaining service-owned inference after model unload."""
+
+import pytest
+
+backend_module = pytest.importorskip("skyrl.backends.skyrl_train_backend")
+
+
+def test_delete_model_keeps_prewarmed_inference():
+    backend = object.__new__(backend_module.SkyRLTrainBackend)
+
+    class Dispatch:
+        stopped = False
+
+        def shutdown(self):
+            self.stopped = True
+
+    dispatch = Dispatch()
+    backend._model_ids_to_role = {"model": "policy"}
+    backend._model_metadata = {"model": object()}
+    backend._keep_inference_warm = True
+    backend._dispatch = dispatch
+    backend._cfg = object()
+    backend._renderer = None
+    backend._colocate_pg = object()
+    backend._base_lora_signature = (8, 16)
+    backend._inference_engine_client = object()
+    backend._inference_engines_initialized = True
+    backend._server_groups = []
+    backend._inference_router = None
+
+    backend.delete_model("model")
+
+    assert dispatch.stopped
+    assert backend._model_ids_to_role == {}
+    assert backend._inference_engines_initialized
+    assert backend._inference_engine_client is not None

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -16,6 +16,22 @@ from skyrl.tinker.engine import (
 BASE_MODEL = "trl-internal-testing/tiny-Qwen3ForCausalLM"
 
 
+def test_prewarm_inference_is_opt_in(monkeypatch: pytest.MonkeyPatch):
+    class Backend:
+        def __init__(self, *_args):
+            self.prewarmed = False
+
+        def set_inference_state_publisher(self, _publisher):
+            pass
+
+        def prewarm_inference(self):
+            self.prewarmed = True
+
+    monkeypatch.setattr("skyrl.tinker.engine.get_backend_classes", lambda *_: (Backend, dict))
+    engine = TinkerEngine(EngineConfig(base_model=BASE_MODEL, prewarm_inference=True))
+    assert engine.backend.prewarmed
+
+
 def test_process_unload_model():
     """Test that process_unload_model removes model from backend."""
     config = EngineConfig(


### PR DESCRIPTION
## Summary
- Start base inference during Tinker service startup when `--prewarm-inference` is enabled.
- On temporary model unload, stop only that model's training workers while retaining the service-owned vLLM/router runtime.
- Preserve existing full teardown behavior for services that were not prewarmed.

## Testing
```bash
python -m py_compile skyrl/backends/skyrl_train_backend.py skyrl/backends/skyrl_train/workers/worker.py skyrl/backends/skyrl_train/workers/worker_dispatch.py
git diff --check HEAD^ HEAD
```
Both passed. The focused pytest requires the SkyRL CUDA environment, which is not installed in this worktree.