### PR TITLE
feat(generators): add generator.skip_failed_rollouts

### DIFF
--- a/docs/content/docs/tutorials/skyrl_gym_generator.mdx
+++ b/docs/content/docs/tutorials/skyrl_gym_generator.mdx
@@ -207,6 +207,31 @@ very first `\n` that makes up the former assistant's `\n`). The `\n` at the **fi
 turn will still be missing, but this is fine.
 You can see `tests/cpu/generators/test_skyrl_gym_generator_chat_templating.py` for more details.
 
+## Tolerating failed rollouts
+
+Rollouts are fanned out with `asyncio.gather`, so by default the first exception raised by any
+trajectory aborts the entire training step and discards the trajectories that already finished. For
+flaky environments (network blips in a multi-turn coding agent, for instance) that can waste a lot of
+compute.
+
+Setting `generator.skip_failed_rollouts=true` contains each rollout's exceptions instead. A failed
+rollout is replaced by a single-token placeholder trajectory with zero reward, a zeroed loss mask,
+and `stop_reason="rollout_error"`, so it contributes neither reward nor gradients while keeping the
+batch size that the trainer's data-parallel sharding expects:
+
+```yaml
+generator:
+  skip_failed_rollouts: true
+```
+
+If *every* rollout in a batch fails, the first exception is re-raised rather than producing a step
+with no usable data. The flag is not supported with `generator.batched=true` or
+`generator.inference_engine.enable_return_routed_experts=true`.
+
+Because `rollout_error` is not `"stop"`, the existing
+[`zero_reward_on_non_stop`](/docs/api-ref/skyrl/config) and `apply_overlong_filtering` knobs already
+treat these placeholders as trajectories that should not contribute.
+
 ## References
 
 - https://jybsuper.github.io/posts/multiturn_tokenization/#the-breakthrough-fixed-base-approach

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -1264,6 +1264,12 @@ class GeneratorConfig(BaseConfig):
     apply_overlong_filtering: bool = False
     """Apply DAPO Overlong Filtering: mask out all tokens in the loss mask for trajectories that
     exceed max length (truncated, no EOS token)."""
+    skip_failed_rollouts: bool = False
+    """Let a training step complete when individual rollouts raise, instead of aborting the whole step.
+    Each failed rollout is replaced by a single-token placeholder trajectory with zero reward, a zeroed
+    loss mask, and ``stop_reason="rollout_error"``. Useful for flaky multi-turn agentic environments.
+    If every rollout in the batch fails, the first exception is re-raised, since the step has no usable
+    data. Not supported with ``batched=True`` or ``enable_return_routed_experts=True``."""
     step_wise_trajectories: bool = False
     """Return outputs step-wise.
     When ``True``, multi-turn generations are returned with each turn's (prompt, response) pair as a separate

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -10,7 +10,7 @@ import copy
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Awaitable, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
 import torch
@@ -73,6 +73,19 @@ class StepWiseOutput:
     # Wall-clock seconds spent in each phase. "llm" is time in inference-engine calls, "env" is
     # time in env.step. Field is None if any loop did not record a split.
     time_splits: Optional[Dict[str, float]] = None
+
+
+# `stop_reason` assigned to placeholder trajectories substituted for rollouts that raised under
+# `generator.skip_failed_rollouts`. Like every other non-"stop" reason, `zero_reward_on_non_stop`
+# and `apply_overlong_filtering` treat it as a trajectory that should not contribute.
+ROLLOUT_ERROR_STOP_REASON = "rollout_error"
+
+
+@dataclass
+class FailedRollout:
+    """Marker returned in place of a rollout that raised under ``skip_failed_rollouts``."""
+
+    exception: Exception
 
 
 @dataclass
@@ -208,6 +221,14 @@ class SkyRLGymGenerator(GeneratorInterface):
                 "`chat_template_kwargs` is not compatible with `batched=True` since the chat templating is handled by the inference engine"
             )
 
+        if generator_cfg.skip_failed_rollouts:
+            if self.batched:
+                raise ValueError("`skip_failed_rollouts` doesn't support `batched=True`")
+
+            # A placeholder trajectory has no routed-expert indices to stand in for.
+            if generator_cfg.inference_engine.enable_return_routed_experts:
+                raise ValueError("`skip_failed_rollouts` doesn't support `enable_return_routed_experts=True`")
+
         if self.generator_cfg.step_wise_trajectories:
             if self.batched:
                 raise ValueError("`step_wise_trajectories` doesn't support `batched=True`")
@@ -323,6 +344,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         session_id = (
             f"{trajectory_id.instance_id}_{trajectory_id.repetition_id}" if trajectory_id is not None else uuid4().hex
         )
+        env = None
         try:
             # NOTE: `custom_chat_template` was mainly for getting accurate loss masks for thinking models.
             # This is no longer needed now given that step wise training is supported
@@ -517,8 +539,6 @@ class SkyRLGymGenerator(GeneratorInterface):
 
             # Get environment-specific metrics after the episode is done
             env_metrics = env.get_metrics()
-            # Close the environment
-            await self._run_in_executor_if_available(env.close)
 
             prompt_ids = agent_loop_state.input_ids[:initial_prompt_length]
             rollout_logprobs = None
@@ -603,6 +623,13 @@ class SkyRLGymGenerator(GeneratorInterface):
             return agent_loop_output
 
         finally:
+            # Closed here rather than after the last env interaction so that a rollout raising
+            # mid-episode still releases the environment.
+            if env is not None:
+                try:
+                    await self._run_in_executor_if_available(env.close)
+                except Exception as exc:
+                    logger.warning(f"Failed to close the environment for session {session_id}: {exc}")
             await self.inference_engine_client.finish_session(session_id)
 
     def _build_per_token_rewards(
@@ -838,6 +865,12 @@ class SkyRLGymGenerator(GeneratorInterface):
                 prompts, env_classes, env_extras, max_tokens, sampling_params, cache_salt=cache_salt
             )
 
+        if sampling_params is not None:
+            # sampling params will be a dict in the format of the inference engine backend
+            get_logprobs = sampling_params.get("logprobs", None) is not None
+        else:
+            get_logprobs = self.generator_cfg.sampling_params.logprobs is not None
+
         # Async agent loop to generate trajectories in parallel.
         tasks = []
         for i in range(len(prompts)):
@@ -854,6 +887,11 @@ class SkyRLGymGenerator(GeneratorInterface):
                 )
             )
 
+        if self.generator_cfg.skip_failed_rollouts:
+            # `tqdm.gather` inherits `asyncio.gather`'s default semantics, where the first exception
+            # aborts the whole batch. Contain each rollout's exceptions so the rest can finish.
+            tasks = [self._rollout_or_marker(i, task) for i, task in enumerate(tasks)]
+
         all_outputs = await tqdm.gather(
             *tasks,
             desc="Generating Trajectories",
@@ -861,6 +899,9 @@ class SkyRLGymGenerator(GeneratorInterface):
             mininterval=5,
             disable=disable_tqdm,
         )
+
+        if self.generator_cfg.skip_failed_rollouts:
+            all_outputs = self._substitute_failed_rollouts(all_outputs, get_logprobs)
         # Per-trajectory end-to-end generation times (one entry per prompt, preserving input order).
         # ``e2e_time`` is optional for agent loops; if any trajectory did not record it, we omit the
         # field entirely rather than emit a partially-populated list.
@@ -921,12 +962,6 @@ class SkyRLGymGenerator(GeneratorInterface):
             [getattr(output, "image_grid_thw", None) for output in all_outputs] if has_vision_features else None
         )
 
-        if sampling_params is not None:
-            # sampling params will be a dict in the format of the inference engine backend
-            get_logprobs = sampling_params.get("logprobs", None) is not None
-        else:
-            get_logprobs = self.generator_cfg.sampling_params.logprobs is not None
-
         if get_logprobs:
             if self.generator_cfg.step_wise_trajectories:
                 rollout_logprobs = sum(
@@ -984,6 +1019,89 @@ class SkyRLGymGenerator(GeneratorInterface):
             generator_output["image_grid_thw"] = image_grid_thw
 
         return generator_output
+
+    async def _rollout_or_marker(
+        self, index: int, rollout: Awaitable[Union[TrajectoryOutput, StepWiseOutput]]
+    ) -> Union[TrajectoryOutput, StepWiseOutput, FailedRollout]:
+        """Await a single rollout, turning a raised exception into a ``FailedRollout`` marker.
+
+        Catches ``Exception`` rather than ``BaseException`` so that cancellation and keyboard
+        interrupts still propagate and tear down the batch.
+        """
+        try:
+            return await rollout
+        except Exception as exc:
+            logger.warning(
+                f"Rollout {index} failed with {type(exc).__name__}: {exc}. Substituting a placeholder "
+                f"trajectory so the training step can complete."
+            )
+            return FailedRollout(exception=exc)
+
+    def _placeholder_rollout(
+        self, token_level_rewards: bool, get_logprobs: bool
+    ) -> Union[TrajectoryOutput, StepWiseOutput]:
+        """Build a single-token trajectory that contributes neither reward nor loss."""
+        # `validate_generator_output` requires a non-empty response, and equal lengths for the
+        # response, loss mask, token-level rewards and rollout logprobs.
+        pad_token_id = self.tokenizer.pad_token_id
+        if pad_token_id is None:
+            pad_token_id = self.tokenizer.eos_token_id
+        trajectory = TrajectoryOutput(
+            response_ids=[pad_token_id],
+            reward=[0.0] if token_level_rewards else 0.0,
+            stop_reason=ROLLOUT_ERROR_STOP_REASON,
+            loss_mask=[0],
+            prompt_ids=[pad_token_id],
+            rollout_logprobs=[0.0] if get_logprobs else None,
+            env_metrics={},
+        )
+        if self.generator_cfg.step_wise_trajectories:
+            return StepWiseOutput(step_outputs=[trajectory])
+        return trajectory
+
+    def _substitute_failed_rollouts(
+        self,
+        all_outputs: List[Union[TrajectoryOutput, StepWiseOutput, FailedRollout]],
+        get_logprobs: bool,
+    ) -> List[Union[TrajectoryOutput, StepWiseOutput]]:
+        """Replace ``FailedRollout`` markers with placeholder trajectories.
+
+        The placeholder's reward matches the shape produced by the rollouts that did succeed, since
+        the trainer requires every reward in a batch to be either trajectory-level or token-level.
+        A fresh placeholder is built per failed rollout so that downstream in-place edits of a
+        trajectory's reward or loss mask cannot alias across trajectories.
+        """
+        failed = [output for output in all_outputs if isinstance(output, FailedRollout)]
+        if not failed:
+            return all_outputs
+
+        succeeded = [output for output in all_outputs if not isinstance(output, FailedRollout)]
+        if not succeeded:
+            raise RuntimeError(
+                f"All {len(failed)} rollouts in the batch failed, so the training step has no data to "
+                f"train on. The first failure is attached as the cause."
+            ) from failed[0].exception
+
+        logger.warning(
+            f"{len(failed)} of {len(all_outputs)} rollouts failed and were replaced with placeholder "
+            f"trajectories with stop_reason={ROLLOUT_ERROR_STOP_REASON!r}."
+        )
+        token_level_rewards = isinstance(self._first_trajectory(succeeded[0]).reward, list)
+        return [
+            (
+                self._placeholder_rollout(token_level_rewards, get_logprobs)
+                if isinstance(output, FailedRollout)
+                else output
+            )
+            for output in all_outputs
+        ]
+
+    @staticmethod
+    def _first_trajectory(output: Union[TrajectoryOutput, StepWiseOutput]) -> TrajectoryOutput:
+        """The first per-step trajectory of a step-wise output, or the trajectory itself."""
+        if isinstance(output, StepWiseOutput):
+            return output.step_outputs[0]
+        return output
 
     def _zero_reward_if_not_stop(
         self, rewards: List[Union[float, List[float]]], stop_reasons: List[str]

--- a/tests/train/generators/test_skyrl_gym_generator.py
+++ b/tests/train/generators/test_skyrl_gym_generator.py
@@ -2075,3 +2075,41 @@ async def test_agent_loop_closes_env_when_rollout_raises(
 
     mock_env.close.assert_called_once()
     mock_llm.finish_session.assert_awaited()
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_skip_failed_rollouts_step_wise(
+    mock_make, mock_tokenizer, mock_llm, mock_env, generator_cfg, mock_env_cfg
+):
+    """Under step-wise training the placeholder must be a one-step ``StepWiseOutput``."""
+    from skyrl.train.generators.base import TrajectoryID
+    from skyrl.train.generators.skyrl_gym_generator import StepWiseOutput
+
+    mock_make.return_value = mock_env
+    generator_cfg.step_wise_trajectories = True
+    generator = _skip_failed_rollouts_generator(generator_cfg, mock_env_cfg, mock_llm, mock_tokenizer)
+
+    async def agent_loop(prompt, *args, **kwargs):
+        if prompt[0]["content"] == "first":
+            raise RuntimeError("network blip")
+        return StepWiseOutput(step_outputs=[_trajectory_output(reward=0.0), _trajectory_output(reward=1.0)])
+
+    generator.agent_loop = agent_loop
+
+    input_batch = _two_prompt_input(mock_env_cfg)
+    input_batch["trajectory_ids"] = [
+        TrajectoryID(instance_id="uid0", repetition_id=0),
+        TrajectoryID(instance_id="uid1", repetition_id=0),
+    ]
+
+    output = await generator.generate(input_batch)
+
+    # The failed trajectory contributes one step; the successful one contributes both of its steps.
+    assert output["stop_reasons"] == [ROLLOUT_ERROR_STOP_REASON, "stop", "stop"]
+    assert output["is_last_step"] == [True, False, True]
+    assert [t.instance_id for t in output["trajectory_ids"]] == ["uid0", "uid1", "uid1"]
+    assert output["loss_masks"][0] == [0]
+    assert output["rewards"] == [0.0, 0.0, 1.0]
+
+    validate_generator_output_for_trainer(2, output, step_wise=True)

--- a/tests/train/generators/test_skyrl_gym_generator.py
+++ b/tests/train/generators/test_skyrl_gym_generator.py
@@ -15,7 +15,15 @@ from skyrl.train.generators.base import (
     GeneratorInput,
     GeneratorOutput,
 )
-from skyrl.train.generators.skyrl_gym_generator import SkyRLGymGenerator, TurnOutput
+from skyrl.train.generators.skyrl_gym_generator import (
+    ROLLOUT_ERROR_STOP_REASON,
+    SkyRLGymGenerator,
+    TrajectoryOutput,
+    TurnOutput,
+)
+from skyrl.train.utils.trainer_utils import (
+    validate_generator_output as validate_generator_output_for_trainer,
+)
 from skyrl_gym.envs.base_text_env import BaseTextEnv, BaseTextEnvStepOutput
 
 # Mock constants, where 4 is the eos token id
@@ -1878,3 +1886,192 @@ async def test_llm_vs_env_time_split_metrics(mock_make, mock_tokenizer, mock_llm
         # The environment is ~3x slower than the engine here, so a swapped attribution would flip this.
         assert env_t > llm_t
         assert llm_t + env_t <= e2e_t + 1e-6
+
+
+def _trajectory_output(reward, rollout_logprobs=None):
+    """A minimal successful rollout with a 3-token response."""
+    return TrajectoryOutput(
+        response_ids=[10, 11, 4],
+        reward=reward,
+        stop_reason="stop",
+        loss_mask=[1, 1, 1],
+        prompt_ids=[1, 2],
+        rollout_logprobs=rollout_logprobs,
+        env_metrics={},
+    )
+
+
+def _skip_failed_rollouts_generator(generator_cfg, mock_env_cfg, mock_llm, mock_tokenizer):
+    generator_cfg.batched = False
+    generator_cfg.skip_failed_rollouts = True
+    mock_tokenizer.pad_token_id = 0
+    return SkyRLGymGenerator(
+        generator_cfg=generator_cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+    )
+
+
+def _two_prompt_input(mock_env_cfg) -> GeneratorInput:
+    return {
+        "prompts": [[{"role": "user", "content": "first"}], [{"role": "user", "content": "second"}]],
+        "env_extras": [{}, {}],
+        "env_classes": [mock_env_cfg.env_class] * 2,
+    }
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_skip_failed_rollouts_substitutes_placeholder(
+    mock_make, mock_tokenizer, mock_llm, mock_env, generator_cfg, mock_env_cfg
+):
+    """A rollout that raises is replaced by a masked placeholder, and the batch still completes."""
+    mock_make.return_value = mock_env
+    generator = _skip_failed_rollouts_generator(generator_cfg, mock_env_cfg, mock_llm, mock_tokenizer)
+
+    async def agent_loop(prompt, *args, **kwargs):
+        if prompt[0]["content"] == "first":
+            raise RuntimeError("network blip")
+        return _trajectory_output(reward=1.0)
+
+    generator.agent_loop = agent_loop
+
+    output = await generator.generate(_two_prompt_input(mock_env_cfg))
+
+    assert output["stop_reasons"] == [ROLLOUT_ERROR_STOP_REASON, "stop"]
+    # The placeholder is a single padding token that contributes no reward and no loss.
+    assert output["response_ids"][0] == [mock_tokenizer.pad_token_id]
+    assert output["loss_masks"][0] == [0]
+    assert output["rewards"] == [0.0, 1.0]
+    # The successful rollout is untouched.
+    assert output["response_ids"][1] == [10, 11, 4]
+    assert output["loss_masks"][1] == [1, 1, 1]
+
+    # The substituted batch must still satisfy the trainer's contract.
+    validate_generator_output_for_trainer(2, output)
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_skip_failed_rollouts_matches_token_level_rewards(
+    mock_make, mock_tokenizer, mock_llm, mock_env, generator_cfg, mock_env_cfg
+):
+    """The placeholder's reward shape follows the successful rollouts, which the trainer requires."""
+    mock_make.return_value = mock_env
+    generator_cfg.sampling_params.logprobs = 0
+    generator = _skip_failed_rollouts_generator(generator_cfg, mock_env_cfg, mock_llm, mock_tokenizer)
+
+    async def agent_loop(prompt, *args, **kwargs):
+        if prompt[0]["content"] == "first":
+            raise RuntimeError("network blip")
+        return _trajectory_output(reward=[0.0, 0.0, 1.0], rollout_logprobs=[-0.1, -0.2, -0.3])
+
+    generator.agent_loop = agent_loop
+
+    output = await generator.generate(_two_prompt_input(mock_env_cfg))
+
+    assert output["rewards"] == [[0.0], [0.0, 0.0, 1.0]]
+    # Logprobs are requested, so the placeholder must carry one per response token.
+    assert output["rollout_logprobs"][0] == [0.0]
+    validate_generator_output_for_trainer(2, output)
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_skip_failed_rollouts_raises_when_every_rollout_fails(
+    mock_make, mock_tokenizer, mock_llm, mock_env, generator_cfg, mock_env_cfg
+):
+    """With no successful rollout there is nothing to train on, so the failure is surfaced."""
+    mock_make.return_value = mock_env
+    generator = _skip_failed_rollouts_generator(generator_cfg, mock_env_cfg, mock_llm, mock_tokenizer)
+
+    async def agent_loop(*args, **kwargs):
+        raise RuntimeError("inference engine is down")
+
+    generator.agent_loop = agent_loop
+
+    with pytest.raises(RuntimeError, match="All 2 rollouts in the batch failed") as exc_info:
+        await generator.generate(_two_prompt_input(mock_env_cfg))
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == "inference engine is down"
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_failed_rollout_aborts_step_by_default(
+    mock_make, mock_tokenizer, mock_llm, mock_env, generator_cfg, mock_env_cfg
+):
+    """Without the flag, a failed rollout still aborts the whole step."""
+    mock_make.return_value = mock_env
+    generator_cfg.batched = False
+    generator = SkyRLGymGenerator(
+        generator_cfg=generator_cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+    )
+
+    async def agent_loop(prompt, *args, **kwargs):
+        if prompt[0]["content"] == "first":
+            raise RuntimeError("network blip")
+        return _trajectory_output(reward=1.0)
+
+    generator.agent_loop = agent_loop
+
+    with pytest.raises(RuntimeError, match="network blip"):
+        await generator.generate(_two_prompt_input(mock_env_cfg))
+
+
+def test_skip_failed_rollouts_rejects_unsupported_configs(mock_tokenizer, mock_llm, mock_env_cfg, generator_cfg):
+    """The placeholder cannot stand in for batched generation or routed-expert indices."""
+    generator_cfg.skip_failed_rollouts = True
+    generator_cfg.batched = True
+    with pytest.raises(ValueError, match="`skip_failed_rollouts` doesn't support `batched=True`"):
+        SkyRLGymGenerator(
+            generator_cfg=generator_cfg,
+            skyrl_gym_cfg=mock_env_cfg,
+            inference_engine_client=mock_llm,
+            tokenizer=mock_tokenizer,
+        )
+
+    generator_cfg.batched = False
+    generator_cfg.inference_engine.enable_return_routed_experts = True
+    with pytest.raises(ValueError, match="doesn't support `enable_return_routed_experts=True`"):
+        SkyRLGymGenerator(
+            generator_cfg=generator_cfg,
+            skyrl_gym_cfg=mock_env_cfg,
+            inference_engine_client=mock_llm,
+            tokenizer=mock_tokenizer,
+        )
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_agent_loop_closes_env_when_rollout_raises(
+    mock_make, mock_tokenizer, mock_llm, mock_env, generator_cfg, mock_env_cfg
+):
+    """The environment is released on the failure path, not only after a completed episode."""
+    mock_make.return_value = mock_env
+    generator_cfg.batched = False
+    mock_env.init.return_value = ([{"role": "user", "content": "Initial input"}], {})
+    mock_env.step.side_effect = RuntimeError("env exploded")
+
+    generator = SkyRLGymGenerator(
+        generator_cfg=generator_cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+    )
+
+    with pytest.raises(RuntimeError, match="env exploded"):
+        await generator.agent_loop(
+            [{"role": "user", "content": "Test prompt"}],
+            mock_env_cfg.env_class,
+            {},
+            max_tokens=5,
+            max_input_length=512,
+        )
+
+    mock_env.close.assert_called_once()
+    mock_llm.finish_session.assert_awaited()


### PR DESCRIPTION
Closes #1613.

`SkyRLGymGenerator.generate` fans rollouts out through `tqdm.gather`, which inherits `asyncio.gather`'s default semantics: the first exception from any rollout aborts the whole training step and throws away the trajectories that already finished. In a flaky multi-turn agentic setting (a network blip in a coding agent, say) one bad rollout wastes the entire step's compute.

`generator.skip_failed_rollouts=true` (default `false`) contains each rollout's exceptions instead. A failed rollout is replaced by a single-token placeholder trajectory with zero reward, a zeroed loss mask, and `stop_reason="rollout_error"`. The placeholder preserves the batch size the trainer's data-parallel sharding expects, and since the stop reason is not `"stop"`, the existing `zero_reward_on_non_stop` and `apply_overlong_filtering` knobs already treat it as a trajectory that should not contribute — no changes needed there.

Notes on the details that the issue's sketch left open:

- **Reward shape.** `validate_generator_output` requires every reward in a batch to be uniformly trajectory-level or token-level, and which one is in play is only known from the rollouts that succeeded. So a failing rollout returns a `FailedRollout` marker and substitution happens after the gather, once a successful output can be inspected. A fresh placeholder is built per failure so that later in-place edits to a reward or loss mask cannot alias across trajectories.
- **All rollouts failing.** The first exception is re-raised as the cause of a `RuntimeError`. A step consisting only of placeholders carries no training signal, and a systemic failure (engine down) should surface rather than be smoothed over.
- **`Exception`, not `BaseException`.** Cancellation and `KeyboardInterrupt` still propagate and tear down the batch.
- **Unsupported combinations.** Rejected at construction for `batched=True` (that path does not go through `agent_loop`, so the flag would silently do nothing) and for `enable_return_routed_experts=True` (a placeholder has no routed-expert indices to stand in for).

## Environment cleanup

This also moves `env.close()` into `agent_loop`'s existing `finally`. It previously ran only on the happy path, so a rollout raising mid-episode never released its environment. The leak was inconsequential while any failure killed the step, but it is not once failures are routine and the run continues — so it is in scope here rather than deferred. It is narrow (one env per failed `agent_loop`) and distinct from the trial/sandbox leakage in #1194. Happy to split it into its own PR if you'd prefer.

## Testing

New CPU tests in `tests/train/generators/test_skyrl_gym_generator.py`:

- placeholder substitution keeps the successful rollout intact, and the result passes the trainer's real `validate_generator_output`
- placeholder reward follows token-level rewards, and carries one logprob per token when logprobs are requested
- all-rollouts-failed raises with the original exception as `__cause__`
- without the flag, a failed rollout still aborts the step (unchanged default)
- `batched=True` and `enable_return_routed_experts=True` are rejected
- `agent_loop` closes the env when the rollout raises (fails without the cleanup change)

`uv run --isolated --extra skyrl-train --extra dev pytest tests/train/ tests/backends/skyrl_train/ --ignore=tests/backends/skyrl_train/gpu -m "not vllm"` — 1463 passed, 7 skipped. Docs build (`npm run build`) passes.

## Known behavior

`e2e_time` and `time_splits` are `None` on a placeholder, so a batch containing any failed rollout omits the trajectory completion-time metrics for that step. This follows the existing convention in `generate` of dropping those fields entirely rather than emitting a partially-populated list, and it seemed better than attributing a fabricated `0.0` to a rollout that never ran. Happy to change it if you'd rather see partial timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
