### PR TITLE
[fix][metrics] Reduce policy_entropy and logprob-diff metrics via sum/count

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/model_utils.py
@@ -1009,13 +1009,13 @@ def vocab_parallel_entropy_packed_sequences(
     sub_seq_lengths: Optional[list[list[int]]] = None,
     chunk_size: Optional[int] = None,
     chunk_memory_mb: int = 512,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Compute action-token entropy directly on TP+CP sharded packed logits.
 
     Returns:
-        A tuple of (global entropy metric, local entropy term for loss). The
-        local term is normalized by the global action-token count. Megatron's
-        schedule already applies the CP loss scale for two-output loss funcs.
+        A tuple of (global entropy metric, local entropy term for loss, global entropy sum,
+        global action-token count). The local term is normalized by the global action-token
+        count. Megatron's schedule already applies the CP loss scale for two-output loss funcs.
     """
     device = vocab_parallel_logits.device
     dtype = vocab_parallel_logits.dtype
@@ -1080,11 +1080,11 @@ def vocab_parallel_entropy_packed_sequences(
     if cp_size > 1:
         torch.distributed.all_reduce(global_count, group=cp_group)
         torch.distributed.all_reduce(global_entropy_sum, group=cp_group)
-    global_count = global_count.clamp(min=1.0)
-
-    entropy = global_entropy_sum / global_count
-    entropy_for_loss = local_entropy_sum / global_count
-    return entropy, entropy_for_loss
+    # `global_count` is returned unclamped so the metric nnz is exact; it is only clamped
+    # (to guard a divide-by-zero) inside the per-micro-batch mean below.
+    entropy = global_entropy_sum / global_count.clamp(min=1.0)
+    entropy_for_loss = local_entropy_sum / global_count.clamp(min=1.0)
+    return entropy, entropy_for_loss, global_entropy_sum, global_count
 
 
 def _fused_vocab_parallel_entropy_from_hidden(
@@ -1134,7 +1134,7 @@ def from_parallel_hidden_to_entropy_packed_sequences(
     sub_seq_lengths: Optional[list[list[int]]] = None,
     chunk_size: Optional[int] = None,
     temperature: float = 1.0,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Fused-LM-head variant of :func:`vocab_parallel_entropy_packed_sequences`.
 
     Identical action-token weighting / CP logic, but per-token entropy is
@@ -1201,11 +1201,11 @@ def from_parallel_hidden_to_entropy_packed_sequences(
     if cp_size > 1:
         torch.distributed.all_reduce(global_count, group=cp_group)
         torch.distributed.all_reduce(global_entropy_sum, group=cp_group)
-    global_count = global_count.clamp(min=1.0)
-
-    entropy = global_entropy_sum / global_count
-    entropy_for_loss = local_entropy_sum / global_count
-    return entropy, entropy_for_loss
+    # `global_count` is returned unclamped so the metric nnz is exact; it is only clamped
+    # (to guard a divide-by-zero) inside the per-micro-batch mean below.
+    entropy = global_entropy_sum / global_count.clamp(min=1.0)
+    entropy_for_loss = local_entropy_sum / global_count.clamp(min=1.0)
+    return entropy, entropy_for_loss, global_entropy_sum, global_count
 
 
 class AllGatherPackedCPTensor(torch.autograd.Function):

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -864,6 +864,12 @@ class MegatronModelWrapper:
                     entropy_for_loss = entropy
                     entropy_sum, entropy_nnz = compute_masked_sum_and_count(entropy_BS, loss_mask)
 
+            # The packed helpers return detached tensors while compute_masked_sum_and_count
+            # returns Python floats; reduce_metrics silently drops non-(int, float) values,
+            # so normalize to floats before emitting the raw sum/count metrics.
+            entropy_sum = float(entropy_sum)
+            entropy_nnz = float(entropy_nnz)
+
             if loss_config.use_entropy_loss:
                 entropy_loss_term = entropy_for_loss * loss_config.entropy_loss_coef
             else:

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -53,6 +53,9 @@ from skyrl.backends.skyrl_train.utils.replay_utils import (
 )
 from skyrl.backends.skyrl_train.utils.torch_utils import masked_mean
 from skyrl.backends.skyrl_train.workers.worker_utils import (
+    LOSS_MASK_NNZ_KEY,
+    POLICY_ENTROPY_SUM_KEY,
+    compute_masked_sum_and_count,
     compute_minibatch_rollout_logprob_diff_metrics,
 )
 from skyrl.train.config import TrainerConfig
@@ -809,19 +812,21 @@ class MegatronModelWrapper:
             # RL path: add optional KL/entropy terms
             with torch.set_grad_enabled(loss_config.use_entropy_loss):
                 if fused_lm_head and packed_seq_params is not None and packed_targets is not None:
-                    entropy, entropy_for_loss = from_parallel_hidden_to_entropy_packed_sequences(
-                        logits,  # decoder hidden states [1, T, H]
-                        lm_head_weight,
-                        packed_seq_params.cu_seqlens_q_padded,
-                        sequences.shape[1],
-                        num_actions,
-                        data["attention_mask"],
-                        loss_mask,
-                        mpu.get_context_parallel_group(),
-                        tp_group=tp_grp,
-                        sub_seq_lengths=data.get("sub_seq_lengths_list"),
-                        chunk_size=self.cfg.logprobs_chunk_size,
-                        temperature=temperature,
+                    entropy, entropy_for_loss, entropy_sum, entropy_nnz = (
+                        from_parallel_hidden_to_entropy_packed_sequences(
+                            logits,  # decoder hidden states [1, T, H]
+                            lm_head_weight,
+                            packed_seq_params.cu_seqlens_q_padded,
+                            sequences.shape[1],
+                            num_actions,
+                            data["attention_mask"],
+                            loss_mask,
+                            mpu.get_context_parallel_group(),
+                            tp_group=tp_grp,
+                            sub_seq_lengths=data.get("sub_seq_lengths_list"),
+                            chunk_size=self.cfg.logprobs_chunk_size,
+                            temperature=temperature,
+                        )
                     )
                 elif fused_lm_head:
                     action_hidden = logits[:, -num_actions - 1 : -1, :]
@@ -834,8 +839,9 @@ class MegatronModelWrapper:
                     )
                     entropy = masked_mean(entropy_BS, loss_mask)
                     entropy_for_loss = entropy
+                    entropy_sum, entropy_nnz = compute_masked_sum_and_count(entropy_BS, loss_mask)
                 elif packed_seq_params is not None and packed_targets is not None:
-                    entropy, entropy_for_loss = vocab_parallel_entropy_packed_sequences(
+                    entropy, entropy_for_loss, entropy_sum, entropy_nnz = vocab_parallel_entropy_packed_sequences(
                         logits,
                         packed_seq_params.cu_seqlens_q_padded,
                         sequences.shape[1],
@@ -856,6 +862,7 @@ class MegatronModelWrapper:
                     )
                     entropy = masked_mean(entropy_BS, loss_mask)
                     entropy_for_loss = entropy
+                    entropy_sum, entropy_nnz = compute_masked_sum_and_count(entropy_BS, loss_mask)
 
             if loss_config.use_entropy_loss:
                 entropy_loss_term = entropy_for_loss * loss_config.entropy_loss_coef
@@ -929,7 +936,8 @@ class MegatronModelWrapper:
             metrics = {
                 "final_loss": unscaled_loss.detach().item(),
                 "policy_loss": policy_loss.detach().item(),
-                "policy_entropy": entropy.detach().item(),
+                POLICY_ENTROPY_SUM_KEY: entropy_sum,
+                LOSS_MASK_NNZ_KEY: entropy_nnz,
                 "policy_kl": kl_loss.detach().item(),
                 "loss_fn_outputs": loss_fn_outputs,
             }

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -64,6 +64,8 @@ from skyrl.backends.skyrl_train.workers.worker import (
     RefWorkerBase,
 )
 from skyrl.backends.skyrl_train.workers.worker_utils import (
+    LOSS_MASK_NNZ_KEY,
+    POLICY_ENTROPY_SUM_KEY,
     BaseBatchIterator,
     BatchIterator,
     TokenBasedBatchIterator,
@@ -1285,6 +1287,13 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
 
         group = mpu.get_data_parallel_group(with_context_parallel=False)
         status = all_reduce_metrics(status, self.strategy, group=group, sum_loss_metrics=True)
+
+        # The entropy sum/count are now summed across micro-batches and DP ranks; divide once for
+        # the exact global entropy of this rank's mini-batch portion. The raw _sum/_nnz keys are
+        # kept so the trainer can sum them again across mini-batches and divide once more for the
+        # final global value.
+        if POLICY_ENTROPY_SUM_KEY in status and LOSS_MASK_NNZ_KEY in status:
+            status["policy_entropy"] = status[POLICY_ENTROPY_SUM_KEY] / max(status[LOSS_MASK_NNZ_KEY], 1.0)
 
         # Collect MoE aux metrics averaged across microbatches (all-reduced across ranks
         # inside get_moe_metrics) aggregating after per-microbatch scalar metrics.

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -48,9 +48,12 @@ from skyrl.backends.skyrl_train.utils.ppo_utils import (
 )
 from skyrl.backends.skyrl_train.utils.torch_utils import masked_mean
 from skyrl.backends.skyrl_train.workers.worker_utils import (
+    LOSS_MASK_NNZ_KEY,
+    POLICY_ENTROPY_SUM_KEY,
     BaseBatchIterator,
     BatchIterator,
     all_reduce_metrics,
+    compute_masked_sum_and_count,
     compute_minibatch_rollout_logprob_diff_metrics,
     get_microbatch_iterator,
     reduce_metrics,
@@ -849,6 +852,13 @@ class PolicyWorkerBase(Worker):
         dp_group = self.device_mesh.get_group("dp")
         result = all_reduce_metrics(result, self.strategy, group=dp_group, sum_loss_metrics=True)
 
+        # The entropy sum/count are now summed across micro-batches and DP ranks; divide once for
+        # the exact global entropy of this rank's mini-batch portion. The raw _sum/_nnz keys are
+        # kept so the trainer can sum them again across mini-batches and divide once more for the
+        # final global value.
+        if POLICY_ENTROPY_SUM_KEY in result and LOSS_MASK_NNZ_KEY in result:
+            result["policy_entropy"] = result[POLICY_ENTROPY_SUM_KEY] / max(result[LOSS_MASK_NNZ_KEY], 1.0)
+
         return WorkerOutput(loss_fn_outputs=all_loss_fn_outputs, metrics=result)
 
     def _forward_backward_micro(
@@ -1001,6 +1011,11 @@ class PolicyWorkerBase(Worker):
                 entropy_BS = output["entropy"]
                 entropy_BS = entropy_BS[:, -num_actions - 1 : -1]
                 entropy = masked_mean(entropy_BS, loss_mask)
+                # Masked per-token sum and its count. Both are summed across micro-batches
+                # and DP ranks (and, at the trainer, mini-batches); the entropy is recovered
+                # with a single final division, so it stays exact under imbalanced shards
+                # instead of being a mean-of-means.
+                entropy_sum, entropy_nnz = compute_masked_sum_and_count(entropy_BS, loss_mask)
 
             if self.cfg.algorithm.use_entropy_loss:
                 entropy_loss_term = entropy * self.cfg.algorithm.entropy_loss_coef
@@ -1054,7 +1069,8 @@ class PolicyWorkerBase(Worker):
             status = {
                 "final_loss": unscaled_loss.item(),
                 "policy_loss": policy_loss.item(),
-                "policy_entropy": entropy.item(),
+                POLICY_ENTROPY_SUM_KEY: entropy_sum,
+                LOSS_MASK_NNZ_KEY: entropy_nnz,
                 "response_length": num_actions,
                 "policy_lr": self.scheduler.get_last_lr()[0],
                 "loss_fn_outputs": loss_fn_outputs,

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -7,7 +7,6 @@ import torch.distributed as dist
 from skyrl.backends.skyrl_train.distributed.strategy import DistributedStrategy
 from skyrl.backends.skyrl_train.training_batch import TensorBatch, TrainingInputBatch
 from skyrl.backends.skyrl_train.utils.replay_utils import make_replay_padding_indices
-from skyrl.backends.skyrl_train.utils.torch_utils import masked_mean
 from skyrl.train.dataset.bin_packing import make_seq_packer
 from skyrl.train.dataset.replay_buffer import Experience
 
@@ -19,12 +18,23 @@ from skyrl.train.dataset.replay_buffer import Experience
 # Summing it would multiply the reported value by the microbatch (and DP) count -- e.g. a true
 # ~0.5 nats reads as ~44. Keep these averaged regardless of `sum_loss_metrics`.
 MEAN_LOSS_METRICS = frozenset({"mtp_loss", "draft_loss"})
-# Per-micro-batch abs diff between train-step and rollout logprobs. The moments (`_mean`,
-# `_sq_mean`) and `_max`/`_min` reduce correctly across micro-batches, DP ranks, and
-# mini-batches; the std is reconstructed from the moments downstream.
+# Metrics named ``*_sum`` / ``*_nnz`` are masked per-token sums and their counts (number of
+# non-zero loss-mask entries). They are ALWAYS summed -- across micro-batches, DP ranks, and
+# mini-batches -- regardless of ``sum_loss_metrics``, and divided once at the end (in the
+# trainer's finalize step). This recovers the exact metric as if it had been computed on the
+# global mini-batch, instead of a mean-of-means that over-weights under-sampled shards.
+POLICY_ENTROPY_SUM_KEY = "policy_entropy_sum"
+LOSS_MASK_NNZ_KEY = "loss_mask_nnz"
+# Per-micro-batch abs diff between train-step and rollout logprobs. The workers emit the masked
+# sums (``_sum``, ``_sq_sum``) and the count (``_nnz``) instead of means; those sum-reduce
+# exactly across micro-batches, DP ranks, and mini-batches, and the moments / std are derived
+# once downstream in `finalize_minibatch_rollout_logprob_diff_std`. ``_max``/``_min`` reduce
+# correctly as-is.
 MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX = "minibatch_rollout_logprobs_abs_diff"
 MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_mean"
-MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_sq_mean"
+MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_sum"
+MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_sq_sum"
+MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_nnz"
 MINIBATCH_ROLLOUT_LOGPROB_DIFF_MAX_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_max"
 MINIBATCH_ROLLOUT_LOGPROB_DIFF_MIN_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_min"
 MINIBATCH_ROLLOUT_LOGPROB_DIFF_STD_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_std"
@@ -41,27 +51,47 @@ def compute_minibatch_rollout_logprob_diff_metrics(
     Unlike the trainer's forward-pass `rollout_train_logprobs_abs_diff` metric, this uses the
     logprobs the loss actually optimizes against, so it reflects mini-batch drift when
     ``train_batch_size > mini_batch_size``. Masked-out tokens are excluded via the same
-    ``masked_mean`` / ``* loss_mask`` pattern as the off-policy `is_ratio_*` metrics, so the keys
-    are emitted for every micro-batch (a fully-masked one contributes 0) -- keeping them present
-    on every DP rank. Returns ``{}`` only when rollout logprobs are unavailable, which is uniform
-    across DP ranks.
+    ``* loss_mask`` pattern as the off-policy `is_ratio_*` metrics, so the keys are emitted for
+    every micro-batch (a fully-masked one contributes 0) -- keeping them present on every DP
+    rank. The ``_sum``/``_sq_sum`` values and the ``_nnz`` count are all sum-reduced by
+    `reduce_metrics` / `all_reduce_metrics`; the mean / std are derived once from them in
+    `finalize_minibatch_rollout_logprob_diff_std`. Returns ``{}`` only when rollout logprobs are
+    unavailable, which is uniform across DP ranks.
     """
     if rollout_logprobs is None:
         return {}
     abs_diff = (action_log_probs - rollout_logprobs).abs()
     masked_abs_diff = abs_diff if loss_mask is None else abs_diff * loss_mask
+    nnz = abs_diff.numel() if loss_mask is None else loss_mask.sum().item()
     return {
-        MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY: masked_mean(abs_diff, loss_mask).item(),
-        MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY: masked_mean(abs_diff.square(), loss_mask).item(),
+        MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY: masked_abs_diff.sum().item(),
+        MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY: masked_abs_diff.square().sum().item(),
+        MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY: float(nnz),
         MINIBATCH_ROLLOUT_LOGPROB_DIFF_MAX_KEY: masked_abs_diff.max().item(),
         MINIBATCH_ROLLOUT_LOGPROB_DIFF_MIN_KEY: masked_abs_diff.min().item(),
     }
 
 
+@torch.no_grad()
+def compute_masked_sum_and_count(tensor: torch.Tensor, mask: Optional[torch.Tensor]) -> tuple[float, float]:
+    """Masked sum and count (number of non-zero mask entries) of a per-token tensor.
+
+    ``sum / count`` reproduces the masked mean for a single tensor, and -- unlike a
+    mean-of-means -- the sum and count each reduce exactly by summation across micro-batches,
+    DP ranks, and mini-batches. They are divided once at the end (in the trainer's finalize
+    step) to recover the exact global mean.
+    """
+    if mask is None:
+        return tensor.sum().item(), float(tensor.numel())
+    return (tensor * mask).sum().item(), mask.sum().item()
+
+
 def reduce_metrics(metrics: Dict[str, List[float]], sum_loss_metrics: bool = False) -> Dict[str, float]:
     """Reduce scalar metrics from a list of entries per key with the appropriate reduction.
 
-    Default reduction is mean. Metrics ending in `_min` or `_max` use min/max respectively.
+    Default reduction is mean. Metrics ending in `_min` or `_max` use min/max respectively,
+    and metrics ending in `_sum` or `_nnz` (masked per-token sums / their counts) are always
+    summed so the exact global mean can be derived with a single final division.
 
     If sum_loss_metrics is True, metrics named 'loss' or ending in `_loss` are summed instead of
     averaged (except those in `MEAN_LOSS_METRICS`, which are always averaged).
@@ -84,6 +114,8 @@ def reduce_metrics(metrics: Dict[str, List[float]], sum_loss_metrics: bool = Fal
             reduced_metrics[k] = max(v)
         elif k.endswith("_min"):
             reduced_metrics[k] = min(v)
+        elif k.endswith("_sum") or k.endswith("_nnz"):
+            reduced_metrics[k] = sum(v)
         elif sum_loss_metrics and (k == "loss" or k.endswith("_loss")) and k not in MEAN_LOSS_METRICS:
             reduced_metrics[k] = sum(v)
         else:
@@ -99,8 +131,9 @@ def all_reduce_metrics(
 ) -> Dict[str, float]:
     """All reduce metrics across all processes.
 
-    Default reduction is mean. Metrics ending in `_min` or `_max` use min/max respectively.
-    If sum_loss_metrics is True, metrics named ``loss`` or ending in ``_loss`` are summed
+    Default reduction is mean. Metrics ending in `_min` or `_max` use min/max respectively,
+    and metrics ending in `_sum` or `_nnz` (masked per-token sums / their counts) are always
+    summed. If sum_loss_metrics is True, metrics named ``loss`` or ending in ``_loss`` are summed
     instead of averaged.
 
     Args:
@@ -115,7 +148,9 @@ def all_reduce_metrics(
     sum_metrics = {
         k: v
         for k, v in metrics.items()
-        if sum_loss_metrics and (k == "loss" or k.endswith("_loss")) and k not in MEAN_LOSS_METRICS
+        if k.endswith("_sum")
+        or k.endswith("_nnz")
+        or (sum_loss_metrics and (k == "loss" or k.endswith("_loss")) and k not in MEAN_LOSS_METRICS)
     }
     mean_metrics = {
         k: v for k, v in metrics.items() if k not in min_metrics and k not in max_metrics and k not in sum_metrics

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -30,9 +30,10 @@ from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
 from skyrl.backends.skyrl_train.workers.worker_dispatch import WorkerDispatch
 from skyrl.backends.skyrl_train.workers.worker_utils import (
     MINIBATCH_ROLLOUT_LOGPROB_DIFF_MAX_KEY,
-    MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY,
     MINIBATCH_ROLLOUT_LOGPROB_DIFF_MIN_KEY,
-    MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY,
+    MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY,
+    MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY,
+    MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY,
 )
 from skyrl.env_vars import SKYRL_RAY_PG_TIMEOUT_IN_S
 from skyrl.tinker import types
@@ -755,18 +756,20 @@ class SkyRLTrainBackend(AbstractBackend):
 
         # Train-vs-rollout logprob gap, computed by the policy workers per
         # micro-batch (masked |logp_train - logp_rollout| over action tokens)
-        # and reduced across micro-batches / DP ranks.  Reconstruct the std
-        # from the reduced first/second moments (std itself cannot be
-        # mean-reduced; same as finalize_minibatch_rollout_logprob_diff_std)
-        # and surface the family under skyrl-train's familiar
+        # and summed across micro-batches / DP ranks (`_sum` / `_nnz` keys,
+        # same as finalize_minibatch_rollout_logprob_diff_std) so the mean /
+        # std can be derived exactly even for imbalanced shards, then surface
+        # the family under skyrl-train's familiar
         # `policy/rollout_train_logprobs_abs_diff_*` names.  The `:mean` /
         # `:max` / `:min` suffixes drive the Tinker SDK's cross-chunk
         # reduction when a request is split into multiple chunks.
-        if MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY in data:
-            mean = float(data[MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY])
+        if MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY in data:
+            total = float(data[MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY])
+            count = float(data[MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY])
+            mean = total / count if count > 0 else 0.0
             metrics["policy/rollout_train_logprobs_abs_diff_mean:mean"] = mean
-            if MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY in data:
-                sq_mean = float(data[MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY])
+            if MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY in data:
+                sq_mean = float(data[MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY]) / count if count > 0 else 0.0
                 # max(0, ...) guards tiny negatives from float round-off.
                 metrics["policy/rollout_train_logprobs_abs_diff_std:mean"] = math.sqrt(max(0.0, sq_mean - mean**2))
             if MINIBATCH_ROLLOUT_LOGPROB_DIFF_MAX_KEY in data:

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -90,6 +90,7 @@ from skyrl.train.utils.trainer_utils import (
     cleanup_old_checkpoints,
     extract_step_from_path,
     finalize_minibatch_rollout_logprob_diff_std,
+    finalize_policy_entropy,
     run_on_each_node,
     validate_consistency_for_latest_checkpoint,
     validate_generator_output,
@@ -1553,6 +1554,7 @@ class RayPPOTrainer:
         # Reduce metrics across all mini-batches and epochs
         reduced_metrics = reduce_metrics(all_metrics, sum_loss_metrics=False)
         finalize_minibatch_rollout_logprob_diff_std(reduced_metrics)
+        finalize_policy_entropy(reduced_metrics)
         return reduced_metrics
 
     def train_critic_and_policy(self, data: TrainingInputBatch):

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -17,9 +17,13 @@ from transformers import AutoTokenizer
 from skyrl.backends.skyrl_train.utils.io import io
 from skyrl.backends.skyrl_train.workers.worker import PPORayActorGroup
 from skyrl.backends.skyrl_train.workers.worker_utils import (
+    LOSS_MASK_NNZ_KEY,
     MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY,
-    MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY,
+    MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY,
+    MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY,
     MINIBATCH_ROLLOUT_LOGPROB_DIFF_STD_KEY,
+    MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY,
+    POLICY_ENTROPY_SUM_KEY,
 )
 from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.dataset import PromptDataset
@@ -36,21 +40,49 @@ GLOBAL_STEP_PREFIX = "global_step_"
 
 
 def finalize_minibatch_rollout_logprob_diff_std(metrics: Dict[str, float]) -> None:
-    """Reconstruct the logprob-diff std from its reduced first/second moments, in place.
+    """Reconstruct the logprob-diff std from its reduced sums/count, in place.
 
-    Std can't be mean-reduced across micro-batches/DP/mini-batches, so the workers emit the
-    moments and we derive ``std = sqrt(E[x^2] - E[x]^2)`` here. Replaces the second-moment key
-    with the std; no-op when the moments are absent (e.g. critic training, or no rollout logprobs).
+    Std can't be reduced across micro-batches/DP/mini-batches, so the workers emit the masked
+    sums (``_sum``, ``_sq_sum``) and the count (``_nnz``) -- all of which sum-reduce exactly --
+    and we derive ``mean = sum/nnz``, ``std = sqrt(E[x^2] - E[x]^2)`` here. Replaces the raw
+    keys with the ``_mean``/``_std`` outputs; no-op when the sums are absent (e.g. critic
+    training, or no rollout logprobs).
     """
     if (
-        MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY not in metrics
-        or MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY not in metrics
+        MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY not in metrics
+        or MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY not in metrics
+        or MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY not in metrics
     ):
         return
-    mean = metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY]
-    sq_mean = metrics.pop(MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY)
+    nnz = metrics.pop(MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY)
+    total = metrics.pop(MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY)
+    sq_total = metrics.pop(MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY)
+    if nnz <= 0:
+        metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY] = 0.0
+        metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_STD_KEY] = 0.0
+        return
+    mean = total / nnz
+    sq_mean = sq_total / nnz
+    metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY] = mean
     # max(0, ...) guards tiny negatives from float round-off.
     metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_STD_KEY] = math.sqrt(max(0.0, sq_mean - mean**2))
+
+
+def finalize_policy_entropy(metrics: Dict[str, float]) -> None:
+    """Derive the exact entropy from its reduced masked sum/count, in place.
+
+    The workers emit the per-token masked sum (``policy_entropy_sum``) and the count
+    (``loss_mask_nnz``), both of which are summed across micro-batches, DP ranks, and
+    mini-batches. The entropy is recovered with a single final division, so it equals the
+    exact global masked mean even when shards carry imbalanced token counts (a mean-of-means
+    would over-weight under-sampled shards). No-op when the keys are absent (e.g. SFT or
+    critic training).
+    """
+    if POLICY_ENTROPY_SUM_KEY not in metrics or LOSS_MASK_NNZ_KEY not in metrics:
+        return
+    total = metrics.pop(POLICY_ENTROPY_SUM_KEY)
+    nnz = metrics.pop(LOSS_MASK_NNZ_KEY)
+    metrics["policy_entropy"] = total / nnz if nnz > 0 else 0.0
 
 
 class ResumeMode(Enum):

--- a/tests/backends/skyrl_train/workers/test_worker_utils.py
+++ b/tests/backends/skyrl_train/workers/test_worker_utils.py
@@ -9,9 +9,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from skyrl.backends.skyrl_train.workers.worker_utils import (
+    LOSS_MASK_NNZ_KEY,
+    POLICY_ENTROPY_SUM_KEY,
     all_reduce_metrics,
     reduce_metrics,
 )
+from skyrl.train.utils.trainer_utils import finalize_policy_entropy
 
 
 class TestReduceMetrics:
@@ -44,6 +47,26 @@ class TestReduceMetrics:
         metrics = {"policy_loss": [1.0, 2.0, 3.0]}
         result = reduce_metrics(metrics, sum_loss_metrics=True)
         assert result["policy_loss"] == 6.0
+
+    def test_reduce_metrics_sum_suffix(self):
+        """Keys ending in _sum should always be summed (masked per-token sums)."""
+        metrics = {"policy_entropy_sum": [1.0, 2.0, 3.0]}
+        result = reduce_metrics(metrics)
+        assert result["policy_entropy_sum"] == 6.0
+
+    def test_reduce_metrics_nnz_suffix(self):
+        """Keys ending in _nnz should always be summed (mask counts)."""
+        metrics = {"loss_mask_nnz": [5.0, 3.0, 2.0]}
+        result = reduce_metrics(metrics)
+        assert result["loss_mask_nnz"] == 10.0
+
+    def test_reduce_metrics_sum_and_nnz_unaffected_by_sum_loss_metrics(self):
+        """_sum/_nnz keys sum regardless of sum_loss_metrics, unlike _loss keys."""
+        metrics = {POLICY_ENTROPY_SUM_KEY: [1.0, 2.0], LOSS_MASK_NNZ_KEY: [4.0, 6.0]}
+        for sum_loss_metrics in (True, False):
+            result = reduce_metrics(metrics, sum_loss_metrics=sum_loss_metrics)
+            assert result[POLICY_ENTROPY_SUM_KEY] == 3.0
+            assert result[LOSS_MASK_NNZ_KEY] == 10.0
 
     def test_reduce_metrics_mixed(self):
         """Test mixed metric types are reduced correctly."""
@@ -148,6 +171,33 @@ class TestAllReduceMetrics:
         max_call = [c for c in ops_and_keys if c[0] == "max"][0]
         assert max_call[1] == {"is_ratio_max"}
 
+    def test_all_reduce_metrics_sums_sum_and_nnz_suffixes(self):
+        """_sum/_nnz keys all-reduce with the sum op even when sum_loss_metrics=False."""
+        strategy = MagicMock()
+
+        def mock_all_reduce(d, op, group=None):
+            return {k: v for k, v in d.items()}
+
+        strategy.all_reduce.side_effect = mock_all_reduce
+
+        metrics = {
+            POLICY_ENTROPY_SUM_KEY: 3.0,
+            LOSS_MASK_NNZ_KEY: 10.0,
+            "entropy": 0.5,
+        }
+        _ = all_reduce_metrics(metrics, strategy, sum_loss_metrics=False)
+
+        ops_and_keys = []
+        for args, kwargs in strategy.all_reduce.call_args_list:
+            op = kwargs.get("op") if kwargs else args[1]
+            ops_and_keys.append((op, set(args[0].keys())))
+
+        sum_call = [c for c in ops_and_keys if c[0] == "sum"][0]
+        assert sum_call[1] == {POLICY_ENTROPY_SUM_KEY, LOSS_MASK_NNZ_KEY}
+
+        mean_call = [c for c in ops_and_keys if c[0] == "mean"][0]
+        assert mean_call[1] == {"entropy"}
+
     def test_all_reduce_metrics_average_loss_metrics(self):
         """Verify _loss keys are averaged when sum_loss_metrics=False."""
         strategy = MagicMock()
@@ -210,3 +260,25 @@ class TestAllReduceMetrics:
         assert result["is_ratio_min"] == 0.05  # 0.1 / 2 (min op)
         assert result["policy_loss"] == 6.0  # sum op
         assert result["entropy"] == 1.0  # 0.5 * 2 (mean op)
+
+
+def test_entropy_sum_nnz_reduce_to_exact_global_mean():
+    """Entropy reduces exactly (sum/count) across imbalanced shards, unlike a mean-of-means.
+
+    Shard means are 1.0, 2.0, 1.0 -> a mean-of-means reads (1+2+1)/3 = 1.33, but the exact
+    global masked mean is (1 + 20 + 3) / (1 + 10 + 3) = 24/14 = 1.71."""
+    shards = [
+        {POLICY_ENTROPY_SUM_KEY: 1.0, LOSS_MASK_NNZ_KEY: 1.0},
+        {POLICY_ENTROPY_SUM_KEY: 20.0, LOSS_MASK_NNZ_KEY: 10.0},
+        {POLICY_ENTROPY_SUM_KEY: 3.0, LOSS_MASK_NNZ_KEY: 3.0},
+    ]
+    # Worker-level reduction over micro-batches within a mini-batch.
+    all_metrics = {k: [sh[k] for sh in shards] for k in shards[0]}
+    reduced = reduce_metrics(all_metrics)
+    # Trainer-level reduction across mini-batches.
+    reduced = reduce_metrics({k: [v] for k, v in reduced.items()})
+    finalize_policy_entropy(reduced)
+
+    assert POLICY_ENTROPY_SUM_KEY not in reduced
+    assert LOSS_MASK_NNZ_KEY not in reduced
+    assert reduced["policy_entropy"] == 24.0 / 14.0

--- a/tests/train/algorithms/test_skip_fwd_logprobs.py
+++ b/tests/train/algorithms/test_skip_fwd_logprobs.py
@@ -19,16 +19,23 @@ from skyrl.backends.skyrl_train.utils.ppo_utils import (
 )
 from skyrl.backends.skyrl_train.utils.torch_utils import masked_mean
 from skyrl.backends.skyrl_train.workers.worker_utils import (
+    LOSS_MASK_NNZ_KEY,
     MINIBATCH_ROLLOUT_LOGPROB_DIFF_MAX_KEY,
     MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY,
     MINIBATCH_ROLLOUT_LOGPROB_DIFF_MIN_KEY,
-    MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY,
+    MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY,
+    MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY,
     MINIBATCH_ROLLOUT_LOGPROB_DIFF_STD_KEY,
+    MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY,
+    POLICY_ENTROPY_SUM_KEY,
     compute_minibatch_rollout_logprob_diff_metrics,
     reduce_metrics,
 )
 from skyrl.train.config import AlgorithmConfig, OffPolicyCorrectionConfig
-from skyrl.train.utils.trainer_utils import finalize_minibatch_rollout_logprob_diff_std
+from skyrl.train.utils.trainer_utils import (
+    finalize_minibatch_rollout_logprob_diff_std,
+    finalize_policy_entropy,
+)
 
 
 def test_losses_without_old_logprobs():
@@ -110,8 +117,8 @@ def test_off_policy_correction_enabled():
 
 
 def test_minibatch_metric_values_match_manual():
-    """The worker metric reports the masked abs diff moments/extremes via the same masked_mean /
-    `* loss_mask` pattern as the off-policy `is_ratio_*` metrics."""
+    """The worker metric reports the masked abs diff sums/count via the same `* loss_mask`
+    pattern as the off-policy `is_ratio_*` metrics; sum/count reproduces the masked mean."""
     action_log_probs = torch.tensor([[-1.0, -2.0, -3.0], [-0.5, -1.5, -2.5]])
     rollout_logprobs = torch.tensor([[-1.5, -1.0, -3.0], [-0.5, -2.0, -1.0]])
     loss_mask = torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 1.0]])
@@ -120,8 +127,13 @@ def test_minibatch_metric_values_match_manual():
 
     abs_diff = (action_log_probs - rollout_logprobs).abs()
     masked = abs_diff * loss_mask
-    assert metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY] == masked_mean(abs_diff, loss_mask).item()
-    assert metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY] == masked_mean(abs_diff.square(), loss_mask).item()
+    assert metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY] == masked.sum().item()
+    assert metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY] == masked.square().sum().item()
+    assert metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY] == loss_mask.sum().item()
+    # sum/count reproduces masked_mean for a single micro-batch.
+    assert metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY] / metrics[
+        MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY
+    ] == pytest.approx(masked_mean(abs_diff, loss_mask).item())
     assert metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_MAX_KEY] == masked.max().item()
     assert metrics[MINIBATCH_ROLLOUT_LOGPROB_DIFF_MIN_KEY] == masked.min().item()
 
@@ -137,8 +149,9 @@ def test_minibatch_metric_emitted_unconditionally_when_rollout_present():
     fully_masked = torch.zeros_like(alp)
     masked_metrics = compute_minibatch_rollout_logprob_diff_metrics(alp, rlp, fully_masked)
     assert set(masked_metrics) == {
-        MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY,
-        MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY,
+        MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY,
+        MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY,
+        MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY,
         MINIBATCH_ROLLOUT_LOGPROB_DIFF_MAX_KEY,
         MINIBATCH_ROLLOUT_LOGPROB_DIFF_MIN_KEY,
     }
@@ -153,35 +166,55 @@ def test_finalize_std_noop_without_moments():
 
 
 def test_std_aggregates_correctly_across_microbatches_and_minibatches():
-    """Reduce per-micro-batch moments over micro-batches then mini-batches, derive the std, and
-    check it equals the exact pooled population std (exact because all sizes are equal)."""
-    # Four equal-size micro-batches grouped into two mini-batches of two micro-batches each.
+    """Reduce per-micro-batch sums/counts over micro-batches then mini-batches, derive the std, and
+    check it equals the exact pooled population std even with unequal micro-batch sizes."""
+    # Four unequal-size micro-batches grouped into two mini-batches of two micro-batches each.
     diffs = [
         torch.tensor([0.1, 0.3, 0.5, 0.2]),
-        torch.tensor([1.0, 0.8, 0.6, 0.4]),
-        torch.tensor([0.2, 0.2, 0.9, 0.7]),
-        torch.tensor([0.3, 0.5, 0.1, 0.6]),
+        torch.tensor([1.0, 0.8, 0.6, 0.4, 0.9, 0.1]),
+        torch.tensor([0.2, 0.2, 0.9]),
+        torch.tensor([0.3, 0.5, 0.1, 0.6, 0.7]),
     ]
 
-    def moments(d):
+    def sums(d):
         return {
-            MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY: d.mean().item(),
-            MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY: d.square().mean().item(),
+            MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY: d.sum().item(),
+            MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY: d.square().sum().item(),
+            MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY: float(d.numel()),
         }
 
-    keys = list(moments(diffs[0]).keys())
+    keys = list(sums(diffs[0]).keys())
     # Worker-level reduction over micro-batches within each mini-batch.
-    mb1 = reduce_metrics({k: [moments(diffs[0])[k], moments(diffs[1])[k]] for k in keys})
-    mb2 = reduce_metrics({k: [moments(diffs[2])[k], moments(diffs[3])[k]] for k in keys})
+    mb1 = reduce_metrics({k: [sums(diffs[0])[k], sums(diffs[1])[k]] for k in keys})
+    mb2 = reduce_metrics({k: [sums(diffs[2])[k], sums(diffs[3])[k]] for k in keys})
 
     # Trainer-level reduction across mini-batches.
     all_metrics = {k: [mb1[k], mb2[k]] for k in keys}
     reduced = reduce_metrics(all_metrics)
     finalize_minibatch_rollout_logprob_diff_std(reduced)
 
-    # All micro-batches are equal size, so the pooled mean/std are exact.
+    # The pooled mean/std are exact even though the micro-batch sizes differ.
     pooled = torch.cat(diffs)
-    assert MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY not in reduced
-    assert abs(reduced[MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY] - pooled.mean().item()) < 1e-6
-    expected_std = pooled.std(unbiased=False).item()
-    assert abs(reduced[MINIBATCH_ROLLOUT_LOGPROB_DIFF_STD_KEY] - expected_std) < 1e-6
+    assert MINIBATCH_ROLLOUT_LOGPROB_DIFF_SUM_KEY not in reduced
+    assert MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_SUM_KEY not in reduced
+    assert MINIBATCH_ROLLOUT_LOGPROB_DIFF_NNZ_KEY not in reduced
+    assert reduced[MINIBATCH_ROLLOUT_LOGPROB_DIFF_MEAN_KEY] == pytest.approx(pooled.mean().item())
+    assert reduced[MINIBATCH_ROLLOUT_LOGPROB_DIFF_STD_KEY] == pytest.approx(pooled.std(unbiased=False).item())
+
+
+def test_finalize_policy_entropy_exact_across_unequal_shards():
+    """Entropy finalizes as sum/count, so an imbalanced set of shards gives the exact global mean
+    rather than a mean-of-means."""
+    metrics = {
+        POLICY_ENTROPY_SUM_KEY: 0.4 + 3.0,
+        LOSS_MASK_NNZ_KEY: 2.0 + 5.0,
+    }
+    finalize_policy_entropy(metrics)
+    assert metrics == {"policy_entropy": (0.4 + 3.0) / (2.0 + 5.0)}
+
+
+def test_finalize_policy_entropy_noop_without_keys():
+    """The entropy derivation is a no-op when the keys are absent."""
+    metrics = {"foo": 1.0}
+    finalize_policy_entropy(metrics)
+    assert metrics == {"foo": 1.0}


### PR DESCRIPTION
Fixes #1822

## What does this PR do?

Updates metric aggregation for `policy_entropy` and `minibatch_rollout_logprobs_abs_diff_*` to compute the exact global mean instead of a mean-of-means.

## Why

Workers reported per-micro-batch masked means, averaged across micro-batches, DP ranks, and mini-batches — over-weighting shards with few unmasked tokens.

Example: Shard A = 1 token (entropy 1.0), Shard B = 100 tokens (entropy 2.0):
- Old (mean-of-means): (1.0 + 2.0) / 2 = 1.5
- New (exact): 201 / 101 ≈ 1.99

Token-based batching (or DP workers getting mostly failed trajectories) makes shards imbalanced, so the old value wasn't the global-batch metric.

## What changes

- Workers emit masked per-token sums (`policy_entropy_sum`, `minibatch_rollout_logprobs_abs_diff_sum`/`_sq_sum`) and counts (`loss_mask_nnz`, `..._nnz`); `reduce_metrics`/`all_reduce_metrics` always sum these.
- Final derivations (entropy = sum/count, std = sqrt(E[x²] − E[x]²)) moved to the trainer, computed once.
- Workers still emit a final `policy_entropy` after the DP all-reduce, so Tinker `_extract_metrics` and worker-level GPU assertions are unchanged.
- Megatron packed-entropy helpers now return the CP-global sum/count, keeping CP invariance.

## Testing

- Added imbalanced-shard exactness tests in `test_worker_utils.py` and `test_skip_fwd_logprobs.py`.
- CPU suite: 1393 passed (`-m "not vllm"`).
- Pre-commit clean.