### PR TITLE
[fix][config] Fix dict override values corrupting through OmegaConf re-parsing

### DIFF
--- a/docs/content/docs/tinker/configuration.mdx
+++ b/docs/content/docs/tinker/configuration.mdx
@@ -18,6 +18,8 @@ uv run --extra tinker --extra fsdp -m skyrl.tinker.api \
 
 Any field in the [SkyRL-Train config](https://docs.skyrl.ai/docs/configuration/config) can be overridden this way (see [`SkyRLTrainConfig` in `skyrl/train/config/config.py`](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/config/config.py) for all available keys and defaults). The most commonly used options are listed below.
 
+JSON types are preserved exactly, so use JSON literals rather than strings: `null` for an unset field, `true`/`false` for booleans, and `4` rather than `"4"` for numbers.
+
 ### GPU and Parallelism
 
 | Key | Default | Description |

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -7,6 +7,7 @@ can be constructed from a Hydra DictConfig via SkyRLTrainConfig.from_dict_config
 
 import copy
 import dataclasses
+import json
 import os
 import typing
 from abc import ABC
@@ -1123,6 +1124,39 @@ def validate_dict_keys_against_dataclass(datacls: Type[Any], d: dict):
         raise ValueError(f"Invalid fields {invalid_keys} for {datacls.__name__}. Valid fields are {valid_fields}.")
 
 
+def overrides_dict_to_dotlist(args: Dict[str, Any]) -> List[str]:
+    """Serialize a dict of config overrides into an OmegaConf dotlist.
+
+    ``OmegaConf.from_cli`` re-parses the right-hand side of each ``key=value``
+    entry using YAML scalar rules, so values are serialized as JSON: JSON is a
+    subset of YAML, so ``None`` becomes ``null``, bools become ``true``/``false``,
+    and strings are quoted, which suppresses YAML scalar interpretation of values
+    like ``"null"``, ``"true"``, ``"1e5"``, ``"[a]"``, ``"a: b"`` and ``""``.
+
+    ``ensure_ascii=False`` keeps non-ASCII characters literal. With the default
+    ``\\uXXXX`` escaping, characters outside the basic multilingual plane are
+    emitted as a surrogate pair, and OmegaConf decodes each half into a separate
+    lone surrogate that later fails to UTF-8 encode.
+
+    Values JSON cannot represent are serialized with ``str()``.
+
+    Args:
+        args: Mapping of dot-notation config keys to override values.
+
+    Returns:
+        A list of ``key=value`` strings suitable for ``OmegaConf.from_cli``.
+    """
+    dotlist = []
+    for key, value in args.items():
+        try:
+            serialized = json.dumps(value, ensure_ascii=False)
+        except (TypeError, ValueError):
+            # TypeError: unsupported type. ValueError: circular reference.
+            serialized = str(value)
+        dotlist.append(f"{key}={serialized}")
+    return dotlist
+
+
 def _has_nested_key(cfg: Any, path: str) -> bool:
     node = cfg
     for key in path.split("."):
@@ -1283,6 +1317,8 @@ class SkyRLTrainConfig(BaseConfig):
                   mapping dot-notation keys to values.
                   Example list: ['trainer.policy.model.path=Qwen/Qwen2.5-1.5B-Instruct', 'trainer.seed=123']
                   Example dict: {'trainer.policy.model.path': 'Qwen/Qwen2.5-1.5B-Instruct', 'trainer.seed': 123}
+                  Dict values are serialized as JSON, so ``None``, bools, strings,
+                  lists and nested dicts keep their types.
 
         Returns:
             A fully constructed SkyRLTrainConfig with CLI overrides applied.
@@ -1291,11 +1327,7 @@ class SkyRLTrainConfig(BaseConfig):
             ValueError: If an argument uses the unsupported '+' prefix.
         """
         if isinstance(args, dict):
-            # OmegaConf's CLI parser only treats "null" as None; Python's
-            # None stringifies to "None" which is parsed as the literal
-            # string. Map None -> "null" so JSON-style overrides survive
-            # the round-trip through OmegaConf.from_cli below.
-            args = [f"{k}=null" if v is None else f"{k}={v}" for k, v in args.items()]
+            args = overrides_dict_to_dotlist(args)
 
         # Check for unsupported '+' prefix
         for arg in args:

--- a/skyrl/train/config/sft_config.py
+++ b/skyrl/train/config/sft_config.py
@@ -23,6 +23,7 @@ from skyrl.train.config import (
     SkyRLTrainConfig,
     TorchProfilerConfig,
 )
+from skyrl.train.config.config import overrides_dict_to_dotlist
 
 # ---------------------------------------------------------------------------
 # TrainOnWhat enum
@@ -84,6 +85,8 @@ class SFTConfig(BaseConfig):
                   mapping dot-notation keys to values.
                   Example list: ['strategy=megatron', 'model.path=Qwen/Qwen3-0.6B']
                   Example dict: {'strategy': 'megatron', 'model.path': 'Qwen/Qwen3-0.6B'}
+                  Dict values are serialized as JSON, so ``None``, bools, strings,
+                  lists and nested dicts keep their types.
 
         Returns:
             A fully constructed SFTConfig with CLI overrides applied.
@@ -92,7 +95,7 @@ class SFTConfig(BaseConfig):
             ValueError: If both ``num_epochs`` and ``num_steps`` are explicitly provided.
         """
         if isinstance(args, dict):
-            args = [f"{k}={v}" for k, v in args.items()]
+            args = overrides_dict_to_dotlist(args)
 
         overrides = OmegaConf.from_cli(args)
         # Check for mutual exclusion before constructing the full config

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -2,6 +2,7 @@
 uv run --isolated --extra dev pytest -s tests/train/test_config.py
 """
 
+import pathlib
 import typing
 from dataclasses import dataclass, field
 from enum import Enum
@@ -16,9 +17,18 @@ from skyrl.train.config.config import (
     TrainerConfig,
     _resolve_class_type,
     build_nested_dataclass,
+    overrides_dict_to_dotlist,
 )
 from skyrl.train.utils.utils import validate_cfg, validate_inference_engine_cfg
 from tests.train.util import example_dummy_config
+
+
+def _get_nested_attr(cfg, dotted_path: str):
+    """Resolve a dot-notation config path to its value."""
+    node = cfg
+    for part in dotted_path.split("."):
+        node = getattr(node, part)
+    return node
 
 
 def _make_validated_test_config():
@@ -446,6 +456,191 @@ def test_fake_int4_qat_requires_unmerged_lora_sync():
                 "trainer.policy.model.fake_int4_qat.enabled=true",
             ]
         )
+
+
+class TestOverridesDictToDotlist:
+    """``overrides_dict_to_dotlist`` emits values that ``OmegaConf.from_cli`` parses
+    back to the same Python object. See https://github.com/NovaSky-AI/SkyRL/issues/1567.
+    """
+
+    @pytest.mark.parametrize(
+        ("value", "expected_arg"),
+        [
+            pytest.param(None, "k=null", id="none"),
+            pytest.param(True, "k=true", id="bool-true"),
+            pytest.param(False, "k=false", id="bool-false"),
+            pytest.param(7, "k=7", id="int"),
+            pytest.param(1.5, "k=1.5", id="float"),
+            pytest.param("hello", 'k="hello"', id="str"),
+            pytest.param("null", 'k="null"', id="str-null"),
+            pytest.param("", 'k=""', id="str-empty"),
+            pytest.param("a,b", 'k="a,b"', id="str-comma"),
+            pytest.param("a: b", 'k="a: b"', id="str-colon"),
+            pytest.param(["a", None], 'k=["a", null]', id="list"),
+            pytest.param({"a": 1}, 'k={"a": 1}', id="dict"),
+            # Non-ASCII stays literal: \\uXXXX escaping splits astral-plane
+            # characters into surrogate halves that OmegaConf decodes separately.
+            pytest.param("café", 'k="café"', id="non-ascii-bmp"),
+            pytest.param("run-\U0001f600", 'k="run-\U0001f600"', id="non-ascii-astral"),
+        ],
+    )
+    def test_serialization(self, value, expected_arg):
+        assert overrides_dict_to_dotlist({"k": value}) == [expected_arg]
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            True,
+            7,
+            1.5,
+            "hello",
+            "null",
+            "true",
+            "",
+            "1e5",
+            "on",
+            "a,b",
+            "a: b",
+            "[a]",
+            "{a: b}",
+            'say "hi"',
+            "a\nb",
+            "a\\b",
+            "café",
+            "run-\U0001f600",
+            ["http://a:1", "http://b:2"],
+            [],
+            {"a": 1, "b": "x"},
+            {},
+        ],
+    )
+    def test_values_round_trip_through_omegaconf(self, value):
+        (arg,) = overrides_dict_to_dotlist({"k": value})
+        parsed = OmegaConf.to_container(OmegaConf.from_cli([arg]), resolve=False)["k"]
+        assert parsed == value
+        assert type(parsed) is type(value)
+        if isinstance(parsed, str):
+            # Lone surrogates only surface on encode.
+            parsed.encode("utf-8")
+
+    def test_multiple_keys_preserve_order(self):
+        assert overrides_dict_to_dotlist({"a": 1, "b": None}) == ["a=1", "b=null"]
+
+    def test_non_json_serializable_values_fall_back_to_str(self):
+        assert overrides_dict_to_dotlist({"k": pathlib.Path("/tmp/x")}) == ["k=/tmp/x"]
+
+    def test_circular_reference_falls_back_to_str(self):
+        value = {}
+        value["self"] = value
+        (arg,) = overrides_dict_to_dotlist({"k": value})
+        assert arg.startswith("k={")
+
+
+class TestCliOverridesFromDict:
+    """Dict overrides round-trip by type rather than through YAML re-parsing.
+
+    The dict path serializes values into ``key=value`` strings for
+    ``OmegaConf.from_cli``, which re-parses each value with YAML scalar rules.
+    See https://github.com/NovaSky-AI/SkyRL/issues/1567.
+    """
+
+    def test_none_values_stay_none(self):
+        """``None`` values arrive as ``None``, not the string ``"None"``."""
+        cfg = SkyRLTrainConfig.from_cli_overrides(
+            {
+                "generator.inference_engine.external_server_urls": None,
+                "generator.inference_engine.external_proxy_url": None,
+                "generator.inference_engine.served_model_name": None,
+            }
+        )
+        ie_cfg = cfg.generator.inference_engine
+        assert ie_cfg.external_server_urls is None
+        assert ie_cfg.external_proxy_url is None
+        assert ie_cfg.served_model_name is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "null",  # YAML null
+            "true",  # YAML bool
+            "false",
+            "",  # empty scalar -> YAML null
+            "[not-a-list]",  # YAML flow sequence
+            "{not: a-dict}",  # YAML flow mapping
+            "name: with colon",  # YAML block mapping
+            "1e5",  # YAML float
+            "on",  # YAML 1.1 bool
+        ],
+    )
+    def test_string_values_stay_strings(self, value):
+        """A ``str`` value stays a ``str``, even when it looks like YAML."""
+        cfg = SkyRLTrainConfig.from_cli_overrides({"generator.inference_engine.served_model_name": value})
+        assert cfg.generator.inference_engine.served_model_name == value
+
+    def test_scalar_and_container_values_keep_their_types(self):
+        cfg = SkyRLTrainConfig.from_cli_overrides(
+            {
+                "generator.inference_engine.max_num_seqs": 512,
+                "generator.sampling_params.temperature": 0.7,
+                "generator.inference_engine.enforce_eager": True,
+                "generator.inference_engine.enable_prefix_caching": False,
+                "generator.inference_engine.external_server_urls": ["http://a:1", "http://b:2"],
+                "generator.inference_engine.engine_init_kwargs": {"a": 1, "b": "x"},
+                "trainer.policy.model.path": "Qwen/Qwen2.5-1.5B-Instruct",
+            }
+        )
+        ie_cfg = cfg.generator.inference_engine
+        assert ie_cfg.max_num_seqs == 512
+        assert cfg.generator.sampling_params.temperature == 0.7
+        assert ie_cfg.enforce_eager is True
+        assert ie_cfg.enable_prefix_caching is False
+        assert ie_cfg.external_server_urls == ["http://a:1", "http://b:2"]
+        assert ie_cfg.engine_init_kwargs == {"a": 1, "b": "x"}
+        assert cfg.trainer.policy.model.path == "Qwen/Qwen2.5-1.5B-Instruct"
+
+    def test_non_json_serializable_values_fall_back_to_str(self):
+        """Values ``json.dumps`` cannot handle serialize via ``str()``."""
+        cfg = SkyRLTrainConfig.from_cli_overrides({"trainer.export_path": pathlib.Path("/tmp/export")})
+        assert cfg.trainer.export_path == "/tmp/export"
+
+    @pytest.mark.parametrize(
+        ("key", "dict_value", "dotlist_arg", "expected"),
+        [
+            pytest.param(
+                "generator.inference_engine.external_server_urls",
+                None,
+                "generator.inference_engine.external_server_urls=null",
+                None,
+                id="none",
+            ),
+            pytest.param(
+                "generator.inference_engine.served_model_name",
+                "null",
+                "generator.inference_engine.served_model_name='null'",
+                "null",
+                id="str-null",
+            ),
+            pytest.param(
+                "generator.inference_engine.external_server_urls",
+                ["http://a:1"],
+                "generator.inference_engine.external_server_urls=['http://a:1']",
+                ["http://a:1"],
+                id="list",
+            ),
+        ],
+    )
+    def test_dict_and_dotlist_paths_agree(self, key, dict_value, dotlist_arg, expected):
+        """A dict override matches the dotlist spelling of the same value."""
+        from_dict = SkyRLTrainConfig.from_cli_overrides({key: dict_value})
+        from_list = SkyRLTrainConfig.from_cli_overrides([dotlist_arg])
+        assert _get_nested_attr(from_dict, key) == expected
+        assert _get_nested_attr(from_list, key) == expected
+
+    def test_plus_prefix_rejected_from_dict(self):
+        """``'+'``-prefixed keys are rejected on the dict path."""
+        with pytest.raises(ValueError, match="The '\\+' prefix"):
+            SkyRLTrainConfig.from_cli_overrides({"+new_field": "value"})
 
 
 class TestTrainerUseSamplePackingAlias:

--- a/tests/train/test_sft_config.py
+++ b/tests/train/test_sft_config.py
@@ -7,6 +7,8 @@ correctly bridged to the internal SkyRLTrainConfig by build_skyrl_config_for_sft
 uv run --isolated --extra dev pytest tests/train/test_sft_config.py -v
 """
 
+import pathlib
+
 import pytest
 
 from skyrl.train.config import (
@@ -49,6 +51,83 @@ class TestUseSamplePackingAlias:
     def test_use_sample_packing_with_new_key_raises(self):
         with pytest.raises(ValueError, match="only one of use_sample_packing"):
             _sft_cfg_from_overrides(["use_sample_packing=true", "remove_microbatch_padding=false"])
+
+
+class TestCliOverridesFromDict:
+    """Dict overrides round-trip by type rather than through YAML re-parsing.
+
+    See https://github.com/NovaSky-AI/SkyRL/issues/1567.
+    """
+
+    def test_none_values_stay_none(self):
+        """``None`` values arrive as ``None``, not the string ``"None"``."""
+        cfg = SFTConfig.from_cli_overrides(
+            {
+                "max_training_steps": None,
+                "num_steps": None,
+                "sampler_class_path": None,
+            }
+        )
+        assert cfg.max_training_steps is None
+        assert cfg.num_steps is None
+        assert cfg.sampler_class_path is None
+
+    def test_none_override_passes_validation(self):
+        """A ``None`` ``max_training_steps`` override passes ``validate_sft_cfg``.
+
+        ``validate_sft_cfg`` compares ``max_training_steps`` against ``0``, which
+        raises ``TypeError`` for a string.
+        """
+        cfg = SFTConfig.from_cli_overrides({"max_training_steps": None, "model.path": "test/my-model"})
+        validate_sft_cfg(cfg)
+        assert cfg.max_training_steps is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "null",
+            "true",
+            "",
+            "[not-a-list]",
+            "{not: a-dict}",
+            "name: with colon",
+        ],
+    )
+    def test_string_values_stay_strings(self, value):
+        cfg = SFTConfig.from_cli_overrides({"run_name": value})
+        assert cfg.run_name == value
+
+    def test_scalar_and_container_values_keep_their_types(self):
+        cfg = SFTConfig.from_cli_overrides(
+            {
+                "num_steps": 10,
+                "remove_microbatch_padding": True,
+                "use_sequence_packing": False,
+                "model.path": "Qwen/Qwen3-0.6B",
+            }
+        )
+        assert cfg.num_steps == 10
+        assert cfg.remove_microbatch_padding is True
+        assert cfg.use_sequence_packing is False
+        assert cfg.model.path == "Qwen/Qwen3-0.6B"
+
+    def test_non_json_serializable_values_fall_back_to_str(self):
+        cfg = SFTConfig.from_cli_overrides({"model.path": pathlib.Path("/tmp/model")})
+        assert cfg.model.path == "/tmp/model"
+
+    @pytest.mark.parametrize(
+        ("dict_value", "dotlist_arg", "expected"),
+        [
+            pytest.param(None, "num_steps=null", None, id="none"),
+            pytest.param(5, "num_steps=5", 5, id="int"),
+        ],
+    )
+    def test_dict_and_dotlist_paths_agree(self, dict_value, dotlist_arg, expected):
+        """A dict override matches the dotlist spelling of the same value."""
+        from_dict = SFTConfig.from_cli_overrides({"num_steps": dict_value})
+        from_list = SFTConfig.from_cli_overrides([dotlist_arg])
+        assert from_dict.num_steps == expected
+        assert from_list.num_steps == expected
 
 
 class TestTopLevelOverrides:


### PR DESCRIPTION
# What does this PR do?

Fixes #1567

`from_cli_overrides` accepts either a CLI dotlist or a dict. On the dict path values were serialized with f-strings and handed to `OmegaConf.from_cli`, which re-parses each value with YAML scalar rules. `str()` does not round-trip through that parser, so `None` became the string "None" and string values that look like YAML ("null", "true", "1e5", "[a]", "a: b", "") changed type.

For `external_server_urls=None` this produced `list("None")` -> ['N','o','n','e'] and a request to the URL `N`, surfacing as
`InvalidUrlClientError: N/get_world_size`.

Serialize dict values as JSON instead, via a shared `overrides_dict_to_dotlist` helper used by both `SkyRLTrainConfig` and `SFTConfig`. 

`ensure_ascii=False` also keeps non-ASCII literal as a bonus for users using fancy Wandb run names, etc

## Test Plan

1. `tests/train/test_config.py::TestOverridesDictToDotlist`: Tests for new utility `overrides_dict_to_dotlist` 
2. `tests/train/test_config.py::TestCliOverridesFromDict`: Tests for CLI override parsing with dicts and dotlists (`cfg.key=value`) including a regression test for the error reported in #1567

```bash
uv run --isolated --extra dev --extra skyrl-train tests/train/test_config.py
```
