### PR TITLE
fix(lora): backload optimizer before adapter swap

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/adapter_store.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/adapter_store.py
@@ -41,6 +41,23 @@ def _new_pinned_like(t: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(t, device="cpu").pin_memory()
 
 
+def _check_resident(t: torch.Tensor, what: str) -> None:
+    """Fail loudly if `t`'s storage has been freed by an offload.
+
+    Megatron offloads DDP buffers in place: `offload_grad_buffers()` /
+    `buffer.offload_to_cpu()` call `storage().resize_(0)` and leave the tensor
+    view intact ("accessing them during offload is undefined behavior").
+    copy_()ing such a tensor hands cudaMemcpyAsync a dangling device pointer,
+    which surfaces as a bare `CUDA error: invalid argument` from whichever
+    line touched it. Say what actually went wrong instead.
+    """
+    if t.numel() > 0 and t.untyped_storage().size() == 0:
+        raise RuntimeError(
+            f"AdapterStore: {what} is offloaded (storage freed); backload the "
+            "policy model *and* optimizer/grad buffers before swapping adapters."
+        )
+
+
 def _expected_lora_param_check(model_chunks) -> None:
     """Sanity-check: every trainable param under DDP buffers is a LoRA adapter param.
 
@@ -227,6 +244,8 @@ class AdapterStore:
     def _snapshot(self, slot: AdapterSlot, model_chunks, optimizer) -> None:
         """Copy live GPU state into `slot` (CPU)."""
         for mc_idx, buf_idx, buf in _iter_buffers(model_chunks):
+            _check_resident(buf.param_data, f"param buffer {mc_idx}/{buf_idx}")
+            _check_resident(buf.grad_data, f"grad buffer {mc_idx}/{buf_idx}")
             slot.cpu_param_data[mc_idx][buf_idx].copy_(buf.param_data, non_blocking=True)
             slot.cpu_grad_data[mc_idx][buf_idx].copy_(buf.grad_data, non_blocking=True)
         for opt_idx, _opt in enumerate(iter_opts(optimizer)):
@@ -254,6 +273,8 @@ class AdapterStore:
     def _restore(self, slot: AdapterSlot, model_chunks, optimizer) -> None:
         """Copy `slot` (CPU) into live GPU state."""
         for mc_idx, buf_idx, buf in _iter_buffers(model_chunks):
+            _check_resident(buf.param_data, f"param buffer {mc_idx}/{buf_idx}")
+            _check_resident(buf.grad_data, f"grad buffer {mc_idx}/{buf_idx}")
             buf.param_data.copy_(slot.cpu_param_data[mc_idx][buf_idx], non_blocking=True)
             buf.grad_data.copy_(slot.cpu_grad_data[mc_idx][buf_idx], non_blocking=True)
         for opt_idx, _opt in enumerate(iter_opts(optimizer)):

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -86,11 +86,20 @@ class WorkerDispatch:
         No-op when ``model_id is None`` (single-tenant / FFT path) or when
         the workers don't have an AdapterStore (non-LoRA strategies).
 
-        Must be called *after* ``_ensure_on_gpu(role, ...)`` so the model
-        and optimizer storages are live before we tensor.copy_() into them.
+        The swap tensor.copy_()s the live param buffer, grad buffer, fp32 main
+        params and Adam state to/from CPU slots, so all of them must be
+        resident first. Megatron's grad offload *frees* grad_data in place
+        (``storage().resize_(0)``) instead of moving it, so swapping while the
+        optimizer half is offloaded reads a dangling device pointer and dies
+        with "CUDA error: invalid argument". Hence we backload with
+        ``need_optimizer=True`` here rather than trusting the caller: paths
+        like ``forward`` and ``save_weights_for_sampler`` deliberately keep the
+        optimizer off GPU. For LoRA (the only case with adapters) the grad
+        buffer and optimizer state cover adapter params only, so this is cheap.
         """
         if model_id is None or role not in self._actor_groups:
             return
+        self._ensure_on_gpu(role, need_optimizer=True, need_model=True)
         ray.get(self._actor_groups[role].async_run_ray_method("pass_through", "swap_to_adapter", model_id))
 
     def register_adapter(self, role: str, model_id: str) -> None:
@@ -641,11 +650,14 @@ class WorkerDispatch:
                 "Pass inference_engine_client to WorkerDispatch constructor or call set_inference_engine_client()."
             )
 
-        # Sync weights to inference engine
-        self._prepare_for_weight_sync()
         # Make the requested adapter live on every worker before broadcasting
         # — otherwise we'd export some other tenant's LoRA weights to vLLM.
+        # This runs *before* _prepare_for_weight_sync: the swap needs the grad
+        # buffer + optimizer state resident (see ensure_active_adapter), and
+        # _prepare_for_weight_sync is what pushes them back off GPU.
         self.ensure_active_adapter("policy", model_id)
+        # Sync weights to inference engine
+        self._prepare_for_weight_sync()
         if self.colocate_all:
             await self._inference_engine_client.wake_up(tags=["weights"])
             self._broadcast_to_inference_engines(self._inference_engine_client, model_id=model_id)


### PR DESCRIPTION
The adapter swap copy_()s the live param buffer, grad buffer, fp32 main params and Adam state to/from CPU slots, so all of them must be resident. Megatron's grad offload frees grad_data in place (storage().resize_(0)) rather than moving it, so swapping while the optimizer half is offloaded reads a dangling device pointer and fails with a bare "CUDA error: invalid argument".

- ensure_active_adapter() now backloads with need_optimizer=True itself instead of trusting the caller, since paths like forward and save_weights_for_sampler deliberately keep the optimizer off GPU.
- Move ensure_active_adapter() ahead of _prepare_for_weight_sync(), which is what pushes those buffers back off GPU.
- Add _check_resident() in AdapterStore so a freed storage raises an actionable error instead of the opaque CUDA failure.