### PR TITLE
[qoc] Rename action_mask to response_mask for Experience to match TrainingInputBatch

### DIFF
--- a/skyrl/backends/skyrl_train/utils/ppo_utils.py
+++ b/skyrl/backends/skyrl_train/utils/ppo_utils.py
@@ -98,7 +98,8 @@ def compute_approx_kl(
     Args:
         log_probs: Log probabilities of the new distribution.
         log_probs_base: Log probabilities of the base distribution.
-        action_mask: Mask for actions.
+        loss_mask: Optional mask over trainable response tokens.
+        kl_estimator_type: One of ``k1``, ``abs``, ``k2``, or ``k3``.
     """
     if kl_estimator_type == "k1":
         kld = log_probs - log_probs_base

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -572,7 +572,7 @@ class MegatronModelWrapper:
             advantages = data["advantages"]
             loss_mask = data["loss_mask"]
             rollout_action_logprobs = data["rollout_action_logprobs"]
-            action_mask = data.get("action_mask")
+            response_mask = data.get("response_mask")
             num_microbatches = data.get("num_microbatches")
             # Number of microbatches carrying real samples (excludes fully-padding
             # microbatches added by token-based batching). Used to normalize the
@@ -770,8 +770,8 @@ class MegatronModelWrapper:
                     # syncs per micro-batch (item()/cpu()/tolist() inside the loop).
                     batch_size = action_log_probs.shape[0]
                     seq_len = action_log_probs.shape[1]
-                    if action_mask is not None:
-                        valid_lens_t = action_mask.sum(dim=-1).long()
+                    if response_mask is not None:
+                        valid_lens_t = response_mask.sum(dim=-1).long()
                     elif loss_mask is not None:
                         valid_lens_t = (loss_mask > 0).sum(dim=-1).long()
                     else:
@@ -910,8 +910,8 @@ class MegatronModelWrapper:
             batch_size = action_log_probs.shape[0]
             seq_len = action_log_probs.shape[1]
 
-            if action_mask is not None:
-                valid_lens = action_mask.sum(dim=1).int().tolist()
+            if response_mask is not None:
+                valid_lens = response_mask.sum(dim=1).int().tolist()
             elif loss_mask is not None:
                 valid_lens = (loss_mask > 0).sum(dim=1).int().tolist()
             else:

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -743,7 +743,7 @@ class MegatronWorker:
     def _pad_microbatch_to_size(self, micro_dict: dict, target_batch_size: int) -> dict:
         """Pad a forward or forward_backward micro-batch dict to target_batch_size with dummy samples.
 
-        Padded samples have loss_mask/action_mask=0 so they don't contribute to the loss
+        Padded samples have loss_mask/response_mask=0 so they don't contribute to the loss
         (forward micro-batches carry neither key, so this is inert there). This is needed
         because Megatron's forward_backward_func requires uniform micro_batch_size across all
         microbatches (especially with PP > 1). Scalar keys (``num_actions``,
@@ -775,7 +775,7 @@ class MegatronWorker:
                     # Give each dummy row a single valid token, so the row is non-degenerate:
                     # it avoids a fully-masked row (NaN in dense attention's softmax) and a
                     # zero-length cu_seqlens segment (rejected by the packed/THD kernel).
-                    # The row is still excluded from the loss via loss_mask/action_mask=0.
+                    # The row is still excluded from the loss via loss_mask/response_mask=0.
                     pad_tensor = torch.zeros((pad_count, *value.shape[1:]), dtype=value.dtype, device=device)
                     pad_tensor[:, 0] = 1
                 elif key == "position_ids":
@@ -790,8 +790,8 @@ class MegatronWorker:
                         dtype=value.dtype,
                         device=device,
                     )
-                elif key == "action_mask":
-                    # action_mask should be zeros for padded samples
+                elif key == "response_mask":
+                    # response_mask should be zeros for padded samples
                     pad_tensor = torch.zeros((pad_count, *value.shape[1:]), dtype=value.dtype, device=device)
                 else:
                     pad_tensor = torch.zeros((pad_count, *value.shape[1:]), dtype=value.dtype, device=device)
@@ -1054,7 +1054,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
                     "advantages": experience.advantages,
                     "loss_mask": experience.loss_mask,
                     "rollout_action_logprobs": experience.rollout_logprobs,
-                    "action_mask": experience.action_mask,
+                    "response_mask": experience.response_mask,
                     "rollout_expert_indices": rollout_expert_indices if self.enable_router_replay else None,
                     "router_padding_mask": experience.router_padding_mask if self.enable_router_replay else None,
                     "sub_seq_lengths": experience.sub_seq_lengths,
@@ -1180,7 +1180,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
                     "advantages": experience.advantages,
                     "loss_mask": experience.loss_mask,
                     "rollout_action_logprobs": experience.rollout_logprobs,
-                    "action_mask": experience.action_mask,
+                    "response_mask": experience.response_mask,
                     "rollout_expert_indices": rollout_expert_indices if self.enable_router_replay else None,
                     "router_padding_mask": experience.router_padding_mask if self.enable_router_replay else None,
                     # used with global sequence packing (None when token-based batching is active)

--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -888,7 +888,7 @@ class PolicyWorkerBase(Worker):
         num_actions = experience.num_actions
         attention_mask = experience.attention_mask
         loss_mask = experience.loss_mask
-        action_mask = experience.action_mask
+        response_mask = experience.response_mask
         rollout_action_logprobs = experience.rollout_logprobs
 
         # Determine which loss function to use
@@ -962,8 +962,8 @@ class PolicyWorkerBase(Worker):
                 # exactly once before iterating in Python — avoids ~3N GPU->CPU syncs.
                 batch_size = action_log_probs.shape[0]
                 seq_len = action_log_probs.shape[1]
-                if action_mask is not None:
-                    valid_lens_t = action_mask.sum(dim=-1).long()
+                if response_mask is not None:
+                    valid_lens_t = response_mask.sum(dim=-1).long()
                 elif loss_mask is not None:
                     valid_lens_t = (loss_mask > 0).sum(dim=-1).long()
                 else:
@@ -1035,8 +1035,8 @@ class PolicyWorkerBase(Worker):
             batch_size = action_log_probs.shape[0]
             seq_len = action_log_probs.shape[1]
 
-            if action_mask is not None:
-                valid_lens = action_mask.sum(dim=1).int().tolist()
+            if response_mask is not None:
+                valid_lens = response_mask.sum(dim=1).int().tolist()
             elif loss_mask is not None:
                 valid_lens = (loss_mask > 0).sum(dim=1).int().tolist()
             else:
@@ -1175,7 +1175,7 @@ class PolicyWorkerBase(Worker):
         num_actions = experience.num_actions
         attention_mask = experience.attention_mask
         loss_mask = experience.loss_mask
-        action_mask = experience.action_mask
+        response_mask = experience.response_mask
         rollout_action_logprobs = experience.rollout_logprobs
 
         current_loss_fn = PolicyLossRegistry.get(loss_fn)
@@ -1220,8 +1220,8 @@ class PolicyWorkerBase(Worker):
                 # per micro-batch (item()/cpu()/tolist() inside the per-sample loop).
                 batch_size = action_log_probs.shape[0]
                 seq_len = action_log_probs.shape[1]
-                if action_mask is not None:
-                    valid_lens_t = action_mask.sum(dim=-1).long()
+                if response_mask is not None:
+                    valid_lens_t = response_mask.sum(dim=-1).long()
                 elif loss_mask is not None:
                     valid_lens_t = (loss_mask > 0).sum(dim=-1).long()
                 else:

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -159,7 +159,7 @@ class BaseBatchIterator:
             advantages=batch.get("advantages"),
             attention_mask=batch.get("attention_mask"),
             loss_mask=batch.get("loss_mask"),
-            action_mask=batch.get("response_mask"),
+            response_mask=batch.get("response_mask"),
             num_actions=batch.metadata["response_length"],  # int
             rollout_logprobs=batch.get("rollout_logprobs"),
             rollout_expert_indices=batch.get("rollout_expert_indices"),

--- a/skyrl/train/dataset/preprocess.py
+++ b/skyrl/train/dataset/preprocess.py
@@ -119,12 +119,12 @@ def convert_prompts_responses_to_batch_tensors(
     The padded sequence length is ``max(prompt_len_i + response_len_i)``.
     This way, the max padded sequence length is ``max_seq_len``.
 
-    This makes the response-level tensors (action_mask, rewards, loss_masks, logprobs):
+    This makes the response-level tensors (response_mask, rewards, loss_masks, logprobs):
     | prompt prompt respon respon |
     | prompt respon respon respon |
     | respon respon respon respon |
 
-    So the action_mask is:
+    So the response_mask is:
     | 0       0       1      1    |
     | 0       1       1      1    |
     | 1       1       1      1    |
@@ -152,7 +152,7 @@ def convert_prompts_responses_to_batch_tensors(
     Returns:
         sequences: ``(batch, max_total)`` where ``max_total = max(prompt_i + response_i)``.
         attention_mask: ``(batch, max_total)``
-        action_mask: ``(batch, max_response)`` — right-aligned response indicator.
+        response_mask: ``(batch, max_response)`` — right-aligned response indicator.
         rewards: ``(batch, max_response)`` — right-aligned.
         loss_masks: ``(batch, max_response)`` — right-aligned.
         logprobs: ``(batch, max_response)`` — right-aligned, or ``None``.
@@ -196,11 +196,11 @@ def convert_prompts_responses_to_batch_tensors(
     # Response tokens occupy the trailing response_len positions.
     col_resp = np.arange(max_response, dtype=np.int64)
     resp_pad = max_response - response_lens
-    action_mask_np = (col_resp[None, :] >= resp_pad[:, None]).astype(np.int64)
+    response_mask_np = (col_resp[None, :] >= resp_pad[:, None]).astype(np.int64)
 
     sequences = torch.from_numpy(sequences_np)
     attention_mask = torch.from_numpy(attention_mask_np)
-    action_mask = torch.from_numpy(action_mask_np)
+    response_mask = torch.from_numpy(response_mask_np)
 
     # Response-level tensors are right-aligned to match the model output.
     ret_loss_masks_np = np.zeros((num_samples, max_response), dtype=np.float32)
@@ -272,7 +272,7 @@ def convert_prompts_responses_to_batch_tensors(
     return (
         sequences,
         attention_mask,
-        action_mask,
+        response_mask,
         ret_rewards,
         ret_loss_masks,
         logprobs_tensor,

--- a/skyrl/train/dataset/replay_buffer.py
+++ b/skyrl/train/dataset/replay_buffer.py
@@ -278,7 +278,7 @@ def make_experience_batch(items: List[BufferItem]) -> Experience:
 
 def remove_padding_in_sequences(items):
     for item in items:
-        seq, act_log_prob, base_act_log_prob, value, ret, adv, att_mask, act_mask = (
+        seq, act_log_prob, base_act_log_prob, value, ret, adv, att_mask, resp_mask = (
             item.sequences,
             item.action_log_probs,
             item.base_action_log_probs,
@@ -288,7 +288,7 @@ def remove_padding_in_sequences(items):
             item.attention_mask,
             item.response_mask,
         )
-        right_pad = (1 - act_mask.long()).sum()
+        right_pad = (1 - resp_mask.long()).sum()
         right_pad = None if right_pad == 0 else -right_pad
 
         # left_pad for seq and att_mask
@@ -310,7 +310,7 @@ def remove_padding_in_sequences(items):
             ret[:right_pad] if ret is not None else None,
             adv[:right_pad] if adv is not None else None,
             att_mask[left_pad:right_pad] if att_mask is not None else None,
-            act_mask[:right_pad] if act_mask is not None else None,
+            resp_mask[:right_pad] if resp_mask is not None else None,
         )
     return items
 

--- a/skyrl/train/dataset/replay_buffer.py
+++ b/skyrl/train/dataset/replay_buffer.py
@@ -51,7 +51,7 @@ class Experience:
     returns: (B, A)
     advatanges: (B, A)
     attention_mask: (B, S)
-    action_mask: (B, A)
+    response_mask: (B, A)
     kl: (B, A)
 
     "A" is the number of actions/ response length.
@@ -65,7 +65,7 @@ class Experience:
     advantages: Optional[Float[torch.Tensor, "batch response_len"]]
     attention_mask: Optional[Integer[torch.LongTensor, "batch seq_len"]]
     loss_mask: Optional[Integer[torch.LongTensor, "batch response_len"]]
-    action_mask: Optional[Integer[torch.Tensor, "batch response_len"]]
+    response_mask: Optional[Integer[torch.Tensor, "batch response_len"]]
     rollout_logprobs: Optional[Float[torch.Tensor, "batch response_len"]]
     rollout_expert_indices: Optional[Integer[torch.Tensor, "batch seq_len layer_num topk"]]
     num_actions: int
@@ -96,8 +96,8 @@ class Experience:
             self.attention_mask = to(self.attention_mask, device)
         if self.loss_mask is not None:
             self.loss_mask = to(self.loss_mask, device)
-        if self.action_mask is not None:
-            self.action_mask = to(self.action_mask, device)
+        if self.response_mask is not None:
+            self.response_mask = to(self.response_mask, device)
         if self.rollout_logprobs is not None:
             self.rollout_logprobs = to(self.rollout_logprobs, device)
         if self.rollout_expert_indices is not None:
@@ -127,8 +127,8 @@ class Experience:
             self.attention_mask = self.attention_mask.pin_memory()
         if self.loss_mask is not None:
             self.loss_mask = self.loss_mask.pin_memory()
-        if self.action_mask is not None:
-            self.action_mask = self.action_mask.pin_memory()
+        if self.response_mask is not None:
+            self.response_mask = self.response_mask.pin_memory()
         if self.rollout_logprobs is not None:
             self.rollout_logprobs = self.rollout_logprobs.pin_memory()
         if self.rollout_expert_indices is not None:
@@ -151,7 +151,7 @@ class BufferItem:
     advatanges: (1)
     attention_mask: (S)
     loss_mask: (A)
-    action_mask: (A)
+    response_mask: (A)
 
     "A" is the number of actions.
     """
@@ -164,7 +164,7 @@ class BufferItem:
     advantages: Optional[Float[torch.Tensor, "response_len"]]  # noqa: F821
     attention_mask: Optional[Integer[torch.LongTensor, "seq_len"]]  # noqa: F821
     loss_mask: Optional[Integer[torch.LongTensor, "response_len"]]  # noqa: F821
-    action_mask: Optional[Integer[torch.Tensor, "response_len"]]  # noqa: F821
+    response_mask: Optional[Integer[torch.Tensor, "response_len"]]  # noqa: F821
     num_actions: int
     info: Optional[dict]
 
@@ -192,7 +192,7 @@ def split_experience_batch(experience: Experience) -> List[BufferItem]:
         "advantages",
         "attention_mask",
         "loss_mask",
-        "action_mask",
+        "response_mask",
         "num_actions",
     )
     if len(experience.sequences.shape) == 1:
@@ -260,7 +260,7 @@ def make_experience_batch(items: List[BufferItem]) -> Experience:
         "advantages",
         "attention_mask",
         "loss_mask",
-        "action_mask",
+        "response_mask",
         "num_actions",
     )
     for key in keys:
@@ -286,7 +286,7 @@ def remove_padding_in_sequences(items):
             item.returns,
             item.advantages,
             item.attention_mask,
-            item.action_mask,
+            item.response_mask,
         )
         right_pad = (1 - act_mask.long()).sum()
         right_pad = None if right_pad == 0 else -right_pad
@@ -301,7 +301,7 @@ def remove_padding_in_sequences(items):
             item.returns,
             item.advantages,
             item.attention_mask,
-            item.action_mask,
+            item.response_mask,
         ) = (
             seq[left_pad:right_pad],
             act_log_prob[:right_pad],

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_models.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_models.py
@@ -173,7 +173,6 @@ async def generate_with_vllm(generator, client, model_name, tokenizer, return_tr
                 "action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
                 "base_action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
                 "advantages": torch.zeros((batch_size, num_actions), dtype=torch.float32),
-                "action_mask": response_mask.to(dtype=torch.int64),
             }
         )
         training_input.metadata = {"response_length": num_actions}

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_router_replay.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_router_replay.py
@@ -129,7 +129,6 @@ def build_training_input_from_text_samples(
             "action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
             "base_action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
             "advantages": torch.zeros((batch_size, num_actions), dtype=torch.float32),
-            "action_mask": response_mask.to(dtype=torch.int64),
         }
     )
     training_input.metadata = {"response_length": num_actions}
@@ -251,7 +250,6 @@ async def test_logprobs(tp, pp, cp, ep, etp, extra_tf_kwargs):
                 "action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
                 "base_action_log_probs": torch.zeros((batch_size, num_actions), dtype=torch.float32),
                 "advantages": torch.zeros((batch_size, num_actions), dtype=torch.float32),
-                "action_mask": response_mask.to(dtype=torch.int64),
             }
         )
         training_input.metadata = {"response_length": num_actions}
@@ -386,7 +384,6 @@ def test_forward_backward(tp, pp, cp, ep, etp, extra_tf_kwargs):
                 "action_log_probs": -torch.rand((batch_size, num_actions), generator=gen) * 2.0,
                 "base_action_log_probs": -torch.rand((batch_size, num_actions), generator=gen) * 2.0,
                 "advantages": torch.randn((batch_size, num_actions), generator=gen),
-                "action_mask": response_mask.to(dtype=torch.int64),
             }
         )
         training_input.metadata = {"response_length": num_actions}

--- a/tests/backends/skyrl_train/gpu/utils.py
+++ b/tests/backends/skyrl_train/gpu/utils.py
@@ -129,7 +129,7 @@ def make_dummy_experience(seq_len=10, num_actions=4) -> Experience:
         advantages=0.6 * torch.ones((B, num_actions), device="cpu"),
         attention_mask=torch.ones((B, T), dtype=int, device="cpu"),
         loss_mask=torch.ones((B, num_actions), dtype=int, device="cpu"),
-        action_mask=torch.ones((B, num_actions), dtype=int, device="cpu"),
+        response_mask=torch.ones((B, num_actions), dtype=int, device="cpu"),
         num_actions=num_actions,
         info={},
     )

--- a/tests/backends/skyrl_train/workers/test_sft_loss_fn_outputs_gate.py
+++ b/tests/backends/skyrl_train/workers/test_sft_loss_fn_outputs_gate.py
@@ -71,7 +71,7 @@ def _make_experience() -> Experience:
         advantages=torch.zeros(BATCH_SIZE, NUM_ACTIONS),
         attention_mask=torch.ones(BATCH_SIZE, SEQ_LEN, dtype=torch.long),
         loss_mask=torch.ones(BATCH_SIZE, NUM_ACTIONS, dtype=torch.long),
-        action_mask=None,
+        response_mask=None,
         rollout_expert_indices=None,
         num_actions=NUM_ACTIONS,
         info={},

--- a/tests/train/dataset/test_preprocess.py
+++ b/tests/train/dataset/test_preprocess.py
@@ -215,7 +215,7 @@ def test_convert_prompts_responses_to_batch_tensors_exact(tokenizer):
     loss_masks = [[1, 1, 0], [1, 1, 1, 0, 0]]
     rewards = [torch.tensor([0, 1, 0]), torch.tensor([1, 0, 0, 0, 0])]
 
-    sequences, attention_mask, action_mask, ret_rewards, ret_loss_masks, ret_log_probs, _ = (
+    sequences, attention_mask, response_mask, ret_rewards, ret_loss_masks, ret_log_probs, _ = (
         convert_prompts_responses_to_batch_tensors(
             tokenizer,
             prompts,
@@ -228,7 +228,7 @@ def test_convert_prompts_responses_to_batch_tensors_exact(tokenizer):
     # max_total = max(3+3, 5+5) = 10, max_response = 5
     assert sequences.shape[0] == len(prompts)
     assert sequences.shape == (2, 10)
-    assert action_mask.shape == ret_loss_masks.shape
+    assert response_mask.shape == ret_loss_masks.shape
     # Response data is RIGHT-ALIGNED within (batch, max_response)
     # Sample 0: response len=3, so 2 leading zeros then 3 values
     assert torch.equal(ret_loss_masks[0], torch.tensor([0, 0, 1, 1, 0]))
@@ -251,7 +251,7 @@ def test_convert_prompts_responses_to_batch_tensors_different_lengths(tokenizer)
     rewards = [torch.tensor([1.0, 0.5, 0.3]), torch.tensor([0.8])]
     loss_masks = [[1, 1, 1], [1]]
 
-    sequences, attention_mask, action_mask, ret_rewards, ret_loss_masks, ret_log_probs, _ = (
+    sequences, attention_mask, response_mask, ret_rewards, ret_loss_masks, ret_log_probs, _ = (
         convert_prompts_responses_to_batch_tensors(
             tokenizer,
             prompts,
@@ -268,7 +268,7 @@ def test_convert_prompts_responses_to_batch_tensors_different_lengths(tokenizer)
     # Check shapes
     assert sequences.shape == (2, max_total)
     assert attention_mask.shape == sequences.shape
-    assert action_mask.shape == (2, max_response_len)
+    assert response_mask.shape == (2, max_response_len)
     assert ret_rewards.shape == (2, max_response_len)
     assert ret_loss_masks.shape == (2, max_response_len)
 

--- a/tests/train/test_collation_vectorization_equivalence.py
+++ b/tests/train/test_collation_vectorization_equivalence.py
@@ -44,18 +44,18 @@ def _ref_convert_prompts_responses(prompts, responses, rewards, loss_masks, logp
 
     sequences = []
     attention_masks = []
-    action_masks = []
+    response_masks = []
     for i in range(len(prompts)):
         total_real = prompt_token_lens[i] + response_token_lens[i]
         pad_len = max_total - total_real
         sequences.append([pad_token_id] * pad_len + prompts[i] + responses[i])
         attention_masks.append([0] * pad_len + [1] * total_real)
         resp_pad = max_response - response_token_lens[i]
-        action_masks.append([0] * resp_pad + [1] * response_token_lens[i])
+        response_masks.append([0] * resp_pad + [1] * response_token_lens[i])
 
     sequences_t = torch.tensor(sequences)
     attention_mask_t = torch.tensor(attention_masks, dtype=torch.int64)
-    action_mask_t = torch.tensor(action_masks, dtype=torch.int64)
+    response_mask_t = torch.tensor(response_masks, dtype=torch.int64)
 
     ret_loss_masks = torch.zeros(len(prompts), max_response, dtype=torch.float)
     for i, lm in enumerate(loss_masks):
@@ -73,7 +73,7 @@ def _ref_convert_prompts_responses(prompts, responses, rewards, loss_masks, logp
             lp = torch.tensor(sample_logprobs, dtype=torch.float)
             logprobs_tensor[i, max_response - len(sample_logprobs) :] = lp
 
-    return sequences_t, attention_mask_t, action_mask_t, ret_rewards, ret_loss_masks, logprobs_tensor
+    return sequences_t, attention_mask_t, response_mask_t, ret_rewards, ret_loss_masks, logprobs_tensor
 
 
 def _ref_collate_sft_batch(examples, pad_token_id):

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -81,10 +81,10 @@ def _get_test_data(trainer: RayPPOTrainer):
     action_log_probs: Float[torch.Tensor, "batch_size total_seq_len"] = torch.log(
         torch.tensor([[0.1, 0.3, 0.2, 0.2, 0.2], [0.3, 0.3, 0.2, 0.1, 0.1]])
     )
-    action_masks: Integer[torch.Tensor, "batch_size total_seq_len"] = torch.stack(
+    response_masks: Integer[torch.Tensor, "batch_size total_seq_len"] = torch.stack(
         [torch.tensor([1, 1, 1, 0, 0], dtype=torch.int32), torch.tensor([1, 1, 1, 1, 1], dtype=torch.int32)], dim=0
     )
-    actual_response_lengths: Float[torch.Tensor, "batch_size"] = action_masks.sum(dim=-1).to(float)
+    actual_response_lengths: Float[torch.Tensor, "batch_size"] = response_masks.sum(dim=-1).to(float)
     rewards_all: Float[torch.Tensor, "batch_size total_seq_len"] = torch.stack(
         [torch.tensor([0.0, 1.0, 0.0, 0.0, 0.0]), torch.tensor([0.0, 0.0, 1.0, 0.0, 0.0])], dim=0
     )
@@ -99,7 +99,7 @@ def _get_test_data(trainer: RayPPOTrainer):
             "loss_mask": ret_loss_masks,
             "base_action_log_probs": base_log_probs,
             "action_log_probs": action_log_probs,
-            "response_mask": action_masks,
+            "response_mask": response_masks,
             "rewards": rewards_all,
             "values": values,
         },


### PR DESCRIPTION
Before this PR, we had both `response_mask` (208 occurrences including test) and `action_mask` (68 occurrences including test) the latter mainly in `Experience`-level, former in `TrainingInputBatch`-level; despite referring to the same thing.

This PR renames `action_mask` to `response_mask`.