### PR TITLE
docs: note experimental Fystash Harbor environment.type

### DIFF
--- a/docs/content/docs/harbor/index.mdx
+++ b/docs/content/docs/harbor/index.mdx
@@ -17,6 +17,8 @@ export WANDB_API_KEY=your_wandb_api_key
 export DAYTONA_API_KEY=your_daytona_api_key
 # export MODAL_TOKEN_ID=your_modal_token_id
 # export MODAL_TOKEN_SECRET=your_modal_token_secret
+# export FYSTASH_API_KEY=your_fystash_api_key   # experimental; needs Harbor --env fystash
+# export FYSTASH_API=https://api.fystash.ai
 
 # 2. Prepare datasets (downloads from HuggingFace, extracts tasks to ~/data/harbor/)
 uv run examples/train_integrations/harbor/prepare_harbor_dataset.py \
@@ -257,7 +259,7 @@ agent:
 | `generator.apply_overlong_filtering` | SkyRL config | When `true`, zero out loss mask for context-length-exceeded trajectories (default: `false`) |
 | `trainer.algorithm.advantage_estimator` | SkyRL config | Advantage method: `grpo`, `rloo`, `reinforce_pp`, etc. |
 | `trainer.train_batch_size` | SkyRL config | Number of unique prompts per training batch |
-| `environment.type` | Harbor config | Sandbox provider: `daytona`, `docker`, `modal`, `e2b`, `gke` |
+| `environment.type` | Harbor config | Sandbox provider: `daytona`, `docker`, `modal`, `e2b`, `gke`, `fystash` (experimental; requires Harbor with Fystash support) |
 | `generator.rate_limit.max_concurrency` | Launch script | Parallel trial cap; tune based on sandbox provider capacity |
 | `generator.rate_limit.trajectories_per_second` | Launch script | Submission rate; prevents overloading the sandbox provider |
 | `timeout_multiplier` | Harbor config | Scales all default timeouts; increase for harder tasks |
@@ -266,12 +268,13 @@ agent:
 
 ```yaml
 environment:
-  type: daytona                       # Sandbox provider
+  type: daytona                       # Sandbox provider (also: docker, modal, e2b, gke, fystash)
   override_cpus: 1
   override_memory_mb: 1024
   kwargs:
     auto_stop_interval_mins: 30       # Daytona-specific: minutes of inactivity before sandbox auto-stops
     # sandbox_timeout_secs: 1800      # Modal-specific: sandbox timeout
+    # Fystash uses FYSTASH_API_KEY / FYSTASH_TEMPLATE_ID from the environment (no Daytona kwargs)
 
 verifier:
   disable: false                      # Set to true to skip verification (debugging)
@@ -356,7 +359,7 @@ You must run `prepare_harbor_dataset.py` before launching training. The launch s
 
 ### Prerequisites
 
-- **Sandbox access**: Daytona API key (`DAYTONA_API_KEY`) or Modal credentials (`MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`), or other sandbox providers that Harbor supports.
+- **Sandbox access**: Daytona API key (`DAYTONA_API_KEY`), Modal credentials (`MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`), Fystash (`FYSTASH_API_KEY`, experimental — requires Harbor `--env fystash`; see [harbor#2491](https://github.com/harbor-framework/harbor/pull/2491) and [docs.fystash.ai/guides/skyrl](https://docs.fystash.ai/guides/skyrl)), or other Harbor-supported providers.
 - **Dataset**: Harbor task directories, each with `instruction.md` and `tests/test.sh`
 - **GPUs**: Typically 4-8 for combined training and inference
 - **SkyRL inference server**: SkyRL launches the vLLM HTTP endpoint and router from `generator.inference_engine.*`.
@@ -383,6 +386,7 @@ uv run --isolated --extra fsdp --extra harbor \
   generator.inference_engine.served_model_name=Qwen3-8B \
   harbor_trial_config.trials_dir=$TRIALS_DIR \
   harbor_trial_config.environment.type=daytona \
+  # harbor_trial_config.environment.type=fystash \  # experimental; Harbor Fystash + FYSTASH_API_KEY
   trainer.algorithm.max_seq_len=32768 \
   generator.apply_overlong_filtering=true \
   generator.n_samples_per_prompt=8 \

--- a/docs/content/docs/harbor/index.mdx
+++ b/docs/content/docs/harbor/index.mdx
@@ -18,6 +18,7 @@ export DAYTONA_API_KEY=your_daytona_api_key
 # export MODAL_TOKEN_ID=your_modal_token_id
 # export MODAL_TOKEN_SECRET=your_modal_token_secret
 # export FYSTASH_API_KEY=your_fystash_api_key   # experimental; needs Harbor --env fystash
+# export FYSTASH_TEMPLATE_ID=default             # optional; docker for Dockerfile-heavy tasks
 # export FYSTASH_API=https://api.fystash.ai
 
 # 2. Prepare datasets (downloads from HuggingFace, extracts tasks to ~/data/harbor/)
@@ -386,7 +387,6 @@ uv run --isolated --extra fsdp --extra harbor \
   generator.inference_engine.served_model_name=Qwen3-8B \
   harbor_trial_config.trials_dir=$TRIALS_DIR \
   harbor_trial_config.environment.type=daytona \
-  # harbor_trial_config.environment.type=fystash \  # experimental; Harbor Fystash + FYSTASH_API_KEY
   trainer.algorithm.max_seq_len=32768 \
   generator.apply_overlong_filtering=true \
   generator.n_samples_per_prompt=8 \
@@ -395,6 +395,12 @@ uv run --isolated --extra fsdp --extra harbor \
   generator.rate_limit.enabled=true \
   generator.rate_limit.trajectories_per_second=5 \
   generator.rate_limit.max_concurrency=512
+```
+
+For experimental Fystash sandboxes (requires Harbor `--env fystash` + `FYSTASH_API_KEY`), swap the environment type:
+
+```bash
+  harbor_trial_config.environment.type=fystash \
 ```
 
 ### Metrics

--- a/examples/train_integrations/harbor/harbor_trial_config/default.yaml
+++ b/examples/train_integrations/harbor/harbor_trial_config/default.yaml
@@ -78,7 +78,7 @@ agent:
 # Environment configuration
 # See: harbor.models.trial.config.EnvironmentConfig
 environment:
-  # Environment type. Options: daytona, docker, e2b, modal, runloop, gke
+  # Environment type. Options: daytona, docker, e2b, modal, runloop, gke, fystash (experimental)
   type: daytona
 
   # Resource overrides (optional)


### PR DESCRIPTION
## Summary

- Documents experimental `harbor_trial_config.environment.type=fystash` on the Harbor integration page (credentials + config table + launch comment).
- Notes Fystash in the default Harbor trial config option list comment.
- Depends on Harbor shipping `--env fystash` ([harbor#2491](https://github.com/harbor-framework/harbor/pull/2491)); SkyRL’s pinned Harbor rev may also need a bump after that merge.
- How-to: https://docs.fystash.ai/guides/skyrl

Docs-only — no SkyRL generator or Harbor pin change in this PR.

## Test plan

- [ ] Harbor docs page renders
- [ ] `environment.type` table lists `fystash` as experimental
- [ ] Quick-start credentials show commented `FYSTASH_API_KEY`


Made with [Cursor](https://cursor.com)