### PR TITLE
Add Qwen3.6-27B DAPO LoRA launcher

### DIFF
--- a/examples/train/megatron/run_megatron_dapo_qwen3.6_27b_lora.sh
+++ b/examples/train/megatron/run_megatron_dapo_qwen3.6_27b_lora.sh
@@ -1,0 +1,135 @@
+set -x
+
+# Colocated DAPO training+generation for dense Qwen3.6-27B on DAPO with Megatron.
+# Runs on 4 nodes of 8xH200s.
+#
+# bash examples/train/algorithms/dapo/prepare_dapo_data.sh
+# bash examples/train/megatron/run_megatron_dapo_qwen3.6_27b_lora.sh
+
+MODEL_NAME="Qwen/Qwen3.6-27B"
+DATA_DIR="${DATA_DIR:-$HOME/data/dapo}"
+TRAIN_FILE="$DATA_DIR/dapo-math-17k-cleaned.parquet"
+TEST_FILE_2024="$DATA_DIR/aime-2024-eval.parquet"
+TEST_FILE_2026="$DATA_DIR/aime-2026-eval.parquet"
+NUM_NODES=4
+NUM_GPUS_PER_NODE=8
+NUM_INFERENCE_ENGINES=8
+INFERENCE_ENGINE_TENSOR_PARALLEL_SIZE=4
+LOGGER="${LOGGER:-wandb}"
+
+CLIP_RATIO_LOW=0.2
+CLIP_RATIO_HIGH=0.28
+LOSS_REDUCTION="token_mean"
+APPLY_OVERLONG_FILTERING=true
+OVERLONG_BUFFER_LEN=$((1024 * 4))
+OVERLONG_BUFFER_PENALTY_FACTOR=1.0
+
+USE_KL_LOSS=false
+TEMPERATURE=1.0
+TOP_P=1.0
+EVAL_TOP_P=0.7
+CLIP_RATIO_C=10.0
+MAX_PROMPT_LENGTH="${MAX_PROMPT_LENGTH:-$((1024 * 2))}"
+MAX_RESPONSE_LENGTH="${MAX_RESPONSE_LENGTH:-$((1024 * 8))}"
+
+TRAIN_BATCH_SIZE="${TRAIN_BATCH_SIZE:-128}"
+MINI_BATCH_SIZE="${MINI_BATCH_SIZE:-32}"
+N_SAMPLES_PER_PROMPT="${N_SAMPLES_PER_PROMPT:-16}"
+EVAL_N_SAMPLES_PER_PROMPT="${EVAL_N_SAMPLES_PER_PROMPT:-32}"
+ENFORCE_EAGER="${ENFORCE_EAGER:-false}"
+LR=1e-5
+
+LORA_RANK=32
+LORA_ALPHA=32
+
+MEGATRON_TP=4
+MEGATRON_PP=1
+MEGATRON_CP=1
+
+TIS_IMP_RATIO_CAP=2.0
+TIS_TYPE=token
+
+OPTIMIZER_OFFLOAD=true
+OPTIMIZER_OFFLOAD_FRACTION=1.0
+
+LANGUAGE_MODEL_ONLY=True
+ENGINE_INIT_KWARGS='{"gdn_prefill_backend": "triton", "disable_custom_all_reduce": true, "compilation_config": {"cudagraph_mode": "FULL_DECODE_ONLY"}}'
+DISTRIBUTED_EXECUTOR_BACKEND="mp"
+REMOVE_MICROBATCH_PADDING="${REMOVE_MICROBATCH_PADDING:-true}"
+RUN_NAME="${RUN_NAME:-dapo_lora_r32_qwen3_6_27b_base_megatron_tp${MEGATRON_TP}_pp${MEGATRON_PP}_cp${MEGATRON_CP}}"
+export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
+
+uv run --extra megatron -m examples.train.algorithms.dapo.main_dapo \
+  data.train_data="['$TRAIN_FILE']" \
+  data.val_data="['$TEST_FILE_2024', '$TEST_FILE_2026']" \
+  trainer.algorithm.advantage_estimator="grpo" \
+  trainer.algorithm.policy_loss_type="dual_clip" \
+  trainer.algorithm.overlong_buffer_len=$OVERLONG_BUFFER_LEN \
+  trainer.algorithm.overlong_buffer_penalty_factor=$OVERLONG_BUFFER_PENALTY_FACTOR \
+  trainer.algorithm.loss_reduction=$LOSS_REDUCTION \
+  generator.inference_engine.enforce_eager=$ENFORCE_EAGER \
+  generator.apply_overlong_filtering=$APPLY_OVERLONG_FILTERING \
+  generator.sampling_params.temperature=$TEMPERATURE \
+  generator.sampling_params.top_p=$TOP_P \
+  generator.eval_sampling_params.top_p=$EVAL_TOP_P \
+  generator.eval_sampling_params.temperature=$TEMPERATURE \
+  generator.eval_sampling_params.max_generate_length=$MAX_RESPONSE_LENGTH \
+  trainer.algorithm.use_kl_loss=$USE_KL_LOSS \
+  trainer.algorithm.clip_ratio_c=$CLIP_RATIO_C \
+  trainer.policy.model.path="$MODEL_NAME" \
+  trainer.policy.language_model_only=$LANGUAGE_MODEL_ONLY \
+  generator.inference_engine.language_model_only=$LANGUAGE_MODEL_ONLY \
+  trainer.placement.colocate_all=true \
+  trainer.strategy=megatron \
+  generator.inference_engine.distributed_executor_backend=$DISTRIBUTED_EXECUTOR_BACKEND \
+  trainer.placement.policy_num_nodes=$NUM_NODES \
+  trainer.placement.policy_num_gpus_per_node=$NUM_GPUS_PER_NODE \
+  generator.inference_engine.engine_init_kwargs="$ENGINE_INIT_KWARGS" \
+  generator.inference_engine.num_engines=$NUM_INFERENCE_ENGINES \
+  generator.inference_engine.tensor_parallel_size=$INFERENCE_ENGINE_TENSOR_PARALLEL_SIZE \
+  trainer.policy.megatron_config.tensor_model_parallel_size=$MEGATRON_TP \
+  trainer.policy.megatron_config.pipeline_model_parallel_size=$MEGATRON_PP \
+  trainer.policy.megatron_config.context_parallel_size=$MEGATRON_CP \
+  trainer.policy.model.lora.rank=$LORA_RANK \
+  trainer.policy.model.lora.alpha=$LORA_ALPHA \
+  trainer.policy.megatron_config.optimizer_config_kwargs.overlap_cpu_optimizer_d2h_h2d=$OPTIMIZER_OFFLOAD \
+  trainer.policy.megatron_config.optimizer_config_kwargs.use_precision_aware_optimizer=$OPTIMIZER_OFFLOAD \
+  trainer.policy.megatron_config.optimizer_config_kwargs.optimizer_cpu_offload=$OPTIMIZER_OFFLOAD \
+  trainer.policy.megatron_config.optimizer_config_kwargs.optimizer_offload_fraction=$OPTIMIZER_OFFLOAD_FRACTION \
+  trainer.algorithm.off_policy_correction.tis_ratio_type=$TIS_TYPE \
+  trainer.algorithm.off_policy_correction.token_tis_ratio_clip_high=$TIS_IMP_RATIO_CAP \
+  trainer.remove_microbatch_padding=$REMOVE_MICROBATCH_PADDING \
+  trainer.epochs=20 \
+  trainer.algorithm.eps_clip_low=$CLIP_RATIO_LOW \
+  trainer.algorithm.eps_clip_high=$CLIP_RATIO_HIGH \
+  trainer.eval_batch_size=1024 \
+  trainer.eval_before_train=false \
+  trainer.eval_interval=5 \
+  trainer.update_epochs_per_batch=1 \
+  trainer.train_batch_size=$TRAIN_BATCH_SIZE \
+  trainer.policy_mini_batch_size=$MINI_BATCH_SIZE \
+  trainer.micro_forward_batch_size_per_gpu=1 \
+  trainer.micro_train_batch_size_per_gpu=1 \
+  trainer.max_tokens_per_microbatch=-1 \
+  trainer.max_training_steps=100 \
+  trainer.ckpt_interval=0 \
+  trainer.max_prompt_length=$MAX_PROMPT_LENGTH \
+  generator.sampling_params.max_generate_length=$MAX_RESPONSE_LENGTH \
+  trainer.policy.optimizer_config.lr=$LR \
+  trainer.policy.optimizer_config.num_warmup_steps=40 \
+  trainer.policy.optimizer_config.weight_decay=0.1 \
+  trainer.policy.optimizer_config.max_grad_norm=1.0 \
+  generator.inference_engine.backend=vllm \
+  generator.inference_engine.run_engines_locally=true \
+  generator.inference_engine.weight_sync_backend=nccl \
+  generator.batched=true \
+  environment.env_class=aime \
+  generator.n_samples_per_prompt=$N_SAMPLES_PER_PROMPT \
+  generator.eval_n_samples_per_prompt=$EVAL_N_SAMPLES_PER_PROMPT \
+  generator.inference_engine.gpu_memory_utilization=0.7 \
+  trainer.logger="$LOGGER" \
+  trainer.project_name="qwen3_6_dapo_lora" \
+  trainer.run_name="$RUN_NAME" \
+  trainer.hf_save_interval=0 \
+  trainer.resume_mode=none \
+  "$@"

--- a/examples/train/megatron/run_megatron_dapo_qwen3.6_27b_lora.sh
+++ b/examples/train/megatron/run_megatron_dapo_qwen3.6_27b_lora.sh
@@ -1,4 +1,5 @@
-set -x
+set -ex
+set -o pipefail
 
 # Colocated DAPO training+generation for dense Qwen3.6-27B on DAPO with Megatron.
 # Runs on 4 nodes of 8xH200s.

--- a/examples/train/megatron/run_megatron_dapo_qwen3.6_27b_lora.sh
+++ b/examples/train/megatron/run_megatron_dapo_qwen3.6_27b_lora.sh
@@ -53,7 +53,7 @@ TIS_TYPE=token
 OPTIMIZER_OFFLOAD=true
 OPTIMIZER_OFFLOAD_FRACTION=1.0
 
-LANGUAGE_MODEL_ONLY=True
+LANGUAGE_MODEL_ONLY=true
 ENGINE_INIT_KWARGS='{"gdn_prefill_backend": "triton", "disable_custom_all_reduce": true, "compilation_config": {"cudagraph_mode": "FULL_DECODE_ONLY"}}'
 DISTRIBUTED_EXECUTOR_BACKEND="mp"
 REMOVE_MICROBATCH_PADDING="${REMOVE_MICROBATCH_PADDING:-true}"


### PR DESCRIPTION
- Add a native Megatron + local vLLM DAPO launcher for dense `Qwen/Qwen3.6-27B` with rank-32 LoRA on 4×8 H200s.
- Preserve the validated workload: batch 128, group size 16, 8,192-token responses, TP4, eight inference engines, AIME 2024/2026 evals, and no checkpoint writes.
- The LoRA path completed 17 consecutive training steps and entered step 18 without a training failure. The [W&B report](https://wandb.ai/trajectory-ai/qwen3_6_dapo_lora/reports/Qwen3.6-27B-SkyRL-DAPO-LoRA-%E2%80%94-reward-and-AIME-curves--VmlldzoxNzU3NjY5OA==) 

## Testing

```bash
bash -n examples/train/megatron/run_megatron_dapo_qwen3.6_27b_lora.sh
git diff --check
```

The launcher passed shell syntax and whitespace checks; the linked 4-node run validates the native LoRA training path end to end.
