### PR TITLE
[fix][train] Shut down DataLoader workers on exit

### DIFF
--- a/skyrl/train/entrypoints/main_base.py
+++ b/skyrl/train/entrypoints/main_base.py
@@ -333,6 +333,12 @@ class BasePPOExp:
             else:
                 logger.error(f"Setup failed before tracker was initialized:\n{e}")
             raise
+        finally:
+            if self.trainer is not None:
+                try:
+                    self.trainer.shutdown()
+                except Exception:
+                    logger.exception("Failed to shut down trainer resources")
 
 
 @ray.remote(num_cpus=1)

--- a/skyrl/train/main_sft.py
+++ b/skyrl/train/main_sft.py
@@ -42,7 +42,6 @@ def sft_entrypoint(cfg: SFTConfig, skyrl_cfg: SkyRLTrainConfig):
     try:
         trainer.setup()
         trainer.train()
-        trainer.shutdown()
     except Exception as e:
         # OOMs (and other crashes) raised inside actor init / training surface
         # here. Route them through the tracker so wandb users see them as an
@@ -52,6 +51,11 @@ def sft_entrypoint(cfg: SFTConfig, skyrl_cfg: SkyRLTrainConfig):
         else:
             logger.error(f"SFT setup failed before tracker was initialized:\n{e}")
         raise
+    finally:
+        try:
+            trainer.shutdown()
+        except Exception:
+            logger.exception("Failed to shut down SFT trainer resources")
 
 
 def main():

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -72,6 +72,7 @@ from skyrl.train.utils.trainer_utils import (
     GLOBAL_STEP_PREFIX,
     cleanup_old_checkpoints,
     extract_step_from_path,
+    shutdown_dataloader,
     validate_consistency_for_latest_checkpoint,
 )
 from skyrl.train.utils.utils import ResolvedPlacementGroup, Timer
@@ -2245,13 +2246,22 @@ class SFTTrainer:
     # ------------------------------------------------------------------ #
 
     def shutdown(self):
-        """Finish tracking.
+        """Stop DataLoader workers and finish tracking.
 
         Does NOT call ``ray.shutdown()`` -- when running inside a Ray task
         (the normal path via ``sft_entrypoint``), shutting down Ray from
         within the task would be incorrect.  The head-node process owns
         the Ray lifecycle.
         """
+        dataloaders = [("train", self.train_dataloader)]
+        if self.eval_dataloaders is not None:
+            dataloaders.extend((f"eval/{name}", dataloader) for name, dataloader in self.eval_dataloaders)
+        for name, dataloader in dataloaders:
+            try:
+                shutdown_dataloader(dataloader)
+            except Exception:
+                logger.exception(f"Failed to shut down {name} DataLoader workers")
+
         if self._ray_gpu_monitor is not None:
             self._ray_gpu_monitor.stop()
         if self.tracker is not None:

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -2253,14 +2253,17 @@ class SFTTrainer:
         within the task would be incorrect.  The head-node process owns
         the Ray lifecycle.
         """
-        dataloaders = [("train", self.train_dataloader)]
+        try:
+            shutdown_dataloader(self.train_dataloader)
+        except Exception:
+            logger.exception("Failed to shut down train DataLoader workers")
+
         if self.eval_dataloaders is not None:
-            dataloaders.extend((f"eval/{name}", dataloader) for name, dataloader in self.eval_dataloaders)
-        for name, dataloader in dataloaders:
-            try:
-                shutdown_dataloader(dataloader)
-            except Exception:
-                logger.exception(f"Failed to shut down {name} DataLoader workers")
+            for name, dataloader in self.eval_dataloaders:
+                try:
+                    shutdown_dataloader(dataloader)
+                except Exception:
+                    logger.exception(f"Failed to shut down eval/{name} DataLoader workers")
 
         if self._ray_gpu_monitor is not None:
             self._ray_gpu_monitor.stop()

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -91,6 +91,7 @@ from skyrl.train.utils.trainer_utils import (
     extract_step_from_path,
     finalize_minibatch_rollout_logprob_diff_std,
     run_on_each_node,
+    shutdown_dataloader,
     validate_consistency_for_latest_checkpoint,
     validate_generator_output,
     zero_variance_filter,
@@ -618,6 +619,17 @@ class RayPPOTrainer:
             logger.warning(f"Failed to flush pending metrics at step {self.global_step}: {e}")
         self.all_metrics = {}
         self.all_timings = {}
+
+    def shutdown(self) -> None:
+        """Stop train and evaluation DataLoader workers."""
+        for name, dataloader in (
+            ("train", self.train_dataloader),
+            ("eval", self.eval_dataloader),
+        ):
+            try:
+                shutdown_dataloader(dataloader)
+            except Exception:
+                logger.exception(f"Failed to shut down {name} DataLoader workers")
 
     def _remove_tail_data(self, entries: List[Any]) -> List[Any]:
         """Remove tail data to have even shards in terms of *effective* samples.

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -874,3 +874,18 @@ def build_dataloader(
         logger.info(f"Validation set size: {len(dataloader)}")
 
     return dataloader
+
+
+def shutdown_dataloader(dataloader: Optional[StatefulDataLoader]) -> None:
+    """Stop worker processes owned by a ``StatefulDataLoader``."""
+    if dataloader is None:
+        return
+
+    # torchdata 0.11 exposes worker shutdown only on its iterator.
+    iterator = getattr(dataloader, "_iterator", None)
+    shutdown_workers = getattr(iterator, "_shutdown_workers", None)
+    if shutdown_workers is None:
+        return
+
+    shutdown_workers()
+    dataloader._iterator = None

--- a/tests/train/test_sft_dataloader.py
+++ b/tests/train/test_sft_dataloader.py
@@ -132,6 +132,33 @@ def _flatten(batches) -> list:
     return out
 
 
+def test_shutdown_stops_train_and_eval_dataloader_workers() -> None:
+    def make_dataloader() -> StatefulDataLoader:
+        return StatefulDataLoader(
+            list(range(8)),
+            batch_size=2,
+            num_workers=1,
+            multiprocessing_context="spawn",
+        )
+
+    train_dataloader = make_dataloader()
+    eval_dataloader = make_dataloader()
+    next(iter(train_dataloader))
+    next(iter(eval_dataloader))
+    workers = [*train_dataloader._iterator._workers, *eval_dataloader._iterator._workers]
+
+    trainer = object.__new__(SFTTrainer)
+    trainer.train_dataloader = train_dataloader
+    trainer.eval_dataloaders = [("validation", eval_dataloader)]
+    trainer._ray_gpu_monitor = None
+    trainer.tracker = None
+
+    trainer.shutdown()
+    trainer.shutdown()
+
+    assert all(not worker.is_alive() for worker in workers)
+
+
 # ---------------------------------------------------------------------------
 # StatefulSequentialSampler (core)
 # ---------------------------------------------------------------------------

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -2,7 +2,7 @@
 uv  run --isolated --extra dev pytest tests/train/test_trainer.py
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
@@ -309,6 +309,7 @@ def test_run_flushes_pending_metrics_before_logging_exception():
     exp = BasePPOExp.__new__(BasePPOExp)
     trainer = MagicMock()
     trainer.global_step = 7
+    trainer.shutdown.side_effect = RuntimeError("cleanup failed")
 
     def fake_setup_trainer():
         # Mirror _setup_trainer: expose the trainer on the exp, then crash
@@ -322,11 +323,31 @@ def test_run_flushes_pending_metrics_before_logging_exception():
         exp.run()
 
     ordered_calls = [
-        name for name, _, _ in trainer.mock_calls if name in ("flush_pending_metrics", "tracker.log_exception")
+        name
+        for name, _, _ in trainer.mock_calls
+        if name in ("flush_pending_metrics", "tracker.log_exception", "shutdown")
     ]
-    assert ordered_calls == ["flush_pending_metrics", "tracker.log_exception"]
+    assert ordered_calls == ["flush_pending_metrics", "tracker.log_exception", "shutdown"]
     trainer.tracker.log_exception.assert_called_once()
     assert trainer.tracker.log_exception.call_args.kwargs["step"] == 7
+
+
+def test_run_shuts_down_trainer_after_success():
+    from skyrl.train.entrypoints.main_base import BasePPOExp
+
+    exp = BasePPOExp.__new__(BasePPOExp)
+    trainer = MagicMock()
+    trainer.train = AsyncMock()
+
+    def fake_setup_trainer():
+        exp.trainer = trainer
+        return trainer
+
+    exp._setup_trainer = fake_setup_trainer
+
+    exp.run()
+
+    trainer.shutdown.assert_called_once_with()
 
 
 def test_micro_batches_accumulated_initialized():

--- a/tests/train/test_trainer_utils.py
+++ b/tests/train/test_trainer_utils.py
@@ -27,6 +27,7 @@ from skyrl.train.utils.trainer_utils import (
     handle_replace_sampling,
     run_on_each_node,
     sanitize_data_source,
+    shutdown_dataloader,
     validate_consistency_for_latest_checkpoint,
     validate_generator_output,
     zero_variance_filter,
@@ -970,6 +971,21 @@ def test_build_dataloader_worker_config(
         None if dataloader.multiprocessing_context is None else dataloader.multiprocessing_context.get_start_method()
     )
     assert start_method == expected_start_method
+
+
+def test_shutdown_dataloader_stops_spawned_workers(dummy_config) -> None:
+    config = copy.deepcopy(dummy_config)
+    config.data.dataloader.num_workers = 1
+    dataloader = build_dataloader(config, MultiItemDataset(size=8), is_train=True)
+
+    next(iter(dataloader))
+    workers = list(dataloader._iterator._workers)
+    assert all(worker.is_alive() for worker in workers)
+
+    shutdown_dataloader(dataloader)
+    shutdown_dataloader(dataloader)
+
+    assert all(not worker.is_alive() for worker in workers)
 
 
 def test_validate_generator_output_invalid_rewards():


### PR DESCRIPTION
## Summary

`StatefulDataLoader` owns worker processes through its iterator. RL and SFT entrypoints only cleaned up dataloaders on successful runs, so training exceptions could leave train or evaluation workers alive.

## Changes

- Add a guarded, idempotent shutdown helper for torchdata 0.11.
- Shut down RL train and evaluation dataloaders on success and failure.
- Move SFT shutdown into the entrypoint's `finally` block and close every train and evaluation dataloader.
- Log cleanup failures without masking the original training exception.

Normal Python unwinding is covered. Abrupt termination such as `SIGKILL` remains outside scope.

## Testing

- Focused lifecycle tests (`123 passed`)
- Full prior SkyRL Train CPU suite (`1467 passed, 5 skipped, 5 deselected`)
- Tests start real train and evaluation workers, call shutdown twice, and verify every worker exits
- `pre-commit run --all-files`
- `git diff --check upstream/main`