### PR TITLE
[style][tinker] Restore Black-clean main

### DIFF
--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -340,6 +340,8 @@ def test_process_batch_requests_per_model_completes_incrementally(scheduling_eng
     assert processed_models == ["model_a", "model_b"]
     with Session(engine.db_engine) as session:
         assert all(f.status == RequestStatus.COMPLETED for f in session.exec(select(FutureDB)).all())
+
+
 def forward_backward_payload() -> dict:
     return types.ForwardBackwardInput(
         data=[


### PR DESCRIPTION
## Problem

Current main fails check_code_quality because Black rewrites tests/tinker/test_engine.py. File is missing required separation between two top-level functions. Since CI runs pre-commit over all files, every pull request based on this commit inherits same failure before train and gym jobs can proceed.

Same unchanged-file failure is visible on #2005, #2006, and #2007.

## Change

Apply exact Black output: add two blank lines between top-level test functions. No executable statement changes.

## Why this belongs upstream

Failure exists on main rather than contributor diffs. Fixing base once restores useful formatting signal for every branch and avoids copying unrelated whitespace into each pull request.

## Validation

- pre-commit run --all-files --config .pre-commit-config.yaml
- Ruff passed
- Black passed
- hardcoded-secret scan passed
- GitHub check_code_quality passed
- GitHub skyrl_gym_tests passed

No runtime test added because this is formatting-only.