### PR TITLE
fix(train): reject a train_batch_size that truncates the prompt batch to zero

### DIFF
--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -641,6 +641,13 @@ class RayPPOTrainer:
             return entries
 
         kept_prompts = (len(entries) // stride) * stride
+        if kept_prompts == 0:
+            raise ValueError(
+                f"Batch of {len(entries)} prompt(s) is smaller than the prompt stride ({stride}) implied by "
+                f"lcm_dp_size={lcm_dp_size} and n_samples_per_prompt={n_samples_per_prompt}, so every prompt would "
+                f"be dropped when truncating to even data parallel shards. Set train_batch_size to a multiple of "
+                f"{stride}, or choose a placement where lcm_dp_size divides n_samples_per_prompt."
+            )
         return entries[:kept_prompts]
 
     def build_models(self, PolicyWorker, CriticWorker, RefWorker):

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -182,13 +182,30 @@ def validate_batch_sizes(cfg: SkyRLTrainConfig):
             ref_dp_size = ref_world_size // cfg.trainer.ref.sequence_parallel_size
         lcm_dp_size = math.lcm(lcm_dp_size, ref_dp_size)
 
-    assert cfg.trainer.train_batch_size * cfg.generator.n_samples_per_prompt >= lcm_dp_size, (
-        f"train_batch_size * n_samples_per_prompt ({cfg.trainer.train_batch_size * cfg.generator.n_samples_per_prompt}) "
-        f"should be larger than or equal to the least common multiple of the data parallel sizes of the enabled models: "
+    # Before generation, the prompt batch is truncated to a multiple of `prompt_stride` so that the
+    # resulting samples shard evenly across `lcm_dp_size` (see `RayPPOTrainer._remove_tail_data`).
+    # A `train_batch_size` below the stride truncates the batch to zero prompts.
+    prompt_stride = lcm_dp_size // math.gcd(lcm_dp_size, cfg.generator.n_samples_per_prompt)
+    dp_sizes_msg = (
         f"policy_dp_size={policy_dp_size}, "
         f"ref_dp_size={ref_dp_size if use_ref_model else 'None'}, "
-        f"lcm_dp_size={lcm_dp_size}"
+        f"lcm_dp_size={lcm_dp_size}, "
+        f"n_samples_per_prompt={cfg.generator.n_samples_per_prompt}"
     )
+    assert cfg.trainer.train_batch_size >= prompt_stride, (
+        f"train_batch_size ({cfg.trainer.train_batch_size}) should be larger than or equal to the prompt stride "
+        f"({prompt_stride}), which is the least common multiple of the data parallel sizes of the enabled models "
+        f"divided by its greatest common divisor with n_samples_per_prompt. Otherwise every prompt is dropped when "
+        f"truncating the batch to even data parallel shards. {dp_sizes_msg}. Set train_batch_size to a multiple of "
+        f"{prompt_stride}, or choose a placement where lcm_dp_size divides n_samples_per_prompt."
+    )
+    if cfg.trainer.train_batch_size % prompt_stride != 0:
+        logger.warning(
+            f"train_batch_size ({cfg.trainer.train_batch_size}) is not a multiple of the prompt stride "
+            f"({prompt_stride}), so {cfg.trainer.train_batch_size % prompt_stride} prompt(s) are dropped from every "
+            f"training batch to keep even data parallel shards. {dp_sizes_msg}. Set train_batch_size to a multiple of "
+            f"{prompt_stride} to use the full batch."
+        )
 
 
 def validate_megatron_cfg(cfg: SkyRLTrainConfig):

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -363,6 +363,33 @@ def test_micro_batches_accumulated_initialized():
     assert critic_worker._micro_batches_accumulated == 0
 
 
+def test_remove_tail_data_rejects_batch_smaller_than_prompt_stride(dummy_config):
+    """
+    ``_remove_tail_data`` truncates the prompt batch to a multiple of the prompt stride
+    (``lcm_dp_size // gcd(lcm_dp_size, n_samples_per_prompt)``). A batch below that stride
+    truncates to zero prompts, which is rejected instead of returning an empty batch.
+    """
+    dummy_config.generator.n_samples_per_prompt = 4
+    trainer = RayPPOTrainer(
+        cfg=dummy_config,
+        tracker=None,
+        tokenizer=None,
+        train_dataset=DummyDataset(),
+        eval_dataset=DummyDataset(),
+        inference_engine_client=None,
+        generator=dummy_generator,
+    )
+    # Normally built by build_models. lcm_dp_size=6 with n_samples_per_prompt=4 gives a stride of 3.
+    trainer.dispatch = MagicMock()
+    trainer.dispatch.get_lcm_dp_size = MagicMock(return_value=6)
+
+    with pytest.raises(ValueError, match="smaller than the prompt stride"):
+        trainer._remove_tail_data(["p0", "p1"])
+
+    # At or above the stride, the largest multiple of the stride is kept.
+    assert trainer._remove_tail_data(["p0", "p1", "p2", "p3"]) == ["p0", "p1", "p2"]
+
+
 def test_validate_batch_sizes():
     """Test the validate_batch_sizes function with various configurations to trigger all error cases."""
 
@@ -531,6 +558,34 @@ def test_validate_batch_sizes():
         AssertionError, match="critic_train_batch_size_per_gpu .* should be divisible by critic_mini_batch_size_per_gpu"
     ):
         validate_batch_sizes(cfg)
+
+    # Test Case 17: Error case - train_batch_size below the prompt stride. policy_dp_size=6 with
+    # n_samples_per_prompt=4 gives a stride of 3, so a 2-prompt batch truncates to zero prompts.
+    cfg = create_test_config(
+        train_batch_size=2,
+        policy_mini_batch_size=2,
+        policy_num_gpus_per_node=6,
+        micro_train_batch_size_per_gpu=1,
+        micro_forward_batch_size_per_gpu=1,
+        n_samples_per_prompt=4,
+    )
+    with pytest.raises(AssertionError, match="train_batch_size .* should be larger than or equal to the prompt stride"):
+        validate_batch_sizes(cfg)
+
+    # Test Case 18: Valid but lossy configuration - train_batch_size is above the prompt stride of 3
+    # but not a multiple of it, so one prompt per batch is dropped and a warning is emitted.
+    cfg = create_test_config(
+        train_batch_size=4,
+        policy_mini_batch_size=2,
+        policy_num_gpus_per_node=6,
+        micro_train_batch_size_per_gpu=1,
+        micro_forward_batch_size_per_gpu=1,
+        n_samples_per_prompt=4,
+    )
+    with patch("skyrl.train.utils.utils.logger") as mock_logger:
+        validate_batch_sizes(cfg)
+    assert mock_logger.warning.call_count == 1
+    assert "not a multiple of the prompt stride" in mock_logger.warning.call_args[0][0]
 
 
 def test_forward_backward_batch_calculations():


### PR DESCRIPTION
Closes #1609.

`RayPPOTrainer._remove_tail_data` keeps the largest multiple of `stride = lcm_dp_size // gcd(lcm_dp_size, n_samples_per_prompt)` prompts so that the resulting samples shard evenly across the data-parallel sizes of the enabled models. When `train_batch_size` is below that stride, `(len(entries) // stride) * stride` is `0`: the generator is called with zero prompts and the run dies several frames later in `get_rollout_metrics` on `np.min` of an empty array (`ValueError: zero-size array to reduction operation minimum which has no identity`), with nothing pointing at the batch size.

`validate_batch_sizes` did check a related condition, `train_batch_size * n_samples_per_prompt >= lcm_dp_size`, but that is necessary rather than sufficient. For the config in the issue (`lcm_dp_size=6`, `n_samples_per_prompt=4`, `train_batch_size=2`) it passes — `8 >= 6` — while the stride is `3`, so the batch still truncates to zero.

Since `tbs * n % lcm == 0` is equivalent to `tbs % (lcm // gcd(lcm, n)) == 0`, the stride is the quantity the truncation actually depends on, so this checks it directly:

- Assert `train_batch_size >= prompt_stride` at startup. This is exactly the condition under which at least one prompt survives truncation, and it subsumes the previous assert. The message reports `policy_dp_size` / `ref_dp_size` / `lcm_dp_size` / `n_samples_per_prompt` and the stride to set `train_batch_size` to.
- Warn when `train_batch_size` is at or above the stride but not a multiple of it. That case is not fatal, but it silently drops the same prompts from every training batch, so the effective batch size is smaller than configured.
- Raise in `_remove_tail_data` as well. `validate_batch_sizes` only sees `train_batch_size`, while the truncation also runs on batches sized by the caller (`examples/train/async/async_trainer.py` and `skyrl-agent`'s trainer), so the guard has to sit where the stride is applied.

Only the fatal case is a hard failure; the lossy-but-nonempty case stays a warning so that existing configs keep running.

## Testing

- `test_remove_tail_data_rejects_batch_smaller_than_prompt_stride` covers the raise and that a batch at or above the stride still truncates to the largest multiple.
- Test cases 17 and 18 in `test_validate_batch_sizes` cover the startup assert (using the placement from the issue) and the non-multiple warning.
- `uv run --isolated --extra skyrl-train --extra dev pytest tests/train/ tests/backends/skyrl_train/ --ignore=tests/backends/skyrl_train/gpu -m "not vllm"` — 1451 passed, 7 skipped.

The pre-existing `test_validate_batch_sizes_lcm_dp_requirement` passes unchanged: it uses `n_samples_per_prompt=1`, where the stride equals `lcm_dp_size` and the new assert reduces to the old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)