### PR TITLE
[feat][SFT] Union sampling for multi-dataset runs without explicit weights

### DIFF
--- a/docs/content/docs/sft/multi_dataset.mdx
+++ b/docs/content/docs/sft/multi_dataset.mdx
@@ -29,17 +29,29 @@ bash examples/train/sft/run_sft_megatron.sh \
 ```
 
 Each dataset is tokenized (and cached) independently, then concatenated. With
-multiple datasets and the default `sampler=random`, the trainer switches to
-weighted per-source sampling via
-[`DataMixingSampler`](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/dataset/samplers.py).
+multiple datasets and the default `sampler=random`, the sampling mode depends
+on whether `train_dataset_weights` is set:
+
+- **No weights (default): union sampling.** One shuffle over the concatenated
+  datasets, **without replacement** -- an epoch covers every sample of every
+  dataset exactly once, and each dataset's share of the batches follows its
+  size. This is "train on the union of my datasets".
+- **Weights set: weighted mixing.** The trainer switches to weighted
+  per-source sampling via
+  [`DataMixingSampler`](https://github.com/NovaSky-AI/SkyRL/blob/main/skyrl/train/dataset/samplers.py),
+  which samples **with replacement** -- the only way per-batch ratios can hold
+  independent of dataset sizes. An epoch is then `len(union)` weighted draws,
+  not a full pass: over-weighted small sources repeat, under-weighted rows may
+  not appear.
 
 ### How weights work
 
 `train_dataset_weights` is the approximate **per-batch ratio of samples drawn
 from each source, independent of the dataset sizes**. A 1k-example dataset with
 weight `0.5` contributes half of every batch even when mixed with a 1M-example
-one. Weights need not sum to 1 (relative scale is what matters) and default to
-equal mixing (`1/N` each).
+one. Weights need not sum to 1 (relative scale is what matters). To make the
+ratios follow dataset sizes, leave the weights unset (union sampling) rather
+than computing size-proportional weights by hand.
 
 The sampler draws a fresh weighted plan every epoch and stores its RNG state in
 the checkpoint, so `resume_from` reproduces the exact sample stream: a mid-epoch

--- a/docs/content/docs/sft/overview.mdx
+++ b/docs/content/docs/sft/overview.mdx
@@ -127,8 +127,8 @@ bash examples/train/sft/run_sft_megatron.sh \
 Each entry is a local path to a file or directory (a directory may hold multiple
 shards) in one of these auto-detected formats: **Parquet**, **JSON-lines**, **raw
 Arrow IPC**, or a HuggingFace **`Dataset.save_to_disk`** directory. Like
-`train_datasets`, multiple stores are concatenated and mixed per
-`train_dataset_weights`; multiple eval stores are evaluated separately under
+`train_datasets`, multiple stores are concatenated and sampled as their union
+(every row once per epoch) -- or mixed per `train_dataset_weights` when set; multiple eval stores are evaluated separately under
 `eval/{name}/`, with names from `eval_dataset_names` (defaulting to each path's
 basename).
 

--- a/examples/train/sft/README.md
+++ b/examples/train/sft/README.md
@@ -21,7 +21,8 @@ bash examples/train/sft/run_sft_megatron.sh \
 
 Each entry of `pretokenized_dataset_paths` is a local path to a file or directory in any of these formats
 (auto-detected): Parquet, JSON-lines, raw Arrow IPC files, or a HuggingFace `Dataset.save_to_disk` directory.
-Like `train_datasets`, multiple stores are concatenated and mixed per `train_dataset_weights`; multiple eval
+Like `train_datasets`, multiple stores are concatenated and sampled as their union (every row once per
+epoch) -- or mixed per `train_dataset_weights` when set; multiple eval
 stores are evaluated separately under `eval/{name}/`, with names from `eval_dataset_names` (defaulting to each
 path's basename).
 
@@ -129,10 +130,10 @@ All SFT configuration is defined in [`skyrl/train/config/sft_config.py`](../../.
 |-----------|---------|-------------|
 | `strategy` | `megatron` | Backend: `megatron` or `fsdp` |
 | `model.path` | `Qwen/Qwen3-0.6B` | HuggingFace model ID or local path |
-| `train_datasets` | `[yahma/alpaca-cleaned]` | List of HuggingFace dataset names to train on; multiple entries are mixed per `train_dataset_weights` |
+| `train_datasets` | `[yahma/alpaca-cleaned]` | List of HuggingFace dataset names to train on; multiple entries are sampled as their union, or mixed per `train_dataset_weights` when set |
 | `train_dataset_splits` | `[train[:100]]` | Split/slice per training dataset (same length as `train_datasets`) |
-| `train_dataset_weights` | equal (`1/N`) | Per-dataset sampling ratios within a batch, independent of dataset sizes; `sampler=random` only |
-| `pretokenized_dataset_paths` | `None` | List of local paths to pretokenized datasets (Parquet/JSONL/Arrow/`save_to_disk`); skips tokenization, mixed per `train_dataset_weights`; exclusive with `train_datasets` |
+| `train_dataset_weights` | `None` (union sampling) | Per-dataset sampling ratios within a batch, independent of dataset sizes (with replacement); unset = one shuffle over the union, without replacement; `sampler=random` only |
+| `pretokenized_dataset_paths` | `None` | List of local paths to pretokenized datasets (Parquet/JSONL/Arrow/`save_to_disk`); skips tokenization, sampled like `train_datasets`; exclusive with `train_datasets` |
 | `eval_datasets` | `None` | List of eval dataset names; `None` disables eval. Metrics logged under `eval/{name}/` |
 | `eval_dataset_splits` | `None` | Split per eval dataset (same length as `eval_datasets`) |
 | `eval_dataset_names` | dataset names | Shorthand names used only for logging (`eval/{name}/loss`); must be unique |

--- a/skyrl/train/config/sft_config.py
+++ b/skyrl/train/config/sft_config.py
@@ -165,8 +165,11 @@ class SFTConfig(BaseConfig):
     ``train_datasets`` in length. Defaults to ``["train[:100]"]``."""
     train_dataset_weights: Optional[List[float]] = None
     """Per-dataset sampling weights: the approximate per-batch ratio of samples drawn from each
-    dataset, independent of dataset sizes. Only supported with ``sampler="random"`` (custom
-    samplers receive ratios via ``sampler_kwargs``). Defaults to equal mixing (``1/N`` each)."""
+    dataset, independent of dataset sizes (sampled with replacement). Only supported with
+    ``sampler="random"`` (custom samplers receive ratios via ``sampler_kwargs``). When left
+    unset (``None``), multiple datasets are instead sampled as their union -- a plain shuffle
+    over the concatenation, without replacement, so an epoch covers every sample exactly once
+    and each dataset's share follows its size."""
     pretokenized_dataset_paths: Optional[List[str]] = None
     """Local paths to *pretokenized* training datasets, each a file or
     directory holding parquet/JSONL/arrow files or a HF
@@ -342,8 +345,9 @@ _DEFAULT_EVAL_SPLIT = "validation"
 
 def _normalize_mixing_weights(cfg: SFTConfig, num_sources: int, sources_field: str) -> None:
     """Validate ``train_dataset_weights`` against the active training source list
-    (``train_datasets`` or ``pretokenized_dataset_paths``), defaulting to equal
-    mixing for ``sampler="random"``."""
+    (``train_datasets`` or ``pretokenized_dataset_paths``). Unset weights stay
+    ``None``: multiple sources then sample as their union (without replacement)
+    rather than as a weighted mix."""
     if cfg.train_dataset_weights is not None:
         if cfg.sampler != "random":
             raise ValueError(
@@ -358,10 +362,12 @@ def _normalize_mixing_weights(cfg: SFTConfig, num_sources: int, sources_field: s
             )
         if any(w <= 0 for w in cfg.train_dataset_weights):
             raise ValueError(f"train_dataset_weights must all be > 0, got {cfg.train_dataset_weights}.")
-    elif cfg.sampler == "random":
-        # Default: equal mixing. Left as None for other samplers (sequential
-        # ignores mixing; custom samplers take ratios via sampler_kwargs).
-        cfg.train_dataset_weights = [1.0 / num_sources] * num_sources
+    # When no weights are given, ``None`` is preserved deliberately: it selects
+    # union sampling (a plain shuffle over the concatenated datasets, without
+    # replacement, so an epoch covers every sample of every dataset exactly
+    # once). Explicit weights select weighted mixing, which samples with
+    # replacement -- the only way per-batch ratios can hold independent of
+    # dataset sizes.
 
 
 def _default_pretokenized_eval_names(paths: List[str]) -> List[str]:

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -1248,8 +1248,9 @@ class SFTTrainer:
         Returns:
             A single :class:`SFTDataset`. Multiple sources are concatenated in
             config order as a :class:`ConcatSFTDataset` (a map-style view, no
-            row materialization), whose ``dataset_lengths`` configures weighted
-            mixing in :meth:`build_train_sampler`.
+            row materialization) and sampled as their union -- or, when
+            ``train_dataset_weights`` is set, as a weighted mix configured
+            from its ``dataset_lengths`` in :meth:`build_train_sampler`.
         """
         sources: list[SFTDataset] = []
         if self.sft_cfg.pretokenized_dataset_paths:
@@ -1356,14 +1357,18 @@ class SFTTrainer:
     def build_train_sampler(self, tokenized) -> Optional[torch.utils.data.Sampler]:
         """Build the training sampler from ``sft_cfg.sampler``.
 
-        Returns ``None`` for the default ``"random"`` strategy over a single
-        dataset, signalling :meth:`build_train_dataloader` to use the
-        dataloader's built-in ``shuffle=True`` path (which is statefully
+        Returns ``None`` for the default ``"random"`` strategy unless weighted
+        mixing is requested, signalling :meth:`build_train_dataloader` to use
+        the dataloader's built-in ``shuffle=True`` path (which is statefully
         checkpointed by ``StatefulDataLoader``). Over a
-        :class:`ConcatSFTDataset` (multiple training datasets), ``"random"``
-        instead returns a :class:`DataMixingSampler` configured with its
-        ``dataset_lengths`` and ``train_dataset_weights``. For ``"sequential"``
-        and ``"custom"`` it returns an explicit stateful sampler.
+        :class:`ConcatSFTDataset` (multiple training datasets) this means
+        **union sampling**: one shuffle over the concatenation, without
+        replacement, so an epoch covers every sample of every dataset exactly
+        once and each dataset's share follows its size. Only when
+        ``train_dataset_weights`` is set does ``"random"`` return a
+        :class:`DataMixingSampler` (weighted per-source mixing, with
+        replacement). For ``"sequential"`` and ``"custom"`` it returns an
+        explicit stateful sampler.
 
         Custom samplers are imported from ``sft_cfg.sampler_class_path`` and
         instantiated as ``ClassName(tokenized, **sft_cfg.sampler_kwargs)``. With
@@ -1385,10 +1390,11 @@ class SFTTrainer:
         dataset_lengths = tokenized.dataset_lengths if multi_dataset else None
         sampler_type = self.sft_cfg.sampler
         if sampler_type == "random":
-            if not multi_dataset:
+            # No explicit weights -> union sampling: the built-in shuffle is a
+            # permutation of the (concatenated) dataset, so every sample of
+            # every source is seen exactly once per epoch.
+            if not multi_dataset or self.sft_cfg.train_dataset_weights is None:
                 return None
-            # Config normalization (validate_sft_cfg) fills equal weights for
-            # the random sampler on every construction path.
             return DataMixingSampler(
                 tokenized,
                 lengths=dataset_lengths,

--- a/tests/train/test_sft_config.py
+++ b/tests/train/test_sft_config.py
@@ -348,7 +348,8 @@ class TestDatasetConfigNormalization:
         _normalize_dataset_cfg(cfg)
         assert cfg.train_datasets == ["yahma/alpaca-cleaned"]
         assert cfg.train_dataset_splits == ["train[:100]"]
-        assert cfg.train_dataset_weights == [1.0]
+        # Unset weights stay None (union sampling; no defaulted mixing).
+        assert cfg.train_dataset_weights is None
         assert cfg.dataset_name is None and cfg.dataset_split is None
         assert cfg.eval_datasets is None  # eval stays disabled
 
@@ -412,10 +413,12 @@ class TestMultiDatasetValidation:
         assert list(cfg.train_datasets) == ["allenai/tulu-3-sft-mixture", "yahma/alpaca-cleaned"]
         assert list(cfg.train_dataset_splits) == ["train[:50000]", "train[:10000]"]
 
-    def test_default_weights_are_equal_mixing(self):
+    def test_unset_weights_stay_none_for_union_sampling(self):
+        # No defaulted equal mixing: unset weights select union sampling
+        # (one shuffle over the concatenation, without replacement).
         cfg = _sft_cfg_from_overrides(["train_datasets=[a,b,c,d]", "train_dataset_splits=[s,s,s,s]"])
         _normalize_dataset_cfg(cfg)
-        assert cfg.train_dataset_weights == pytest.approx([0.25] * 4)
+        assert cfg.train_dataset_weights is None
 
     def test_splits_length_mismatch_rejected(self):
         cfg = _sft_cfg_from_overrides(["train_datasets=[a,b]", "train_dataset_splits=[s1]"])

--- a/tests/train/test_sft_dataloader.py
+++ b/tests/train/test_sft_dataloader.py
@@ -234,11 +234,30 @@ class TestBuildTrainSampler:
         assert list(sampler) == list(other)
 
     def test_random_multi_dataset_builds_mixing_sampler(self):
-        # train_dataset_weights is filled by config normalization
-        # (validate_sft_cfg) on every construction path.
+        # Explicit weights select weighted mixing (with replacement).
         trainer = _make_trainer(sampler="random", train_dataset_weights=[0.5, 0.5])
         sampler = trainer.build_train_sampler(_concat_dataset(10, 10))
         assert isinstance(sampler, DataMixingSampler)
+
+    def test_random_multi_dataset_without_weights_returns_none(self):
+        # Unset weights select union sampling: the built-in shuffle path
+        # (sampler=None) permutes the concatenation without replacement.
+        trainer = _make_trainer(sampler="random")
+        assert trainer.sft_cfg.train_dataset_weights is None
+        assert trainer.build_train_sampler(_concat_dataset(10, 10)) is None
+
+    def test_union_sampling_epoch_covers_every_sample_once(self):
+        # Without weights, one epoch over two unequal sources yields every
+        # index of both exactly once (a permutation of the union).
+        trainer = _make_trainer(sampler="random", batch_size=4, seed=7)
+        dl = trainer.build_train_dataloader(_concat_dataset(12, 8))
+        epoch = _flatten(dl)
+        assert sorted(epoch) == list(range(20))
+        assert epoch != list(range(20))  # shuffled, not sequential
+        # And the next epoch is a fresh permutation with the same coverage.
+        second = _flatten(dl)
+        assert sorted(second) == list(range(20))
+        assert second != epoch
 
     def test_custom_multi_dataset_injects_lengths(self):
         trainer = _make_trainer(

--- a/tests/train/test_sft_pretokenized.py
+++ b/tests/train/test_sft_pretokenized.py
@@ -418,8 +418,8 @@ def test_trainer_concatenates_multiple_pretokenized_stores(tmp_path):
         disable_cache=True,
     )
     validate_sft_cfg(cfg)
-    # Equal mixing weights are defaulted for the random sampler.
-    assert cfg.train_dataset_weights == [0.5, 0.5]
+    # Unset weights stay None: multiple stores sample as their union.
+    assert cfg.train_dataset_weights is None
 
     trainer = SFTTrainer(cfg)
     tokenized = trainer.load_dataset()
@@ -427,7 +427,12 @@ def test_trainer_concatenates_multiple_pretokenized_stores(tmp_path):
     assert tokenized.dataset_lengths == [2, 1]
     assert list(tokenized.sequence_lengths) == [5, 3, 5]
 
-    # Multiple sources -> DataMixingSampler configured from the store lengths.
+    # No weights -> union sampling: the built-in shuffle (sampler=None) covers
+    # every row of every store exactly once per epoch.
+    assert trainer.build_train_sampler(tokenized) is None
+
+    # Explicit weights -> weighted mixing over the same stores.
+    cfg.train_dataset_weights = [0.5, 0.5]
     sampler = trainer.build_train_sampler(tokenized)
     assert sampler is not None
     assert len(list(iter(sampler))) > 0


### PR DESCRIPTION
## What

Multiple `train_datasets` (or `pretokenized_dataset_paths`) with **no `train_dataset_weights`** now sample as the **union** of the datasets: one shuffle over the concatenation per epoch, **without replacement** -- every sample of every dataset is seen exactly once per epoch, and each dataset's share of the batches follows its size.

Explicit weights behave exactly as before: weighted per-source mixing via `DataMixingSampler`, **with replacement** (the only way per-batch ratios can hold independent of dataset sizes).

## Why

Previously, unset weights were silently defaulted to equal mixing (`1/N` per source, with replacement). Two consequences surprised users who mentally modeled "I gave it two datasets, it trains on their union":

- A 10k-row source mixed with a 1M-row source got **50/50 batch representation by default** -- the small source oversampled ~100x, with no signal that rebalancing was happening.
- `num_epochs=1` was `len(union)` weighted **draws**, not a pass: some rows repeated, others were never seen (~37% missed even in the equal-size case), so "1 epoch" did not mean "saw everything once".

With this change the two sampling semantics map onto explicit user intent:

| Config | Semantics | Replacement | Epoch means |
|---|---|---|---|
| weights unset (default) | union of the datasets | without | every row of every dataset exactly once |
| weights set | rebalanced mix per the ratios | with | `len(union)` weighted draws |

## How

Small diff -- the machinery already existed:

- `_normalize_mixing_weights` no longer fills `[1/N] * N`; unset weights stay `None` as the union-sampling signal (explicit weights are validated as before).
- `build_train_sampler` returns `None` (the dataloader's built-in stateful `shuffle=True` -- a `randperm` over the `ConcatSFTDataset`) for `sampler="random"` unless weights are set. Checkpoint/resume is unchanged: the built-in shuffle path is the same one single-dataset runs already use.
- Docs (`multi_dataset.mdx`, `overview.mdx`, README) updated to describe both modes and the replacement semantics of each.

## ⚠️ Behavior change

Multi-dataset runs that relied on the implicit equal-weight default will now train on the union instead of a 1/N mix. To keep the old behavior, set the weights explicitly, e.g. `train_dataset_weights="[0.5,0.5]"`.

## Tests

- Config: unset weights stay `None` (no defaulted mixing); explicit-weights validation unchanged.
- Sampler dispatch: multi + no weights -> `None` (union); multi + weights -> `DataMixingSampler`.
- Coverage: one epoch over two unequal sources yields every index of both exactly once, shuffled, with a fresh permutation the next epoch.
- Trainer-level: two pretokenized stores without weights -> union; with weights -> mixing.
- Full `tests/train` suite green: 893 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for multi-dataset training defaults can alter data exposure and epoch meaning for existing configs; logic is localized to sampling/config with good test coverage, but reruns without explicit weights will not match prior equal-mix training.
> 
> **Overview**
> **Changes default multi-dataset SFT sampling** when `train_dataset_weights` is unset: instead of silently defaulting to equal `1/N` mixing via `DataMixingSampler` (with replacement), the trainer now **union-samples**—one stateful shuffle over the concatenated datasets **without replacement**, so each epoch sees every row once and batch mix follows dataset sizes.
> 
> **Implementation:** `_normalize_mixing_weights` keeps `train_dataset_weights` as `None` (no auto `[1/N, …]`). `build_train_sampler` only builds `DataMixingSampler` when weights are explicitly set; otherwise it returns `None` and uses the dataloader’s built-in shuffle (same checkpoint path as single-dataset runs). Explicit weights behave as before (weighted per-source mixing with replacement).
> 
> **Docs** (`multi_dataset.mdx`, `overview.mdx`, SFT README, `SFTConfig` field docs) describe union vs weighted modes and epoch semantics. **Tests** assert `None` weights, sampler dispatch, and per-epoch full union coverage.
> 
> **⚠️ Breaking:** Multi-dataset jobs that depended on implicit equal mixing need explicit weights (e.g. `[0.5, 0.5]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3698d281d5058d9d9fd1584089dfdf0104daf5f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->