### PR TITLE
[ci] Pin ruff to 0.11.9 in lint step to match pre-commit

### DIFF
--- a/.github/workflows/cpu_skyrl.yaml
+++ b/.github/workflows/cpu_skyrl.yaml
@@ -41,7 +41,9 @@ jobs:
         curl -LsSf https://astral.sh/uv/install.sh | sh
     - name: Run lint
       run: |
-        uvx ruff check
+        # Pin to match the ruff rev in .pre-commit-config.yaml. Unpinned `uvx ruff`
+        # picks up ruff's expanded default rule set in newer releases and fails CI.
+        uvx ruff@0.11.9 check
     - name: Run pytest
       run: |
         uv run --extra tinker --extra jax --extra dev --with transformers==5.2.0 pytest --forked -s tests/tx/models/test_qwen3_5.py


### PR DESCRIPTION
The lint step used unpinned `uvx ruff check`, which picks up ruff's expanded default rule set in newer releases (0.16.0 enables ~414 rules vs ~60 in 0.11.9) and fails CI. Pin to 0.11.9 to match the rev in .pre-commit-config.yaml so CI and local pre-commit stay consistent.