### PR TITLE
[feat][SFT] Serve the tokenized-dataset cache memory-mapped

### DIFF
--- a/skyrl/train/dataset/pretokenized.py
+++ b/skyrl/train/dataset/pretokenized.py
@@ -160,6 +160,21 @@ def _locate_row(lengths: np.ndarray, flat_idx: int) -> int:
     return int(np.searchsorted(np.cumsum(lengths), flat_idx, side="right"))
 
 
+def sequence_lengths_from_arrow(dataset: Dataset) -> np.ndarray:
+    """Per-row ``input_ids`` lengths from arrow offsets, in bounded chunks.
+
+    For datasets already stored in the trainer's internal row form (e.g. the
+    tokenized-dataset cache), lengths are the only load-time scan needed --
+    validation and truncation already happened when the rows were produced.
+    """
+    arrow_ds = dataset.with_format("arrow")
+    chunks = [
+        _list_lengths(arrow_ds[start : start + _VALIDATION_CHUNK_ROWS], "input_ids")
+        for start in range(0, len(dataset), _VALIDATION_CHUNK_ROWS)
+    ]
+    return np.concatenate(chunks) if chunks else np.zeros(0, dtype=np.int64)
+
+
 def _validate_and_plan(dataset: Dataset, max_length: Optional[int]) -> tuple[np.ndarray, np.ndarray, int]:
     """Eagerly validate the store and compute the keep/drop plan.
 
@@ -316,7 +331,9 @@ class PretokenizedDataset(SFTDataset):
     """Map-style view over a validated, memory-mapped pretokenized store.
 
     Wraps an arrow-backed :class:`datasets.Dataset` (with the lazy
-    normalization transform applied) and strips ``None``-valued keys per row:
+    normalization transform applied when rows need normalizing; stores
+    already in the internal row form -- e.g. the tokenized-dataset cache --
+    are wrapped without one) and strips ``None``-valued keys per row:
     mixed text+VLM stores materialize the image columns as ``None`` on text
     rows, and a ``None`` ``pixel_values`` key would break the collator's
     homogeneity check.

--- a/skyrl/train/dataset/pretokenized.py
+++ b/skyrl/train/dataset/pretokenized.py
@@ -327,8 +327,9 @@ class _NormalizeTransform:
         return out
 
 
-class PretokenizedDataset(SFTDataset):
-    """Map-style view over a validated, memory-mapped pretokenized store.
+class MemoryMappedDataset(SFTDataset):
+    """Map-style view over a validated, memory-mapped arrow store (a
+    pretokenized dataset or the trainer's tokenized-dataset cache).
 
     Wraps an arrow-backed :class:`datasets.Dataset` (with the lazy
     normalization transform applied when rows need normalizing; stores
@@ -382,7 +383,7 @@ class PretokenizedDataset(SFTDataset):
 def load_from_pretokenized(
     path: str,
     max_length: Optional[int] = None,
-) -> PretokenizedDataset:
+) -> MemoryMappedDataset:
     """Load a pretokenized SFT dataset from a local file or directory.
 
     The pretokenized counterpart of ``SFTTrainer._load_and_tokenize``: returns
@@ -401,7 +402,7 @@ def load_from_pretokenized(
             matching the online tokenization path.
 
     Returns:
-        A :class:`PretokenizedDataset` of normalized examples (``input_ids`` /
+        A :class:`MemoryMappedDataset` of normalized examples (``input_ids`` /
         ``attention_mask`` / ``num_actions`` / window ``loss_mask``, plus
         pass-through columns like ``pixel_values`` / ``image_grid_thw``) ready
         for the SFT collators.
@@ -454,4 +455,4 @@ def load_from_pretokenized(
 
     dataset.set_transform(_NormalizeTransform(max_length))
     logger.info(f"Prepared {num_kept} pretokenized examples (memory-mapped)")
-    return PretokenizedDataset(dataset, lengths)
+    return MemoryMappedDataset(dataset, lengths)

--- a/skyrl/train/dataset/sft_dataset.py
+++ b/skyrl/train/dataset/sft_dataset.py
@@ -2,7 +2,7 @@
 
 ``SFTTrainer.load_dataset`` returns a :class:`SFTDataset` regardless of the
 ingestion path: :class:`TextDataset` for tokenize-on-load sources,
-:class:`~skyrl.train.dataset.pretokenized.PretokenizedDataset` for
+:class:`~skyrl.train.dataset.pretokenized.MemoryMappedDataset` for
 pretokenized stores, and :class:`ConcatSFTDataset` when multiple sources are
 configured. All are map-style (samplers, ``StatefulDataLoader`` prefetching
 and resume, and the collators are agnostic to which one they receive) and
@@ -45,7 +45,7 @@ class TextDataset(SFTDataset):
     Wraps the ``list[dict]`` produced by ``SFTTrainer._load_and_tokenize``
     when caching is disabled. With caching enabled (the default), the trainer
     instead serves the tokenized arrow cache memory-mapped through
-    ``PretokenizedDataset``, so this fully-materialized form is only resident
+    ``MemoryMappedDataset``, so this fully-materialized form is only resident
     for ``disable_cache=True`` runs.
     """
 

--- a/skyrl/train/dataset/sft_dataset.py
+++ b/skyrl/train/dataset/sft_dataset.py
@@ -42,9 +42,11 @@ class SFTDataset(torch.utils.data.Dataset, abc.ABC):
 class TextDataset(SFTDataset):
     """In-memory dataset of tokenized examples (the tokenize-on-load path).
 
-    Wraps the ``list[dict]`` produced by ``SFTTrainer._load_and_tokenize``.
-    Rows are fully materialized; making this path lazy is a possible
-    follow-up, independent of the interface.
+    Wraps the ``list[dict]`` produced by ``SFTTrainer._load_and_tokenize``
+    when caching is disabled. With caching enabled (the default), the trainer
+    instead serves the tokenized arrow cache memory-mapped through
+    ``PretokenizedDataset``, so this fully-materialized form is only resident
+    for ``disable_cache=True`` runs.
     """
 
     def __init__(self, examples: list):

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -53,7 +53,11 @@ from skyrl.train.config.sft_config import (
     _normalize_dataset_cfg,
     build_skyrl_config_for_sft,
 )
-from skyrl.train.dataset.pretokenized import load_from_pretokenized
+from skyrl.train.dataset.pretokenized import (
+    PretokenizedDataset,
+    load_from_pretokenized,
+    sequence_lengths_from_arrow,
+)
 from skyrl.train.dataset.sft_dataset import ConcatSFTDataset, SFTDataset, TextDataset
 from skyrl.train.generators.utils import (
     get_response_ids_and_loss_mask_from_messages,
@@ -235,20 +239,23 @@ def _get_cache_path(cache_dir: str, cache_key: str) -> str:
     return os.path.join(cache_dir, cache_key)
 
 
-def _load_from_cache(cache_path: str) -> Optional[list]:
-    """Load tokenized dataset from cache.
+def _load_from_cache(cache_path: str) -> Optional["PretokenizedDataset"]:
+    """Load tokenized dataset from cache as a memory-mapped dataset.
 
     Reads an arrow-backed HF ``Dataset`` directory written by
-    :func:`_save_to_cache` and materializes it back to the ``list[dict]``
-    representation expected by the trainer (which slices, shuffles, and
-    concatenates the result during the training loop).
+    :func:`_save_to_cache`. Cached rows are already in the trainer's internal
+    form (``input_ids`` / ``attention_mask`` / ``num_actions`` / window
+    ``loss_mask``), so the store is served memory-mapped through the same
+    map-style wrapper as pretokenized stores -- no rows are materialized, and
+    per-row lengths come from arrow offsets. Access-time cost is row
+    extraction only (no transform is attached).
 
     Args:
         cache_path: Path to cached dataset directory.
 
     Returns:
-        List of tokenized examples, or ``None`` if the cache directory
-        does not exist or fails to load.
+        A memory-mapped :class:`PretokenizedDataset`, or ``None`` if the
+        cache directory does not exist or fails to load.
     """
     if not os.path.isdir(cache_path):
         return None
@@ -256,9 +263,9 @@ def _load_from_cache(cache_path: str) -> Optional[list]:
     try:
         logger.info(f"Loading tokenized dataset from cache: {cache_path}")
         dataset = Dataset.load_from_disk(cache_path)
-        tokenized = dataset.to_list()
-        logger.info(f"Loaded {len(tokenized)} examples from cache")
-        return tokenized
+        lengths = sequence_lengths_from_arrow(dataset)
+        logger.info(f"Loaded {len(dataset)} examples from cache (memory-mapped)")
+        return PretokenizedDataset(dataset, lengths)
     except Exception as e:
         logger.warning(f"Failed to load cache from {cache_path}: {e}")
         return None
@@ -1029,7 +1036,7 @@ class SFTTrainer:
     # Data
     # ------------------------------------------------------------------ #
 
-    def _load_and_tokenize(self, dataset_name: str, dataset_split: str) -> list:
+    def _load_and_tokenize(self, dataset_name: str, dataset_split: str):
         """Load and tokenize a dataset with caching support.
 
         Auto-detects the dataset format based on column names:
@@ -1052,8 +1059,11 @@ class SFTTrainer:
             dataset_name: HuggingFace dataset name (e.g. ``"yahma/alpaca-cleaned"``).
             dataset_split: Dataset split (e.g. ``"train[:100]"`` or ``"test"``).
 
-        Returns a list of tokenized examples (dicts with ``input_ids``,
-        ``attention_mask``, ``num_actions``).
+        Returns the tokenized examples (dicts with ``input_ids``,
+        ``attention_mask``, ``num_actions``): a memory-mapped
+        :class:`PretokenizedDataset` served from the arrow cache when caching
+        is enabled (nothing materialized in memory), or a ``list`` when
+        ``disable_cache=True``.
         """
         # Check cache first (unless disabled or force_recache)
         if not self.sft_cfg.disable_cache:
@@ -1126,13 +1136,14 @@ class SFTTrainer:
             tokenized = [ex for ex in tokenized if ex is not None]
             logger.info(f"Tokenized {len(tokenized)} examples (filtered from {len(dataset)})")
 
-            # Save to cache if enabled
+            # With caching enabled, round-trip through the arrow cache so the
+            # returned dataset is memory-mapped rather than the in-memory list
+            # (the list stays resident only when caching is disabled).
             if not self.sft_cfg.disable_cache:
-                # TODO (sumanthrh): Currently we use a simple list instead of dataset + stateful dataloader
-                # for simplicity but for caching we use HF Dataset since file sizes can get large
-                # We should migrate to using HF datasets + a dataloader so that we don't materialize
-                # the full dataset in memory
                 _save_to_cache(cache_path, tokenized)
+                mmapped = _load_from_cache(cache_path)
+                if mmapped is not None:
+                    return mmapped
 
             return tokenized
 
@@ -1221,9 +1232,13 @@ class SFTTrainer:
 
             logger.info(f"Tokenized {len(tokenized)} examples (filtered from {dataset_size})")
 
-            # Save to cache if enabled
+            # Same as the sequential path: serve the arrow cache memory-mapped
+            # when caching is enabled.
             if not self.sft_cfg.disable_cache:
                 _save_to_cache(cache_path, tokenized)
+                mmapped = _load_from_cache(cache_path)
+                if mmapped is not None:
+                    return mmapped
 
             return tokenized
 
@@ -1262,7 +1277,9 @@ class SFTTrainer:
                 source = self._load_and_tokenize(name, split)
                 if len(source) == 0:
                     raise ValueError(f"Training dataset '{name}' (split '{split}') tokenized to 0 examples.")
-                sources.append(TextDataset(source))
+                # Cache-backed sources arrive as memory-mapped SFTDatasets;
+                # only in-memory lists (disable_cache) need the wrapper.
+                sources.append(source if isinstance(source, SFTDataset) else TextDataset(source))
         if len(sources) == 1:
             return sources[0]
         per_dataset = ", ".join(f"{name}={len(source)}" for name, source in zip(source_names, sources))

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -54,7 +54,7 @@ from skyrl.train.config.sft_config import (
     build_skyrl_config_for_sft,
 )
 from skyrl.train.dataset.pretokenized import (
-    PretokenizedDataset,
+    MemoryMappedDataset,
     load_from_pretokenized,
     sequence_lengths_from_arrow,
 )
@@ -239,7 +239,7 @@ def _get_cache_path(cache_dir: str, cache_key: str) -> str:
     return os.path.join(cache_dir, cache_key)
 
 
-def _load_from_cache(cache_path: str) -> Optional["PretokenizedDataset"]:
+def _load_from_cache(cache_path: str) -> Optional["MemoryMappedDataset"]:
     """Load tokenized dataset from cache as a memory-mapped dataset.
 
     Reads an arrow-backed HF ``Dataset`` directory written by
@@ -254,7 +254,7 @@ def _load_from_cache(cache_path: str) -> Optional["PretokenizedDataset"]:
         cache_path: Path to cached dataset directory.
 
     Returns:
-        A memory-mapped :class:`PretokenizedDataset`, or ``None`` if the
+        A memory-mapped :class:`MemoryMappedDataset`, or ``None`` if the
         cache directory does not exist or fails to load.
     """
     if not os.path.isdir(cache_path):
@@ -265,7 +265,7 @@ def _load_from_cache(cache_path: str) -> Optional["PretokenizedDataset"]:
         dataset = Dataset.load_from_disk(cache_path)
         lengths = sequence_lengths_from_arrow(dataset)
         logger.info(f"Loaded {len(dataset)} examples from cache (memory-mapped)")
-        return PretokenizedDataset(dataset, lengths)
+        return MemoryMappedDataset(dataset, lengths)
     except Exception as e:
         logger.warning(f"Failed to load cache from {cache_path}: {e}")
         return None
@@ -1061,7 +1061,7 @@ class SFTTrainer:
 
         Returns the tokenized examples (dicts with ``input_ids``,
         ``attention_mask``, ``num_actions``): a memory-mapped
-        :class:`PretokenizedDataset` served from the arrow cache when caching
+        :class:`MemoryMappedDataset` served from the arrow cache when caching
         is enabled (nothing materialized in memory), or a ``list`` when
         ``disable_cache=True``.
         """

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -983,14 +983,14 @@ def test_load_and_tokenize_cache_backed_is_memory_mapped(tokenizer, tmp_path, mo
     SFTDataset served from the arrow cache (nothing materialized); with
     caching disabled it returns the in-memory list. Rows are identical."""
     from skyrl.train import sft_trainer as sft_mod
-    from skyrl.train.dataset.pretokenized import PretokenizedDataset
+    from skyrl.train.dataset.pretokenized import MemoryMappedDataset
 
     dataset = _make_inmem_dataset()
     monkeypatch.setattr(sft_mod, "load_dataset", lambda *a, **kw: dataset)
 
     cached_cfg = SFTConfig(num_workers=0, cache_dir=str(tmp_path), disable_cache=False)
     mmapped = _build_trainer(tokenizer, cached_cfg)._load_and_tokenize("dummy/ds", "train")
-    assert isinstance(mmapped, PretokenizedDataset)
+    assert isinstance(mmapped, MemoryMappedDataset)
     assert list(mmapped.sequence_lengths) == [len(ex["input_ids"]) for ex in mmapped]
 
     uncached_cfg = SFTConfig(num_workers=0, disable_cache=True)

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -976,3 +976,30 @@ def test_load_and_tokenize_cache_hit_skips_retokenization(tokenizer, tmp_path, m
         assert a["attention_mask"] == b["attention_mask"]
         assert a["num_actions"] == b["num_actions"]
         assert a["loss_mask"] == b["loss_mask"]
+
+
+def test_load_and_tokenize_cache_backed_is_memory_mapped(tokenizer, tmp_path, monkeypatch):
+    """With caching enabled the tokenize-on-load path returns a memory-mapped
+    SFTDataset served from the arrow cache (nothing materialized); with
+    caching disabled it returns the in-memory list. Rows are identical."""
+    from skyrl.train import sft_trainer as sft_mod
+    from skyrl.train.dataset.pretokenized import PretokenizedDataset
+
+    dataset = _make_inmem_dataset()
+    monkeypatch.setattr(sft_mod, "load_dataset", lambda *a, **kw: dataset)
+
+    cached_cfg = SFTConfig(num_workers=0, cache_dir=str(tmp_path), disable_cache=False)
+    mmapped = _build_trainer(tokenizer, cached_cfg)._load_and_tokenize("dummy/ds", "train")
+    assert isinstance(mmapped, PretokenizedDataset)
+    assert list(mmapped.sequence_lengths) == [len(ex["input_ids"]) for ex in mmapped]
+
+    uncached_cfg = SFTConfig(num_workers=0, disable_cache=True)
+    materialized = _build_trainer(tokenizer, uncached_cfg)._load_and_tokenize("dummy/ds", "train")
+    assert isinstance(materialized, list)
+
+    assert len(mmapped) == len(materialized)
+    for a, b in zip(mmapped, materialized):
+        assert a["input_ids"] == b["input_ids"]
+        assert a["attention_mask"] == b["attention_mask"]
+        assert a["num_actions"] == b["num_actions"]
+        assert a["loss_mask"] == b["loss_mask"]


### PR DESCRIPTION
## What

The tokenize-on-load path (`train_datasets`) no longer materializes the tokenized dataset in memory for training. Follow-up to #1961 flagged in review: *"`TextDataset` currently materializes the entire dataset in memory, but it doesn't have to be."*

## How

One observation makes this small: the tokenized-dataset **cache is already an arrow-backed HF `Dataset` on disk in the trainer's internal row form** -- it is, in effect, a pretokenized store. But `_load_from_cache` immediately materialized it back into a `list[dict]` via `.to_list()` (O(dataset) RAM, re-pickled into every spawn dataloader worker). This PR serves it through the same map-style mmap wrapper the pretokenized path uses, with **no transform attached** (cached rows are already normalized):

- `_load_from_cache` returns `MemoryMappedDataset(Dataset.load_from_disk(...), lengths)` -- memory-mapped, rows page in per accessed batch through the existing dataloader prefetch. Per-row lengths come from arrow offsets (`sequence_lengths_from_arrow`, chunked scan, nothing materialized).
- **Fresh tokenization round-trips through the cache** in both the sequential and parallel paths (`_save_to_cache` -> reload mmap'd), so cold runs also train from the mmap. Tokenization cost is unchanged -- it was always one-time; only the residency of the results changes.
- **`disable_cache=True` keeps today's behavior** (in-memory list wrapped in `TextDataset`): with no arrow file on disk there is nothing to map.

This also resolves the old TODO at the cache-save site ("migrate to HF datasets + dataloader so we don't materialize the full dataset in memory").

### Rename: `PretokenizedDataset` -> `MemoryMappedDataset`

Since the class now serves two roles (pretokenized stores *and* the tokenized cache), the old name was wrong for one of them: it is a map-style view over any validated arrow store in (or normalizable to) the trainer's internal row form. Renamed now, before anything external depends on the name (#1961 merged it one release ago). The module keeps the `pretokenized.py` name for diff locality; moving the class to `sft_dataset.py` could be a later cleanup.

## Known limitation

Cache-**miss** tokenization still materializes the full `list[dict]` transiently (tokenize -> save -> reload mmap'd); the list dies at function exit, so this bounds first-run peak memory, not steady state. Closing the transient too would mean chunked tokenize-and-append arrow writing -- a possible follow-up.

## Effect

With caching enabled (the default), the text path now has the same memory profile as pretokenized stores: resident memory is the OS page cache (reclaimable) instead of the dataset, and dataloader workers pickle a file reference instead of receiving a full copy -- the old peak was `(dataloader_num_workers + 1) x` the dataset.

## Tests

- New: cache-backed `_load_and_tokenize` returns a memory-mapped `SFTDataset` with arrow-derived lengths, row-parity against the materialized (`disable_cache=True`) path.
- Existing cache round-trip / parallel-vs-serial parity tests pass unchanged (they compare rows by iteration, which the map-style dataset satisfies).
- Full `tests/train` suite green: 884 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)