### PR TITLE
[fix][megatron] Add `MegatronConfig.async_save_prestage_to_cpu` to stage tensors to CPU on the same process before async save with `mcore`

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -47,6 +47,44 @@ from skyrl.backends.skyrl_train.workers.megatron.megatron_model_wrapper import (
 _PP_SEED_OFFSET = 100
 
 
+def _stage_async_request_to_host(async_request):
+    """Run an async checkpoint request's GPU->host staging in *this* process.
+
+    Megatron's ``PersistentAsyncCaller`` pickles the whole ``AsyncRequest`` to a
+    spawned worker and calls ``preload_fn`` *there*, so the still-on-GPU shards
+    cross the process boundary via CUDA IPC.
+
+    That breaks under ``expandable_segments:True`` -- which SkyRL turns on for
+    training workers (see ``Worker._set_expandable_segments``). Expandable
+    segments are ``cuMemCreate``-backed, and their shareable handle is a POSIX
+    file descriptor rather than a copyable ``cudaIpcMemHandle_t``, so the
+    importing process has to pull the fd out of the producer with
+    ``pidfd_getfd``. That syscall requires ptrace-attach permission.
+    The checkpoint worker is a child of the training rank,
+    so it dies with ``pidfd_getfd: Operation not permitted`` on some machines
+    and the training rank then hangs forever on the preload barrier.
+
+    Staging here avoids CUDA IPC altogether: only CPU tensors get pickled to the
+    worker. It is not a throughput regression -- ``schedule_async_call`` already
+    blocks on the preload queue until the worker finishes the D2H copy, so the
+    copy was always synchronous from the training rank's point of view. Reference:
+    https://github.com/NVIDIA/Megatron-LM/blob/b78cfd5279be41ced082d344e9380a09a146c458/megatron/core/dist_checkpointing/strategies/async_utils.py#L578-L584
+
+    Takes and returns an ``AsyncRequest``; both the ``mcore`` and ``nvrx`` request types
+    are named tuples with the same ``async_fn_args``/``preload_fn`` fields. The attribute
+    access is deliberately unguarded so a future upstream change to that contract fails
+    loudly here rather than silently restoring the hang.
+    """
+    if async_request.preload_fn is None:
+        return async_request
+    args = list(async_request.async_fn_args)
+    # ``preload_fn`` stages ``async_fn_args[1]`` (the write buckets); Megatron
+    # asserts the same arity in ``AsyncRequest.execute_sync``.
+    assert len(args) == 3, f"expected 3 async_fn_args, got {len(args)}: {args!r}"
+    args[1] = async_request.preload_fn()
+    return async_request._replace(async_fn_args=tuple(args), preload_fn=None)
+
+
 def _patched_update_fp32_params_by_new_state(self):
     """Monkeypatch for megatron-core HybridDeviceOptimizer._update_fp32_params_by_new_state.
 
@@ -321,7 +359,9 @@ class MegatronStrategy(DistributedStrategy):
             )
             if async_save:
                 # Shards are staged to host; the disk write runs in the background.
-                ckpt_base.async_calls.schedule_async_request(async_save_request)
+                # Stage before scheduling so no GPU tensor is handed to the worker
+                # process -- see `_stage_async_request_to_host`.
+                ckpt_base.async_calls.schedule_async_request(_stage_async_request_to_host(async_save_request))
             else:
                 assert async_save_request is None, "save() must not return a request when sync"
 

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -54,20 +54,20 @@ def _stage_async_request_to_host(async_request):
     spawned worker and calls ``preload_fn`` *there*, so the still-on-GPU shards
     cross the process boundary via CUDA IPC.
 
-    That breaks under ``expandable_segments:True`` -- which SkyRL turns on for
+    That can break under ``expandable_segments:True`` -- which SkyRL turns on for
     training workers (see ``Worker._set_expandable_segments``). Expandable
     segments are ``cuMemCreate``-backed, and their shareable handle is a POSIX
     file descriptor rather than a copyable ``cudaIpcMemHandle_t``, so the
     importing process has to pull the fd out of the producer with
     ``pidfd_getfd``. That syscall requires ptrace-attach permission.
     The checkpoint worker is a child of the training rank,
-    so it dies with ``pidfd_getfd: Operation not permitted`` on some machines
-    and the training rank then hangs forever on the preload barrier.
+    so it can error out with ``pidfd_getfd: Operation not permitted`` on machines
+    with restricted ptrace permissions and the training rank
+    then hangs forever on the preload barrier.
 
     Staging here avoids CUDA IPC altogether: only CPU tensors get pickled to the
-    worker. It is not a throughput regression -- ``schedule_async_call`` already
-    blocks on the preload queue until the worker finishes the D2H copy, so the
-    copy was always synchronous from the training rank's point of view. Reference:
+    worker, and those cross by fd-passing over a unix socket, which needs no ptrace
+    permission. Reference:
     https://github.com/NVIDIA/Megatron-LM/blob/b78cfd5279be41ced082d344e9380a09a146c458/megatron/core/dist_checkpointing/strategies/async_utils.py#L578-L584
 
     Takes and returns an ``AsyncRequest``; both the ``mcore`` and ``nvrx`` request types
@@ -359,9 +359,11 @@ class MegatronStrategy(DistributedStrategy):
             )
             if async_save:
                 # Shards are staged to host; the disk write runs in the background.
-                # Stage before scheduling so no GPU tensor is handed to the worker
-                # process -- see `_stage_async_request_to_host`.
-                ckpt_base.async_calls.schedule_async_request(_stage_async_request_to_host(async_save_request))
+                if self.megatron_config.async_save_prestage_to_cpu:
+                    # Keeps GPU tensors from crossing the process boundary, which the writer
+                    # cannot always do -- see `_stage_async_request_to_host`.
+                    async_save_request = _stage_async_request_to_host(async_save_request)
+                ckpt_base.async_calls.schedule_async_request(async_save_request)
             else:
                 assert async_save_request is None, "save() must not return a request when sync"
 

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -403,6 +403,21 @@ class MegatronConfig(BaseConfig):
     async_dist_ckpt_strategy: str = "mcore"
     """Backend for the async write. ``mcore`` needs no extra deps; megatron-core's own
     default ``nvrx`` requires nvidia-resiliency-ext. Only used when async saves are on."""
+    async_save_prestage_to_cpu: bool = False
+    """Copy shards to host memory on the training rank before handing them to the async
+    checkpoint writer, instead of letting the writer pull them over CUDA IPC.
+
+    Enable this when using async save on machines with restricted ptrace permissions. 
+    megatron-core hands the writer the *GPU* tensors and copies them in the writer process;
+    with ``expandable_segments:True`` those handles are file descriptors that the writer 
+    imports via ``pidfd_getfd``, which needs ptrace-attach permission on the rank. 
+    Where that is refused (e.g. ``kernel.yama.ptrace_scope=1``, as on some CI runners) 
+    the writer dies with ``pidfd_getfd: Operation not permitted`` and every rank then 
+    hangs on the preload barrier.
+
+    Off by default: prestaging shrinks the rank's blocking
+    window but delays the background write (per-tensor shared-memory handoff cost).
+    See ``_stage_async_request_to_host``."""
 
     def __post_init__(self):
         # Backfill defaults for any keys the user didn't override so an override dict

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py
@@ -118,6 +118,9 @@ def test_save_load_checkpoint(ray_init_fixture, strategy, lora, fully_reshardabl
         cfg.trainer.policy.megatron_config.optimizer_config_kwargs["optimizer_offload_fraction"] = 1
     if async_save:
         cfg.trainer.policy.megatron_config.async_dist_ckpt_save = True
+        # CI runners restrict ptrace, so the checkpoint writer cannot import the rank's CUDA
+        # handles and the run would hang. Prestage on the rank instead.
+        cfg.trainer.policy.megatron_config.async_save_prestage_to_cpu = True
 
     checkpoint_dir = None
     try:


### PR DESCRIPTION
# What does this PR do?

Fixes hang with async save introduced in #1838 .  Issue first noticed on CI ([job link](https://console.anyscale.com/cld_hxkifz7xa22mwicp21nzkds1lw/prj_4b6c498rypyq6g7yhk6vzgjevt/jobs/prodjob_uk2n7lmibfubmd19lizgamutui?job-tab=overview&job-logs-section-tabs=application_logs)) for test `tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py::test_save_load_checkpoint[megatron_async_dist_ckpt_save]`

Currently, async saves with megatron will deadlock after the following failure on CI machines:

```bash
[36m(MegatronPolicyWorkerBase pid=51155)[0m [32m2026-07-28 13:31:00.200[0m | [33m[1mWARNING [0m | [36mmegatron.core.dist_checkpointing.strategies.torch[0m:[36masync_save[0m:[36m675[0m - [33m[1mMCore's async save is deprecated and will be removed in the future releases. Please, use NVRx async solution by setting `async_strategy` to `nvrx`.[0m[32m [repeated 3x across cluster][0m
[36m(MegatronPolicyWorkerBase pid=51155)[0m PID 52839: Skipping CPU nice (current 15 already <= target 10; lowering requires superuser
[36m(MegatronPolicyWorkerBase pid=51155)[0m Process SpawnProcess-2:
[36m(MegatronPolicyWorkerBase pid=51155)[0m Traceback (most recent call last):
[36m(MegatronPolicyWorkerBase pid=51155)[0m   File "/home/ray/anaconda3/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
[36m(MegatronPolicyWorkerBase pid=51155)[0m     self.run()
[36m(MegatronPolicyWorkerBase pid=51155)[0m   File "/home/ray/anaconda3/lib/python3.12/multiprocessing/process.py", line 108, in run
[36m(MegatronPolicyWorkerBase pid=51155)[0m     self._target(*self._args, **self._kwargs)
[36m(MegatronPolicyWorkerBase pid=51155)[0m   File "/home/ray/anaconda3/lib/python3.12/contextlib.py", line 81, in inner
[36m(MegatronPolicyWorkerBase pid=51155)[0m     return func(*args, **kwds)
[36m(MegatronPolicyWorkerBase pid=51155)[0m            ^^^^^^^^^^^^^^^^^^^
[36m(MegatronPolicyWorkerBase pid=51155)[0m   File "/home/ray/.cache/uv/builds-v0/.tmpiQCzTt/lib/python3.12/site-packages/megatron/core/dist_checkpointing/strategies/async_utils.py", line 573, in async_loop
[36m(MegatronPolicyWorkerBase pid=51155)[0m     item = queue.get()
[36m(MegatronPolicyWorkerBase pid=51155)[0m            ^^^^^^^^^^^
[36m(MegatronPolicyWorkerBase pid=51155)[0m   File "/home/ray/anaconda3/lib/python3.12/multiprocessing/queues.py", line 122, in get
[36m(MegatronPolicyWorkerBase pid=51155)[0m     return _ForkingPickler.loads(res)
[36m(MegatronPolicyWorkerBase pid=51155)[0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(MegatronPolicyWorkerBase pid=51155)[0m   File "/home/ray/.cache/uv/builds-v0/.tmpiQCzTt/lib/python3.12/site-packages/torch/multiprocessing/reductions.py", line 180, in rebuild_cuda_tensor
[36m(MegatronPolicyWorkerBase pid=51155)[0m     storage = storage_cls._new_shared_cuda(
[36m(MegatronPolicyWorkerBase pid=51155)[0m               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(MegatronPolicyWorkerBase pid=51155)[0m   File "/home/ray/.cache/uv/builds-v0/.tmpiQCzTt/lib/python3.12/site-packages/torch/storage.py", line 1464, in _new_shared_cuda
[36m(MegatronPolicyWorkerBase pid=51155)[0m     return torch.UntypedStorage._new_shared_cuda(*args, **kwargs)
[36m(MegatronPolicyWorkerBase pid=51155)[0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[36m(MegatronPolicyWorkerBase pid=51155)[0m RuntimeError: pidfd_getfd: Operation not permitted
```

The error occurs because:
1. We have expandable segments true
2. GPU tensor handles are copied to ckpt worker processes via CUDA IPC
3. This requires the child process to be able to copy fd from parent , which translates to a `pidfd_getfd`
4. The CI container has a restricted `ptrace_scope`, so the operation fails

The fix is to run the staging from GPU -> CPU on the parent process itself instead of having the worker process handle it. This is guarded by `async_save_prestage_to_cpu` flag and it is default `False` - prestaging to CPU affects the overall background write times (for a 0.6B model, this increased the write time by 5x)


## Test Plan

Ran :

```
uv run --isolated --extra megatron -- pytest -s tests/backends/skyrl_train/gpu/gpu_ci/test_save_load_checkpoint.py::test_save_load_checkpoint[megatron_async_dist_ckpt_save]
```

Test reports the above error message and hangs on `main` . 
Test passes with the fixes in this PR.
