### PR TITLE
[feat][SFT] Stream tokenization to arrow, bounding memory for large text datasets

### DIFF
--- a/skyrl/train/dataset/pretokenized.py
+++ b/skyrl/train/dataset/pretokenized.py
@@ -160,6 +160,21 @@ def _locate_row(lengths: np.ndarray, flat_idx: int) -> int:
     return int(np.searchsorted(np.cumsum(lengths), flat_idx, side="right"))
 
 
+def sequence_lengths_from_arrow(dataset: Dataset) -> np.ndarray:
+    """Per-row ``input_ids`` lengths from arrow offsets, in bounded chunks.
+
+    For datasets already stored in the trainer's internal row form (e.g. the
+    tokenized-dataset cache), lengths are the only load-time scan needed --
+    validation and truncation already happened when the rows were produced.
+    """
+    arrow_ds = dataset.with_format("arrow")
+    chunks = [
+        _list_lengths(arrow_ds[start : start + _VALIDATION_CHUNK_ROWS], "input_ids")
+        for start in range(0, len(dataset), _VALIDATION_CHUNK_ROWS)
+    ]
+    return np.concatenate(chunks) if chunks else np.zeros(0, dtype=np.int64)
+
+
 def _validate_and_plan(dataset: Dataset, max_length: Optional[int]) -> tuple[np.ndarray, np.ndarray, int]:
     """Eagerly validate the store and compute the keep/drop plan.
 
@@ -316,7 +331,9 @@ class PretokenizedDataset(SFTDataset):
     """Map-style view over a validated, memory-mapped pretokenized store.
 
     Wraps an arrow-backed :class:`datasets.Dataset` (with the lazy
-    normalization transform applied) and strips ``None``-valued keys per row:
+    normalization transform applied when rows need normalizing; stores
+    already in the internal row form -- e.g. the tokenized-dataset cache --
+    are wrapped without one) and strips ``None``-valued keys per row:
     mixed text+VLM stores materialize the image columns as ``None`` on text
     rows, and a ``None`` ``pixel_values`` key would break the collator's
     homogeneity check.

--- a/skyrl/train/dataset/pretokenized.py
+++ b/skyrl/train/dataset/pretokenized.py
@@ -327,8 +327,9 @@ class _NormalizeTransform:
         return out
 
 
-class PretokenizedDataset(SFTDataset):
-    """Map-style view over a validated, memory-mapped pretokenized store.
+class MemoryMappedDataset(SFTDataset):
+    """Map-style view over a validated, memory-mapped arrow store (a
+    pretokenized dataset or the trainer's tokenized-dataset cache).
 
     Wraps an arrow-backed :class:`datasets.Dataset` (with the lazy
     normalization transform applied when rows need normalizing; stores
@@ -382,7 +383,7 @@ class PretokenizedDataset(SFTDataset):
 def load_from_pretokenized(
     path: str,
     max_length: Optional[int] = None,
-) -> PretokenizedDataset:
+) -> MemoryMappedDataset:
     """Load a pretokenized SFT dataset from a local file or directory.
 
     The pretokenized counterpart of ``SFTTrainer._load_and_tokenize``: returns
@@ -401,7 +402,7 @@ def load_from_pretokenized(
             matching the online tokenization path.
 
     Returns:
-        A :class:`PretokenizedDataset` of normalized examples (``input_ids`` /
+        A :class:`MemoryMappedDataset` of normalized examples (``input_ids`` /
         ``attention_mask`` / ``num_actions`` / window ``loss_mask``, plus
         pass-through columns like ``pixel_values`` / ``image_grid_thw``) ready
         for the SFT collators.
@@ -454,4 +455,4 @@ def load_from_pretokenized(
 
     dataset.set_transform(_NormalizeTransform(max_length))
     logger.info(f"Prepared {num_kept} pretokenized examples (memory-mapped)")
-    return PretokenizedDataset(dataset, lengths)
+    return MemoryMappedDataset(dataset, lengths)

--- a/skyrl/train/dataset/sft_dataset.py
+++ b/skyrl/train/dataset/sft_dataset.py
@@ -2,7 +2,7 @@
 
 ``SFTTrainer.load_dataset`` returns a :class:`SFTDataset` regardless of the
 ingestion path: :class:`TextDataset` for tokenize-on-load sources,
-:class:`~skyrl.train.dataset.pretokenized.PretokenizedDataset` for
+:class:`~skyrl.train.dataset.pretokenized.MemoryMappedDataset` for
 pretokenized stores, and :class:`ConcatSFTDataset` when multiple sources are
 configured. All are map-style (samplers, ``StatefulDataLoader`` prefetching
 and resume, and the collators are agnostic to which one they receive) and
@@ -45,7 +45,7 @@ class TextDataset(SFTDataset):
     Wraps the ``list[dict]`` produced by ``SFTTrainer._load_and_tokenize``
     when caching is disabled. With caching enabled (the default), the trainer
     instead serves the tokenized arrow cache memory-mapped through
-    ``PretokenizedDataset``, so this fully-materialized form is only resident
+    ``MemoryMappedDataset``, so this fully-materialized form is only resident
     for ``disable_cache=True`` runs.
     """
 

--- a/skyrl/train/dataset/sft_dataset.py
+++ b/skyrl/train/dataset/sft_dataset.py
@@ -42,9 +42,11 @@ class SFTDataset(torch.utils.data.Dataset, abc.ABC):
 class TextDataset(SFTDataset):
     """In-memory dataset of tokenized examples (the tokenize-on-load path).
 
-    Wraps the ``list[dict]`` produced by ``SFTTrainer._load_and_tokenize``.
-    Rows are fully materialized; making this path lazy is a possible
-    follow-up, independent of the interface.
+    Wraps the ``list[dict]`` produced by ``SFTTrainer._load_and_tokenize``
+    when caching is disabled. With caching enabled (the default), the trainer
+    instead serves the tokenized arrow cache memory-mapped through
+    ``PretokenizedDataset``, so this fully-materialized form is only resident
+    for ``disable_cache=True`` runs.
     """
 
     def __init__(self, examples: list):

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -53,7 +53,11 @@ from skyrl.train.config.sft_config import (
     _normalize_dataset_cfg,
     build_skyrl_config_for_sft,
 )
-from skyrl.train.dataset.pretokenized import load_from_pretokenized
+from skyrl.train.dataset.pretokenized import (
+    PretokenizedDataset,
+    load_from_pretokenized,
+    sequence_lengths_from_arrow,
+)
 from skyrl.train.dataset.sft_dataset import ConcatSFTDataset, SFTDataset, TextDataset
 from skyrl.train.generators.utils import (
     get_response_ids_and_loss_mask_from_messages,
@@ -235,20 +239,23 @@ def _get_cache_path(cache_dir: str, cache_key: str) -> str:
     return os.path.join(cache_dir, cache_key)
 
 
-def _load_from_cache(cache_path: str) -> Optional[list]:
-    """Load tokenized dataset from cache.
+def _load_from_cache(cache_path: str) -> Optional["PretokenizedDataset"]:
+    """Load tokenized dataset from cache as a memory-mapped dataset.
 
     Reads an arrow-backed HF ``Dataset`` directory written by
-    :func:`_save_to_cache` and materializes it back to the ``list[dict]``
-    representation expected by the trainer (which slices, shuffles, and
-    concatenates the result during the training loop).
+    :func:`_save_to_cache`. Cached rows are already in the trainer's internal
+    form (``input_ids`` / ``attention_mask`` / ``num_actions`` / window
+    ``loss_mask``), so the store is served memory-mapped through the same
+    map-style wrapper as pretokenized stores -- no rows are materialized, and
+    per-row lengths come from arrow offsets. Access-time cost is row
+    extraction only (no transform is attached).
 
     Args:
         cache_path: Path to cached dataset directory.
 
     Returns:
-        List of tokenized examples, or ``None`` if the cache directory
-        does not exist or fails to load.
+        A memory-mapped :class:`PretokenizedDataset`, or ``None`` if the
+        cache directory does not exist or fails to load.
     """
     if not os.path.isdir(cache_path):
         return None
@@ -256,9 +263,9 @@ def _load_from_cache(cache_path: str) -> Optional[list]:
     try:
         logger.info(f"Loading tokenized dataset from cache: {cache_path}")
         dataset = Dataset.load_from_disk(cache_path)
-        tokenized = dataset.to_list()
-        logger.info(f"Loaded {len(tokenized)} examples from cache")
-        return tokenized
+        lengths = sequence_lengths_from_arrow(dataset)
+        logger.info(f"Loaded {len(dataset)} examples from cache (memory-mapped)")
+        return PretokenizedDataset(dataset, lengths)
     except Exception as e:
         logger.warning(f"Failed to load cache from {cache_path}: {e}")
         return None
@@ -1029,7 +1036,7 @@ class SFTTrainer:
     # Data
     # ------------------------------------------------------------------ #
 
-    def _load_and_tokenize(self, dataset_name: str, dataset_split: str) -> list:
+    def _load_and_tokenize(self, dataset_name: str, dataset_split: str):
         """Load and tokenize a dataset with caching support.
 
         Auto-detects the dataset format based on column names:
@@ -1052,8 +1059,11 @@ class SFTTrainer:
             dataset_name: HuggingFace dataset name (e.g. ``"yahma/alpaca-cleaned"``).
             dataset_split: Dataset split (e.g. ``"train[:100]"`` or ``"test"``).
 
-        Returns a list of tokenized examples (dicts with ``input_ids``,
-        ``attention_mask``, ``num_actions``).
+        Returns the tokenized examples (dicts with ``input_ids``,
+        ``attention_mask``, ``num_actions``): a memory-mapped
+        :class:`PretokenizedDataset` served from the arrow cache when caching
+        is enabled (nothing materialized in memory), or a ``list`` when
+        ``disable_cache=True``.
         """
         # Check cache first (unless disabled or force_recache)
         if not self.sft_cfg.disable_cache:
@@ -1126,13 +1136,14 @@ class SFTTrainer:
             tokenized = [ex for ex in tokenized if ex is not None]
             logger.info(f"Tokenized {len(tokenized)} examples (filtered from {len(dataset)})")
 
-            # Save to cache if enabled
+            # With caching enabled, round-trip through the arrow cache so the
+            # returned dataset is memory-mapped rather than the in-memory list
+            # (the list stays resident only when caching is disabled).
             if not self.sft_cfg.disable_cache:
-                # TODO (sumanthrh): Currently we use a simple list instead of dataset + stateful dataloader
-                # for simplicity but for caching we use HF Dataset since file sizes can get large
-                # We should migrate to using HF datasets + a dataloader so that we don't materialize
-                # the full dataset in memory
                 _save_to_cache(cache_path, tokenized)
+                mmapped = _load_from_cache(cache_path)
+                if mmapped is not None:
+                    return mmapped
 
             return tokenized
 
@@ -1221,9 +1232,13 @@ class SFTTrainer:
 
             logger.info(f"Tokenized {len(tokenized)} examples (filtered from {dataset_size})")
 
-            # Save to cache if enabled
+            # Same as the sequential path: serve the arrow cache memory-mapped
+            # when caching is enabled.
             if not self.sft_cfg.disable_cache:
                 _save_to_cache(cache_path, tokenized)
+                mmapped = _load_from_cache(cache_path)
+                if mmapped is not None:
+                    return mmapped
 
             return tokenized
 
@@ -1262,7 +1277,9 @@ class SFTTrainer:
                 source = self._load_and_tokenize(name, split)
                 if len(source) == 0:
                     raise ValueError(f"Training dataset '{name}' (split '{split}') tokenized to 0 examples.")
-                sources.append(TextDataset(source))
+                # Cache-backed sources arrive as memory-mapped SFTDatasets;
+                # only in-memory lists (disable_cache) need the wrapper.
+                sources.append(source if isinstance(source, SFTDataset) else TextDataset(source))
         if len(sources) == 1:
             return sources[0]
         per_dataset = ", ".join(f"{name}={len(source)}" for name, source in zip(source_names, sources))

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -31,7 +31,7 @@ from typing import Any, Optional
 import numpy as np
 import ray
 import torch
-from datasets import Dataset, load_dataset
+from datasets import Dataset, concatenate_datasets, load_dataset
 from loguru import logger
 from ray.util.placement_group import placement_group
 from torchdata.stateful_dataloader import StatefulDataLoader
@@ -90,6 +90,36 @@ from skyrl.utils.tok import (
 # ---------------------------------------------------------------------------
 
 
+# ArrowWriter flush granularity for streamed tokenization: rows are written
+# out every this-many examples, bounding peak memory during tokenization to
+# O(batch) instead of O(dataset).
+_TOKENIZE_WRITER_BATCH_ROWS = 1000
+
+
+def _write_tokenized_arrow(rows, shard_path: str) -> int:
+    """Stream tokenized rows into an arrow file in bounded batches.
+
+    Consumes an iterable of tokenized examples (``None`` entries -- rows the
+    tokenizers filtered out -- are skipped) and writes them with HF's
+    ``ArrowWriter``, which flushes every ``writer_batch_size`` examples, so
+    the full tokenized dataset is never resident in memory. Returns the
+    number of rows written; on 0 rows no arrow file is finalized (there is
+    no schema to write) and the caller must not read ``shard_path``.
+    """
+    from datasets.arrow_writer import ArrowWriter
+
+    written = 0
+    with ArrowWriter(path=shard_path, writer_batch_size=_TOKENIZE_WRITER_BATCH_ROWS) as writer:
+        for row in rows:
+            if row is None:
+                continue
+            writer.write(row)
+            written += 1
+        if written:
+            writer.finalize()
+    return written
+
+
 def _tokenize_chat_slice_worker(args):
     """Worker function for parallel chat-format tokenization with slice-based loading.
 
@@ -109,6 +139,7 @@ def _tokenize_chat_slice_worker(args):
         train_on_what_str,
         tools_key,
         system_key,
+        shard_path,
     ) = args
 
     # Worker loads tokenizer from cached path
@@ -126,10 +157,11 @@ def _tokenize_chat_slice_worker(args):
     dataset = load_dataset(dataset_name, split=dataset_split)
     dataset_slice = dataset.select(range(start_idx, end_idx))
 
-    # Tokenize and filter inline
-    results = []
-    for example in dataset_slice:
-        tokenized = tokenize_chat_example(
+    # Tokenize and stream to the worker's shard file: rows are flushed in
+    # bounded batches instead of accumulating in (and pickling back from)
+    # worker memory. Returns the number of rows written.
+    rows = (
+        tokenize_chat_example(
             example,
             tokenizer,
             max_length=max_length,
@@ -138,10 +170,9 @@ def _tokenize_chat_slice_worker(args):
             tools_key=tools_key,
             system_key=system_key,
         )
-        if tokenized is not None:
-            results.append(tokenized)
-
-    return results
+        for example in dataset_slice
+    )
+    return _write_tokenized_arrow(rows, shard_path)
 
 
 def _tokenize_alpaca_slice_worker(args):
@@ -152,7 +183,7 @@ def _tokenize_alpaca_slice_worker(args):
 
     Must be top-level for pickling with spawn.
     """
-    dataset_name, dataset_split, start_idx, end_idx, tokenizer_path, max_length = args
+    dataset_name, dataset_split, start_idx, end_idx, tokenizer_path, max_length, shard_path = args
 
     # Worker loads tokenizer from cached path
     tokenizer = AutoTokenizer.from_pretrained(
@@ -166,14 +197,9 @@ def _tokenize_alpaca_slice_worker(args):
     dataset = load_dataset(dataset_name, split=dataset_split)
     dataset_slice = dataset.select(range(start_idx, end_idx))
 
-    # Tokenize and filter inline
-    results = []
-    for example in dataset_slice:
-        tokenized = tokenize_sft_example(example, tokenizer, max_length)
-        if tokenized is not None:
-            results.append(tokenized)
-
-    return results
+    # Tokenize and stream to the worker's shard file (see the chat worker).
+    rows = (tokenize_sft_example(example, tokenizer, max_length) for example in dataset_slice)
+    return _write_tokenized_arrow(rows, shard_path)
 
 
 def _compute_cache_key(
@@ -271,19 +297,19 @@ def _load_from_cache(cache_path: str) -> Optional["MemoryMappedDataset"]:
         return None
 
 
-def _save_to_cache(cache_path: str, tokenized: list) -> None:
+def _save_to_cache(cache_path: str, tokenized) -> None:
     """Save tokenized dataset to cache.
 
-    Materializes the in-memory ``list[dict]`` as a HuggingFace ``Dataset``
-    and writes it via ``save_to_disk``. At 1M-row scale, the arrow-backed,
-    memory-mapped format reads and writes dramatically faster than pickle
-    while also being portable across Python versions. The write goes to a
-    sibling ``<cache_path>.tmp`` directory which is then atomically renamed
-    onto ``cache_path`` for NFS safety.
+    Accepts either an in-memory ``list[dict]`` (materialized as a HuggingFace
+    ``Dataset`` first) or an already arrow-backed ``Dataset`` (e.g. streamed
+    shards from tokenization), which ``save_to_disk`` writes through in
+    bounded batches without materializing rows. The write goes to a sibling
+    ``<cache_path>.tmp`` directory which is then atomically renamed onto
+    ``cache_path`` for NFS safety.
 
     Args:
         cache_path: Path to the cache directory to create.
-        tokenized: List of tokenized examples.
+        tokenized: List of tokenized examples, or an arrow-backed ``Dataset``.
     """
     try:
         import shutil
@@ -292,10 +318,9 @@ def _save_to_cache(cache_path: str, tokenized: list) -> None:
         os.makedirs(parent_dir, exist_ok=True)
 
         logger.info(f"Saving {len(tokenized)} examples to cache: {cache_path}")
-        # Build the HF Dataset from rows and write to a sibling temp dir.
-        # An atomic rename onto cache_path makes concurrent readers see only
-        # a fully-written cache (NFS-safe; matches the previous pickle path).
-        dataset = Dataset.from_list(tokenized)
+        # Write to a sibling temp dir; an atomic rename onto cache_path makes
+        # concurrent readers see only a fully-written cache (NFS-safe).
+        dataset = tokenized if isinstance(tokenized, Dataset) else Dataset.from_list(tokenized)
         temp_path = cache_path + ".tmp"
         # Clean up any stale temp dir from an interrupted prior run.
         if os.path.isdir(temp_path):
@@ -1062,8 +1087,15 @@ class SFTTrainer:
         Returns the tokenized examples (dicts with ``input_ids``,
         ``attention_mask``, ``num_actions``): a memory-mapped
         :class:`MemoryMappedDataset` served from the arrow cache when caching
-        is enabled (nothing materialized in memory), or a ``list`` when
-        ``disable_cache=True``.
+        is enabled, or a ``list`` when ``disable_cache=True``.
+
+        With caching enabled (text datasets), tokenization itself is also
+        memory-bounded: rows stream into arrow files in bounded batches
+        (per-worker shard files on the parallel path) instead of accumulating
+        in a list, so dataset size is limited by disk, not RAM. The
+        materializing fallbacks are ``disable_cache=True`` (no arrow file to
+        stream to) and VLM datasets (image tensors only round-trip through
+        ``Dataset.from_list``).
         """
         # Check cache first (unless disabled or force_recache)
         if not self.sft_cfg.disable_cache:
@@ -1112,7 +1144,7 @@ class SFTTrainer:
             if self.sft_cfg.messages_key in columns:
                 tools_key = self.sft_cfg.tools_key if self.sft_cfg.tools_key in columns else None
                 system_key = self.sft_cfg.system_key if self.sft_cfg.system_key in columns else None
-                tokenized = [
+                rows = (
                     tokenize_chat_example(
                         ex,
                         self.tokenizer,
@@ -1124,34 +1156,52 @@ class SFTTrainer:
                         processor=self.processor,
                     )
                     for ex in dataset
-                ]
+                )
             elif "instruction" in columns and "output" in columns:
-                tokenized = [tokenize_sft_example(ex, self.tokenizer, self.sft_cfg.max_length) for ex in dataset]
+                rows = (tokenize_sft_example(ex, self.tokenizer, self.sft_cfg.max_length) for ex in dataset)
             else:
                 raise ValueError(
                     f"Unrecognized dataset format. Expected '{self.sft_cfg.messages_key}' column "
                     f"(chat format) or 'instruction'+'output' columns (Alpaca format). "
                     f"Found columns: {columns}"
                 )
-            tokenized = [ex for ex in tokenized if ex is not None]
-            logger.info(f"Tokenized {len(tokenized)} examples (filtered from {len(dataset)})")
 
-            # With caching enabled, round-trip through the arrow cache so the
-            # returned dataset is memory-mapped rather than the in-memory list
-            # (the list stays resident only when caching is disabled).
-            if not self.sft_cfg.disable_cache:
-                _save_to_cache(cache_path, tokenized)
-                mmapped = _load_from_cache(cache_path)
-                if mmapped is not None:
-                    return mmapped
+            # Materializing fallbacks: with caching disabled there is no arrow
+            # file to stream to (and to serve from), and VLM rows carry image
+            # tensors that only round-trip through Dataset.from_list.
+            if self.sft_cfg.disable_cache or self.is_vlm:
+                tokenized = [ex for ex in rows if ex is not None]
+                logger.info(f"Tokenized {len(tokenized)} examples (filtered from {len(dataset)})")
+                if not self.sft_cfg.disable_cache:
+                    _save_to_cache(cache_path, tokenized)
+                    mmapped = _load_from_cache(cache_path)
+                    if mmapped is not None:
+                        return mmapped
+                return tokenized
 
-            return tokenized
+            # Stream tokenize -> bounded arrow writes -> cache -> mmap: the
+            # tokenized dataset is never resident in memory, so dataset size
+            # is bounded by disk, not RAM.
+            with tempfile.TemporaryDirectory(prefix="skyrl_tokenize_") as tmp_dir:
+                shard_path = os.path.join(tmp_dir, "data.arrow")
+                written = _write_tokenized_arrow(rows, shard_path)
+                logger.info(f"Tokenized {written} examples (filtered from {len(dataset)}), streamed to arrow")
+                if written == 0:
+                    raise ValueError(f"Dataset '{dataset_name}' (split '{dataset_split}') tokenized to 0 examples.")
+                _save_to_cache(cache_path, Dataset.from_file(shard_path))
+            mmapped = _load_from_cache(cache_path)
+            if mmapped is None:
+                raise RuntimeError(f"Failed to reload tokenized dataset cache at {cache_path}")
+            return mmapped
 
         # Parallel tokenization path with slice-based loading
         logger.info(f"Tokenizing dataset with {num_workers} workers (slice-based loading)...")
 
-        # Cache tokenizer to temp dir for fast worker loading
+        # Cache tokenizer to temp dir for fast worker loading; workers stream
+        # their tokenized slices into per-worker arrow shards here rather than
+        # pickling rows back, so neither side holds a slice in memory.
         tokenizer_cache_dir = tempfile.mkdtemp(prefix="skyrl_tokenizer_")
+        shard_dir = tempfile.mkdtemp(prefix="skyrl_tokenize_shards_")
         try:
             self.tokenizer.save_pretrained(tokenizer_cache_dir)
 
@@ -1174,6 +1224,8 @@ class SFTTrainer:
                 if worker_start >= worker_end:
                     continue
 
+                shard_path = os.path.join(shard_dir, f"shard-{worker_idx:05d}.arrow")
+
                 # Prepare worker arguments based on format
                 if self.sft_cfg.messages_key in columns:
                     tools_key = self.sft_cfg.tools_key if self.sft_cfg.tools_key in columns else None
@@ -1190,6 +1242,7 @@ class SFTTrainer:
                             self.sft_cfg.train_on_what.value,
                             tools_key,
                             system_key,
+                            shard_path,
                         )
                     )
                 elif "instruction" in columns and "output" in columns:
@@ -1201,6 +1254,7 @@ class SFTTrainer:
                             worker_end,
                             tokenizer_cache_dir,
                             self.sft_cfg.max_length,
+                            shard_path,
                         )
                     )
                 else:
@@ -1221,32 +1275,40 @@ class SFTTrainer:
             # Use spawn to avoid Ray fork issues
             ctx = mp.get_context("spawn")
 
-            # Process in parallel
+            # Process in parallel; each worker returns only its row count --
+            # the tokenized rows live in the shard files, not in pickled
+            # results.
             with ctx.Pool(processes=num_workers) as pool:
-                results = pool.map(worker_fn, worker_args)
+                shard_counts = pool.map(worker_fn, worker_args)
 
-            # Flatten results
-            tokenized = []
-            for chunk_results in results:
-                tokenized.extend(chunk_results)
+            written = sum(shard_counts)
+            logger.info(f"Tokenized {written} examples (filtered from {dataset_size}), streamed to arrow shards")
+            if written == 0:
+                raise ValueError(f"Dataset '{dataset_name}' (split '{dataset_split}') tokenized to 0 examples.")
 
-            logger.info(f"Tokenized {len(tokenized)} examples (filtered from {dataset_size})")
+            # Concatenate the memory-mapped shards (a view, nothing loaded).
+            # Empty shards were never finalized and cannot be opened.
+            shards = [Dataset.from_file(args[-1]) for args, count in zip(worker_args, shard_counts) if count > 0]
+            tokenized_ds = shards[0] if len(shards) == 1 else concatenate_datasets(shards)
 
-            # Same as the sequential path: serve the arrow cache memory-mapped
-            # when caching is enabled.
-            if not self.sft_cfg.disable_cache:
-                _save_to_cache(cache_path, tokenized)
-                mmapped = _load_from_cache(cache_path)
-                if mmapped is not None:
-                    return mmapped
+            if self.sft_cfg.disable_cache:
+                # No cache directory to serve the mmap from (the shard dir is
+                # deleted below), so keep the materialized-list behavior.
+                return tokenized_ds.to_list()
 
-            return tokenized
+            _save_to_cache(cache_path, tokenized_ds)
+            mmapped = _load_from_cache(cache_path)
+            if mmapped is None:
+                raise RuntimeError(f"Failed to reload tokenized dataset cache at {cache_path}")
+            return mmapped
 
         finally:
-            # Cleanup temp tokenizer cache
+            # Cleanup temp tokenizer cache and tokenized shards (already
+            # copied into the tokenized-dataset cache, or materialized).
             import shutil
 
             shutil.rmtree(tokenizer_cache_dir, ignore_errors=True)
+            shutil.rmtree(shard_dir, ignore_errors=True)
 
     def load_dataset(self) -> SFTDataset:
         """Load the training dataset(s): pretokenized stores or tokenize-on-load.

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -105,14 +105,32 @@ def _write_tokenized_arrow(rows, shard_path: str) -> int:
     the full tokenized dataset is never resident in memory. Returns the
     number of rows written; on 0 rows no arrow file is finalized (there is
     no schema to write) and the caller must not read ``shard_path``.
+
+    Rows must share one key set: arrow schemas are inferred from the first
+    example, and rows whose keys differ (e.g. a dataset mixing text-only and
+    multimodal conversations, where only image rows carry ``pixel_values``)
+    would have the extra columns *silently dropped* -- by this writer and by
+    ``Dataset.from_list`` alike. Raising here turns that data loss into an
+    explicit error.
     """
     from datasets.arrow_writer import ArrowWriter
 
     written = 0
+    row_keys: Optional[frozenset] = None
     with ArrowWriter(path=shard_path, writer_batch_size=_TOKENIZE_WRITER_BATCH_ROWS) as writer:
+        # Flushed batches release their row references, allowing prior tokenized rows to be reclaimed.
         for row in rows:
             if row is None:
                 continue
+            keys = frozenset(row.keys())
+            if row_keys is None:
+                row_keys = keys
+            elif keys != row_keys:
+                raise ValueError(
+                    f"Tokenized rows have inconsistent keys: row {written} has {sorted(keys)} "
+                    f"vs {sorted(row_keys)} before it. Datasets mixing text-only and multimodal "
+                    f"rows cannot be cached without losing the image columns."
+                )
             writer.write(row)
             written += 1
         if written:
@@ -1089,13 +1107,12 @@ class SFTTrainer:
         :class:`MemoryMappedDataset` served from the arrow cache when caching
         is enabled, or a ``list`` when ``disable_cache=True``.
 
-        With caching enabled (text datasets), tokenization itself is also
-        memory-bounded: rows stream into arrow files in bounded batches
-        (per-worker shard files on the parallel path) instead of accumulating
-        in a list, so dataset size is limited by disk, not RAM. The
-        materializing fallbacks are ``disable_cache=True`` (no arrow file to
-        stream to) and VLM datasets (image tensors only round-trip through
-        ``Dataset.from_list``).
+        With caching enabled, tokenization itself is also memory-bounded:
+        rows (including VLM image tensors) stream into arrow files in bounded
+        batches (per-worker shard files on the parallel path) instead of
+        accumulating in a list, so dataset size is limited by disk, not RAM.
+        The materializing fallback is ``disable_cache=True`` (no arrow file
+        to stream to).
         """
         # Check cache first (unless disabled or force_recache)
         if not self.sft_cfg.disable_cache:
@@ -1166,22 +1183,19 @@ class SFTTrainer:
                     f"Found columns: {columns}"
                 )
 
-            # Materializing fallbacks: with caching disabled there is no arrow
-            # file to stream to (and to serve from), and VLM rows carry image
-            # tensors that only round-trip through Dataset.from_list.
-            if self.sft_cfg.disable_cache or self.is_vlm:
+            # Materializing fallback: with caching disabled there is no arrow
+            # file to stream to (or serve from), so rows stay an in-memory list.
+            if self.sft_cfg.disable_cache:
                 tokenized = [ex for ex in rows if ex is not None]
                 logger.info(f"Tokenized {len(tokenized)} examples (filtered from {len(dataset)})")
-                if not self.sft_cfg.disable_cache:
-                    _save_to_cache(cache_path, tokenized)
-                    mmapped = _load_from_cache(cache_path)
-                    if mmapped is not None:
-                        return mmapped
                 return tokenized
 
             # Stream tokenize -> bounded arrow writes -> cache -> mmap: the
             # tokenized dataset is never resident in memory, so dataset size
-            # is bounded by disk, not RAM.
+            # is bounded by disk, not RAM. VLM rows stream like text: the
+            # processor's image tensors round-trip through ArrowWriter with
+            # full parity to Dataset.from_list (validated against Qwen3-VL
+            # output; see test_vlm_rows_stream_to_arrow).
             with tempfile.TemporaryDirectory(prefix="skyrl_tokenize_") as tmp_dir:
                 shard_path = os.path.join(tmp_dir, "data.arrow")
                 written = _write_tokenized_arrow(rows, shard_path)

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -54,7 +54,7 @@ from skyrl.train.config.sft_config import (
     build_skyrl_config_for_sft,
 )
 from skyrl.train.dataset.pretokenized import (
-    PretokenizedDataset,
+    MemoryMappedDataset,
     load_from_pretokenized,
     sequence_lengths_from_arrow,
 )
@@ -239,7 +239,7 @@ def _get_cache_path(cache_dir: str, cache_key: str) -> str:
     return os.path.join(cache_dir, cache_key)
 
 
-def _load_from_cache(cache_path: str) -> Optional["PretokenizedDataset"]:
+def _load_from_cache(cache_path: str) -> Optional["MemoryMappedDataset"]:
     """Load tokenized dataset from cache as a memory-mapped dataset.
 
     Reads an arrow-backed HF ``Dataset`` directory written by
@@ -254,7 +254,7 @@ def _load_from_cache(cache_path: str) -> Optional["PretokenizedDataset"]:
         cache_path: Path to cached dataset directory.
 
     Returns:
-        A memory-mapped :class:`PretokenizedDataset`, or ``None`` if the
+        A memory-mapped :class:`MemoryMappedDataset`, or ``None`` if the
         cache directory does not exist or fails to load.
     """
     if not os.path.isdir(cache_path):
@@ -265,7 +265,7 @@ def _load_from_cache(cache_path: str) -> Optional["PretokenizedDataset"]:
         dataset = Dataset.load_from_disk(cache_path)
         lengths = sequence_lengths_from_arrow(dataset)
         logger.info(f"Loaded {len(dataset)} examples from cache (memory-mapped)")
-        return PretokenizedDataset(dataset, lengths)
+        return MemoryMappedDataset(dataset, lengths)
     except Exception as e:
         logger.warning(f"Failed to load cache from {cache_path}: {e}")
         return None
@@ -1061,7 +1061,7 @@ class SFTTrainer:
 
         Returns the tokenized examples (dicts with ``input_ids``,
         ``attention_mask``, ``num_actions``): a memory-mapped
-        :class:`PretokenizedDataset` served from the arrow cache when caching
+        :class:`MemoryMappedDataset` served from the arrow cache when caching
         is enabled (nothing materialized in memory), or a ``list`` when
         ``disable_cache=True``.
         """

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -1003,3 +1003,32 @@ def test_load_and_tokenize_cache_backed_is_memory_mapped(tokenizer, tmp_path, mo
         assert a["attention_mask"] == b["attention_mask"]
         assert a["num_actions"] == b["num_actions"]
         assert a["loss_mask"] == b["loss_mask"]
+
+
+def test_streamed_tokenization_matches_materialized(tokenizer, tmp_path, monkeypatch):
+    """Streamed tokenize->arrow writes (cache path) produce the same rows as
+    the materializing path, including across ArrowWriter flush boundaries."""
+    from skyrl.train import sft_trainer as sft_mod
+    from skyrl.train.dataset.pretokenized import MemoryMappedDataset
+
+    dataset = _make_inmem_dataset()
+    monkeypatch.setattr(sft_mod, "load_dataset", lambda *a, **kw: dataset)
+    # Force a flush every 2 rows so the 6-row fixture spans multiple batches.
+    monkeypatch.setattr(sft_mod, "_TOKENIZE_WRITER_BATCH_ROWS", 2)
+
+    streamed = _build_trainer(
+        tokenizer, SFTConfig(num_workers=0, cache_dir=str(tmp_path), disable_cache=False)
+    )._load_and_tokenize("dummy/ds", "train")
+    assert isinstance(streamed, MemoryMappedDataset)
+
+    materialized = _build_trainer(tokenizer, SFTConfig(num_workers=0, disable_cache=True))._load_and_tokenize(
+        "dummy/ds", "train"
+    )
+    assert isinstance(materialized, list)
+
+    assert len(streamed) == len(materialized) == 6
+    for a, b in zip(streamed, materialized):
+        assert a["input_ids"] == b["input_ids"]
+        assert a["attention_mask"] == b["attention_mask"]
+        assert a["num_actions"] == b["num_actions"]
+        assert a["loss_mask"] == b["loss_mask"]

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -1032,3 +1032,52 @@ def test_streamed_tokenization_matches_materialized(tokenizer, tmp_path, monkeyp
         assert a["attention_mask"] == b["attention_mask"]
         assert a["num_actions"] == b["num_actions"]
         assert a["loss_mask"] == b["loss_mask"]
+
+
+def test_streamed_write_rejects_inconsistent_row_keys(tmp_path):
+    """Rows with differing key sets would silently lose columns to arrow
+    schema inference (first example wins); the writer raises instead."""
+    from skyrl.train.sft_trainer import _write_tokenized_arrow
+
+    rows = [
+        {"input_ids": [1, 2], "loss_mask": [0, 1]},
+        {"input_ids": [3, 4], "loss_mask": [0, 1], "pixel_values": [[0.1]], "image_grid_thw": [[1, 1, 1]]},
+    ]
+    with pytest.raises(ValueError, match="inconsistent keys"):
+        _write_tokenized_arrow(iter(rows), str(tmp_path / "bad.arrow"))
+
+
+# NOTE: requires torchvision (via the fsdp extras); routed like the other VLM tests.
+@pytest.mark.vllm
+def test_vlm_rows_stream_to_arrow(vlm_processor, tmp_path):
+    """VLM tokenize output (torch image tensors) round-trips through the
+    streaming ArrowWriter with full parity to the Dataset.from_list path."""
+    from datasets import Dataset
+
+    from skyrl.train.sft_trainer import _write_tokenized_arrow, tokenize_chat_example
+
+    img = (
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+        "AAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )
+    examples = [
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": f"prompt {i}"}, {"type": "image", "image": img}],
+                },
+                {"role": "assistant", "content": "Hello!"},
+            ]
+        }
+        for i in range(3)
+    ]
+    rows = [tokenize_chat_example(ex, vlm_processor.tokenizer, processor=vlm_processor) for ex in examples]
+    assert all(r is not None and "pixel_values" in r for r in rows)
+
+    shard = str(tmp_path / "vlm.arrow")
+    assert _write_tokenized_arrow(iter(rows), shard) == 3
+    streamed = list(Dataset.from_file(shard))
+    baseline = list(Dataset.from_list(rows))
+    assert streamed == baseline
+    assert all(row["pixel_values"] is not None for row in streamed)

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -983,14 +983,14 @@ def test_load_and_tokenize_cache_backed_is_memory_mapped(tokenizer, tmp_path, mo
     SFTDataset served from the arrow cache (nothing materialized); with
     caching disabled it returns the in-memory list. Rows are identical."""
     from skyrl.train import sft_trainer as sft_mod
-    from skyrl.train.dataset.pretokenized import PretokenizedDataset
+    from skyrl.train.dataset.pretokenized import MemoryMappedDataset
 
     dataset = _make_inmem_dataset()
     monkeypatch.setattr(sft_mod, "load_dataset", lambda *a, **kw: dataset)
 
     cached_cfg = SFTConfig(num_workers=0, cache_dir=str(tmp_path), disable_cache=False)
     mmapped = _build_trainer(tokenizer, cached_cfg)._load_and_tokenize("dummy/ds", "train")
-    assert isinstance(mmapped, PretokenizedDataset)
+    assert isinstance(mmapped, MemoryMappedDataset)
     assert list(mmapped.sequence_lengths) == [len(ex["input_ids"]) for ex in mmapped]
 
     uncached_cfg = SFTConfig(num_workers=0, disable_cache=True)

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -976,3 +976,30 @@ def test_load_and_tokenize_cache_hit_skips_retokenization(tokenizer, tmp_path, m
         assert a["attention_mask"] == b["attention_mask"]
         assert a["num_actions"] == b["num_actions"]
         assert a["loss_mask"] == b["loss_mask"]
+
+
+def test_load_and_tokenize_cache_backed_is_memory_mapped(tokenizer, tmp_path, monkeypatch):
+    """With caching enabled the tokenize-on-load path returns a memory-mapped
+    SFTDataset served from the arrow cache (nothing materialized); with
+    caching disabled it returns the in-memory list. Rows are identical."""
+    from skyrl.train import sft_trainer as sft_mod
+    from skyrl.train.dataset.pretokenized import PretokenizedDataset
+
+    dataset = _make_inmem_dataset()
+    monkeypatch.setattr(sft_mod, "load_dataset", lambda *a, **kw: dataset)
+
+    cached_cfg = SFTConfig(num_workers=0, cache_dir=str(tmp_path), disable_cache=False)
+    mmapped = _build_trainer(tokenizer, cached_cfg)._load_and_tokenize("dummy/ds", "train")
+    assert isinstance(mmapped, PretokenizedDataset)
+    assert list(mmapped.sequence_lengths) == [len(ex["input_ids"]) for ex in mmapped]
+
+    uncached_cfg = SFTConfig(num_workers=0, disable_cache=True)
+    materialized = _build_trainer(tokenizer, uncached_cfg)._load_and_tokenize("dummy/ds", "train")
+    assert isinstance(materialized, list)
+
+    assert len(mmapped) == len(materialized)
+    for a, b in zip(mmapped, materialized):
+        assert a["input_ids"] == b["input_ids"]
+        assert a["attention_mask"] == b["attention_mask"]
+        assert a["num_actions"] == b["num_actions"]
+        assert a["loss_mask"] == b["loss_mask"]


### PR DESCRIPTION
> **Stacked on #1970** -- builds on the memory-mapped cache serving introduced there; the diff collapses once #1970 merges.

## What

Closes the transient flagged in #1970's known-limitations note: cache-**miss** tokenization accumulated every tokenized row in a Python list before writing the arrow cache (and on the parallel path, pickled each worker's slice back to the controller), so first-run peak memory was still O(dataset). With this PR, the tokenize-on-load path never holds the tokenized dataset in memory -- text **and VLM** datasets are bounded by disk, not RAM, end to end.

## How

Tokenized rows stream into arrow files in bounded batches via HF's `ArrowWriter` (flush every `_TOKENIZE_WRITER_BATCH_ROWS = 1000` examples):

- **Sequential path**: tokenization becomes a generator feeding `_write_tokenized_arrow` (tokenize -> bounded arrow writes to a temp shard -> `_save_to_cache(Dataset.from_file(shard))` -> serve memory-mapped). Peak memory during tokenization is O(writer batch).
- **Parallel path**: each spawn worker streams its slice into a **per-worker arrow shard** and returns only its row count; the controller concatenates the memory-mapped shards (a view, nothing loaded) into the cache. This also removes the old pickle-the-results round-trip from workers to controller.
- `_save_to_cache` accepts an arrow-backed `Dataset` directly (`save_to_disk` writes through in batches) in addition to `list[dict]`.
- **VLM streams too**: validated against real Qwen3-VL processor output -- image tensors (`pixel_values`, `image_grid_thw`) round-trip through the streaming writer with full parity to `Dataset.from_list` (`test_vlm_rows_stream_to_arrow`, run under the `vllm` marker with the fsdp extras like the other VLM tests). VLM rows are the megabyte-sized ones, so they benefit most.
- **Materializing fallback**: `disable_cache=True` only (no arrow file to stream to or serve from).

### Behavior change: inconsistent row keys now raise

The VLM validation surfaced a pre-existing hazard: datasets mixing text-only and multimodal rows **silently lose their image columns** to arrow schema inference (locked from the first example) -- identically under the old `Dataset.from_list` path, so training would proceed without images and no one would know. `_write_tokenized_arrow` now raises an explicit error on inconsistent row keys. Runs that previously trained silently-wrong on such datasets now fail loudly at tokenization.

## Measured (cache-miss tokenization; peak **anonymous heap** = the memory that can OOM, vs reclaimable file-backed pages)

| Rows | Streamed heap | Materialized heap (old) |
|---|---|---|
| 60k | 720 MB | 1,569 MB |
| 120k | **722 MB (flat)** | **2,585 MB (linear)** |

The ~720 MB floor is torch/transformers/tokenizer imports; doubling the dataset moved the streamed heap by 2 MB. Streamed growth appears only in file-backed page cache (the arrow file being written/read), which the OS reclaims under pressure.

## Memory profile of the tokenize-on-load path, across the stack

| Phase | main (pre #1961) | after #1970 | after this PR |
|---|---|---|---|
| Tokenization (cache miss) | O(dataset) | O(dataset), transient | **O(writer batch)** |
| Training (serving) | O(dataset) x (workers+1) | O(page cache) | O(page cache) |

## Tests

- Streamed-vs-materialized row parity with the flush size forced to 2 (multiple batch boundaries).
- Existing parallel-vs-serial parity test exercises the shard-writing workers end to end (real spawn pool, cache enabled).
- VLM tensor round-trip parity (`vllm`-marked); inconsistent-keys guard test.
- Full `tests/train` suite green: 884 (+36 tokenization, +3 vllm-marked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)