### PR TITLE
[fix][fsdp] Resume bitsandbytes checkpoints strictly

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -67,9 +67,12 @@ _BNB_QUANTIZATION_STATE_SUFFIXES = (
 
 
 def _is_bnb_quantization_state_key(key: str, loaded_keys: set[str]) -> bool:
-    return any(
-        key.endswith(suffix) and key[: -len(suffix)] in loaded_keys for suffix in _BNB_QUANTIZATION_STATE_SUFFIXES
-    )
+    if not key.endswith(_BNB_QUANTIZATION_STATE_SUFFIXES):
+        return False
+    for suffix in _BNB_QUANTIZATION_STATE_SUFFIXES:
+        if key.endswith(suffix):
+            return key[: -len(suffix)] in loaded_keys
+    return False
 
 
 def _load_model_state_dict(model: nn.Module, state_dict, *, strict: bool) -> None:
@@ -78,7 +81,7 @@ def _load_model_state_dict(model: nn.Module, state_dict, *, strict: bool) -> Non
         return
 
     incompatible = model.load_state_dict(state_dict, strict=False)
-    loaded_keys = set(state_dict).difference(incompatible.unexpected_keys)
+    loaded_keys = state_dict.keys() - incompatible.unexpected_keys
     unexpected = [key for key in incompatible.unexpected_keys if not _is_bnb_quantization_state_key(key, loaded_keys)]
     if incompatible.missing_keys or unexpected:
         errors = []

--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -83,12 +83,31 @@ def _load_model_state_dict(model: nn.Module, state_dict, *, strict: bool) -> Non
     incompatible = model.load_state_dict(state_dict, strict=False)
     loaded_keys = state_dict.keys() - incompatible.unexpected_keys
     unexpected = [key for key in incompatible.unexpected_keys if not _is_bnb_quantization_state_key(key, loaded_keys)]
-    if incompatible.missing_keys or unexpected:
+    metadata_keys = set(incompatible.unexpected_keys) - set(unexpected)
+    mismatched_metadata = []
+    if metadata_keys:
+        # Linear4bit saves quantization state but does not restore it through
+        # load_state_dict. Ignoring it is safe only when the frozen base was
+        # initialized with exactly the same state. Otherwise the loaded packed
+        # bytes would be interpreted using different scales or a different codebook.
+        initialized_state = model.state_dict()
+        mismatched_metadata = [
+            key
+            for key in sorted(metadata_keys)
+            if key not in initialized_state
+            or not torch.equal(state_dict[key].detach().cpu(), initialized_state[key].detach().cpu())
+        ]
+    if incompatible.missing_keys or unexpected or mismatched_metadata:
         errors = []
         if incompatible.missing_keys:
             errors.append(f"Missing key(s): {incompatible.missing_keys}")
         if unexpected:
             errors.append(f"Unexpected key(s): {unexpected}")
+        if mismatched_metadata:
+            errors.append(
+                f"Bitsandbytes quantization state differs from the initialized model: {mismatched_metadata}. "
+                "Resume with the same base model and quantization settings."
+            )
         raise RuntimeError("Error(s) in loading model state_dict:\n\t" + "\n\t".join(errors))
 
 

--- a/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_strategy.py
@@ -56,6 +56,39 @@ else:
     CPUOffloadPolicy, FSDPModule, MixedPrecisionPolicy = None, None, None
 
 
+_BNB_QUANTIZATION_STATE_SUFFIXES = (
+    ".absmax",
+    ".quant_map",
+    ".nested_absmax",
+    ".nested_quant_map",
+    ".quant_state.bitsandbytes__fp4",
+    ".quant_state.bitsandbytes__nf4",
+)
+
+
+def _is_bnb_quantization_state_key(key: str, loaded_keys: set[str]) -> bool:
+    return any(
+        key.endswith(suffix) and key[: -len(suffix)] in loaded_keys for suffix in _BNB_QUANTIZATION_STATE_SUFFIXES
+    )
+
+
+def _load_model_state_dict(model: nn.Module, state_dict, *, strict: bool) -> None:
+    if not strict:
+        model.load_state_dict(state_dict, strict=False)
+        return
+
+    incompatible = model.load_state_dict(state_dict, strict=False)
+    loaded_keys = set(state_dict).difference(incompatible.unexpected_keys)
+    unexpected = [key for key in incompatible.unexpected_keys if not _is_bnb_quantization_state_key(key, loaded_keys)]
+    if incompatible.missing_keys or unexpected:
+        errors = []
+        if incompatible.missing_keys:
+            errors.append(f"Missing key(s): {incompatible.missing_keys}")
+        if unexpected:
+            errors.append(f"Unexpected key(s): {unexpected}")
+        raise RuntimeError("Error(s) in loading model state_dict:\n\t" + "\n\t".join(errors))
+
+
 class FSDPStrategy(DistributedStrategy):
     """
     The strategy for training with FSDP.
@@ -519,7 +552,7 @@ class FSDPStrategy(DistributedStrategy):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             # FSDP2: load_state_dict accepts DTensors directly; no state_dict_type context needed.
-            load_model.load_state_dict(model_state_dict, strict=load_module_strict)
+            _load_model_state_dict(load_model, model_state_dict, strict=load_module_strict)
             self.print(f"[rank-{rank}]: Successfully loaded model state dict")
 
             # Load optimizer state dict if optimizer object is provided and loading is requested

--- a/tests/backends/skyrl_train/distributed/test_fsdp_checkpoint.py
+++ b/tests/backends/skyrl_train/distributed/test_fsdp_checkpoint.py
@@ -6,6 +6,18 @@ from skyrl.backends.skyrl_train.distributed.fsdp_strategy import (
 )
 
 
+class LinearWithSavedMetadata(torch.nn.Linear):
+    """Exercise metadata emitted by state_dict but not consumed by its loader."""
+
+    def __init__(self, suffix):
+        super().__init__(2, 2)
+        self.suffix = suffix
+
+    def _save_to_state_dict(self, destination, prefix, keep_vars):
+        super()._save_to_state_dict(destination, prefix, keep_vars)
+        destination[f"{prefix}weight{self.suffix}"] = torch.tensor(0)
+
+
 @pytest.mark.parametrize(
     "suffix",
     [
@@ -18,11 +30,36 @@ from skyrl.backends.skyrl_train.distributed.fsdp_strategy import (
     ],
 )
 def test_strict_load_allows_bitsandbytes_quantization_metadata(suffix: str) -> None:
-    model = torch.nn.Linear(2, 2)
+    model = LinearWithSavedMetadata(suffix)
     state_dict = model.state_dict()
-    state_dict[f"weight{suffix}"] = torch.tensor(0)
 
     _load_model_state_dict(model, state_dict, strict=True)
+
+
+def test_strict_load_rejects_changed_quantization_metadata() -> None:
+    model = LinearWithSavedMetadata(".absmax")
+    state_dict = model.state_dict()
+    state_dict["weight.absmax"] = torch.tensor(1)
+
+    with pytest.raises(RuntimeError, match="quantization state differs"):
+        _load_model_state_dict(model, state_dict, strict=True)
+
+
+def test_strict_load_rejects_quantization_metadata_for_ordinary_weight() -> None:
+    model = torch.nn.Linear(2, 2)
+    state_dict = model.state_dict()
+    state_dict["weight.absmax"] = torch.tensor(0)
+
+    with pytest.raises(RuntimeError, match="quantization state differs"):
+        _load_model_state_dict(model, state_dict, strict=True)
+
+
+def test_non_strict_load_still_ignores_metadata() -> None:
+    model = LinearWithSavedMetadata(".absmax")
+    state_dict = model.state_dict()
+    state_dict["weight.absmax"] = torch.tensor(1)
+
+    _load_model_state_dict(model, state_dict, strict=False)
 
 
 @pytest.mark.parametrize(
@@ -44,3 +81,54 @@ def test_strict_load_allows_bitsandbytes_quantization_metadata(suffix: str) -> N
 def test_strict_load_rejects_other_incompatible_keys(state_dict) -> None:
     with pytest.raises(RuntimeError, match="loading model state_dict"):
         _load_model_state_dict(torch.nn.Linear(2, 2), state_dict, strict=True)
+
+
+def _quantized_linear(bnb, weight, quant_type, double_quant):
+    model = bnb.nn.Linear4bit(
+        64,
+        64,
+        bias=False,
+        quant_type=quant_type,
+        compress_statistics=double_quant,
+        quant_storage=torch.bfloat16,
+        compute_dtype=torch.bfloat16,
+    )
+    model.weight.data.copy_(weight)
+    return model.to("cpu")
+
+
+@pytest.mark.parametrize("quant_type", ["fp4", "nf4"])
+@pytest.mark.parametrize("double_quant", [False, True])
+def test_bitsandbytes_strict_resume_preserves_outputs(quant_type, double_quant):
+    bnb = pytest.importorskip("bitsandbytes", minversion="0.50.2")
+    generator = torch.Generator().manual_seed(17)
+    weight = torch.randn(64, 64, dtype=torch.bfloat16, generator=generator)
+    inputs = torch.randn(3, 64, dtype=torch.bfloat16, generator=generator)
+    saved = _quantized_linear(bnb, weight, quant_type, double_quant)
+    resumed = _quantized_linear(bnb, weight, quant_type, double_quant)
+    state_dict = {key: value.clone() for key, value in saved.state_dict().items()}
+    expected = saved(inputs)
+    # Prove that the load restores bytes, rather than merely retaining a model
+    # that was already initialized to the expected weights.
+    with torch.no_grad():
+        resumed.weight.zero_()
+
+    _load_model_state_dict(resumed, state_dict, strict=True)
+
+    torch.testing.assert_close(resumed(inputs), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("changed", ["quant_type", "double_quant", "base_weight"])
+def test_bitsandbytes_strict_resume_rejects_incompatible_quantization(changed):
+    bnb = pytest.importorskip("bitsandbytes", minversion="0.50.2")
+    weight = torch.randn(64, 64, dtype=torch.bfloat16, generator=torch.Generator().manual_seed(17))
+    saved = _quantized_linear(bnb, weight, "nf4", True)
+    resumed = _quantized_linear(
+        bnb,
+        weight * 2 if changed == "base_weight" else weight,
+        "fp4" if changed == "quant_type" else "nf4",
+        changed != "double_quant",
+    )
+
+    with pytest.raises(RuntimeError, match="Resume with the same base model and quantization settings"):
+        _load_model_state_dict(resumed, saved.state_dict(), strict=True)

--- a/tests/backends/skyrl_train/distributed/test_fsdp_checkpoint.py
+++ b/tests/backends/skyrl_train/distributed/test_fsdp_checkpoint.py
@@ -1,0 +1,35 @@
+import pytest
+import torch
+
+from skyrl.backends.skyrl_train.distributed.fsdp_strategy import (
+    _load_model_state_dict,
+)
+
+
+def test_strict_load_allows_bitsandbytes_quantization_metadata() -> None:
+    model = torch.nn.Linear(2, 2)
+    state_dict = model.state_dict()
+    state_dict["weight.quant_state.bitsandbytes__nf4"] = torch.tensor(0)
+
+    _load_model_state_dict(model, state_dict, strict=True)
+
+
+@pytest.mark.parametrize(
+    "state_dict",
+    [
+        {"weight": torch.zeros(2, 2)},
+        {
+            "weight": torch.zeros(2, 2),
+            "bias": torch.zeros(2),
+            "unexpected": torch.tensor(0),
+        },
+        {
+            "weight": torch.zeros(2, 2),
+            "bias": torch.zeros(2),
+            "unexpected.absmax": torch.tensor(0),
+        },
+    ],
+)
+def test_strict_load_rejects_other_incompatible_keys(state_dict) -> None:
+    with pytest.raises(RuntimeError, match="loading model state_dict"):
+        _load_model_state_dict(torch.nn.Linear(2, 2), state_dict, strict=True)

--- a/tests/backends/skyrl_train/distributed/test_fsdp_checkpoint.py
+++ b/tests/backends/skyrl_train/distributed/test_fsdp_checkpoint.py
@@ -6,10 +6,21 @@ from skyrl.backends.skyrl_train.distributed.fsdp_strategy import (
 )
 
 
-def test_strict_load_allows_bitsandbytes_quantization_metadata() -> None:
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        ".absmax",
+        ".quant_map",
+        ".nested_absmax",
+        ".nested_quant_map",
+        ".quant_state.bitsandbytes__fp4",
+        ".quant_state.bitsandbytes__nf4",
+    ],
+)
+def test_strict_load_allows_bitsandbytes_quantization_metadata(suffix: str) -> None:
     model = torch.nn.Linear(2, 2)
     state_dict = model.state_dict()
-    state_dict["weight.quant_state.bitsandbytes__nf4"] = torch.tensor(0)
+    state_dict[f"weight{suffix}"] = torch.tensor(0)
 
     _load_model_state_dict(model, state_dict, strict=True)
 


### PR DESCRIPTION
## Summary

FSDP checkpoints for bitsandbytes 4-bit modules include quantization metadata beside each packed weight. Freshly constructed modules can accept the weight while reporting that metadata as unexpected, causing strict resume to fail before optimizer, scheduler, RNG, or dataloader state is restored.

Accept known FP4/NF4 metadata only when its associated weight loaded and the metadata matches the initialized model. A mismatch must fail: `Linear4bit.load_state_dict` does not restore that quantization state, so loading NF4 packed bytes into an FP4 model otherwise silently produces wrong outputs. The same check covers changed base scales and double-quantization settings.

Missing model keys and unrelated unexpected keys still fail strict loading. Non-strict loading and the saved checkpoint format are unchanged.

## Validation

- 19 focused tests pass with actual bitsandbytes 0.50.2 and PyTorch 2.11 on CPU. The five new mismatch rejections fail against the previous helper.
- NF4/FP4 and both double-quantization settings restore exact outputs after destination packed weights are deliberately cleared.
- Independent review reran all 19 tests and verified a real nested PEFT + bitsandbytes checkpoint round trip, including trained adapters.
- Without the optional bitsandbytes dependency, 12 tests pass and 7 integration cases skip.
- Required Ruff, Black, gitleaks, and diff checks pass.

The earlier PR version had single-GPU NF4 QLoRA resume validation from step 20 to 40 and then 40 to 60, with training state restored, nonzero gradients, and subsequent checkpoints. The new metadata comparison has CPU regression coverage; GPU/FSDP integration has not been rerun for this follow-up.

## Repro command

```bash
uv run --isolated --extra fsdp --extra dev pytest --noconftest \
  tests/backends/skyrl_train/distributed/test_fsdp_checkpoint.py -q
```

## Downsides

Strict loading compares ignored scale and codebook tensors on the CPU, adding host copies when initialized quantization state is on the GPU. It does not gather packed model weights or add distributed collectives. Resume requires the same base model and quantization settings. As with PyTorch strict loading, an exception can occur after some parameter values were copied; callers must treat that restore as failed.
