### PR TITLE
[perf][tinker] Scan pending requests without loading their payloads

### DIFF
--- a/skyrl/benchmarks/bench_tinker_db.py
+++ b/skyrl/benchmarks/bench_tinker_db.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Benchmark the Tinker server's database layer under multi-LoRA concurrency.
+
+Isolates the DB from the GPU: no backend, no HTTP server, no inference engine.
+Every phase drives the same functions the API server and engine use, so the
+numbers move when those code paths change.
+
+Phases
+  submit       Concurrent request submission (``create_future`` + commit), the
+               path every forward_backward/forward/sample POST takes.
+  engine_scan  One iteration of the engine's scheduling queries against a
+               backlog of pending rows, including rows parked behind a barrier.
+  complete     Result write-back (``_complete_futures``).
+  await        Concurrent ``retrieve_future`` waiters.
+
+Alongside wall-clock timings each phase reports the number of SQL statements
+and write transactions issued, which is what actually serializes on SQLite's
+single writer.
+
+Usage:
+  uv run --isolated --extra dev --extra tinker python skyrl/benchmarks/bench_tinker_db.py
+
+  # Heavier multi-LoRA shape
+  uv run --isolated --extra dev --extra tinker python skyrl/benchmarks/bench_tinker_db.py \
+      --num-models 16 --concurrency 128 --num-requests 512
+"""
+
+import argparse
+import asyncio
+import statistics
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from uuid import uuid4
+
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from skyrl.tinker import types
+from skyrl.tinker.api import create_future
+from skyrl.tinker.config import EngineConfig
+from skyrl.tinker.db_models import (
+    FutureDB,
+    ModelDB,
+    RequestStatus,
+    SessionDB,
+    enable_sqlite_wal,
+    get_async_database_url,
+)
+from skyrl.tinker.engine import TinkerEngine
+
+
+@dataclass
+class SQLCounter:
+    """Counts statements and commits issued on an engine.
+
+    ``writes`` counts data-modifying statements; on SQLite these are what
+    contend for the single write lock, and ``commits`` is how many separate
+    write transactions they were spread across.
+    """
+
+    statements: int = 0
+    writes: int = 0
+    commits: int = 0
+
+    def attach(self, sync_engine) -> None:
+        @event.listens_for(sync_engine, "before_cursor_execute")
+        def _count(conn, cursor, statement, parameters, context, executemany):
+            self.statements += 1
+            verb = statement.lstrip().split(" ", 1)[0].upper()
+            if verb in ("INSERT", "UPDATE", "DELETE"):
+                self.writes += 1
+
+        @event.listens_for(sync_engine, "commit")
+        def _count_commit(conn):
+            self.commits += 1
+
+    def reset(self) -> None:
+        self.statements = self.writes = self.commits = 0
+
+    def snapshot(self) -> dict[str, int]:
+        return {"statements": self.statements, "writes": self.writes, "commits": self.commits}
+
+
+@dataclass
+class PhaseResult:
+    name: str
+    n: int
+    elapsed_s: float
+    sql: dict[str, int]
+    latencies_ms: list[float] = field(default_factory=list)
+    note: str = ""
+
+    def report(self) -> str:
+        rate = self.n / self.elapsed_s if self.elapsed_s > 0 else float("inf")
+        line = f"  {self.name:<12} n={self.n:>5}  {self.elapsed_s:>7.3f}s  {rate:>8.1f} op/s"
+        if self.latencies_ms:
+            ordered = sorted(self.latencies_ms)
+            p50 = statistics.median(ordered)
+            p99 = ordered[min(len(ordered) - 1, int(0.99 * len(ordered)))]
+            line += f"  p50={p50:>7.1f}ms  p99={p99:>7.1f}ms"
+        line += f"  sql={self.sql['statements']:>5} (w={self.sql['writes']:>5}, commits={self.sql['commits']:>5})"
+        if self.note:
+            line += f"  {self.note}"
+        return line
+
+
+def make_forward_backward_input(seq_len: int, seqs_per_request: int) -> types.ForwardBackwardInput:
+    """Build a realistically sized forward_backward payload."""
+    tokens = list(range(seq_len))
+    floats = [0.1234567] * seq_len
+    datum = types.Datum(
+        model_input=types.ModelInput(chunks=[types.EncodedTextChunk(tokens=tokens)]),
+        loss_fn_inputs=types.LossFnInputs(
+            target_tokens=types.TensorData(data=tokens),
+            weights=types.TensorData(data=floats),
+            advantages=types.TensorData(data=floats),
+            logprobs=types.TensorData(data=floats),
+        ),
+    )
+    return types.ForwardBackwardInput(data=[datum] * seqs_per_request, loss_fn="importance_sampling")
+
+
+def make_sample_input(prompt_len: int) -> types.SampleInput:
+    return types.SampleInput(
+        prompt=types.ModelInput(chunks=[types.EncodedTextChunk(tokens=list(range(prompt_len)))]),
+        sampling_params=types.SamplingParams(temperature=1.0, max_tokens=128, seed=0),
+        num_samples=1,
+        checkpoint_id="",
+        prompt_logprobs=False,
+    )
+
+
+def seed_models(sync_engine, num_models: int) -> list[str]:
+    """Create a session plus ``num_models`` LoRA model rows, returning model ids."""
+    session_id = f"sess_{uuid4().hex[:8]}"
+    model_ids = [f"model_{i}" for i in range(num_models)]
+    with Session(sync_engine) as session:
+        session.add(
+            SessionDB(
+                session_id=session_id,
+                sdk_version="bench",
+                last_heartbeat_at=datetime.now(timezone.utc),
+            )
+        )
+        for i, model_id in enumerate(model_ids):
+            session.add(
+                ModelDB(
+                    model_id=model_id,
+                    base_model="bench/base",
+                    lora_config={"rank": 32, "alpha": 64.0, "seed": 0},
+                    status="active",
+                    request_id=i,
+                    session_id=session_id,
+                )
+            )
+        session.commit()
+    return model_ids
+
+
+async def phase_submit(
+    db_engine,
+    counter: SQLCounter,
+    model_ids: list[str],
+    num_requests: int,
+    concurrency: int,
+    payload: types.ForwardBackwardInput,
+) -> PhaseResult:
+    """Submit ``num_requests`` forward_backward futures with ``concurrency`` in flight.
+
+    Mirrors the API server: one AsyncSession and one commit per request.
+    """
+    semaphore = asyncio.Semaphore(concurrency)
+    latencies: list[float] = []
+
+    async def submit_one(index: int) -> None:
+        async with semaphore:
+            started = time.perf_counter()
+            async with AsyncSession(db_engine) as session:
+                await create_future(
+                    session=session,
+                    request_type=types.RequestType.FORWARD_BACKWARD,
+                    model_id=model_ids[index % len(model_ids)],
+                    request_data=payload,
+                )
+                await session.commit()
+            latencies.append((time.perf_counter() - started) * 1000)
+
+    counter.reset()
+    started = time.perf_counter()
+    await asyncio.gather(*(submit_one(i) for i in range(num_requests)))
+    elapsed = time.perf_counter() - started
+    return PhaseResult("submit", num_requests, elapsed, counter.snapshot(), latencies)
+
+
+def add_barriers(sync_engine, model_ids: list[str], fraction: float) -> int:
+    """Insert a pending optim_step for the first ``fraction`` of models.
+
+    These are the scheduling barriers that park later requests, which is the
+    steady state of a multi-LoRA run: some adapters stepping while others queue.
+    """
+    blocked = model_ids[: max(1, int(len(model_ids) * fraction))]
+    payload = types.OptimStepInput(
+        adam_params=types.AdamParams(learning_rate=1e-4, beta1=0.9, beta2=0.95, eps=1e-8, weight_decay=0.0)
+    ).model_dump(mode="json")
+    with Session(sync_engine) as session:
+        for model_id in blocked:
+            session.add(
+                FutureDB(
+                    request_type=types.RequestType.OPTIM_STEP,
+                    model_id=model_id,
+                    request_data=payload,
+                    status=RequestStatus.PENDING,
+                )
+            )
+        session.commit()
+    return len(blocked)
+
+
+def phase_engine_scan(
+    engine: TinkerEngine, counter: SQLCounter, iterations: int, name: str
+) -> tuple[PhaseResult, list[str]]:
+    """Time the engine's per-iteration scheduling queries.
+
+    Returns the phase result plus the ids of the model passes the last iteration
+    would have dispatched. Barriers are intentionally excluded so the caller can
+    retire the passes and leave the queue in its parked state.
+    """
+    counter.reset()
+    latencies: list[float] = []
+    started = time.perf_counter()
+    passes: list[str] = []
+    singles = 0
+    for _ in range(iterations):
+        iteration_start = time.perf_counter()
+        with Session(engine.db_engine) as session:
+            # Tolerate engines without the shared metadata scan so this benchmark
+            # can also be run against an older checkout for comparison.
+            if hasattr(engine, "scan_pending_requests"):
+                pending = [engine.scan_pending_requests(session)]
+            else:
+                pending = []
+            fb = engine.find_batchable_model_passes(session, types.RequestType.FORWARD_BACKWARD, *pending)
+            fwd = engine.find_batchable_model_passes(session, types.RequestType.FORWARD, *pending)
+            samples = engine.find_batchable_sample(session, *pending)
+            others = engine.find_single_requests(session, *pending)
+        passes = [*fb, *fwd, *samples]
+        singles = len(others)
+        latencies.append((time.perf_counter() - iteration_start) * 1000)
+    elapsed = time.perf_counter() - started
+    return (
+        PhaseResult(
+            name,
+            iterations,
+            elapsed,
+            counter.snapshot(),
+            latencies,
+            note=f"dispatchable={len(passes)} passes + {singles} singles",
+        ),
+        passes,
+    )
+
+
+def phase_complete(engine: TinkerEngine, counter: SQLCounter, request_ids: list[str]) -> PhaseResult:
+    """Time result write-back for a dispatched batch.
+
+    Treat this number as indicative only, and do not read it as a cross-build
+    comparison. All phases share one database in a fixed order, and this write is
+    sensitive to process and I/O state left behind by the scan phases -- enough
+    to swing it ~1.7x between two builds that provably write identically (an
+    isolated harness measuring only the status update reports ~105ms for every
+    index shape and scan history). Checkpointing the WAL first removes one source
+    of variance but not all of it.
+    """
+    with engine.db_engine.connect() as conn:
+        conn.exec_driver_sql("PRAGMA wal_checkpoint(TRUNCATE)")
+
+    result = types.ForwardBackwardOutput(
+        loss_fn_output_type="importance_sampling",
+        loss_fn_outputs=[{"loss": 0.5}],
+        metrics={"loss:sum": 1.0, "loss:count": 2.0},
+    )
+    results = {request_id: result for request_id in request_ids}
+
+    counter.reset()
+    started = time.perf_counter()
+    engine._complete_futures(results)
+    elapsed = time.perf_counter() - started
+    return PhaseResult("complete", len(results), elapsed, counter.snapshot())
+
+
+async def _await_future(db_engine, request_id: int, deadline: float) -> dict | None:
+    """The retrieve_future wait loop: one session and query per waiter."""
+    poll = 0.1
+    max_poll = 1.0
+    while time.perf_counter() < deadline:
+        async with AsyncSession(db_engine) as session:
+            status = (await session.exec(select(FutureDB.status).where(FutureDB.request_id == request_id))).first()
+            if status in (RequestStatus.COMPLETED, RequestStatus.FAILED):
+                future = (await session.exec(select(FutureDB).where(FutureDB.request_id == request_id))).first()
+                return future.result_data
+        await asyncio.sleep(poll)
+        poll = min(poll * 1.5, max_poll)
+    return None
+
+
+async def phase_await(
+    db_engine,
+    counter: SQLCounter,
+    request_ids: list[int],
+    hold_s: float,
+) -> PhaseResult:
+    """Measure DB load from concurrent waiters while results are still pending.
+
+    Waiters start before the results land, so this counts the polling traffic a
+    real run pays while the engine is busy on the GPU.
+    """
+    counter.reset()
+    deadline = time.perf_counter() + hold_s
+
+    tasks = [asyncio.create_task(_await_future(db_engine, rid, deadline)) for rid in request_ids]
+
+    started = time.perf_counter()
+    await asyncio.sleep(hold_s)
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+    elapsed = time.perf_counter() - started
+
+    sql = counter.snapshot()
+    return PhaseResult(
+        "await",
+        len(request_ids),
+        elapsed,
+        sql,
+        note=f"{sql['statements'] / max(elapsed, 1e-9):.0f} stmt/s",
+    )
+
+
+async def run(args) -> None:
+    with TemporaryDirectory(prefix="bench_tinker_db_") as tmpdir:
+        db_path = Path(tmpdir) / "tinker.db"
+        db_url = f"sqlite:///{db_path}"
+
+        sync_engine = create_engine(db_url, echo=False)
+        enable_sqlite_wal(sync_engine)
+        SQLModel.metadata.create_all(sync_engine)
+
+        async_engine = create_async_engine(get_async_database_url(db_url), echo=False)
+        enable_sqlite_wal(async_engine.sync_engine)
+
+        counter = SQLCounter()
+        counter.attach(async_engine.sync_engine)
+        sync_counter = SQLCounter()
+        sync_counter.attach(sync_engine)
+
+        model_ids = seed_models(sync_engine, args.num_models)
+
+        payload = make_forward_backward_input(args.seq_len, args.seqs_per_request)
+        payload_kb = len(payload.model_dump_json()) / 1024
+
+        engine = object.__new__(TinkerEngine)
+        engine.config = EngineConfig(base_model="bench/base", backend="fsdp", database_url=db_url)
+        engine.db_engine = sync_engine
+
+        print("Tinker DB benchmark")
+        print(f"  db={db_path}")
+        print(f"  models={args.num_models}  concurrency={args.concurrency}  requests={args.num_requests}")
+        print(f"  payload={payload_kb:.1f} KiB/request ({args.seqs_per_request} seqs x {args.seq_len} tokens)")
+        print()
+
+        results: list[PhaseResult] = []
+
+        results.append(
+            await phase_submit(async_engine, counter, model_ids, args.num_requests, args.concurrency, payload)
+        )
+
+        # Reproduce the multi-LoRA steady state: some adapters have an optim_step
+        # queued (a barrier) with further passes stacked behind it. Those parked
+        # requests cannot be dispatched, but the scheduler still sees them on
+        # every poll.
+        blocked_models = add_barriers(sync_engine, model_ids, args.barrier_fraction)
+        if args.blocked_requests:
+            await phase_submit(
+                async_engine, counter, model_ids[:blocked_models], args.blocked_requests, args.concurrency, payload
+            )
+
+        scan, dispatched = phase_engine_scan(engine, sync_counter, args.scan_iterations, "scan_ready")
+        scan.note += f", barriers={blocked_models}/{args.num_models}, parked={args.blocked_requests}"
+        results.append(scan)
+
+        results.append(phase_complete(engine, sync_counter, dispatched))
+
+        # With the dispatchable batch retired, only requests parked behind a
+        # barrier remain. This is where the engine sits between barriers, and it
+        # re-runs this scan every poll interval.
+        parked_scan, _ = phase_engine_scan(engine, sync_counter, args.scan_iterations, "scan_parked")
+        results.append(parked_scan)
+
+        with Session(sync_engine) as session:
+            pending_ids = session.exec(
+                select(FutureDB.request_id)
+                .where(FutureDB.status == RequestStatus.PENDING)
+                .where(FutureDB.request_type == types.RequestType.FORWARD_BACKWARD)
+                .limit(args.await_waiters)
+            ).all()
+        results.append(await phase_await(async_engine, counter, list(pending_ids), args.await_hold_s))
+
+        db_bytes = db_path.stat().st_size
+        wal = db_path.with_name(db_path.name + "-wal")
+        wal_bytes = wal.stat().st_size if wal.exists() else 0
+
+        for result in results:
+            print(result.report())
+        print()
+        print(f"  db file={db_bytes / 1e6:.1f} MB   wal={wal_bytes / 1e6:.1f} MB")
+
+        await async_engine.dispose()
+        sync_engine.dispose()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--num-models", type=int, default=8, help="Number of concurrent LoRA adapters")
+    parser.add_argument("--num-requests", type=int, default=256, help="forward_backward requests to submit")
+    parser.add_argument("--concurrency", type=int, default=64, help="Submissions in flight")
+    parser.add_argument("--seq-len", type=int, default=512, help="Tokens per sequence in the payload")
+    parser.add_argument("--seqs-per-request", type=int, default=4, help="Sequences per forward_backward request")
+    parser.add_argument("--scan-iterations", type=int, default=20, help="Engine scheduling iterations to time")
+    parser.add_argument(
+        "--barrier-fraction",
+        type=float,
+        default=0.5,
+        help="Fraction of models given a pending optim_step barrier before the scan phase",
+    )
+    parser.add_argument(
+        "--blocked-requests",
+        type=int,
+        default=256,
+        help="Extra forward_backward requests queued behind the barriers (parked, re-seen every poll)",
+    )
+    parser.add_argument("--await-waiters", type=int, default=128, help="Concurrent retrieve_future waiters")
+    parser.add_argument("--await-hold-s", type=float, default=3.0, help="Seconds to hold waiters on pending futures")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    asyncio.run(run(parse_args()))

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -3,13 +3,14 @@
 import argparse
 import time
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable
 
 from cloudpathlib import AnyPath
 from pydantic import BaseModel
-from sqlmodel import Session, create_engine, func, select, update
+from sqlmodel import Session, create_engine, select, update
 
 from skyrl.backends.utils import log_timing
 from skyrl.tinker import types
@@ -25,6 +26,29 @@ from skyrl.tinker.db_models import (
     enable_sqlite_wal,
 )
 from skyrl.utils.log import logger
+
+# SQLite caps the number of bound parameters in a single statement, so id lists
+# are queried in chunks well under that limit.
+_MAX_IDS_PER_QUERY = 500
+
+# Request types the engine dispatches through a batch path rather than
+# individually, and so excludes from find_single_requests. EXTERNAL requests are
+# completed by the API process and never dispatched by the engine at all.
+_BATCHED_REQUEST_TYPES = (
+    types.RequestType.FORWARD_BACKWARD,
+    types.RequestType.FORWARD,
+    types.RequestType.SAMPLE,
+    types.RequestType.EXTERNAL,
+)
+
+
+@dataclass(frozen=True)
+class PendingRequest:
+    """Scheduling metadata for one pending request, without its payload."""
+
+    request_id: int
+    model_id: str | None
+    request_type: types.RequestType
 
 
 def _model_not_found_error(model_id: str) -> types.ErrorResponse:
@@ -335,25 +359,75 @@ class TinkerEngine:
                     )
                 session.commit()
 
-    def _find_destructive_barriers(self, session: Session) -> dict[str, int]:
+    def scan_pending_requests(self, session: Session) -> list[PendingRequest]:
+        """Read scheduling metadata for every pending request, in arrival order.
+
+        Deliberately excludes request_data. Scheduling decisions need only ids
+        and types, while model-pass payloads run to hundreds of KB each; loading
+        them here would mean deserializing the entire backlog on every poll,
+        including requests parked behind a barrier that cannot run yet. Payloads
+        are fetched afterwards for just the requests being dispatched.
+        """
+        rows = session.exec(
+            select(FutureDB.request_id, FutureDB.model_id, FutureDB.request_type)
+            .where(FutureDB.status == RequestStatus.PENDING)
+            .order_by(FutureDB.request_id)
+        ).all()
+        return [
+            PendingRequest(request_id=request_id, model_id=model_id, request_type=request_type)
+            for request_id, model_id, request_type in rows
+        ]
+
+    def _load_request_payloads(self, session: Session, request_ids: list[int]) -> dict[int, dict]:
+        """Fetch request_data for the given request_ids."""
+        payloads: dict[int, dict] = {}
+        for start in range(0, len(request_ids), _MAX_IDS_PER_QUERY):
+            chunk = request_ids[start : start + _MAX_IDS_PER_QUERY]
+            rows = session.exec(
+                select(FutureDB.request_id, FutureDB.request_data).where(FutureDB.request_id.in_(chunk))
+            ).all()
+            payloads.update(rows)
+        return payloads
+
+    def _load_sample_checkpoint_ids(self, session: Session, request_ids: list[int]) -> dict[int, str]:
+        """Fetch just the checkpoint_id of each given sample request.
+
+        Sample batch compatibility depends only on this one field, so extract it
+        inside the database rather than pulling whole prompt payloads back to
+        reach it.
+        """
+        checkpoint_ids: dict[int, str] = {}
+        for start in range(0, len(request_ids), _MAX_IDS_PER_QUERY):
+            chunk = request_ids[start : start + _MAX_IDS_PER_QUERY]
+            rows = session.exec(
+                select(FutureDB.request_id, FutureDB.request_data["checkpoint_id"].as_string()).where(
+                    FutureDB.request_id.in_(chunk)
+                )
+            ).all()
+            checkpoint_ids.update(rows)
+        return checkpoint_ids
+
+    def _find_destructive_barriers(self, pending: list[PendingRequest]) -> dict[str, int]:
         """Find the earliest pending destructive operation (optim_step/load_weights) per model.
 
         These act as scheduling barriers: model passes before them can be batched
         safely, and single requests after a blocked pass must wait.
+
+        Args:
+            pending: Pending request metadata ordered by request_id
         """
-        query = (
-            select(FutureDB.model_id, func.min(FutureDB.request_id).label("barrier_id"))
-            .where(
-                (FutureDB.request_type == types.RequestType.OPTIM_STEP)
-                | (FutureDB.request_type == types.RequestType.LOAD_WEIGHTS)
-            )
-            .where(FutureDB.status == RequestStatus.PENDING)
-            .group_by(FutureDB.model_id)
-        )
-        return dict(session.exec(query).all())
+        barriers: dict[str, int] = {}
+        for request in pending:
+            if request.request_type in (types.RequestType.OPTIM_STEP, types.RequestType.LOAD_WEIGHTS):
+                # First match per model wins because pending is request_id-ordered.
+                barriers.setdefault(request.model_id, request.request_id)
+        return barriers
 
     def find_batchable_model_passes(
-        self, session: Session, request_type: types.RequestType
+        self,
+        session: Session,
+        request_type: types.RequestType,
+        pending: list[PendingRequest] | None = None,
     ) -> dict[str, tuple[str, types.ForwardBackwardInput]]:
         """Find all requests of the given type that come before any destructive update for their model.
 
@@ -363,30 +437,36 @@ class TinkerEngine:
         Args:
             session: Database session
             request_type: The type of request to find (e.g., FORWARD or FORWARD_BACKWARD)
+            pending: Pre-scanned pending metadata; scanned here when omitted
 
         Returns:
             Dict mapping request_id to (model_id, request_data) tuples
         """
-        barriers = self._find_destructive_barriers(session)
+        if pending is None:
+            pending = self.scan_pending_requests(session)
+        barriers = self._find_destructive_barriers(pending)
 
-        # Get all pending operations of the requested type ordered by request_id
-        query = (
-            select(FutureDB)
-            .where(FutureDB.request_type == request_type)
-            .where(FutureDB.status == RequestStatus.PENDING)
-            .order_by(FutureDB.request_id)
-        )
-        ops = session.exec(query).all()
+        # Only include ops of this type that come before their model's barrier
+        batchable = [
+            request
+            for request in pending
+            if request.request_type == request_type
+            and (request.model_id not in barriers or request.request_id < barriers[request.model_id])
+        ]
 
-        # Filter: only include ops that come before their model's barrier
-        batchable = [op for op in ops if op.model_id not in barriers or op.request_id < barriers[op.model_id]]
-
+        payloads = self._load_request_payloads(session, [request.request_id for request in batchable])
         return {
-            str(f.request_id): (f.model_id, types.ForwardBackwardInput.model_validate(f.request_data))
-            for f in batchable
+            str(request.request_id): (
+                request.model_id,
+                types.ForwardBackwardInput.model_validate(payloads[request.request_id]),
+            )
+            for request in batchable
+            if request.request_id in payloads
         }
 
-    def find_batchable_sample(self, session: Session) -> dict[str, tuple[str, types.SampleInput]]:
+    def find_batchable_sample(
+        self, session: Session, pending: list[PendingRequest] | None = None
+    ) -> dict[str, tuple[str, types.SampleInput]]:
         """Find all sample ops that can be safely batched together.
 
         Returns sample operations ensuring that each model_id has only one checkpoint_id
@@ -398,22 +478,24 @@ class TinkerEngine:
 
         Args:
             session: Database session
+            pending: Pre-scanned pending metadata; scanned here when omitted
 
         Returns:
             Dict mapping request_id to (model_id, request_data) tuples
         """
-        sample_query = (
-            select(FutureDB)
-            .where(FutureDB.request_type == types.RequestType.SAMPLE)
-            .where(FutureDB.status == RequestStatus.PENDING)
-            .order_by(FutureDB.request_id)
-        )
-        sample_ops = session.exec(sample_query).all()
+        if pending is None:
+            pending = self.scan_pending_requests(session)
+
+        sample_ops = [request for request in pending if request.request_type == types.RequestType.SAMPLE]
+        if not sample_ops:
+            return {}
+
+        checkpoint_ids = self._load_sample_checkpoint_ids(session, [request.request_id for request in sample_ops])
 
         batchable = []
         model_checkpoints = {}  # Map from model_id to checkpoint_id of first request to that model
         for op in sample_ops:
-            checkpoint_id = op.request_data["checkpoint_id"]
+            checkpoint_id = checkpoint_ids.get(op.request_id, "")
             # Base model requests (empty checkpoint_id) are always compatible, otherwise only
             # take only requests with one checkpoint_id for a given model_id
             if checkpoint_id == "" or model_checkpoints.setdefault(op.model_id, checkpoint_id) == checkpoint_id:
@@ -424,56 +506,57 @@ class TinkerEngine:
         if self.config.backend == "jax" and self.backend.config.sample_max_num_sequences > 0:
             batchable = batchable[: self.backend.config.sample_max_num_sequences]
 
-        return {str(f.request_id): (f.model_id, types.SampleInput.model_validate(f.request_data)) for f in batchable}
+        payloads = self._load_request_payloads(session, [request.request_id for request in batchable])
+        return {
+            str(request.request_id): (request.model_id, types.SampleInput.model_validate(payloads[request.request_id]))
+            for request in batchable
+            if request.request_id in payloads
+        }
 
-    def find_single_requests(self, session: Session) -> dict[str, tuple[str, types.RequestType, dict]]:
+    def find_single_requests(
+        self, session: Session, pending: list[PendingRequest] | None = None
+    ) -> dict[str, tuple[str, types.RequestType, dict]]:
         """Find all requests that need to be processed individually (not batchable).
 
         Args:
             session: Database session
+            pending: Pre-scanned pending metadata; scanned here when omitted
 
         Returns:
             Dict mapping request_id to (model_id, request_type, request_data) tuples
         """
+        if pending is None:
+            pending = self.scan_pending_requests(session)
+
         # Find the first blocked forward pass per model: a pending FORWARD/FORWARD_BACKWARD
         # that sits behind a destructive barrier and won't be batched this iteration.
         # Single requests must not jump ahead of these.
-        destructive_barriers = self._find_destructive_barriers(session)
+        destructive_barriers = self._find_destructive_barriers(pending)
         blocked_pass_barriers: dict[str, int] = {}
-        if destructive_barriers:
-            pending_passes = session.exec(
-                select(FutureDB.model_id, FutureDB.request_id)
-                .where(
-                    (FutureDB.request_type == types.RequestType.FORWARD_BACKWARD)
-                    | (FutureDB.request_type == types.RequestType.FORWARD)
-                )
-                .where(FutureDB.status == RequestStatus.PENDING)
-                .where(FutureDB.model_id.in_(destructive_barriers.keys()))
-                .order_by(FutureDB.request_id)
-            ).all()
-            for model_id, req_id in pending_passes:
-                if req_id >= destructive_barriers[model_id]:
-                    blocked_pass_barriers.setdefault(model_id, req_id)
+        for request in pending:
+            if request.request_type not in (types.RequestType.FORWARD_BACKWARD, types.RequestType.FORWARD):
+                continue
+            barrier_id = destructive_barriers.get(request.model_id)
+            if barrier_id is not None and request.request_id >= barrier_id:
+                blocked_pass_barriers.setdefault(request.model_id, request.request_id)
 
-        statement = (
-            select(FutureDB)
-            .where(FutureDB.status == RequestStatus.PENDING)
-            .where(FutureDB.request_type != types.RequestType.FORWARD_BACKWARD)
-            .where(FutureDB.request_type != types.RequestType.FORWARD)
-            .where(FutureDB.request_type != types.RequestType.SAMPLE)
-            .where(FutureDB.request_type != types.RequestType.EXTERNAL)
-            .order_by(FutureDB.request_id)
-        )
-        other_futures = session.exec(statement).all()
-
-        # Filter: only include ops that come before the first blocked pass for their model
+        # Only include ops that come before the first blocked pass for their model
         other_futures = [
-            op
-            for op in other_futures
-            if op.model_id not in blocked_pass_barriers or op.request_id < blocked_pass_barriers[op.model_id]
+            request
+            for request in pending
+            if request.request_type not in _BATCHED_REQUEST_TYPES
+            and (
+                request.model_id not in blocked_pass_barriers
+                or request.request_id < blocked_pass_barriers[request.model_id]
+            )
         ]
 
-        return {str(f.request_id): (f.model_id, f.request_type, f.request_data) for f in other_futures}
+        payloads = self._load_request_payloads(session, [request.request_id for request in other_futures])
+        return {
+            str(request.request_id): (request.model_id, request.request_type, payloads[request.request_id])
+            for request in other_futures
+            if request.request_id in payloads
+        }
 
     def process_create_model(self, model_id: str, request_data: types.CreateModelInput) -> types.CreateModelOutput:
         """Create and initialize a model."""
@@ -756,15 +839,18 @@ class TinkerEngine:
         while True:
             # Query for pending requests and extract data within session context
             with Session(self.db_engine) as session:
+                # One metadata scan feeds every scheduling decision below, so a
+                # poll that finds nothing to run costs a single indexed query.
+                pending = self.scan_pending_requests(session)
                 # Use look-ahead scheduling to find batchable forward_backward and forward model passes
                 forward_backward_requests = self.find_batchable_model_passes(
-                    session, types.RequestType.FORWARD_BACKWARD
+                    session, types.RequestType.FORWARD_BACKWARD, pending
                 )
-                forward_requests = self.find_batchable_model_passes(session, types.RequestType.FORWARD)
+                forward_requests = self.find_batchable_model_passes(session, types.RequestType.FORWARD, pending)
                 # Find pending sample requests that can be batched
-                sample_requests = self.find_batchable_sample(session)
+                sample_requests = self.find_batchable_sample(session, pending)
                 # Get other pending requests (non forward_backward and non sampling)
-                other_requests = self.find_single_requests(session)
+                other_requests = self.find_single_requests(session, pending)
 
             # Process batches outside of session context
             self.process_batch_requests(forward_backward_requests, self.process_forward_backward, "forward_backward")

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -296,3 +296,138 @@ def test_find_single_requests_barrier_is_per_model(scheduling_engine):
         assert list(singles.keys()) == ["2", "5"]
         assert singles["2"][0] == "model_a"
         assert singles["5"][0] == "model_b"
+
+
+def add_futures(engine, specs) -> list[int]:
+    """Insert pending futures from (request_type, model_id, request_data) specs."""
+    with Session(engine.db_engine) as session:
+        rows = [
+            FutureDB(
+                request_type=request_type,
+                model_id=model_id,
+                request_data=request_data,
+                status=RequestStatus.PENDING,
+            )
+            for request_type, model_id, request_data in specs
+        ]
+        for row in rows:
+            session.add(row)
+        session.commit()
+        return [row.request_id for row in rows]
+
+
+def test_scan_pending_requests_returns_metadata_in_arrival_order(scheduling_engine):
+    """The scheduling scan sees only pending rows, ordered by request_id."""
+    engine = scheduling_engine
+    request_ids = add_futures(
+        engine,
+        [
+            (types.RequestType.FORWARD_BACKWARD, "model_a", {}),
+            (types.RequestType.OPTIM_STEP, "model_a", {}),
+            (types.RequestType.FORWARD, "model_b", {}),
+        ],
+    )
+
+    with Session(engine.db_engine) as session:
+        # Retire the middle request so it must drop out of the scan.
+        engine._complete_futures({str(request_ids[1]): types.OptimStepOutput(metrics={})})
+        pending = engine.scan_pending_requests(session)
+
+    assert [request.request_id for request in pending] == [request_ids[0], request_ids[2]]
+    assert [request.request_type for request in pending] == [
+        types.RequestType.FORWARD_BACKWARD,
+        types.RequestType.FORWARD,
+    ]
+    assert [request.model_id for request in pending] == ["model_a", "model_b"]
+
+
+def forward_backward_payload() -> dict:
+    return types.ForwardBackwardInput(
+        data=[
+            types.Datum(
+                model_input=types.ModelInput(chunks=[types.EncodedTextChunk(tokens=[1, 2, 3])]),
+                loss_fn_inputs=types.LossFnInputs(
+                    target_tokens=types.TensorData(data=[1, 2, 3]),
+                    weights=types.TensorData(data=[1.0, 1.0, 1.0]),
+                    advantages=types.TensorData(data=[0.0, 0.0, 0.0]),
+                    logprobs=types.TensorData(data=[0.0, 0.0, 0.0]),
+                ),
+            )
+        ],
+        loss_fn="cross_entropy",
+    ).model_dump(mode="json")
+
+
+def test_find_batchable_model_passes_stops_at_barrier(scheduling_engine):
+    """Passes queued behind an optim_step must not be dispatched with earlier ones."""
+    engine = scheduling_engine
+    payload = forward_backward_payload()
+    request_ids = add_futures(
+        engine,
+        [
+            (types.RequestType.FORWARD_BACKWARD, "model_a", payload),
+            (types.RequestType.OPTIM_STEP, "model_a", {}),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", payload),
+            # model_b has no barrier, so its pass batches even though it arrived last
+            (types.RequestType.FORWARD_BACKWARD, "model_b", payload),
+        ],
+    )
+
+    with Session(engine.db_engine) as session:
+        batchable = engine.find_batchable_model_passes(session, types.RequestType.FORWARD_BACKWARD)
+
+    assert set(batchable) == {str(request_ids[0]), str(request_ids[3])}
+    # Payloads are fetched for the dispatched requests and parsed into inputs
+    model_id, request_data = batchable[str(request_ids[0])]
+    assert model_id == "model_a"
+    assert isinstance(request_data, types.ForwardBackwardInput)
+    assert request_data.data[0].loss_fn_inputs.target_tokens.data == [1, 2, 3]
+
+
+def sample_payload(checkpoint_id: str) -> dict:
+    return types.SampleInput(
+        prompt=types.ModelInput(chunks=[types.EncodedTextChunk(tokens=[1, 2])]),
+        sampling_params=types.SamplingParams(temperature=1.0, max_tokens=4, seed=0),
+        num_samples=1,
+        checkpoint_id=checkpoint_id,
+        prompt_logprobs=False,
+    ).model_dump(mode="json")
+
+
+def test_find_batchable_sample_keeps_one_checkpoint_per_model(scheduling_engine):
+    """checkpoint_id is read out of the payload in the database, not by loading prompts."""
+    engine = scheduling_engine
+    engine.config = EngineConfig(base_model=BASE_MODEL, backend="fsdp")
+    request_ids = add_futures(
+        engine,
+        [
+            (types.RequestType.SAMPLE, "model_a", sample_payload("ckpt_1")),
+            (types.RequestType.SAMPLE, "model_a", sample_payload("ckpt_2")),
+            (types.RequestType.SAMPLE, "model_a", sample_payload("ckpt_1")),
+            # Base-model requests carry an empty checkpoint_id and always batch
+            (types.RequestType.SAMPLE, "", sample_payload("")),
+        ],
+    )
+
+    with Session(engine.db_engine) as session:
+        batchable = engine.find_batchable_sample(session)
+
+    # ckpt_2 is held back so the batch loads a single checkpoint for model_a
+    assert set(batchable) == {str(request_ids[0]), str(request_ids[2]), str(request_ids[3])}
+    assert isinstance(batchable[str(request_ids[0])][1], types.SampleInput)
+    assert batchable[str(request_ids[0])][1].checkpoint_id == "ckpt_1"
+
+
+def test_scheduling_handles_more_requests_than_one_query_can_bind(scheduling_engine):
+    """Payload lookups are chunked, so a backlog past the bound-parameter cap works."""
+    from skyrl.tinker.engine import _MAX_IDS_PER_QUERY
+
+    engine = scheduling_engine
+    count = _MAX_IDS_PER_QUERY + 25
+    payload = forward_backward_payload()
+    add_futures(engine, [(types.RequestType.FORWARD_BACKWARD, "model_a", payload)] * count)
+
+    with Session(engine.db_engine) as session:
+        batchable = engine.find_batchable_model_passes(session, types.RequestType.FORWARD_BACKWARD)
+
+    assert len(batchable) == count


### PR DESCRIPTION
## What

The Tinker engine's scheduling loop read every pending request's full payload on every poll, then threw away the ones it could not run. This makes the scheduler cost scale with the depth of the queue rather than with the work it dispatches — which is the multi-LoRA steady state, where some adapters are stepping while others have passes stacked behind a barrier.

This is the first of several PRs splitting up #1972. It contains only the scheduling-scan change — the covering index that originally rode along has moved to its own PR, since it turned out to be worth far less than this part (details under *What this leaves on the table*).

## The problem

`find_batchable_model_passes`, `find_batchable_sample`, and `find_single_requests` each ran their own `SELECT FutureDB ...` over all pending rows and then filtered in Python. Three consequences:

1. Requests parked behind an `optim_step`/`load_weights` barrier had their payloads deserialized on every poll and immediately discarded. A `forward_backward` with 4×512 tokens is ~76 KiB of JSON, so a few hundred parked requests is tens of MB of wasted decode per 100 ms tick — enough to keep the engine CPU-bound and slow to dispatch anything.
2. The three finders issued eight queries between them, recomputing the same barrier set three times.
3. Scanning touched the payload-bearing table rows, so a poll that had nothing to run still paid for them.

## The change

- **`scan_pending_requests`** reads only `(request_id, model_id, request_type)` for pending rows. Barrier detection and all three finders now work from that metadata as plain Python, and `request_data` is fetched only for the requests actually being dispatched. The main loop scans once and passes the result to all four finders, so a poll with nothing runnable is a single indexed query.
- Sample batch compatibility reads `checkpoint_id` through a JSON path extraction (`json_extract`) rather than loading whole prompts to reach one field. This is what makes skipping possible for samples at all: the scheduler needs that one field to group them, so without extracting it in the database you would have to pull every sample's payload into Python and there would be nothing left to skip.

Scheduling semantics are unchanged: barriers are still per-model, still keyed on `request_id` order, and the existing regression tests for that pin the behaviour.

## Results

`skyrl/benchmarks/bench_tinker_db.py` (new; no GPU, drives the real engine functions, reports SQL statement and commit counts). 8 adapters, 64 concurrent submitters, 256 dispatchable requests plus 256 parked behind barriers, ~76 KiB payloads. Measured on this branch vs. an otherwise identical `main` worktree:

| phase | before | after |
|---|---|---|
| **`scan_parked`** — backlog behind barriers, re-run every poll | **247 ms** | **1.2 ms** |
| `scan_ready` — scan + decode a dispatchable batch | 928 ms | 648 ms |
| `find_batchable_sample`, 640 samples, half held back by checkpoint | 119 ms | **72 ms** |
| SQL statements per scan | 8 | 2–3 |

`scan_parked` is the one that matters most: it is the cost the engine pays on every poll while it waits for a barrier to clear, and it previously grew with the queue. It is now flat.

`scan_ready` still decodes the batch it is about to dispatch, which is real work; the remaining win there comes from not also decoding the parked rows.

## Where this is *not* a win

This is not strictly better, so here is everything I could find that it costs. Each row below is measured, not reasoned about — I was wrong twice while checking, so nothing here is an estimate unless it says so.

**Neutral, verified rather than assumed:**

| | before | after |
|---|---|---|
| nothing parked — the case that *should* regress | 661 ms | **630 ms** |
| insert 512 rows, one transaction | 59.1 ms | 59.4 ms |
| insert 128 rows, one transaction each (the API's submit shape) | 91.2 ms | 89.6 ms |
| `find_batchable_sample`, 640 samples, all dispatchable | 143 ms | 144 ms |
| status write-back (isolated) | ~105 ms | ~105 ms |

The no-parked case is the one I expected to lose: it now pays for a metadata scan plus a primary-key payload fetch, where before a single query got rows and payloads together. It comes out ~5% ahead anyway, because the old path constructed full ORM `FutureDB` objects for every pending row and the new one returns lightweight tuples.

**Actually worse:**

1. **Weaker atomicity.** Scheduling metadata and payloads now come from two queries rather than one snapshot, so a row can in principle change between them. Guarded with `if request_id in payloads`, and safe today *only* because the single-threaded engine is the sole completer of these request types. That is a new invariant a future change could break, and it is the part of this PR I would most like a second opinion on.
2. **No gain when everything is dispatchable — a hair worse, in fact.** The whole saving is in *not* loading payloads for requests that cannot run, so a queue where everything can run has nothing to skip, and pays for one extra query. Measured on samples: 143 → 144 ms all-dispatchable, versus 119 → 72 ms when half are held back. Same for passes: 661 → 630 ms with nothing parked, versus 247 → 1.2 ms with a parked backlog. The change is a win in proportion to how much of the queue is blocked.
3. **More surface area** — three helper methods and a dataclass in place of three inline queries.

**One number in the benchmark output is misleading:** its `complete` phase reads ~1.7x slower here, and nothing in this PR touches the write path. It is a harness artifact — all phases share one database in a fixed order, and this write picks up process and I/O state from the scan phases that precede it. An isolated harness measuring only the status update reports ~105 ms either way, and `--scan-iterations 1` gives identical numbers on both sides (~0.122 s). The phase docstring now says so. I took it for a real regression at first and only found otherwise by measuring, so it is called out here rather than left for a reviewer to trip over.

## What this leaves on the table

A covering index on `(status, request_id, request_type, model_id)` would let the scan run without visiting the table rows at all. I had it in here originally and split it out, because measuring the two halves separately showed the split is very lopsided:

- full-row query → **247 ms**
- 3-column query, existing `status` index (**this PR**) → **1.2 ms**
- 3-column query, covering index → **1.2 ms** (below noise end-to-end; ~2x on an isolated 512-row scan)

Not asking for the payload is the whole win. The index is a refinement worth roughly 2x on a microbenchmark, and it costs ~2.8x index storage, so it deserves its own accept-or-decline decision rather than being smuggled in here. It follows as a separate PR.

## Not in this PR

Split out of #1972 and coming separately, in rough priority order:

- **Covering index** for the pending scan, as above.
- **Retry the result write** so a forwarded sample cannot hang forever (`EXTERNAL` requests are completed by exactly one fire-and-forget task; any failure there orphans them permanently). Relevant to the stuck Tinker Fully Async E2E job.
- **Shared batched poller** for `retrieve_future`, replacing per-caller polling that scales connection-pool checkouts with in-flight requests.
- **orjson codec** for JSON payload columns.
- **DB path handling** — node-local default, missing-directory creation, network-filesystem warning.

Also unaddressed anywhere: completed futures are never pruned and each retains its full payload, so a long run grows the SQLite file without bound. That needs a policy decision on how long results stay fetchable.

## Testing

```bash
uv run --isolated --extra dev --extra jax --extra tinker pytest tests/tinker/ --ignore=tests/tinker/skyrl_train
```

55 passed. New coverage in `tests/tinker/test_engine.py`:
- metadata scan ordering, and that it excludes non-pending rows
- passes held back at a barrier while another model's pass still dispatches
- one-checkpoint-per-model sample batching, exercising the JSON path extraction
- a backlog larger than the bound-parameter chunk size, covering the chunking in `_load_request_payloads`

The pre-existing barrier regression tests pass untouched, which is the main evidence that scheduling semantics did not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
