### PR TITLE
Initialize base inference before training model creation

### DIFF
--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -429,6 +429,18 @@ class SkyRLTrainBackend(AbstractBackend):
             self._render_server.shutdown()
             self._render_server = None
 
+    def initialize_base_inference(self) -> None:
+        """Start base-model inference before the first training model is created."""
+        if self._inference_engines_initialized:
+            return
+        self._cfg = _build_skyrl_train_config(self.base_model, self.config)
+        if not ray.is_initialized():
+            logger.info("Initializing Ray for base-model inference")
+            initialize_ray(self._cfg)
+        self._colocate_pg = self._create_colocate_pg() if self._cfg.trainer.placement.colocate_all else None
+        self._create_new_inference_client()
+        self._inference_engines_initialized = True
+
     def _lora_signature_from(self, lora_config: types.LoraConfig) -> tuple:
         # Tinker's public LoraConfig only exposes rank + alpha (plus
         # seed/train_attn/train_mlp/train_unembed) - pending support https://github.com/NovaSky-AI/SkyRL/issues/1632.
@@ -497,6 +509,9 @@ class SkyRLTrainBackend(AbstractBackend):
 
             logger.info("Building models.")
             self._build_policy(PolicyWorker, model_id=model_id)
+            if self._inference_engines_initialized:
+                self._dispatch.set_inference_engine_client(self._inference_engine_client)
+                self.init_weight_sync_state()
             if is_lora:
                 self._base_lora_signature = self._lora_signature_from(lora_config)
         elif model_role == "critic":

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -272,6 +272,10 @@ class TinkerEngine:
         if hasattr(self.backend, "set_inference_state_publisher"):
             self.backend.set_inference_state_publisher(self._write_inference_state_to_db)
 
+        is_colocated = bool(config.backend_config.get("trainer.placement.colocate_all", True))
+        if not is_colocated and hasattr(self.backend, "initialize_base_inference"):
+            self.backend.initialize_base_inference()
+
         # Track last cleanup time for periodic stale session cleanup
         self._last_cleanup_time: float = time.time()
 
@@ -295,6 +299,11 @@ class TinkerEngine:
             row.updated_at = datetime.now(timezone.utc)
             session.add(row)
             session.commit()
+        if proxy_url is not None:
+            logger.info(
+                'SKYRL_DEPLOYMENT_EVENT {"event":"inference_proxy_published","model":"%s"}',
+                self.config.base_model,
+            )
 
     @contextmanager
     def _checkpoint_status_context(self, model_id: str, checkpoint_id: str, checkpoint_type: types.CheckpointType):

--- a/tests/tinker/skyrl_train/test_text_only_batch_no_inference.py
+++ b/tests/tinker/skyrl_train/test_text_only_batch_no_inference.py
@@ -128,3 +128,25 @@ def test_engine_init_invalidates_cpu_render_state():
     assert fake_self._renderer is None
     assert render_server.shutdown_called
     assert fake_self._render_server is None
+
+
+def test_base_inference_initializes_without_training_dispatch(monkeypatch):
+    cfg = SimpleNamespace(trainer=SimpleNamespace(placement=SimpleNamespace(colocate_all=False)))
+    calls = []
+    fake_self = SimpleNamespace(
+        _inference_engines_initialized=False,
+        base_model="model_test",
+        config=object(),
+        _cfg=None,
+        _colocate_pg=None,
+        _create_new_inference_client=lambda: calls.append("inference"),
+    )
+    monkeypatch.setattr(skyrl_train_backend, "_build_skyrl_train_config", lambda *_args: cfg)
+    monkeypatch.setattr(skyrl_train_backend.ray, "is_initialized", lambda: True)
+
+    skyrl_train_backend.SkyRLTrainBackend.initialize_base_inference(fake_self)
+
+    assert fake_self._cfg is cfg
+    assert not hasattr(fake_self, "_dispatch")
+    assert fake_self._inference_engines_initialized
+    assert calls == ["inference"]


### PR DESCRIPTION
- Initialize non-colocated base-model inference when the service starts, before any training model exists.
- Publish a structured readiness event after the inference proxy reaches the shared engine-state database.
- Reuse the warm inference client when the first training model is created.

## Testing

```
ruff check skyrl/backends/skyrl_train_backend.py skyrl/tinker/engine.py tests/tinker/skyrl_train/test_text_only_batch_no_inference.py
```

Focused backend tests: 10 passed; two unrelated JAX engine tests require the JAX extra.
