### PR TITLE
[tinker][fsdp] Multi-LoRA adapter store + Tinker API

### DIFF
--- a/.github/workflows/gpu_skyrl.yaml
+++ b/.github/workflows/gpu_skyrl.yaml
@@ -28,6 +28,10 @@ concurrency:
 
 jobs:
   skyrl_gpu_tests:
+    # GitHub does not expose repository secrets to pull requests from forks.
+    # Fork GPU validation is handled by the label-gated pull_request_target
+    # workflows, which require an explicit maintainer action.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/skyrl/backends/skyrl_train/workers/fsdp/adapter_store.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/adapter_store.py
@@ -1,0 +1,321 @@
+"""CPU-backed adapter storage for the FSDP LoRA worker.
+
+The FSDP policy keeps one PEFT adapter live on GPU. Each registered Tinker
+model owns a pinned-CPU snapshot of that adapter's local parameter shards,
+gradients, and Adam state. Switching adapters copies only local shards; it
+does not gather parameters or issue FSDP collectives.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import torch
+import torch.distributed as dist
+
+try:
+    from torch.distributed.tensor import DTensor
+except ImportError:
+    from torch.distributed._tensor import DTensor
+
+
+@dataclass(frozen=True)
+class FSDPLoraSignature:
+    """LoRA and sharding properties that must match across adapter slots."""
+
+    rank: int
+    alpha: int
+    target_modules: tuple[str, ...]
+    world_size: int
+
+    @classmethod
+    def from_lora_config(cls, lora_config) -> "FSDPLoraSignature":
+        targets = lora_config.target_modules
+        target_modules = (targets,) if isinstance(targets, str) else tuple(targets)
+        world_size = dist.get_world_size() if dist.is_available() and dist.is_initialized() else 1
+        return cls(
+            rank=int(lora_config.rank),
+            alpha=int(lora_config.alpha),
+            target_modules=target_modules,
+            world_size=world_size,
+        )
+
+
+@dataclass
+class AdapterSlot:
+    """Pinned-CPU mirrors of one worker's local LoRA and optimizer shards."""
+
+    parameter_data: list[torch.Tensor] = field(default_factory=list)
+    gradient_data: list[Optional[torch.Tensor]] = field(default_factory=list)
+    optimizer_state: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _local_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.to_local() if isinstance(tensor, DTensor) else tensor
+
+
+def _cpu_copy(tensor: torch.Tensor) -> torch.Tensor:
+    local = _local_tensor(tensor).detach()
+    pin_memory = local.device.type == "cuda" or local.is_pinned()
+    result = torch.empty_like(local, device="cpu", pin_memory=pin_memory)
+    result.copy_(local, non_blocking=pin_memory)
+    return result
+
+
+def _copy_to_live(target: torch.Tensor, source: torch.Tensor) -> None:
+    local = _local_tensor(target)
+    local.copy_(source, non_blocking=local.device.type == "cuda")
+
+
+def _synchronize_cuda() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.current_stream().synchronize()
+
+
+class FSDPAdapterStore:
+    """Registry of CPU adapter slots with exactly one live GPU adapter."""
+
+    def __init__(self) -> None:
+        self._slots: dict[str, AdapterSlot] = {}
+        self._pristine: Optional[AdapterSlot] = None
+        self._current_id: Optional[str] = None
+        self._signature: Optional[FSDPLoraSignature] = None
+        self._parameter_names: tuple[str, ...] = ()
+
+    @property
+    def current_id(self) -> Optional[str]:
+        return self._current_id
+
+    @property
+    def signature(self) -> Optional[FSDPLoraSignature]:
+        return self._signature
+
+    def registered_ids(self) -> list[str]:
+        return list(self._slots)
+
+    def num_adapters(self) -> int:
+        return len(self._slots)
+
+    @staticmethod
+    def _trainable_parameters(model: torch.nn.Module) -> list[tuple[str, torch.nn.Parameter]]:
+        parameters = [(name, parameter) for name, parameter in model.named_parameters() if parameter.requires_grad]
+        if not parameters:
+            raise RuntimeError("FSDPAdapterStore found no trainable LoRA parameters")
+        unexpected = [name for name, _ in parameters if "lora_" not in name and "adapter" not in name]
+        if unexpected:
+            raise RuntimeError(
+                "FSDPAdapterStore only supports LoRA parameters, but found trainable non-adapter parameters: "
+                + ", ".join(unexpected)
+            )
+        return parameters
+
+    def _checked_parameters(self, model: torch.nn.Module) -> list[torch.nn.Parameter]:
+        named_parameters = self._trainable_parameters(model)
+        names = tuple(name for name, _ in named_parameters)
+        if self._parameter_names and names != self._parameter_names:
+            raise RuntimeError(
+                "FSDPAdapterStore trainable parameter layout changed after registration: "
+                f"expected {self._parameter_names}, got {names}"
+            )
+        return [parameter for _, parameter in named_parameters]
+
+    @staticmethod
+    def _snapshot_value(value: Any) -> Any:
+        return _cpu_copy(value) if isinstance(value, torch.Tensor) else copy.deepcopy(value)
+
+    @staticmethod
+    def _clone_slot(slot: AdapterSlot) -> AdapterSlot:
+        return AdapterSlot(
+            parameter_data=[_cpu_copy(value) for value in slot.parameter_data],
+            gradient_data=[None if value is None else _cpu_copy(value) for value in slot.gradient_data],
+            optimizer_state=[
+                {
+                    key: _cpu_copy(value) if isinstance(value, torch.Tensor) else copy.deepcopy(value)
+                    for key, value in state.items()
+                }
+                for state in slot.optimizer_state
+            ],
+        )
+
+    def _new_snapshot(self, model: torch.nn.Module, optimizer: torch.optim.Optimizer) -> AdapterSlot:
+        parameters = self._checked_parameters(model)
+        slot = AdapterSlot(
+            parameter_data=[_cpu_copy(parameter) for parameter in parameters],
+            gradient_data=[None if parameter.grad is None else _cpu_copy(parameter.grad) for parameter in parameters],
+            optimizer_state=[
+                {key: self._snapshot_value(value) for key, value in optimizer.state.get(parameter, {}).items()}
+                for parameter in parameters
+            ],
+        )
+        _synchronize_cuda()
+        return slot
+
+    def _snapshot_into(
+        self,
+        slot: AdapterSlot,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+    ) -> None:
+        parameters = self._checked_parameters(model)
+        for index, parameter in enumerate(parameters):
+            slot.parameter_data[index].copy_(_local_tensor(parameter), non_blocking=parameter.device.type == "cuda")
+
+            gradient = parameter.grad
+            if gradient is None:
+                slot.gradient_data[index] = None
+            elif slot.gradient_data[index] is None:
+                slot.gradient_data[index] = _cpu_copy(gradient)
+            else:
+                local_gradient = _local_tensor(gradient)
+                slot.gradient_data[index].copy_(
+                    local_gradient,
+                    non_blocking=local_gradient.device.type == "cuda",
+                )
+
+            live_state = optimizer.state.get(parameter, {})
+            saved_state = slot.optimizer_state[index]
+            for stale_key in saved_state.keys() - live_state.keys():
+                del saved_state[stale_key]
+            for key, value in live_state.items():
+                saved_value = saved_state.get(key)
+                if isinstance(value, torch.Tensor):
+                    local_value = _local_tensor(value)
+                    if not isinstance(saved_value, torch.Tensor) or saved_value.shape != local_value.shape:
+                        saved_state[key] = _cpu_copy(value)
+                    else:
+                        saved_value.copy_(local_value, non_blocking=local_value.device.type == "cuda")
+                else:
+                    saved_state[key] = copy.deepcopy(value)
+        _synchronize_cuda()
+
+    def _restore(
+        self,
+        slot: AdapterSlot,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+    ) -> None:
+        parameters = self._checked_parameters(model)
+        for index, parameter in enumerate(parameters):
+            _copy_to_live(parameter, slot.parameter_data[index])
+
+            saved_gradient = slot.gradient_data[index]
+            if saved_gradient is None:
+                parameter.grad = None
+            else:
+                if parameter.grad is None:
+                    parameter.grad = torch.zeros_like(parameter)
+                _copy_to_live(parameter.grad, saved_gradient)
+
+            live_state = optimizer.state[parameter]
+            saved_state = slot.optimizer_state[index]
+            for stale_key in live_state.keys() - saved_state.keys():
+                del live_state[stale_key]
+            for key, saved_value in saved_state.items():
+                live_value = live_state.get(key)
+                if isinstance(saved_value, torch.Tensor):
+                    if not isinstance(live_value, torch.Tensor):
+                        raise RuntimeError(f"Optimizer state '{key}' was not materialized before adapter registration")
+                    _copy_to_live(live_value, saved_value)
+                else:
+                    live_state[key] = copy.deepcopy(saved_value)
+        _synchronize_cuda()
+
+    @torch.no_grad()
+    def prime_optimizer_state(self, model: torch.nn.Module, optimizer: torch.optim.Optimizer) -> None:
+        """Materialize Adam state without changing the pristine adapter."""
+
+        parameters = self._checked_parameters(model)
+        saved_parameters = [_cpu_copy(parameter) for parameter in parameters]
+        saved_gradients = [None if parameter.grad is None else _cpu_copy(parameter.grad) for parameter in parameters]
+        _synchronize_cuda()
+
+        for parameter in parameters:
+            parameter.grad = torch.zeros_like(parameter)
+        optimizer.step()
+
+        for parameter, saved_parameter in zip(parameters, saved_parameters):
+            _copy_to_live(parameter, saved_parameter)
+        optimizer.zero_grad(set_to_none=True)
+
+        for parameter in parameters:
+            for key, value in optimizer.state[parameter].items():
+                if isinstance(value, torch.Tensor):
+                    value.zero_()
+                elif isinstance(value, (int, float)):
+                    optimizer.state[parameter][key] = type(value)(0)
+
+        for parameter, saved_gradient in zip(parameters, saved_gradients):
+            if saved_gradient is None:
+                parameter.grad = None
+            else:
+                parameter.grad = torch.zeros_like(parameter)
+                _copy_to_live(parameter.grad, saved_gradient)
+        _synchronize_cuda()
+
+    def register_pristine(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        signature: FSDPLoraSignature,
+    ) -> None:
+        if self._pristine is not None:
+            raise RuntimeError("FSDPAdapterStore.register_pristine called twice")
+        named_parameters = self._trainable_parameters(model)
+        self._parameter_names = tuple(name for name, _ in named_parameters)
+        self._signature = signature
+        self._pristine = self._new_snapshot(model, optimizer)
+
+    def create(
+        self,
+        model_id: str,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        signature: FSDPLoraSignature,
+    ) -> None:
+        if self._pristine is None or self._signature is None:
+            raise RuntimeError("FSDPAdapterStore.create called before register_pristine")
+        if signature != self._signature:
+            raise ValueError(
+                f"FSDPAdapterStore LoRA signature mismatch for '{model_id}': "
+                f"pristine={self._signature}, requested={signature}"
+            )
+        if model_id in self._slots:
+            raise ValueError(f"FSDPAdapterStore adapter '{model_id}' is already registered")
+
+        self._checked_parameters(model)
+        self._slots[model_id] = self._clone_slot(self._pristine)
+        if self._current_id is None:
+            self._current_id = model_id
+
+    def delete(self, model_id: str) -> None:
+        if model_id not in self._slots:
+            raise KeyError(f"FSDPAdapterStore unknown adapter '{model_id}'")
+        del self._slots[model_id]
+        if self._current_id == model_id:
+            self._current_id = None
+
+    @torch.no_grad()
+    def swap_to(
+        self,
+        model_id: str,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+    ) -> None:
+        if model_id not in self._slots:
+            raise KeyError(f"FSDPAdapterStore unknown adapter '{model_id}'")
+        if self._current_id == model_id:
+            return
+
+        distributed = dist.is_available() and dist.is_initialized()
+        if distributed:
+            dist.barrier()
+
+        if self._current_id is not None:
+            self._snapshot_into(self._slots[self._current_id], model, optimizer)
+        self._restore(self._slots[model_id], model, optimizer)
+        self._current_id = model_id
+
+        if distributed:
+            dist.barrier()

--- a/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
+++ b/skyrl/backends/skyrl_train/workers/fsdp/fsdp_worker.py
@@ -33,6 +33,10 @@ from skyrl.backends.skyrl_train.weight_sync import (
 from skyrl.backends.skyrl_train.weight_sync.weight_extractor_utils import (
     yield_module_grouped_chunks,
 )
+from skyrl.backends.skyrl_train.workers.fsdp.adapter_store import (
+    FSDPAdapterStore,
+    FSDPLoraSignature,
+)
 from skyrl.backends.skyrl_train.workers.model_wrapper import (
     HFModelWrapper,
     get_llm_for_sequence_regression,
@@ -191,6 +195,7 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
             assert (
                 self.optimizer is not None and self.scheduler is not None
             ), "FSDP preparation should create optimizer and scheduler"
+        self.adapter_store = FSDPAdapterStore() if self._is_lora and self.optimizer is not None else None
 
         # Enable expandable_segments after init so model weights stay in IPC-compatible
         # standard CUDA memory; only subsequent activations use expandable segments.
@@ -198,6 +203,43 @@ class FSDPPolicyWorkerBase(PolicyWorkerBase):
 
         # Created only on profiled ranks.
         self.profiler = build_profiler_from_policy_cfg(self.cfg)
+
+    def prime_optimizer_state(self) -> None:
+        if self.adapter_store is None or self.optimizer is None:
+            raise RuntimeError("FSDP adapter store is only available for trainable LoRA policies")
+        self.adapter_store.prime_optimizer_state(self.model, self.optimizer)
+
+    def register_pristine_adapter(self) -> None:
+        if self.adapter_store is None or self.optimizer is None:
+            raise RuntimeError("FSDP adapter store is only available for trainable LoRA policies")
+        signature = FSDPLoraSignature.from_lora_config(self.cfg.policy.model.lora)
+        self.adapter_store.register_pristine(self.model, self.optimizer, signature)
+
+    def register_adapter(self, model_id: str) -> None:
+        if self.adapter_store is None or self.optimizer is None:
+            raise RuntimeError("FSDP adapter store is only available for trainable LoRA policies")
+        signature = FSDPLoraSignature.from_lora_config(self.cfg.policy.model.lora)
+        self.adapter_store.create(model_id, self.model, self.optimizer, signature)
+
+    def delete_adapter(self, model_id: str) -> None:
+        if self.adapter_store is None:
+            raise RuntimeError("FSDP adapter store is only available for trainable LoRA policies")
+        self.adapter_store.delete(model_id)
+
+    def swap_to_adapter(self, model_id: str) -> None:
+        if self.adapter_store is None or self.optimizer is None:
+            return
+        self.adapter_store.swap_to(model_id, self.model, self.optimizer)
+
+    def adapter_store_state(self) -> dict:
+        if self.adapter_store is None:
+            return {"enabled": False}
+        return {
+            "enabled": True,
+            "current_id": self.adapter_store.current_id,
+            "registered": self.adapter_store.registered_ids(),
+            "num_adapters": self.adapter_store.num_adapters(),
+        }
 
     async def init_weight_sync_state(self, inference_engine_client, inference_engine_cfg: "InferenceEngineConfig"):
         # Call super first to set _transfer_strategy_cls and create sender/receivers

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -264,12 +264,10 @@ class SkyRLTrainBackend(AbstractBackend):
         )
         ray.get(policy_model.async_run_ray_method("pass_through", "_set_pad_token_id", self._tokenizer.pad_token_id))
 
-        if is_lora and cfg.trainer.strategy == "megatron":
-            # For multi-tenant LoRA training: prime DistributedOptimizer state and snapshot
-            # the freshly-initialised LoRA into a per-worker pristine slot, then
-            # register the first adapter under `model_id`. Must happen while the
-            # model + optimizer are still GPU-resident (i.e. before the offload).
-            # currently, this is only supported for megatron backend
+        if is_lora and cfg.trainer.strategy in {"fsdp", "megatron"}:
+            # Snapshot the freshly initialized LoRA and optimizer state before
+            # any colocated offload. Both backends keep one adapter live and
+            # swap per-model state from CPU storage.
             ray.get(policy_model.async_run_ray_method("pass_through", "prime_optimizer_state"))
             ray.get(policy_model.async_run_ray_method("pass_through", "register_pristine_adapter"))
             ray.get(policy_model.async_run_ray_method("pass_through", "register_adapter", model_id))

--- a/tests/backends/skyrl_train/test_fsdp_adapter_store.py
+++ b/tests/backends/skyrl_train/test_fsdp_adapter_store.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from skyrl.backends.skyrl_train.workers.fsdp.adapter_store import (
+    FSDPAdapterStore,
+    FSDPLoraSignature,
+)
+
+
+class ToyLoRAModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.base = nn.Linear(3, 2, bias=False)
+        self.base.requires_grad_(False)
+        self.lora_A = nn.Linear(3, 2, bias=False)
+        self.lora_B = nn.Linear(2, 2, bias=False)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return self.base(inputs) + self.lora_B(self.lora_A(inputs))
+
+
+def _signature(rank: int = 2) -> FSDPLoraSignature:
+    return FSDPLoraSignature(rank=rank, alpha=4, target_modules=("all-linear",), world_size=1)
+
+
+def _build_store():
+    torch.manual_seed(7)
+    model = ToyLoRAModel()
+    optimizer = torch.optim.AdamW(
+        [parameter for parameter in model.parameters() if parameter.requires_grad],
+        lr=0.05,
+        betas=(0.8, 0.9),
+        weight_decay=0.1,
+    )
+    store = FSDPAdapterStore()
+    pristine = [parameter.detach().clone() for parameter in model.parameters() if parameter.requires_grad]
+    store.prime_optimizer_state(model, optimizer)
+    for expected, parameter in zip(pristine, (p for p in model.parameters() if p.requires_grad)):
+        torch.testing.assert_close(parameter, expected)
+    store.register_pristine(model, optimizer, _signature())
+    store.create("adapter-a", model, optimizer, _signature())
+    store.create("adapter-b", model, optimizer, _signature())
+    return model, optimizer, store
+
+
+def _step(model: ToyLoRAModel, optimizer: torch.optim.Optimizer, scale: float) -> None:
+    inputs = torch.tensor([[1.0, -2.0, 0.5]]) * scale
+    model(inputs).square().sum().backward()
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+
+
+def _trainable_parameters(model: nn.Module) -> list[nn.Parameter]:
+    return [parameter for parameter in model.parameters() if parameter.requires_grad]
+
+
+def _optimizer_steps(model: nn.Module, optimizer: torch.optim.Optimizer) -> list[int]:
+    return [int(optimizer.state[parameter]["step"].item()) for parameter in _trainable_parameters(model)]
+
+
+def test_adapter_weights_and_adam_state_are_isolated():
+    model, optimizer, store = _build_store()
+
+    _step(model, optimizer, scale=1.0)
+    adapter_a_weights = [parameter.detach().clone() for parameter in _trainable_parameters(model)]
+    assert _optimizer_steps(model, optimizer) == [1, 1]
+
+    store.swap_to("adapter-b", model, optimizer)
+    assert _optimizer_steps(model, optimizer) == [0, 0]
+    _step(model, optimizer, scale=2.0)
+    _step(model, optimizer, scale=2.0)
+    adapter_b_weights = [parameter.detach().clone() for parameter in _trainable_parameters(model)]
+    assert _optimizer_steps(model, optimizer) == [2, 2]
+
+    store.swap_to("adapter-a", model, optimizer)
+    assert _optimizer_steps(model, optimizer) == [1, 1]
+    for expected, parameter in zip(adapter_a_weights, _trainable_parameters(model)):
+        torch.testing.assert_close(parameter, expected)
+
+    store.swap_to("adapter-b", model, optimizer)
+    assert _optimizer_steps(model, optimizer) == [2, 2]
+    for expected, parameter in zip(adapter_b_weights, _trainable_parameters(model)):
+        torch.testing.assert_close(parameter, expected)
+
+
+def test_unconsumed_gradients_follow_their_adapter():
+    model, optimizer, store = _build_store()
+    parameters = _trainable_parameters(model)
+
+    model(torch.ones(1, 3)).sum().backward()
+    adapter_a_gradients = [parameter.grad.detach().clone() for parameter in parameters]
+
+    store.swap_to("adapter-b", model, optimizer)
+    assert all(parameter.grad is None for parameter in parameters)
+
+    model(torch.full((1, 3), 2.0)).sum().backward()
+    adapter_b_gradients = [parameter.grad.detach().clone() for parameter in parameters]
+
+    store.swap_to("adapter-a", model, optimizer)
+    for expected, parameter in zip(adapter_a_gradients, parameters):
+        torch.testing.assert_close(parameter.grad, expected)
+
+    store.swap_to("adapter-b", model, optimizer)
+    for expected, parameter in zip(adapter_b_gradients, parameters):
+        torch.testing.assert_close(parameter.grad, expected)
+
+
+def test_registration_validates_signature_and_parameter_layout():
+    model, optimizer, store = _build_store()
+
+    with pytest.raises(ValueError, match="signature mismatch"):
+        store.create("wrong-rank", model, optimizer, _signature(rank=4))
+
+    model.base.weight.requires_grad_(True)
+    with pytest.raises(RuntimeError, match="non-adapter"):
+        store.swap_to("adapter-b", model, optimizer)
+
+
+def test_delete_releases_slot_and_clears_current_adapter():
+    model, optimizer, store = _build_store()
+
+    store.delete("adapter-a")
+    assert store.current_id is None
+    assert store.registered_ids() == ["adapter-b"]
+
+    store.swap_to("adapter-b", model, optimizer)
+    assert store.current_id == "adapter-b"
+    with pytest.raises(KeyError, match="unknown adapter"):
+        store.swap_to("adapter-a", model, optimizer)

--- a/tests/tinker/skyrl_train/test_fsdp_tinker.py
+++ b/tests/tinker/skyrl_train/test_fsdp_tinker.py
@@ -6,20 +6,17 @@ module need at least one GPU and the ``tinker`` + ``fsdp`` extras installed. The
 sampling test additionally brings up a vLLM engine (non-colocated), so a second
 GPU is required for it.
 
-Scope: this mirrors ``test_multi_lora_megatron.py`` but exercises only the
-*single-adapter* (non multi-LoRA) path on FSDP — multi-tenant LoRA / the
-worker-side AdapterStore is currently Megatron-only and the FSDP worker raises
-a clear ``NotImplementedError`` for it. FSDP therefore supports exactly one
-adapter for the lifetime of a server, so every test shares one module-scoped
-training client. These tests confirm that initialising an FSDP Tinker engine
-and sending basic requests works:
+Scope: this mirrors ``test_multi_lora_megatron.py`` using FSDP's CPU-backed
+adapter store. FSDP keeps one PEFT adapter live on GPU and swaps per-model
+weights, gradients, and optimizer state between requests.
 
   - test_forward_backward_optim_step_improves_loss: the adapter trains; loss on
     a fixed micro-batch decreases after an optim step.
   - test_forward_only_returns_logprobs: a forward-only pass returns per-token
     logprobs + elementwise loss without mutating optimizer state.
-  - test_second_adapter_rejected: creating a second adapter is rejected with a
-    clear NotImplementedError (multi-tenant LoRA is Megatron-only for now).
+  - test_second_adapter_trains: a second adapter can be registered and trained.
+  - test_per_adapter_step_isolation: identical alternating updates keep two
+    pristine adapters bit-identical.
   - test_sample_after_training: weight-sync to vLLM + greedy sampling returns a
     deterministic token sequence.
 
@@ -83,11 +80,7 @@ def _api_server(port: int, backend_config: dict | None = None):
         cmd = [
             "uv",
             "run",
-            "--isolated",
-            "--extra",
-            "tinker",
-            "--extra",
-            "fsdp",
+            "--no-sync",
             "-m",
             "skyrl.tinker.api",
             "--host",
@@ -162,9 +155,8 @@ def service_client(server):
 def training_client(server):
     """A single LoRA training client shared by every test.
 
-    FSDP supports exactly one adapter per server (multi-tenant LoRA is
-    Megatron-only), so all tests must reuse the same client. Tests are additive
-    (each mutates the shared adapter) but their assertions are self-contained.
+    Tests are additive (each mutates the shared adapter) but their assertions
+    are self-contained.
     """
     sc = tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
     return sc.create_lora_training_client(base_model=BASE_MODEL, rank=8)
@@ -209,12 +201,37 @@ def test_forward_only_returns_logprobs(training_client):
     assert all(isinstance(x, float) for x in logprobs)
 
 
-def test_second_adapter_rejected(training_client, service_client):
-    """Test that creating a second adapter against the same FSDP server is rejected."""
-    with pytest.raises(Exception) as exc:
-        service_client.create_lora_training_client(base_model=BASE_MODEL, rank=8)
-    msg = str(exc.value).lower()
-    assert "not implemented" in msg
+def test_second_adapter_trains(training_client, service_client):
+    """A second adapter can train without rebuilding the FSDP worker group."""
+    second_client = service_client.create_lora_training_client(base_model=BASE_MODEL, rank=8)
+    tok = second_client.get_tokenizer()
+    data = [_make_datum(tok, "Question: 3+3?\nAnswer:", " 6")]
+
+    output = second_client.forward_backward(data, "cross_entropy").result()
+    second_client.optim_step(tinker_types.AdamParams(learning_rate=1e-3)).result()
+
+    assert _sum_loss(output) > 0
+
+
+def test_per_adapter_step_isolation(service_client):
+    """Adam state and weights advance independently for each adapter."""
+    client_a = service_client.create_lora_training_client(base_model=BASE_MODEL, rank=8)
+    client_b = service_client.create_lora_training_client(base_model=BASE_MODEL, rank=8)
+    tok = client_a.get_tokenizer()
+    data = [_make_datum(tok, "Question: 4+4?\nAnswer:", " 8")]
+
+    def forward_backward_and_step(client):
+        output = client.forward_backward(data, "cross_entropy").result()
+        client.optim_step(tinker_types.AdamParams(learning_rate=1e-3)).result()
+        return _sum_loss(output)
+
+    a_step_0 = forward_backward_and_step(client_a)
+    b_step_0 = forward_backward_and_step(client_b)
+    a_step_1 = forward_backward_and_step(client_a)
+    b_step_1 = forward_backward_and_step(client_b)
+
+    assert a_step_0 == b_step_0
+    assert a_step_1 == b_step_1
 
 
 @pytest.mark.skipif(cuda_device_count < 2, reason="sampling brings up a separate vLLM engine (needs a 2nd GPU)")


### PR DESCRIPTION
> First PR in a two-part series. The concurrent resident/grouped-GEMM implementation follows in #1938.

Adds multi-tenant LoRA training to the SkyRL-Train FSDP Tinker backend with one PEFT adapter resident on GPU at a time. Multiple Tinker clients share one frozen base model while each client retains independent LoRA weights, gradients, and optimizer state.

## Architecture

- New `FSDPAdapterStore` holds a pinned-CPU snapshot per `model_id`, plus a pristine template used to initialize new adapters.
- Each snapshot contains the worker's local FSDP parameter shards, unconsumed gradients, and Adam state. Adapter swaps copy local shards only; they do not gather full parameters.
- Swaps are bracketed by distributed barriers when the process group is initialized and synchronize CUDA copies before the next request.
- The store validates a fixed `(rank, alpha, target_modules, world_size)` signature and rejects trainable non-LoRA parameters.

## API surface

- The first LoRA `create_model` primes Adam state, captures the pristine adapter, and registers the initial `model_id`.
- Later policy `create_model` calls register CPU-backed adapter slots through the existing Tinker/Megatron adapter lifecycle.
- `forward`, `forward_backward`, `optim_step`, checkpoint operations, and sampler synchronization use the existing `WorkerDispatch.ensure_active_adapter` path.
- Deleting one of multiple adapters releases only that slot; deleting the last model retains the existing full-runtime teardown behavior.

## Scope

- This PR intentionally keeps exactly one trainer adapter resident at a time, matching the current Megatron backend.
- Resident concurrent adapters, mixed-adapter batches, grouped GEMMs, batched optimizer steps, and MoE support remain in #1938.
- No new trainer capacity setting is introduced; adapter capacity is bounded by host memory. Existing `max_loras` and `max_cpu_loras` continue to configure vLLM serving.

## Verification

- CPU state-isolation tests cover independent weights, gradients, Adam moments/steps, signature validation, parameter-layout validation, deletion, and swap recovery.
- Ruff, Black, and `git diff --check` pass.
- Two-H100 Modal Tinker run: `9 passed` in 8m47s.
- Real FSDP forward/backward and optimizer updates passed.
- Second-adapter registration and training completed without rebuilding the worker group.
- Alternating identical updates remained bit-identical across two adapters.
- Per-adapter LoRA export, vLLM load, and sampling completed successfully.
