### PR TITLE
Retry transient inference proxy unavailability

### DIFF
--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -96,8 +96,8 @@ class SkyRLTrainInferenceForwardingClient:
             await session.commit()
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
-        # Retry missing/stale vLLM proxy discovery and transport failures; genuine
-        # vLLM response errors still surface immediately.
+        # Retry missing/stale vLLM proxy discovery and httpx transport errors.
+        # Keep vLLM HTTP 4xx/5xx responses non-retryable.
         timeout_sec = float(os.environ.get("SKYRL_PROXY_RETRY_TIMEOUT_SEC", "900"))
         backoff_sec = float(os.environ.get("SKYRL_PROXY_RETRY_BACKOFF_SEC", "5"))
         deadline = time.monotonic() + timeout_sec

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -96,19 +96,19 @@ class SkyRLTrainInferenceForwardingClient:
             await session.commit()
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
-        # A transient vLLM router<->worker breakdown surfaces as either httpx.RequestError
-        # (stale/dead cached proxy URL) or RuntimeError("...no proxy URL published...") (the
-        # router dropped its worker and hasn't republished yet). The engine/worker stays
-        # alive across these, so poll-retry with a re-read proxy URL instead of failing the
-        # whole run. Genuine vLLM 4xx/5xx responses still surface (not retried here).
+        # Retry missing/stale vLLM proxy discovery and transport failures; genuine
+        # vLLM response errors still surface immediately.
         timeout_sec = float(os.environ.get("SKYRL_PROXY_RETRY_TIMEOUT_SEC", "900"))
         backoff_sec = float(os.environ.get("SKYRL_PROXY_RETRY_BACKOFF_SEC", "5"))
         deadline = time.monotonic() + timeout_sec
         attempt = 0
+        last_tried_url = None
         while True:
             attempt += 1
             try:
-                proxy_url = await self._resolve_proxy_url(force_refresh=attempt > 1)
+                force_refresh = attempt > 1 and (last_tried_url is None or last_tried_url == self._cached_proxy_url)
+                proxy_url = await self._resolve_proxy_url(force_refresh=force_refresh)
+                last_tried_url = proxy_url
                 return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
             except httpx.RequestError as e:
                 last = f"{type(e).__name__}: {e}"

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -5,6 +5,8 @@ Pair to :class:`ExternalInferenceClient`; resolves the target URL from
 """
 
 import asyncio
+import os
+import time
 from datetime import datetime, timezone
 
 import httpx
@@ -94,20 +96,35 @@ class SkyRLTrainInferenceForwardingClient:
             await session.commit()
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
-        # httpx.RequestError covers ConnectError, ReadError, TimeoutException, etc.
-        # HTTP 4xx/5xx surfaces as RuntimeError below and is NOT retried.
-        try:
-            proxy_url = await self._resolve_proxy_url()
-            return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
-        except httpx.RequestError as e:
+        # A transient vLLM router<->worker breakdown surfaces as either httpx.RequestError
+        # (stale/dead cached proxy URL) or RuntimeError("...no proxy URL published...") (the
+        # router dropped its worker and hasn't republished yet). The engine/worker stays
+        # alive across these, so poll-retry with a re-read proxy URL instead of failing the
+        # whole run. Genuine vLLM 4xx/5xx responses still surface (not retried here).
+        timeout_sec = float(os.environ.get("SKYRL_PROXY_RETRY_TIMEOUT_SEC", "900"))
+        backoff_sec = float(os.environ.get("SKYRL_PROXY_RETRY_BACKOFF_SEC", "5"))
+        deadline = time.monotonic() + timeout_sec
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                proxy_url = await self._resolve_proxy_url(force_refresh=attempt > 1)
+                return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
+            except httpx.RequestError as e:
+                last = f"{type(e).__name__}: {e}"
+            except RuntimeError as e:
+                if "no proxy URL published" not in str(e):
+                    raise
+                last = str(e)
+            if time.monotonic() >= deadline:
+                raise RuntimeError(f"inference proxy unavailable after {attempt} attempts / {timeout_sec:.0f}s: {last}")
             logger.warning(
-                "Network error talking to %s (%s: %s) — refreshing proxy URL and retrying once",
-                self._cached_proxy_url,
-                type(e).__name__,
-                e,
+                "vLLM proxy unavailable (attempt %d: %s) — re-reading proxy URL, retrying in %.0fs",
+                attempt,
+                last,
+                backoff_sec,
             )
-            proxy_url = await self._resolve_proxy_url(force_refresh=True)
-            return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
+            await asyncio.sleep(backoff_sec)
 
     async def _forward(
         self, proxy_url: str, sample_req, model_id: str, *, base_model: str | None

--- a/tests/tinker/skyrl_train/test_inference_forwarding_retry.py
+++ b/tests/tinker/skyrl_train/test_inference_forwarding_retry.py
@@ -14,37 +14,27 @@ def forwarding_client() -> SkyRLTrainInferenceForwardingClient:
     return client
 
 
+@pytest.mark.parametrize("failure", ["missing_proxy", "network"])
 @pytest.mark.asyncio
-async def test_missing_proxy_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_transient_proxy_failure_is_retried(monkeypatch: pytest.MonkeyPatch, failure: str) -> None:
     monkeypatch.setenv("SKYRL_PROXY_RETRY_TIMEOUT_SEC", "1")
     monkeypatch.setenv("SKYRL_PROXY_RETRY_BACKOFF_SEC", "0")
     client = forwarding_client()
-    client._resolve_proxy_url = AsyncMock(
-        side_effect=[RuntimeError("inference engine not ready: no proxy URL published"), "http://proxy"]
-    )
     expected = object()
-    client._forward = AsyncMock(return_value=expected)
+    if failure == "missing_proxy":
+        client._resolve_proxy_url = AsyncMock(
+            side_effect=[RuntimeError("inference engine not ready: no proxy URL published"), "http://proxy"]
+        )
+        client._forward = AsyncMock(return_value=expected)
+    else:
+        client._cached_proxy_url = "http://stale-proxy"
+        client._resolve_proxy_url = AsyncMock(side_effect=["http://stale-proxy", "http://fresh-proxy"])
+        client._forward = AsyncMock(side_effect=[httpx.ConnectError("connection lost"), expected])
 
     result = await client._forward_with_retry(object(), "model", base_model=None)
 
     assert result is expected
     assert client._resolve_proxy_url.await_count == 2
-    client._resolve_proxy_url.assert_awaited_with(force_refresh=True)
-
-
-@pytest.mark.asyncio
-async def test_proxy_network_error_refreshes_and_retries(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SKYRL_PROXY_RETRY_TIMEOUT_SEC", "1")
-    monkeypatch.setenv("SKYRL_PROXY_RETRY_BACKOFF_SEC", "0")
-    client = forwarding_client()
-    client._cached_proxy_url = "http://stale-proxy"
-    client._resolve_proxy_url = AsyncMock(side_effect=["http://stale-proxy", "http://fresh-proxy"])
-    expected = object()
-    client._forward = AsyncMock(side_effect=[httpx.ConnectError("connection lost"), expected])
-
-    result = await client._forward_with_retry(object(), "model", base_model=None)
-
-    assert result is expected
     client._resolve_proxy_url.assert_awaited_with(force_refresh=True)
 
 

--- a/tests/tinker/skyrl_train/test_inference_forwarding_retry.py
+++ b/tests/tinker/skyrl_train/test_inference_forwarding_retry.py
@@ -1,0 +1,62 @@
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
+    SkyRLTrainInferenceForwardingClient,
+)
+
+
+def forwarding_client() -> SkyRLTrainInferenceForwardingClient:
+    client = object.__new__(SkyRLTrainInferenceForwardingClient)
+    client._cached_proxy_url = None
+    return client
+
+
+@pytest.mark.asyncio
+async def test_missing_proxy_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SKYRL_PROXY_RETRY_TIMEOUT_SEC", "1")
+    monkeypatch.setenv("SKYRL_PROXY_RETRY_BACKOFF_SEC", "0")
+    client = forwarding_client()
+    client._resolve_proxy_url = AsyncMock(
+        side_effect=[RuntimeError("inference engine not ready: no proxy URL published"), "http://proxy"]
+    )
+    expected = object()
+    client._forward = AsyncMock(return_value=expected)
+
+    result = await client._forward_with_retry(object(), "model", base_model=None)
+
+    assert result is expected
+    assert client._resolve_proxy_url.await_count == 2
+    client._resolve_proxy_url.assert_awaited_with(force_refresh=True)
+
+
+@pytest.mark.asyncio
+async def test_proxy_network_error_refreshes_and_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SKYRL_PROXY_RETRY_TIMEOUT_SEC", "1")
+    monkeypatch.setenv("SKYRL_PROXY_RETRY_BACKOFF_SEC", "0")
+    client = forwarding_client()
+    client._cached_proxy_url = "http://stale-proxy"
+    client._resolve_proxy_url = AsyncMock(side_effect=["http://stale-proxy", "http://fresh-proxy"])
+    expected = object()
+    client._forward = AsyncMock(side_effect=[httpx.ConnectError("connection lost"), expected])
+
+    result = await client._forward_with_retry(object(), "model", base_model=None)
+
+    assert result is expected
+    client._resolve_proxy_url.assert_awaited_with(force_refresh=True)
+
+
+@pytest.mark.asyncio
+async def test_non_transient_runtime_error_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SKYRL_PROXY_RETRY_TIMEOUT_SEC", "1")
+    monkeypatch.setenv("SKYRL_PROXY_RETRY_BACKOFF_SEC", "0")
+    client = forwarding_client()
+    client._resolve_proxy_url = AsyncMock(return_value="http://proxy")
+    client._forward = AsyncMock(side_effect=RuntimeError("vLLM returned 400"))
+
+    with pytest.raises(RuntimeError, match="vLLM returned 400"):
+        await client._forward_with_retry(object(), "model", base_model=None)
+
+    client._forward.assert_awaited_once()


### PR DESCRIPTION
- Retry a missing or stale vLLM proxy until the engine republishes its URL instead of failing the sample immediately.
- Keep genuine vLLM response errors non-retryable and cover both paths with focused tests.

## Testing

```
uv run --extra dev --extra tinker pytest tests/tinker/skyrl_train/test_inference_forwarding_retry.py
uv run --extra dev pre-commit run --files skyrl/tinker/extra/skyrl_train_inference_forwarding.py tests/tinker/skyrl_train/test_inference_forwarding_retry.py
```

Verified 3 retry tests pass and all configured hooks pass.