### PR TITLE
fix(algo): allow rollout-anchored CISPO under fully-async training

### DIFF
--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -30,7 +30,7 @@ from skyrl.backends.skyrl_train.inference_servers.engine_utils import (
 )
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.backends.skyrl_train.utils.io import io
-from skyrl.backends.skyrl_train.utils.ppo_utils import LOSSES_WITH_OLD_LOGPROBS
+from skyrl.backends.skyrl_train.utils.ppo_utils import LOSSES_WITH_OLD_LOGPROBS, PolicyLossType
 from skyrl.train.generators.base import GeneratorOutput
 from skyrl.train.generators.utils import (
     concatenate_generator_outputs,
@@ -387,11 +387,23 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         ), "batched is not supported for fully async training since a batched generate() call does not support pause/continue."
         # TODO(Charlie): we can support it, just multi-turn partial rollout but synchronous.
         assert not self.colocate_all, "colocate_all is not supported for async training yet."
-        assert self.cfg.trainer.algorithm.policy_loss_type not in LOSSES_WITH_OLD_LOGPROBS, (
-            f"Found trainer.algorithm.policy_loss_type={self.cfg.trainer.algorithm.policy_loss_type} in "
+        # Fully-async training must optimize against ROLLOUT logprobs: the sampler lags the trainer
+        # by up to max_staleness_steps, and stale policies are not kept around to recompute "old"
+        # logprobs. `cispo` is anchor-dependent, so this is anchor-aware rather than a static
+        # membership in LOSSES_WITH_OLD_LOGPROBS (which is keyed by policy_loss_type and cannot
+        # distinguish the two CISPO anchors) -- mirrors RayPPOTrainer._skip_policy_forward. With
+        # cispo.cispo_anchor="rollout" the ratio anchors on pi_rollout (the clamped counterpart of
+        # rollout_is) and never reads the old logprobs, so it is safe under async.
+        loss_type = self.cfg.trainer.algorithm.policy_loss_type
+        if loss_type == PolicyLossType.CISPO and self.cfg.trainer.algorithm.cispo.cispo_anchor == "rollout":
+            optimizes_against_rollout = True
+        else:
+            optimizes_against_rollout = loss_type not in LOSSES_WITH_OLD_LOGPROBS
+        assert optimizes_against_rollout, (
+            f"Found trainer.algorithm.policy_loss_type={loss_type} in "
             f"{sorted([loss.value for loss in LOSSES_WITH_OLD_LOGPROBS])}. Fully async training should use "
-            "rollout logprobs (i.e. rollout_is or dppo) instead of recomputing logprobs, since stale "
-            "policies are not kept for logprob computation."
+            "rollout logprobs (i.e. rollout_is, dppo, or cispo with cispo.cispo_anchor='rollout') instead "
+            "of recomputing logprobs, since stale policies are not kept for logprob computation."
         )
 
         # TODO(Charlie): need to assert we are doing TIS and returning logprobs

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -30,7 +30,10 @@ from skyrl.backends.skyrl_train.inference_servers.engine_utils import (
 )
 from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.backends.skyrl_train.utils.io import io
-from skyrl.backends.skyrl_train.utils.ppo_utils import LOSSES_WITH_OLD_LOGPROBS, PolicyLossType
+from skyrl.backends.skyrl_train.utils.ppo_utils import (
+    LOSSES_WITH_OLD_LOGPROBS,
+    PolicyLossType,
+)
 from skyrl.train.generators.base import GeneratorOutput
 from skyrl.train.generators.utils import (
     concatenate_generator_outputs,
@@ -387,13 +390,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         ), "batched is not supported for fully async training since a batched generate() call does not support pause/continue."
         # TODO(Charlie): we can support it, just multi-turn partial rollout but synchronous.
         assert not self.colocate_all, "colocate_all is not supported for async training yet."
-        # Fully-async training must optimize against ROLLOUT logprobs: the sampler lags the trainer
-        # by up to max_staleness_steps, and stale policies are not kept around to recompute "old"
-        # logprobs. `cispo` is anchor-dependent, so this is anchor-aware rather than a static
-        # membership in LOSSES_WITH_OLD_LOGPROBS (which is keyed by policy_loss_type and cannot
-        # distinguish the two CISPO anchors) -- mirrors RayPPOTrainer._skip_policy_forward. With
-        # cispo.cispo_anchor="rollout" the ratio anchors on pi_rollout (the clamped counterpart of
-        # rollout_is) and never reads the old logprobs, so it is safe under async.
+        # Ensure we're using a policy loss that doesn't depend on pi_old ~= pi_rollout
         loss_type = self.cfg.trainer.algorithm.policy_loss_type
         if loss_type == PolicyLossType.CISPO and self.cfg.trainer.algorithm.cispo.cispo_anchor == "rollout":
             optimizes_against_rollout = True


### PR DESCRIPTION
PR #1859 added `cispo.cispo_anchor` and made the sync trainer's `_skip_policy_forward` anchor-aware, motivated specifically by fully-async training (where the old-anchored CISPO ratio stays ~1 and the clamp never bites). But `FullyAsyncRayPPOTrainer.__init__` still guards on the anchor-blind `LOSSES_WITH_OLD_LOGPROBS` frozenset, which contains `CISPO` keyed by loss type. So `policy_loss_type=cispo` + `cispo_anchor=rollout` crashes at trainer construction with `AssertionError: Fully async training should use rollout logprobs`.

Make the assert anchor-aware, mirroring `RayPPOTrainer._skip_policy_forward` (skyrl/train/trainer.py): with `cispo_anchor='rollout'` the ratio anchors on the rollout logprobs (the clamped counterpart of `rollout_is`) and never reads the old logprobs, so it is safe under async; the default `'old'` anchor still falls back to the `LOSSES_WITH_OLD_LOGPROBS` membership check and is rejected.