### PR TITLE
[fix[ Fix `test_megatron_correctness::TestWeightSyncPauseFlush` after #1934

### DIFF
--- a/tests/backends/skyrl_train/distributed/test_megatron_correctness.py
+++ b/tests/backends/skyrl_train/distributed/test_megatron_correctness.py
@@ -23,7 +23,8 @@ def _fft_dispatch_cfg() -> SimpleNamespace:
                 model=SimpleNamespace(lora=SimpleNamespace(rank=0)),
                 megatron_config=SimpleNamespace(lora_config=SimpleNamespace(merge_lora=False)),
             ),
-        )
+        ),
+        generator=SimpleNamespace(inference_engine=SimpleNamespace(offload_kv_for_weight_sync=False)),
     )
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes failing CPU tests after #1934 

#1934  introduced a new `generator.inference_engine.offload_kv_for_weight_sync` flag that is used in `WorkerDispatch.save_weights_for_sampler`. We need to add this field to the mocked cfg object used in `tests/backends/skyrl_train/distributed/test_megatron_correctness::TestWeightSyncPauseFlush`