### PR TITLE
[feat][tinker] Honor trainer.algorithm.loss_reduction on the Tinker-serving path

### DIFF
--- a/skyrl/backends/skyrl_train/utils/ppo_utils.py
+++ b/skyrl/backends/skyrl_train/utils/ppo_utils.py
@@ -1163,7 +1163,7 @@ def apply_loss_reduction_to_advantages_minibatch(
             For step-wise training, minibatch_size can be variable.
         loss_mask: Mask of shape (minibatch_size, seq_len) indicating valid loss tokens.
         loss_reduction: One of "token_mean", "token_mean_legacy", "sequence_mean",
-            "seq_mean_token_sum_norm", "prompt_mean".
+            "seq_mean_token_sum_norm", "prompt_mean", "token_sum".
         micro_batch_size: Number of sequences per micro-batch
         max_seq_len: Maximum sequence length.
         prompt_boundaries: Mini-batch-relative (start, end) slices grouping the sequences of
@@ -1175,8 +1175,14 @@ def apply_loss_reduction_to_advantages_minibatch(
     batch_size = advantages.shape[0]
     normalized_advantages = torch.zeros_like(advantages)
 
+    # Option 0: raw token sum (identity). The default on the Tinker-serving
+    # path, where the API contract is that per-token losses are summed and
+    # clients pre-normalize advantages themselves.
+    if loss_reduction == "token_sum":
+        normalized_advantages = advantages
+
     # Option 1: token mean
-    if loss_reduction == "token_mean":
+    elif loss_reduction == "token_mean":
         normalized_advantages = advantages / loss_mask.sum().clamp(min=1)
 
     # Option 1b: legacy token-mean that normalizes per-microbatch then averages across microbatches.

--- a/skyrl/backends/skyrl_train/utils/ppo_utils.py
+++ b/skyrl/backends/skyrl_train/utils/ppo_utils.py
@@ -1179,7 +1179,7 @@ def apply_loss_reduction_to_advantages_minibatch(
     # path, where the API contract is that per-token losses are summed and
     # clients pre-normalize advantages themselves.
     if loss_reduction == "token_sum":
-        normalized_advantages = advantages
+        return advantages
 
     # Option 1: token mean
     elif loss_reduction == "token_mean":

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -103,6 +103,13 @@ def _build_skyrl_train_config(
     user_overrides.setdefault("trainer.algorithm.loss_reduction", "token_sum")
     cfg = SkyRLTrainConfig.from_cli_overrides(user_overrides)
 
+    valid_reductions = {"token_mean", "sequence_mean", "seq_mean_token_sum_norm", "token_sum"}
+    if cfg.trainer.algorithm.loss_reduction not in valid_reductions:
+        raise ValueError(
+            f"Invalid or unsupported loss_reduction: {cfg.trainer.algorithm.loss_reduction}. "
+            f"Must be one of {sorted(valid_reductions)} on the Tinker-serving path."
+        )
+
     if cfg.trainer.algorithm.loss_reduction == "seq_mean_token_sum_norm" and cfg.trainer.algorithm.max_seq_len is None:
         # Mirror `validate_cfg`; the Tinker-serving path never calls it.
         raise ValueError(

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -26,6 +26,9 @@ from skyrl.backends.skyrl_train.training_batch import (
     TrainingInputBatch,
     pad_training_input_batch,
 )
+from skyrl.backends.skyrl_train.utils.ppo_utils import (
+    apply_loss_reduction_to_advantages_minibatch,
+)
 from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
 from skyrl.backends.skyrl_train.workers.worker_dispatch import WorkerDispatch
 from skyrl.backends.skyrl_train.workers.worker_utils import (
@@ -91,7 +94,23 @@ def _build_skyrl_train_config(
         "megatron",
     ), f"Only fsdp and megatron are supported for SkyRL-Train backend, got {overrides.strategy!r}"
     user_overrides["trainer.strategy"] = overrides.strategy
+    # The Tinker-serving path has historically *summed* per-token losses with
+    # no reduction: SkyRL-Train applies `loss_reduction` to advantages in its
+    # native RL loop (trainer.py), which the Tinker API bypasses. Default to
+    # the explicit no-op so existing behavior is preserved; an explicit
+    # `trainer.algorithm.loss_reduction` in --backend-config is honored when
+    # the batch is built (see `_to_training_batch`).
+    user_overrides.setdefault("trainer.algorithm.loss_reduction", "token_sum")
     cfg = SkyRLTrainConfig.from_cli_overrides(user_overrides)
+
+    if cfg.trainer.algorithm.loss_reduction == "seq_mean_token_sum_norm" and cfg.trainer.algorithm.max_seq_len is None:
+        # Mirror `validate_cfg`; the Tinker-serving path never calls it.
+        raise ValueError(
+            "`trainer.algorithm.max_seq_len` must be set explicitly when "
+            "`trainer.algorithm.loss_reduction='seq_mean_token_sum_norm'`. "
+            "Choose the total sequence-length normalization constant for your setup; "
+            "this often matches the model context window / vLLM `max_model_len` when appropriate."
+        )
 
     # Disable scheduler - Tinker manages learning rate externally via set_lr()
     cfg.trainer.policy.optimizer_config.scheduler = "constant_with_warmup"
@@ -109,6 +128,40 @@ def _build_skyrl_train_config(
 
     logger.info("SkyRL-Train config:\n%s", get_config_as_yaml_str(cfg))
     return cfg
+
+
+def _apply_tinker_loss_reduction(
+    advantages: torch.Tensor,
+    loss_mask: torch.Tensor,
+    loss_reduction: str,
+    micro_batch_size: int,
+    max_seq_len: int | None,
+) -> torch.Tensor:
+    """Scale Tinker-client advantages per ``trainer.algorithm.loss_reduction``.
+
+    The Tinker API contract is that the trainer *sums* per-token losses, so
+    clients pre-normalize advantages (see ``examples/tinker/ppo/ppo_client.py``).
+    SkyRL-Train expresses that normalization as ``loss_reduction`` and applies
+    it to advantages in its native RL loop — which the Tinker-serving path
+    bypasses. Honor the same config key here so setting
+    ``trainer.algorithm.loss_reduction`` via ``--backend-config`` takes effect
+    for Tinker clients too. ``token_sum`` (the serving default) is the identity.
+    """
+    if loss_reduction == "token_sum":
+        return advantages
+    if loss_reduction == "prompt_mean":
+        raise ValueError(
+            "`prompt_mean` loss reduction is not supported on the Tinker-serving path: "
+            "prompt groupings are not visible to the trainer. Use `token_mean`, "
+            "`sequence_mean`, or `seq_mean_token_sum_norm`."
+        )
+    return apply_loss_reduction_to_advantages_minibatch(
+        advantages=advantages,
+        loss_mask=loss_mask,
+        loss_reduction=loss_reduction,
+        micro_batch_size=micro_batch_size,
+        max_seq_len=max_seq_len,
+    )
 
 
 class SkyRLTrainBackend(AbstractBackend):
@@ -663,7 +716,20 @@ class SkyRLTrainBackend(AbstractBackend):
             # configured (rollout logprobs are its intended input).
             batch_dict["rollout_logprobs"] = action_log_probs_tensor
         if has_advantages:
-            batch_dict["advantages"] = torch.tensor(advantages_list, dtype=torch.float32)
+            advantages_tensor = torch.tensor(advantages_list, dtype=torch.float32)
+            if role != "critic":
+                # Honor trainer.algorithm.loss_reduction on the Tinker-serving
+                # path; "token_sum" (the default) leaves advantages untouched.
+                # Applied before `_pad_batch`, whose zero-masked pad rows would
+                # not change the normalization but are cheaper to exclude.
+                advantages_tensor = _apply_tinker_loss_reduction(
+                    advantages_tensor,
+                    loss_mask_tensor,
+                    loss_reduction=self._cfg.trainer.algorithm.loss_reduction,
+                    micro_batch_size=self._cfg.trainer.micro_train_batch_size_per_gpu,
+                    max_seq_len=self._cfg.trainer.algorithm.max_seq_len,
+                )
+            batch_dict["advantages"] = advantages_tensor
         if role == "critic":
             if has_values != has_returns:
                 raise ValueError("Critic batches must provide both values and returns, or neither")

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -149,10 +149,10 @@ def _apply_tinker_loss_reduction(
     """
     if loss_reduction == "token_sum":
         return advantages
-    if loss_reduction == "prompt_mean":
+    if loss_reduction in ("prompt_mean", "token_mean_legacy"):
         raise ValueError(
-            "`prompt_mean` loss reduction is not supported on the Tinker-serving path: "
-            "prompt groupings are not visible to the trainer. Use `token_mean`, "
+            f"`{loss_reduction}` loss reduction is not supported on the Tinker-serving path: "
+            "it is incompatible with dynamic client-side batch sizes. Use `token_mean`, "
             "`sequence_mean`, or `seq_mean_token_sum_norm`."
         )
     return apply_loss_reduction_to_advantages_minibatch(

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -646,7 +646,7 @@ class AlgorithmConfig(BaseConfig):
     policy_loss_type: str = "regular"
     """``"regular"``, ``"dual_clip"``, ``"gspo"``, ``"clip_cov"``, ``"kl_cov"``, ``cispo``, ``sapo``, ``"rollout_is"``, ``"dppo"``, or custom via ``PolicyLossRegistry``."""
     loss_reduction: str = "token_mean"
-    """``"token_mean"``, ``"sequence_mean"``, ``"prompt_mean"``, or ``"seq_mean_token_sum_norm"``. ``max_seq_len`` must be set explicitly for ``"seq_mean_token_sum_norm"``."""
+    """``"token_mean"``, ``"sequence_mean"``, ``"prompt_mean"``, ``"seq_mean_token_sum_norm"``, or ``"token_sum"`` (identity; the default on the Tinker-serving path, which sums per-token losses and expects pre-normalized advantages). ``max_seq_len`` must be set explicitly for ``"seq_mean_token_sum_norm"``."""
     grpo_norm_by_std: bool = True
     zero_variance_filter: bool = False
     """Loss-mask prompts with zero-variance rewards. Only applicable when rewards are response-level."""

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -370,10 +370,11 @@ def validate_cfg(cfg: SkyRLTrainConfig):
         "sequence_mean",
         "seq_mean_token_sum_norm",
         "prompt_mean",
+        "token_sum",
     ), (
         f"invalid loss_reduction: {cfg.trainer.algorithm.loss_reduction}. "
         f"Must be one of `['token_mean', 'token_mean_legacy', 'sequence_mean', "
-        f"'seq_mean_token_sum_norm', 'prompt_mean']`"
+        f"'seq_mean_token_sum_norm', 'prompt_mean', 'token_sum']`"
     )
     if cfg.trainer.algorithm.loss_reduction == "seq_mean_token_sum_norm":
         if cfg.trainer.algorithm.max_seq_len is None:

--- a/tests/backends/skyrl_train/utils/test_ppo_utils.py
+++ b/tests/backends/skyrl_train/utils/test_ppo_utils.py
@@ -614,6 +614,21 @@ def test_registry_reset_after_ray_shutdown():
 class TestApplyLossReductionToAdvantagesMinibatch:
     """Tests for apply_loss_reduction_to_advantages_minibatch."""
 
+    def test_token_sum_is_identity(self):
+        """Token sum: raw sum with no normalization (Tinker-serving default)."""
+        advantages = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        loss_mask = torch.tensor([[1.0, 1.0], [1.0, 0.0]])
+        scaled = apply_loss_reduction_to_advantages_minibatch(
+            advantages=advantages,
+            loss_mask=loss_mask,
+            loss_reduction="token_sum",
+            micro_batch_size=1,
+            max_seq_len=2,
+        )
+        assert torch.equal(scaled, advantages)
+        loss = reduce_loss(scaled, loss_mask)
+        assert torch.allclose(loss, torch.tensor(6.0))
+
     def test_token_mean(self):
         advantages = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         loss_mask = torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 1.0]])

--- a/tests/tinker/skyrl_train/test_loss_reduction.py
+++ b/tests/tinker/skyrl_train/test_loss_reduction.py
@@ -1,0 +1,69 @@
+"""Unit tests for honoring ``trainer.algorithm.loss_reduction`` on the
+Tinker-serving path (``SkyRLTrainBackend``).
+
+The Tinker API sums per-token losses and expects pre-normalized advantages;
+these tests cover the config default (``token_sum``, preserving that contract)
+and the application of an explicitly configured reduction when the batch is
+built. No Ray runtime or GPUs are needed — the functions under test are pure.
+Requires the SkyRL-Train backend deps (ray/vllm) to be importable. Run:
+  uv run --extra dev --extra fsdp pytest tests/tinker/skyrl_train/test_loss_reduction.py
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+# Skip if skyrl_train_backend.py cannot be imported
+skyrl_train_backend = pytest.importorskip("skyrl.backends.skyrl_train_backend")
+
+_apply_tinker_loss_reduction = skyrl_train_backend._apply_tinker_loss_reduction
+_build_skyrl_train_config = skyrl_train_backend._build_skyrl_train_config
+MegatronBackendOverrides = skyrl_train_backend.MegatronBackendOverrides
+
+ADVANTAGES = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+LOSS_MASK = torch.tensor([[1.0, 1.0], [1.0, 0.0]])
+
+
+class TestApplyTinkerLossReduction:
+    def test_token_sum_is_identity(self):
+        out = _apply_tinker_loss_reduction(ADVANTAGES, LOSS_MASK, "token_sum", micro_batch_size=1, max_seq_len=None)
+        assert out is ADVANTAGES
+
+    def test_token_mean_scales_by_masked_token_count(self):
+        out = _apply_tinker_loss_reduction(ADVANTAGES, LOSS_MASK, "token_mean", micro_batch_size=1, max_seq_len=None)
+        assert torch.allclose(out, ADVANTAGES / 3.0)
+
+    def test_seq_mean_token_sum_norm_scales_by_constant(self):
+        out = _apply_tinker_loss_reduction(
+            ADVANTAGES, LOSS_MASK, "seq_mean_token_sum_norm", micro_batch_size=1, max_seq_len=32768
+        )
+        assert torch.allclose(out, ADVANTAGES / (2 * 32768))
+
+    def test_prompt_mean_raises(self):
+        with pytest.raises(ValueError, match="prompt_mean"):
+            _apply_tinker_loss_reduction(ADVANTAGES, LOSS_MASK, "prompt_mean", micro_batch_size=1, max_seq_len=None)
+
+
+class TestBuildSkyRLTrainConfigLossReduction:
+    def test_loss_reduction_defaults_to_token_sum(self):
+        cfg = _build_skyrl_train_config("Qwen/Qwen2.5-0.5B-Instruct", MegatronBackendOverrides())
+        assert cfg.trainer.algorithm.loss_reduction == "token_sum"
+
+    def test_explicit_loss_reduction_is_honored(self):
+        overrides = MegatronBackendOverrides.model_validate(
+            {
+                "trainer.algorithm.loss_reduction": "seq_mean_token_sum_norm",
+                "trainer.algorithm.max_seq_len": 32768,
+            }
+        )
+        cfg = _build_skyrl_train_config("Qwen/Qwen2.5-0.5B-Instruct", overrides)
+        assert cfg.trainer.algorithm.loss_reduction == "seq_mean_token_sum_norm"
+        assert cfg.trainer.algorithm.max_seq_len == 32768
+
+    def test_seq_mean_token_sum_norm_requires_max_seq_len(self):
+        overrides = MegatronBackendOverrides.model_validate(
+            {"trainer.algorithm.loss_reduction": "seq_mean_token_sum_norm"}
+        )
+        with pytest.raises(ValueError, match=r"trainer\.algorithm\.max_seq_len"):
+            _build_skyrl_train_config("Qwen/Qwen2.5-0.5B-Instruct", overrides)


### PR DESCRIPTION
The Tinker API contract is that per-token losses are summed and clients send pre-normalized advantages: SkyRL-Train's loss_reduction handling lives in its native RL loop (trainer.py), which the Tinker-serving path bypasses. As a result, setting trainer.algorithm.loss_reduction via --backend-config had no effect for Tinker clients.

- Apply the configured reduction to client advantages when building the training batch in SkyRLTrainBackend._to_training_batch, reusing apply_loss_reduction_to_advantages_minibatch (the same helper SkyRL's example Tinker client uses client-side).
- Add "token_sum" (identity) as an explicit reduction mode and make it the serving-path default, so existing behavior is preserved unless a reduction is explicitly configured.
- Reject prompt_mean on the serving path (prompt groupings are not visible to the trainer) and mirror the validate_cfg requirement that seq_mean_token_sum_norm sets trainer.algorithm.max_seq_len.