### PR TITLE
[qoc] Change convert_prompts_responses_to_batch_tensors() from tokenizer to pad_token_id

### DIFF
--- a/skyrl/train/dataset/preprocess.py
+++ b/skyrl/train/dataset/preprocess.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Tuple, Union
 import numpy as np
 import torch
 from jaxtyping import Bool, Float, Integer
-from transformers import AutoTokenizer
 
 from skyrl.backends.skyrl_train.utils.replay_utils import make_replay_padding_indices_np
 from skyrl.backends.skyrl_train.utils.routed_experts import (
@@ -89,7 +88,7 @@ def _reward_to_numpy(custom_reward: Union[List[float], torch.Tensor]) -> np.ndar
 
 
 def convert_prompts_responses_to_batch_tensors(
-    tokenizer: AutoTokenizer,
+    pad_token_id: int,
     prompts: List[List[int]],
     responses: List[List[int]],
     rewards: List[Union[List[float], torch.Tensor]],
@@ -140,7 +139,7 @@ def convert_prompts_responses_to_batch_tensors(
     Assumes that the responses already contain an eos token at index -1.
 
     Args:
-        tokenizer: Model tokenizer
+        pad_token_id: Token id used to left-pad ``sequences``
         prompts: List of tokenized prompts
         responses: List of tokenized responses
         rewards: List of rewards for each response (lists or 1D tensors)
@@ -172,7 +171,6 @@ def convert_prompts_responses_to_batch_tensors(
             f"No truncation is performed; consider checking generator settings."
         )
 
-    pad_token_id = tokenizer.pad_token_id
     num_samples = len(prompts)
 
     # Fill NumPy buffers by slice, then convert once.

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -896,7 +896,7 @@ class RayPPOTrainer:
             rollout_logprobs_tensor,
             rollout_expert_indices_tensor,
         ) = convert_prompts_responses_to_batch_tensors(
-            self.tokenizer,
+            self.tokenizer.pad_token_id,
             prompt_ids,
             response_ids,
             rewards,

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_models.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_models.py
@@ -146,7 +146,7 @@ async def generate_with_vllm(generator, client, model_name, tokenizer, return_tr
 
     sequences, attention_mask, response_mask, rewards_t, loss_mask_t, logprobs_t, _ = (
         convert_prompts_responses_to_batch_tensors(
-            tokenizer=tokenizer,
+            pad_token_id=tokenizer.pad_token_id,
             prompts=generator_output["prompt_token_ids"],
             responses=responses,
             rewards=rewards,
@@ -183,7 +183,7 @@ async def generate_with_vllm(generator, client, model_name, tokenizer, return_tr
 
 async def construct_training_input_from_generator_output(generator_output, tokenizer):
     return convert_prompts_responses_to_batch_tensors(
-        tokenizer=tokenizer,
+        pad_token_id=tokenizer.pad_token_id,
         prompts=generator_output["prompt_token_ids"],
         responses=generator_output["response_ids"],
         rewards=generator_output["rewards"],

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_router_replay.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_router_replay.py
@@ -109,7 +109,7 @@ def build_training_input_from_text_samples(
         loss_masks.append([1] * len(response_ids))
 
     sequences, attention_mask, response_mask, rewards_t, loss_mask_t, _, _ = convert_prompts_responses_to_batch_tensors(
-        tokenizer=tokenizer,
+        pad_token_id=tokenizer.pad_token_id,
         prompts=prompts,
         responses=responses,
         rewards=rewards,
@@ -219,7 +219,7 @@ async def test_logprobs(tp, pp, cp, ep, etp, extra_tf_kwargs):
             rewards = [[r] * len(resp) for r, resp in zip(rewards, responses)]
         sequences, attention_mask, response_mask, rewards_t, loss_mask_t, logprobs_t, rii_tensor = (
             convert_prompts_responses_to_batch_tensors(
-                tokenizer=tokenizer,
+                pad_token_id=tokenizer.pad_token_id,
                 prompts=generator_output["prompt_token_ids"],
                 responses=responses,
                 rewards=rewards,
@@ -344,7 +344,7 @@ def test_forward_backward(tp, pp, cp, ep, etp, extra_tf_kwargs):
 
         sequences, attention_mask, response_mask, rewards_t, loss_mask_t, _, _ = (
             convert_prompts_responses_to_batch_tensors(
-                tokenizer=tokenizer,
+                pad_token_id=tokenizer.pad_token_id,
                 prompts=prompts,
                 responses=responses,
                 rewards=rewards,

--- a/tests/train/dataset/test_preprocess.py
+++ b/tests/train/dataset/test_preprocess.py
@@ -86,7 +86,7 @@ def test_routed_expert_tensor_uses_unique_dummy_routes(tokenizer):
     ]
 
     *_, routed = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts=[[10], [20]],
         responses=[[11, 12], [21, 22]],
         rewards=[[0.0, 0.0], [0.0, 0.0]],
@@ -115,7 +115,7 @@ def test_routed_expert_tensor_promotes_mixed_batch_dtype(
     ]
 
     *_, routed = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts=[[10], [20]],
         responses=[[11], [21]],
         rewards=[[0.0], [0.0]],
@@ -132,7 +132,7 @@ def test_routed_expert_tensor_accepts_read_only_arrays(tokenizer):
     routes.flags.writeable = False
 
     *_, routed = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts=[[10]],
         responses=[[11]],
         rewards=[[0.0]],
@@ -147,7 +147,7 @@ def test_routed_expert_tensor_accepts_read_only_arrays(tokenizer):
 def test_routed_expert_tensor_rejects_nested_lists(tokenizer):
     with pytest.raises(TypeError, match="NumPy arrays"):
         convert_prompts_responses_to_batch_tensors(
-            tokenizer,
+            tokenizer.pad_token_id,
             prompts=[[10]],
             responses=[[11]],
             rewards=[[0.0]],
@@ -167,7 +167,7 @@ def test_routed_expert_tensor_narrows_wide_dtypes(tokenizer, dtype):
     routes = np.asarray([[[1, 2]], [[3, 4]]], dtype=dtype)
 
     *_, routed = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts=[[10]],
         responses=[[11]],
         rewards=[[0.0]],
@@ -185,7 +185,7 @@ def test_routed_expert_tensor_retightens_after_truncation(tokenizer):
     routes = np.asarray([[[1, 2]], [[3, 4]], [[300, 5]]], dtype=np.int16)
 
     *_, routed = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts=[[10]],
         responses=[[11]],
         rewards=[[0.0]],
@@ -217,7 +217,7 @@ def test_convert_prompts_responses_to_batch_tensors_exact(tokenizer):
 
     sequences, attention_mask, response_mask, ret_rewards, ret_loss_masks, ret_log_probs, _ = (
         convert_prompts_responses_to_batch_tensors(
-            tokenizer,
+            tokenizer.pad_token_id,
             prompts,
             outputs,
             rewards,
@@ -253,7 +253,7 @@ def test_convert_prompts_responses_to_batch_tensors_different_lengths(tokenizer)
 
     sequences, attention_mask, response_mask, ret_rewards, ret_loss_masks, ret_log_probs, _ = (
         convert_prompts_responses_to_batch_tensors(
-            tokenizer,
+            tokenizer.pad_token_id,
             prompts,
             outputs,
             rewards,
@@ -290,7 +290,7 @@ def test_convert_prompts_responses_to_batch_tensors_empty_input(tokenizer):
 
     with pytest.raises(AssertionError):
         convert_prompts_responses_to_batch_tensors(
-            tokenizer,
+            tokenizer.pad_token_id,
             prompts,
             outputs,
             rewards,
@@ -309,7 +309,7 @@ def test_convert_prompts_responses_to_batch_tensors_mismatched_lengths(tokenizer
 
     with pytest.raises(AssertionError):
         convert_prompts_responses_to_batch_tensors(
-            tokenizer,
+            tokenizer.pad_token_id,
             prompts,
             outputs,
             rewards,
@@ -333,7 +333,7 @@ def test_unified_left_padding_layout(tokenizer):
     loss_masks = [[1] * 3, [1] * 2]
 
     seq, attn, action, rew, lm, _, _ = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts,
         responses,
         rewards,
@@ -363,7 +363,7 @@ def test_right_aligned_response_data(tokenizer):
     responses_copy = [r[:] for r in responses]
 
     seq, attn, action, rew, lm, lp, _ = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts,
         responses,
         rewards,
@@ -398,7 +398,7 @@ def test_max_seq_len_warns_but_does_not_truncate(tokenizer):
     loss_masks = [[1] * 10, [1] * 50]
 
     seq, _, action, _, _, _, _ = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts,
         responses,
         rewards,
@@ -435,7 +435,7 @@ def test_rollout_expert_indices_shape_padding_and_alignment(tokenizer):
     rei_1 = np.asarray([[[3, 4]] * num_layers for _ in range(6)], dtype=np.uint8)  # 6 tokens
 
     seq, attn, action, rew, lm, lp, rei_tensor = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts,
         responses,
         rewards,
@@ -472,7 +472,7 @@ def test_rollout_expert_indices_none_when_not_provided(tokenizer):
     loss_masks = [[1], [1]]
 
     *_, rei_tensor = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts,
         responses,
         rewards,
@@ -492,7 +492,7 @@ def test_stepwise_anti_correlation_no_inflation(tokenizer):
     loss_masks = [[1] * 90, [1] * 10]
 
     seq, attn, action, rew, lm, _, _ = convert_prompts_responses_to_batch_tensors(
-        tokenizer,
+        tokenizer.pad_token_id,
         prompts,
         responses,
         rewards,

--- a/tests/train/test_collation_vectorization_equivalence.py
+++ b/tests/train/test_collation_vectorization_equivalence.py
@@ -154,7 +154,7 @@ def test_rl_preprocess_bit_identical(seed, with_logprobs):
     tokenizer.pad_token_id = 0
 
     seq, attn, action, rew, lm, lp, _ = convert_prompts_responses_to_batch_tensors(
-        tokenizer, prompts, responses, rewards, loss_masks, logprobs
+        tokenizer.pad_token_id, prompts, responses, rewards, loss_masks, logprobs
     )
     r_seq, r_attn, r_action, r_rew, r_lm, r_lp = _ref_convert_prompts_responses(
         prompts, responses, rewards, loss_masks, logprobs, pad_token_id=0
@@ -186,7 +186,7 @@ def test_rl_preprocess_accepts_tensor_rewards():
     loss_masks = [[1], [1, 0, 1]]
 
     _, _, _, rew, _, _, _ = convert_prompts_responses_to_batch_tensors(
-        tokenizer, prompts, responses, rewards, loss_masks
+        tokenizer.pad_token_id, prompts, responses, rewards, loss_masks
     )
     _, _, _, r_rew, _, _ = _ref_convert_prompts_responses(prompts, responses, rewards, loss_masks, None, pad_token_id=0)
     assert torch.equal(rew, r_rew)
@@ -204,7 +204,7 @@ def test_rl_preprocess_accepts_grad_tensor_rewards():
     loss_masks = [[1], [1, 0, 1]]
 
     _, _, _, rew, _, _, _ = convert_prompts_responses_to_batch_tensors(
-        tokenizer, prompts, responses, rewards, loss_masks
+        tokenizer.pad_token_id, prompts, responses, rewards, loss_masks
     )
 
     expected = torch.tensor([[0.0, 0.0, 1.0], [0.5, 0.6, 0.7]], dtype=torch.float32)
@@ -224,7 +224,7 @@ def test_rl_preprocess_accepts_cuda_tensor_rewards():
     loss_masks = [[1], [1, 0, 1]]
 
     _, _, _, rew, _, _, _ = convert_prompts_responses_to_batch_tensors(
-        tokenizer, prompts, responses, rewards, loss_masks
+        tokenizer.pad_token_id, prompts, responses, rewards, loss_masks
     )
 
     expected = torch.tensor([[0.0, 0.0, 1.0], [0.5, 0.6, 0.7]], dtype=torch.float32)


### PR DESCRIPTION
Change `convert_prompts_responses_to_batch_tensors()` input from `tokenizer` to `pad_token_id` since that is the only thing needed
