### PR TITLE
[feat][checkpoint] Allow selective state restore on resume

### DIFF
--- a/docs/content/docs/checkpointing-logging/checkpointing.mdx
+++ b/docs/content/docs/checkpointing-logging/checkpointing.mdx
@@ -127,6 +127,29 @@ Checkpointing behavior is controlled by several parameters in the YAML configura
   - **Purpose**: Specific checkpoint directory to resume from (only used when `resume_mode: "from_path"`)
   - **Format**: Must point to a `global_step_N` directory
 
+`resume_load_optimizer_states`
+  - **Default**: `true`
+  - **Purpose**: Restore policy and critic optimizer states. Set to `false` to use optimizers initialized from the current configuration.
+
+`resume_load_dataloader_state`
+  - **Default**: `true`
+  - **Purpose**: Restore dataloader position. Set to `false` when starting a new training phase or changing datasets.
+
+`resume_load_lr_scheduler_states`
+  - **Default**: `true`
+  - **Purpose**: Restore policy and critic learning rate scheduler states. Set to `false` to use schedulers initialized from the current configuration.
+
+Disable selected state-loading options when using checkpoint weights to start a new training phase or dataset:
+
+```yaml
+trainer:
+  resume_mode: from_path
+  resume_path: /path/to/ckpts/global_step_100
+  resume_load_dataloader_state: false
+  resume_load_optimizer_states: false
+  resume_load_lr_scheduler_states: false
+```
+
 ## HuggingFace Model Export
 
 In addition to checkpointing, users can optionally save the policy model in HuggingFace safetensors format at regular intervals.

--- a/docs/content/docs/checkpointing-logging/checkpointing.mdx
+++ b/docs/content/docs/checkpointing-logging/checkpointing.mdx
@@ -127,13 +127,17 @@ Checkpointing behavior is controlled by several parameters in the YAML configura
   - **Purpose**: Specific checkpoint directory to resume from (only used when `resume_mode: "from_path"`)
   - **Format**: Must point to a `global_step_N` directory
 
-`resume_load_optimizer_states`
+`resume_load_global_step`
   - **Default**: `true`
-  - **Purpose**: Restore policy and critic optimizer states. Set to `false` to use optimizers initialized from the current configuration.
+  - **Purpose**: Restore the checkpoint's global step. Set to `false` to start a new training phase at step zero.
 
 `resume_load_dataloader_state`
   - **Default**: `true`
   - **Purpose**: Restore dataloader position. Set to `false` when starting a new training phase or changing datasets.
+
+`resume_load_optimizer_states`
+  - **Default**: `true`
+  - **Purpose**: Restore policy and critic optimizer states. Set to `false` to use optimizers initialized from the current configuration.
 
 `resume_load_lr_scheduler_states`
   - **Default**: `true`
@@ -145,10 +149,14 @@ Disable selected state-loading options when using checkpoint weights to start a 
 trainer:
   resume_mode: from_path
   resume_path: /path/to/ckpts/global_step_100
+  ckpt_path: /path/to/new-phase-ckpts
+  resume_load_global_step: false
   resume_load_dataloader_state: false
   resume_load_optimizer_states: false
   resume_load_lr_scheduler_states: false
 ```
+
+Use a different `ckpt_path` when resetting the global step so new checkpoints cannot overwrite the source run.
 
 ## HuggingFace Model Export
 

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -1360,6 +1360,8 @@ class TrainerConfig(BaseConfig):
     See https://docs.skyrl.ai/docs/checkpointing-logging/checkpointing"""
     resume_path: Optional[str] = None
     """Checkpoint directory to resume from. Only used when ``resume_mode="from_path"``."""
+    resume_load_global_step: bool = True
+    """Restore the global step when resuming. Disable to start a new training phase at step zero."""
     resume_load_dataloader_state: bool = True
     """Restore dataloader position when resuming. Disable when starting a new phase or using different data."""
     resume_load_optimizer_states: bool = True

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -1360,6 +1360,12 @@ class TrainerConfig(BaseConfig):
     See https://docs.skyrl.ai/docs/checkpointing-logging/checkpointing"""
     resume_path: Optional[str] = None
     """Checkpoint directory to resume from. Only used when ``resume_mode="from_path"``."""
+    resume_load_dataloader_state: bool = True
+    """Restore dataloader position when resuming. Disable when starting a new phase or using different data."""
+    resume_load_optimizer_states: bool = True
+    """Restore optimizer state when resuming. Disable to initialize a fresh optimizer from the current config."""
+    resume_load_lr_scheduler_states: bool = True
+    """Restore LR scheduler state when resuming. Disable to initialize a fresh scheduler from the current config."""
     log_path: str = "/tmp/skyrl-logs"
     """Path for infrastructure log files.
     vLLM engine startup, model loading, and worker initialization logs are written to

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -463,6 +463,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         self.epoch = 0
         resumed_start_epoch = None
         resumed_steps_into_epoch = None
+        bound_first_resumed_epoch = False
 
         # Load checkpoint state if resumption is enabled. Also load the data UIDs that are already trained on.
         if self.resume_mode != ResumeMode.NONE:
@@ -480,6 +481,9 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                         loaded_consumed_data_uids_set,
                         loaded_filtered_data_uids_set,
                         loaded_epoch,
+                    )
+                    bound_first_resumed_epoch = (
+                        not self.cfg.trainer.resume_load_dataloader_state and resumed_steps_into_epoch > 0
                     )
 
         # Initialize weight sync state
@@ -515,9 +519,19 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 # Buffer of completed generation, size bounded by capacity - consumed = B * (max_staleness_steps + 1)
                 generation_output_group_buffer = asyncio.Queue[GeneratedOutputGroup](maxsize=self._gen_buffer_maxsize)
 
+                # A global-step-only mid-epoch resume starts from fresh data but trains only the
+                # logical remainder. Limit producers so epoch teardown cannot inherit surplus work.
+                generation_group_budget = None
+                if epoch == start_epoch and bound_first_resumed_epoch:
+                    assert resumed_steps_into_epoch is not None
+                    groups_remaining = (self.num_steps_per_epoch - resumed_steps_into_epoch) * self.mini_batch_size
+                    generation_group_budget = asyncio.Semaphore(groups_remaining)
+
                 # Maintain self.num_parallel_generation_workers concurrent group-generation workers
                 generator_tasks = [
-                    asyncio.create_task(self._run_generate_for_a_group_loop(generation_output_group_buffer))
+                    asyncio.create_task(
+                        self._run_generate_for_a_group_loop(generation_output_group_buffer, generation_group_budget)
+                    )
                     for _ in range(self.num_parallel_generation_workers)
                 ]
 
@@ -557,7 +571,9 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                             cur_dropped_groups,
                             epoch_exhausted,
                         ) = await self._collect_generation_mini_batch(
-                            generation_output_group_buffer, all_generators_done
+                            generation_output_group_buffer,
+                            all_generators_done,
+                            generation_group_budget,
                         )
 
                         if epoch_exhausted:
@@ -804,12 +820,14 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         self,
         generation_output_group_buffer: asyncio.Queue,
         all_generators_done: asyncio.Event,
+        generation_group_budget: Optional[asyncio.Semaphore] = None,
     ) -> Tuple[List[GeneratedOutputGroup], List[GeneratedOutputGroup], bool]:
         """Pull a full mini-batch of generated groups from the buffer.
 
         Without ``sample_full_batch``, blocks until ``mini_batch_size`` groups are available. With it,
         drops zero-variance groups (freeing their capacity, marking UIDs consumed) and keeps pulling
         until ``mini_batch_size`` non-zero-variance groups are collected, which can exhaust the epoch.
+        A bounded resumed epoch returns one generation permit for each dropped group.
 
         Returns ``(kept_groups, dropped_groups, epoch_exhausted)``. On exhaustion the kept groups are a
         (possibly empty) partial batch to discard; dropped groups are kept for metrics only.
@@ -844,6 +862,8 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                         dropped_groups.append(group)
                         await self._staleness_manager.on_rollout_filtered()
                         await self.async_train_dataloader.mark_filtered_uids([group.uid])
+                        if generation_group_budget is not None:
+                            generation_group_budget.release()
                 except Exception:
                     self._log_group_processing_error(group, len(kept_groups), len(dropped_groups))
                     raise
@@ -898,16 +918,27 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
 
         return status
 
-    async def _run_generate_for_a_group_loop(self, generation_output_group_buffer: asyncio.Queue):
+    async def _run_generate_for_a_group_loop(
+        self,
+        generation_output_group_buffer: asyncio.Queue,
+        generation_group_budget: Optional[asyncio.Semaphore] = None,
+    ):
         """
         Generator worker: repeatedly pulls the next prompt (possibly blocked by staleness control),
         generates one single generation group, respecting a pause/resume event, and enqueues the result.
+        ``generation_group_budget`` bounds work in a shortened first resumed epoch.
         """
         try:
             while True:
+                if generation_group_budget is not None:
+                    await generation_group_budget.acquire()
+
                 # 0. Pull next batch from dataloader. If returns None, then dataloader is exhausted.
                 rand_prompts = await self.async_train_dataloader.get_next_non_consumed_data()
                 if rand_prompts is None:
+                    if generation_group_budget is not None:
+                        for _ in range(self.num_parallel_generation_workers):
+                            generation_group_budget.release()
                     return
 
                 # 1. Prepare generator input

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -434,10 +434,13 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         consumed_data_uids: Optional[Set[str]],
         filtered_data_uids: Optional[Set[str]],
         epoch: Optional[int],
-    ) -> Optional[int]:
+    ) -> Tuple[int, int]:
         self._staleness_manager.load_state_from_checkpoint(self.global_step + 1)
         if consumed_data_uids is None:
-            return self.global_step // self.num_steps_per_epoch
+            return (
+                self.global_step // self.num_steps_per_epoch,
+                self.global_step % self.num_steps_per_epoch,
+            )
 
         filtered_data_uids = filtered_data_uids or set()
         self.async_train_dataloader.load_state_from_checkpoint(consumed_data_uids, filtered_data_uids)
@@ -449,7 +452,8 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
             f"mini_batch_size={self.mini_batch_size}. Got: {num_trained_loaded}"
         )
         # Fall back to deriving the epoch for checkpoints that predate epoch tracking.
-        return epoch if epoch is not None else self.global_step // self.num_steps_per_epoch
+        start_epoch = epoch if epoch is not None else self.global_step // self.num_steps_per_epoch
+        return start_epoch, num_trained_loaded // self.mini_batch_size
 
     async def train(self):
         """
@@ -458,6 +462,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         self.global_step = 0
         self.epoch = 0
         resumed_start_epoch = None
+        resumed_steps_into_epoch = None
 
         # Load checkpoint state if resumption is enabled. Also load the data UIDs that are already trained on.
         if self.resume_mode != ResumeMode.NONE:
@@ -471,7 +476,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 ) = self.load_checkpoints()
                 logger.info(f"Resumed training from global_step {self.global_step}")
                 if self.global_step > 0:
-                    resumed_start_epoch = self._restore_async_training_state(
+                    resumed_start_epoch, resumed_steps_into_epoch = self._restore_async_training_state(
                         loaded_consumed_data_uids_set,
                         loaded_filtered_data_uids_set,
                         loaded_epoch,
@@ -529,10 +534,14 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
 
                     generators_done_watcher = asyncio.create_task(_watch_generators_done())
 
-                # Steps trained in THIS epoch (not global_step % num_steps_per_epoch: sample_full_batch can
-                # end an epoch early, drifting global_step out of epoch alignment). On resume the dataloader
-                # already reflects this epoch's trained steps. The range below is just an upper bound.
+                # Track actual trained data separately from logical epoch progress. They differ when resume
+                # keeps global_step but intentionally skips the dataloader cursor.
                 trained_steps_this_epoch = self.async_train_dataloader.num_trained() // self.mini_batch_size
+                steps_into_epoch = (
+                    resumed_steps_into_epoch
+                    if epoch == start_epoch and resumed_steps_into_epoch is not None
+                    else trained_steps_this_epoch
+                )
                 for _step_idx in range(self.global_step, (1 + epoch) * self.num_steps_per_epoch + 1):
                     with Timer("step", self.all_timings):
                         self._loop_gauges.set(
@@ -607,6 +616,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
 
                     # A training step completed: count it for this epoch's bookkeeping.
                     trained_steps_this_epoch += 1
+                    steps_into_epoch += 1
 
                     # One profiler step per async global step.
                     self._profiler_step()
@@ -631,7 +641,7 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                     self.all_metrics = {}
 
                     # 7. Checkpointing. At interval and at the last step of each epoch.
-                    is_epoch_end = trained_steps_this_epoch == self.num_steps_per_epoch
+                    is_epoch_end = steps_into_epoch == self.num_steps_per_epoch
                     if self.cfg.trainer.ckpt_interval > 0:
                         if is_epoch_end or self.global_step % self.cfg.trainer.ckpt_interval == 0:
                             with self._phase_gauge.timed_phase("save_checkpoints", self.all_timings):

--- a/skyrl/train/fully_async_trainer.py
+++ b/skyrl/train/fully_async_trainer.py
@@ -429,6 +429,28 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         logger.info(f"Number of steps per epoch: {self.num_steps_per_epoch}")
         logger.info(f"Total training steps: {self.total_training_steps}")
 
+    def _restore_async_training_state(
+        self,
+        consumed_data_uids: Optional[Set[str]],
+        filtered_data_uids: Optional[Set[str]],
+        epoch: Optional[int],
+    ) -> Optional[int]:
+        self._staleness_manager.load_state_from_checkpoint(self.global_step + 1)
+        if consumed_data_uids is None:
+            return self.global_step // self.num_steps_per_epoch
+
+        filtered_data_uids = filtered_data_uids or set()
+        self.async_train_dataloader.load_state_from_checkpoint(consumed_data_uids, filtered_data_uids)
+        # Only trained UIDs map to completed steps (filtered UIDs are extra consumption),
+        # so validate the trained count is a whole number of steps.
+        num_trained_loaded = len(consumed_data_uids) - len(filtered_data_uids)
+        assert num_trained_loaded % self.mini_batch_size == 0, (
+            "Loaded trained (consumed minus filtered) data UIDs must be a multiple of "
+            f"mini_batch_size={self.mini_batch_size}. Got: {num_trained_loaded}"
+        )
+        # Fall back to deriving the epoch for checkpoints that predate epoch tracking.
+        return epoch if epoch is not None else self.global_step // self.num_steps_per_epoch
+
     async def train(self):
         """
         Main fully async training loop for PPO
@@ -449,24 +471,10 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 ) = self.load_checkpoints()
                 logger.info(f"Resumed training from global_step {self.global_step}")
                 if self.global_step > 0:
-                    # Set async dataloader manager and staleness manager to the loaded state.
-                    self.async_train_dataloader.load_state_from_checkpoint(
-                        loaded_consumed_data_uids_set, loaded_filtered_data_uids_set
-                    )
-                    self._staleness_manager.load_state_from_checkpoint(
-                        self.global_step + 1
-                    )  # +1 due to we haven't incremented yet
-                    # Only trained UIDs map to completed steps (filtered UIDs are extra consumption),
-                    # so validate the trained count is a whole number of steps.
-                    num_trained_loaded = len(loaded_consumed_data_uids_set) - len(loaded_filtered_data_uids_set)
-                    assert num_trained_loaded % self.mini_batch_size == 0, (
-                        "Loaded trained (consumed minus filtered) data UIDs must be a multiple of "
-                        f"mini_batch_size={self.mini_batch_size}. Got: {num_trained_loaded}"
-                    )
-                    # Use the persisted epoch; fall back to deriving it for pre-sample_full_batch
-                    # checkpoints (where global_step stays aligned to epoch boundaries).
-                    resumed_start_epoch = (
-                        loaded_epoch if loaded_epoch is not None else self.global_step // self.num_steps_per_epoch
+                    resumed_start_epoch = self._restore_async_training_state(
+                        loaded_consumed_data_uids_set,
+                        loaded_filtered_data_uids_set,
+                        loaded_epoch,
                     )
 
         # Initialize weight sync state
@@ -1184,8 +1192,8 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
         checkpoint predates epoch tracking, in which case the caller derives it from global_step).
         """
         global_step, checkpoint_path = super().load_checkpoints()
-        if global_step == 0:
-            return 0, checkpoint_path, None, None, None
+        if global_step == 0 or not self.cfg.trainer.resume_load_dataloader_state:
+            return global_step, checkpoint_path, None, None, None
         fully_async_state_path = os.path.join(checkpoint_path, "fully_async_state.pt")
         assert io.exists(fully_async_state_path), f"Fully-async state file not found at {fully_async_state_path}"
         with io.open_file(fully_async_state_path, "rb") as f:

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -122,6 +122,7 @@ class RayPPOTrainer:
         self.inference_engine_client = inference_engine_client
         self.generator = generator
         self.train_dataloader = None
+        self._dataloader_state_restored = False
         self.total_training_steps = None
         self._build_train_dataloader_and_compute_training_steps()
 
@@ -187,6 +188,13 @@ class RayPPOTrainer:
         """Build a CallbackInput and dispatch the given event to all callbacks."""
         cb_input = self._build_callback_input(**fields)
         getattr(self._callback_handler, event_name)(self, cb_input, self._training_control)
+
+    def _get_resumed_epoch_steps_remaining(self) -> Optional[int]:
+        """Bound the first resumed epoch when the global step is kept but the data cursor is not."""
+        if self.global_step == 0 or self._dataloader_state_restored:
+            return None
+        steps_per_epoch = len(self.train_dataloader)
+        return steps_per_epoch - (self.global_step % steps_per_epoch)
 
     @property
     def has_critic(self) -> bool:
@@ -291,6 +299,7 @@ class RayPPOTrainer:
         # Compute start_epoch up-front so callback metadata is ready before
         # any event fires (including the baseline eval below).
         start_epoch = self.global_step // len(self.train_dataloader)
+        resumed_epoch_steps_remaining = self._get_resumed_epoch_steps_remaining()
         self._current_epoch = start_epoch
         self._training_control.reset()
 
@@ -542,6 +551,9 @@ class RayPPOTrainer:
                     # update progress bar after logging
                     pbar.update(1)
 
+                    if resumed_epoch_steps_remaining is not None and epoch == start_epoch:
+                        resumed_epoch_steps_remaining -= 1
+
                     self.global_step += 1
 
                     if (
@@ -555,6 +567,9 @@ class RayPPOTrainer:
                         break
 
                     del training_input, generator_output
+
+                    if resumed_epoch_steps_remaining == 0 and epoch == start_epoch:
+                        break
 
                 self._fire("on_epoch_end")
 
@@ -1801,6 +1816,7 @@ class RayPPOTrainer:
             )
 
         # 2. Load dataloader state if requested and available
+        self._dataloader_state_restored = False
         if self.train_dataloader is None:
             logger.info("No train dataloader initialized; skipping dataloader state restore")
         elif not self.cfg.trainer.resume_load_dataloader_state:
@@ -1810,6 +1826,7 @@ class RayPPOTrainer:
                 with io.open_file(dataloader_state_path, "rb") as f:
                     dataloader_state = torch.load(f, map_location="cpu", weights_only=False)
                 self.train_dataloader.load_state_dict(dataloader_state)
+                self._dataloader_state_restored = True
                 logger.info("Successfully loaded dataloader state")
             except Exception as e:
                 logger.warning(f"Failed to load dataloader state: {e}. Dataloader will start from beginning.")

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -1794,8 +1794,10 @@ class RayPPOTrainer:
         if saved_global_step != global_step:
             logger.warning(f"Global step mismatch: path={global_step}, saved={saved_global_step}. Using path value.")
 
-        # 2. Load dataloader state if available
-        if io.exists(dataloader_state_path):
+        # 2. Load dataloader state if requested and available
+        if not self.cfg.trainer.resume_load_dataloader_state:
+            logger.info("Skipping dataloader state restore; dataloader will start from beginning")
+        elif io.exists(dataloader_state_path):
             try:
                 with io.open_file(dataloader_state_path, "rb") as f:
                     dataloader_state = torch.load(f, map_location="cpu", weights_only=False)
@@ -1813,8 +1815,8 @@ class RayPPOTrainer:
         self.dispatch.load_checkpoint(
             "policy",
             policy_ckpt_dir,
-            load_optimizer_states=True,
-            load_lr_scheduler_states=True,
+            load_optimizer_states=self.cfg.trainer.resume_load_optimizer_states,
+            load_lr_scheduler_states=self.cfg.trainer.resume_load_lr_scheduler_states,
         )
         logger.info("Successfully loaded policy checkpoint")
 
@@ -1824,8 +1826,8 @@ class RayPPOTrainer:
             self.dispatch.load_checkpoint(
                 "critic",
                 critic_ckpt_dir,
-                load_optimizer_states=True,
-                load_lr_scheduler_states=True,
+                load_optimizer_states=self.cfg.trainer.resume_load_optimizer_states,
+                load_lr_scheduler_states=self.cfg.trainer.resume_load_lr_scheduler_states,
             )
             logger.info("Successfully loaded critic checkpoint")
 

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -1801,7 +1801,9 @@ class RayPPOTrainer:
             )
 
         # 2. Load dataloader state if requested and available
-        if not self.cfg.trainer.resume_load_dataloader_state:
+        if self.train_dataloader is None:
+            logger.info("No train dataloader initialized; skipping dataloader state restore")
+        elif not self.cfg.trainer.resume_load_dataloader_state:
             logger.info("Skipping dataloader state restore; dataloader will start from beginning")
         elif io.exists(dataloader_state_path):
             try:

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -1721,8 +1721,8 @@ class RayPPOTrainer:
 
     def load_checkpoints(self) -> Tuple[int, str]:
         """
-        Load complete checkpoint state and return the global_step to resume from.
-        Returns 0 if no checkpoint is loaded.
+        Load checkpoint state and return the configured starting global step.
+        Returns 0 if no checkpoint is loaded or global-step restore is disabled.
 
         If colocate_all is True, assumes that the policy model is currently on GPU.
 
@@ -1771,10 +1771,14 @@ class RayPPOTrainer:
         logger.info(f"Loading checkpoint from: {checkpoint_path}")
 
         # Extract global step from checkpoint path
-        global_step = extract_step_from_path(Path(checkpoint_path))
-        if global_step == -1:
+        checkpoint_global_step = extract_step_from_path(Path(checkpoint_path))
+        if checkpoint_global_step == -1:
             raise ValueError(f"Checkpoint path {checkpoint_path} is not a valid checkpoint path")
-        logger.info(f"Resuming from global_step: {global_step}")
+        global_step = checkpoint_global_step if self.cfg.trainer.resume_load_global_step else 0
+        if self.cfg.trainer.resume_load_global_step:
+            logger.info(f"Resuming from global_step: {global_step}")
+        else:
+            logger.info(f"Loading checkpoint weights from global_step_{checkpoint_global_step}; global step reset to 0")
 
         # Define paths for different checkpoint components
         policy_ckpt_dir = os.path.join(checkpoint_path, "policy")
@@ -1789,10 +1793,12 @@ class RayPPOTrainer:
         # 1. Load and validate trainer state
         with io.open_file(trainer_state_path, "rb") as f:
             trainer_state = torch.load(f, map_location="cpu", weights_only=False)
-        saved_global_step = trainer_state.get("global_step", global_step)
-        logger.info("Successfully loaded trainer state")
-        if saved_global_step != global_step:
-            logger.warning(f"Global step mismatch: path={global_step}, saved={saved_global_step}. Using path value.")
+        saved_global_step = trainer_state.get("global_step", checkpoint_global_step)
+        logger.info("Successfully loaded trainer metadata")
+        if saved_global_step != checkpoint_global_step:
+            logger.warning(
+                f"Global step mismatch: path={checkpoint_global_step}, saved={saved_global_step}. Using path value."
+            )
 
         # 2. Load dataloader state if requested and available
         if not self.cfg.trainer.resume_load_dataloader_state:
@@ -1831,7 +1837,7 @@ class RayPPOTrainer:
             )
             logger.info("Successfully loaded critic checkpoint")
 
-        logger.info(f"Successfully loaded complete checkpoint state from global_step_{global_step}")
+        logger.info(f"Successfully loaded checkpoint state from global_step_{checkpoint_global_step}")
         return global_step, str(checkpoint_path)
 
     def save_models(self):

--- a/tests/train/test_fully_async_trainer.py
+++ b/tests/train/test_fully_async_trainer.py
@@ -5,6 +5,7 @@ UID tracking, and the consumer's exhaustion-aware buffer drain.
 """
 
 import asyncio
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -24,6 +25,96 @@ def _make_async_dataloader(num_prompts: int, mini_batch_size: int) -> _AsyncData
     # batch_size=1 (one prompt per draw) and identity collate so each batch is a list with one dict.
     loader = StatefulDataLoader(dataset, batch_size=1, collate_fn=lambda batch: batch[0])
     return _AsyncDataloader(loader, mini_batch_size)
+
+
+@pytest.mark.asyncio
+async def test_partial_resume_generation_budget_bounds_and_replaces_filtered_groups(monkeypatch):
+    class Generator:
+        async def generate(self, generator_input):
+            uid = generator_input["uid"]
+            await asyncio.sleep(int(uid) * 0.01)
+            rewards = [1.0, 1.0] if uid == "0" else [0.0, 1.0]
+            return {"rewards": rewards, "loss_masks": [[1], [1]]}
+
+    def prepare_generator_input(rand_prompts, *_args, **_kwargs):
+        uid = rand_prompts[0]["uid"]
+        return {"uid": uid, "prompts": []}, [uid]
+
+    monkeypatch.setattr(
+        "skyrl.train.fully_async_trainer.prepare_generator_input",
+        prepare_generator_input,
+    )
+    monkeypatch.setattr(
+        "skyrl.train.fully_async_trainer.get_sampling_params_for_backend",
+        lambda *_args, **_kwargs: {},
+    )
+
+    trainer = FullyAsyncRayPPOTrainer.__new__(FullyAsyncRayPPOTrainer)
+    trainer.async_train_dataloader = _make_async_dataloader(num_prompts=8, mini_batch_size=2)
+    trainer._staleness_manager = _AsyncStalenessManager(
+        max_concurrent_generation_groups=4,
+        mini_batch_size=2,
+        max_staleness_steps=1,
+    )
+    trainer.generator = Generator()
+    trainer.global_step = 8
+    trainer.mini_batch_size = 2
+    trainer.num_parallel_generation_workers = 4
+    trainer.sample_full_batch = True
+    trainer.all_metrics = {}
+    trainer.all_timings = {}
+    trainer._phase_gauge = SimpleNamespace(timed_phase=lambda *_args: nullcontext())
+    trainer.cfg = SimpleNamespace(
+        generator=SimpleNamespace(
+            n_samples_per_prompt=2,
+            inference_engine=SimpleNamespace(backend="test"),
+            sampling_params={},
+        ),
+        environment=SimpleNamespace(env_class="test"),
+        trainer=SimpleNamespace(algorithm=SimpleNamespace(zero_variance_filter_tol=0.0)),
+    )
+
+    buffer = asyncio.Queue(maxsize=4)
+    generation_budget = asyncio.Semaphore(2)
+    tasks = [asyncio.create_task(trainer._run_generate_for_a_group_loop(buffer, generation_budget)) for _ in range(4)]
+    try:
+        kept, dropped, exhausted = await asyncio.wait_for(
+            trainer._collect_generation_mini_batch(buffer, asyncio.Event(), generation_budget),
+            timeout=1,
+        )
+        while trainer._staleness_manager._stat.running:
+            await asyncio.sleep(0)
+
+        assert [group.uid for group in dropped] == ["0"]
+        assert [group.uid for group in kept] == ["1", "2"]
+        assert exhausted is False
+        assert buffer.empty()
+        assert trainer._staleness_manager._stat.accepted == 2
+        assert trainer._staleness_manager._stat.filtered == 1
+        assert all(not task.done() for task in tasks)
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Exhaustion must also wake peers blocked on permits so sample_full_batch can terminate.
+    trainer.async_train_dataloader = _make_async_dataloader(num_prompts=2, mini_batch_size=2)
+    trainer._staleness_manager = _AsyncStalenessManager(
+        max_concurrent_generation_groups=4,
+        mini_batch_size=2,
+        max_staleness_steps=1,
+    )
+    buffer = asyncio.Queue(maxsize=4)
+    generation_budget = asyncio.Semaphore(4)
+    tasks = [asyncio.create_task(trainer._run_generate_for_a_group_loop(buffer, generation_budget)) for _ in range(4)]
+    try:
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=1)
+        assert buffer.qsize() == 2
+        assert trainer._staleness_manager._stat.running == 0
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -339,6 +339,27 @@ def test_resume_can_skip_training_states(dummy_config, tmp_path: Path, load_glob
     )
 
 
+def test_resume_without_train_dataloader_skips_cursor_restore(dummy_config, tmp_path: Path):
+    checkpoint_path = tmp_path / "global_step_7"
+    (checkpoint_path / "policy").mkdir(parents=True)
+    torch.save({"global_step": 7}, checkpoint_path / "trainer_state.pt")
+    torch.save({"position": 5}, checkpoint_path / "data.pt")
+
+    dummy_config.trainer.resume_path = str(checkpoint_path)
+
+    trainer = RayPPOTrainer.__new__(RayPPOTrainer)
+    trainer.cfg = dummy_config
+    trainer.resume_mode = ResumeMode.FROM_PATH
+    trainer.train_dataloader = None
+    trainer.dispatch = MagicMock()
+
+    with patch("skyrl.train.trainer.logger") as mock_logger:
+        assert trainer.load_checkpoints() == (7, str(checkpoint_path))
+
+    mock_logger.info.assert_any_call("No train dataloader initialized; skipping dataloader state restore")
+    mock_logger.warning.assert_not_called()
+
+
 def test_fully_async_new_phase_resume_skips_async_state(dummy_config, tmp_path: Path):
     checkpoint_path = tmp_path / "global_step_7"
     (checkpoint_path / "policy").mkdir(parents=True)
@@ -369,6 +390,44 @@ def test_fully_async_new_phase_resume_skips_async_state(dummy_config, tmp_path: 
         load_optimizer_states=False,
         load_lr_scheduler_states=False,
     )
+
+
+def test_fully_async_resume_skips_async_state_without_dataloader_cursor(dummy_config, tmp_path: Path):
+    checkpoint_path = tmp_path / "global_step_7"
+    (checkpoint_path / "policy").mkdir(parents=True)
+    torch.save({"global_step": 7}, checkpoint_path / "trainer_state.pt")
+    torch.save({"position": 5}, checkpoint_path / "data.pt")
+    torch.save(
+        {"consumed_uids": ["trained", "filtered"], "filtered_uids": ["filtered"], "epoch": 3},
+        checkpoint_path / "fully_async_state.pt",
+    )
+
+    dummy_config.trainer.resume_path = str(checkpoint_path)
+    dummy_config.trainer.resume_load_dataloader_state = False
+
+    trainer = FullyAsyncRayPPOTrainer.__new__(FullyAsyncRayPPOTrainer)
+    trainer.cfg = dummy_config
+    trainer.resume_mode = ResumeMode.FROM_PATH
+    trainer.train_dataloader = MagicMock()
+    trainer.dispatch = MagicMock()
+
+    assert trainer.load_checkpoints() == (7, str(checkpoint_path), None, None, None)
+    trainer.train_dataloader.load_state_dict.assert_not_called()
+
+
+def test_fully_async_resume_without_data_state_derives_progress_from_step(dummy_config):
+    trainer = FullyAsyncRayPPOTrainer.__new__(FullyAsyncRayPPOTrainer)
+    trainer.cfg = dummy_config
+    trainer.global_step = 7
+    trainer.async_train_dataloader = MagicMock()
+    trainer._staleness_manager = MagicMock()
+    trainer.num_steps_per_epoch = 4
+
+    start_epoch = trainer._restore_async_training_state(None, None, None)
+
+    assert start_epoch == 1
+    trainer.async_train_dataloader.load_state_from_checkpoint.assert_not_called()
+    trainer._staleness_manager.load_state_from_checkpoint.assert_called_once_with(8)
 
 
 def test_run_flushes_pending_metrics_before_logging_exception():

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -15,6 +15,7 @@ from skyrl.backends.skyrl_train.training_batch import TrainingInputBatch
 from skyrl.backends.skyrl_train.workers.worker import CriticWorkerBase, PolicyWorkerBase
 from skyrl.backends.skyrl_train.workers.worker_utils import BatchIterator
 from skyrl.train.config import SkyRLTrainConfig
+from skyrl.train.fully_async_trainer import FullyAsyncRayPPOTrainer
 from skyrl.train.trainer import RayPPOTrainer
 from skyrl.train.utils.trainer_utils import ResumeMode
 from skyrl.train.utils.utils import validate_batch_sizes
@@ -304,7 +305,8 @@ def test_flush_pending_metrics_swallows_tracker_errors(dummy_config):
     assert trainer.all_timings == {}
 
 
-def test_resume_can_skip_optimizer_and_scheduler_states(dummy_config, tmp_path: Path):
+@pytest.mark.parametrize(("load_global_step", "expected_global_step"), [(True, 7), (False, 0)])
+def test_resume_can_skip_training_states(dummy_config, tmp_path: Path, load_global_step, expected_global_step):
     checkpoint_path = tmp_path / "global_step_7"
     (checkpoint_path / "policy").mkdir(parents=True)
     torch.save({"global_step": 7}, checkpoint_path / "trainer_state.pt")
@@ -312,6 +314,7 @@ def test_resume_can_skip_optimizer_and_scheduler_states(dummy_config, tmp_path: 
 
     dummy_config.trainer.resume_mode = "from_path"
     dummy_config.trainer.resume_path = str(checkpoint_path)
+    dummy_config.trainer.resume_load_global_step = load_global_step
     dummy_config.trainer.resume_load_dataloader_state = False
     dummy_config.trainer.resume_load_optimizer_states = False
     dummy_config.trainer.resume_load_lr_scheduler_states = False
@@ -325,8 +328,40 @@ def test_resume_can_skip_optimizer_and_scheduler_states(dummy_config, tmp_path: 
 
     global_step, loaded_path = trainer.load_checkpoints()
 
-    assert global_step == 7
+    assert global_step == expected_global_step
     assert loaded_path == str(checkpoint_path)
+    trainer.train_dataloader.load_state_dict.assert_not_called()
+    trainer.dispatch.load_checkpoint.assert_called_once_with(
+        "policy",
+        str(checkpoint_path / "policy"),
+        load_optimizer_states=False,
+        load_lr_scheduler_states=False,
+    )
+
+
+def test_fully_async_new_phase_resume_skips_async_state(dummy_config, tmp_path: Path):
+    checkpoint_path = tmp_path / "global_step_7"
+    (checkpoint_path / "policy").mkdir(parents=True)
+    torch.save({"global_step": 7}, checkpoint_path / "trainer_state.pt")
+    torch.save({"position": 5}, checkpoint_path / "data.pt")
+    torch.save(
+        {"consumed_uids": ["old-prompt"], "filtered_uids": [], "epoch": 3},
+        checkpoint_path / "fully_async_state.pt",
+    )
+
+    dummy_config.trainer.resume_path = str(checkpoint_path)
+    dummy_config.trainer.resume_load_global_step = False
+    dummy_config.trainer.resume_load_dataloader_state = False
+    dummy_config.trainer.resume_load_optimizer_states = False
+    dummy_config.trainer.resume_load_lr_scheduler_states = False
+
+    trainer = FullyAsyncRayPPOTrainer.__new__(FullyAsyncRayPPOTrainer)
+    trainer.cfg = dummy_config
+    trainer.resume_mode = ResumeMode.FROM_PATH
+    trainer.train_dataloader = MagicMock()
+    trainer.dispatch = MagicMock()
+
+    assert trainer.load_checkpoints() == (0, str(checkpoint_path), None, None, None)
     trainer.train_dataloader.load_state_dict.assert_not_called()
     trainer.dispatch.load_checkpoint.assert_called_once_with(
         "policy",

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -2,6 +2,7 @@
 uv  run --isolated --extra dev pytest tests/train/test_trainer.py
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -15,6 +16,7 @@ from skyrl.backends.skyrl_train.workers.worker import CriticWorkerBase, PolicyWo
 from skyrl.backends.skyrl_train.workers.worker_utils import BatchIterator
 from skyrl.train.config import SkyRLTrainConfig
 from skyrl.train.trainer import RayPPOTrainer
+from skyrl.train.utils.trainer_utils import ResumeMode
 from skyrl.train.utils.utils import validate_batch_sizes
 from tests.train.util import example_dummy_config
 
@@ -300,6 +302,38 @@ def test_flush_pending_metrics_swallows_tracker_errors(dummy_config):
 
     assert trainer.all_metrics == {}
     assert trainer.all_timings == {}
+
+
+def test_resume_can_skip_optimizer_and_scheduler_states(dummy_config, tmp_path: Path):
+    checkpoint_path = tmp_path / "global_step_7"
+    (checkpoint_path / "policy").mkdir(parents=True)
+    torch.save({"global_step": 7}, checkpoint_path / "trainer_state.pt")
+    torch.save({"position": 5}, checkpoint_path / "data.pt")
+
+    dummy_config.trainer.resume_mode = "from_path"
+    dummy_config.trainer.resume_path = str(checkpoint_path)
+    dummy_config.trainer.resume_load_dataloader_state = False
+    dummy_config.trainer.resume_load_optimizer_states = False
+    dummy_config.trainer.resume_load_lr_scheduler_states = False
+
+    trainer = RayPPOTrainer.__new__(RayPPOTrainer)
+    trainer.cfg = dummy_config
+    trainer.resume_mode = ResumeMode.FROM_PATH
+    trainer.train_dataloader = MagicMock()
+    trainer.dispatch = MagicMock()
+    trainer.critic_model = None
+
+    global_step, loaded_path = trainer.load_checkpoints()
+
+    assert global_step == 7
+    assert loaded_path == str(checkpoint_path)
+    trainer.train_dataloader.load_state_dict.assert_not_called()
+    trainer.dispatch.load_checkpoint.assert_called_once_with(
+        "policy",
+        str(checkpoint_path / "policy"),
+        load_optimizer_states=False,
+        load_lr_scheduler_states=False,
+    )
 
 
 def test_run_flushes_pending_metrics_before_logging_exception():

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -415,7 +415,7 @@ def test_fully_async_resume_skips_async_state_without_dataloader_cursor(dummy_co
     trainer.train_dataloader.load_state_dict.assert_not_called()
 
 
-def test_fully_async_resume_without_data_state_derives_progress_from_step(dummy_config):
+def test_fully_async_resume_without_data_state_restores_epoch_progress(dummy_config):
     trainer = FullyAsyncRayPPOTrainer.__new__(FullyAsyncRayPPOTrainer)
     trainer.cfg = dummy_config
     trainer.global_step = 7
@@ -423,9 +423,11 @@ def test_fully_async_resume_without_data_state_derives_progress_from_step(dummy_
     trainer._staleness_manager = MagicMock()
     trainer.num_steps_per_epoch = 4
 
-    start_epoch = trainer._restore_async_training_state(None, None, None)
+    start_epoch, steps_into_epoch = trainer._restore_async_training_state(None, None, None)
 
     assert start_epoch == 1
+    assert steps_into_epoch == 3
+    assert steps_into_epoch + 1 == trainer.num_steps_per_epoch
     trainer.async_train_dataloader.load_state_from_checkpoint.assert_not_called()
     trainer._staleness_manager.load_state_from_checkpoint.assert_called_once_with(8)
 

--- a/tests/train/test_trainer.py
+++ b/tests/train/test_trainer.py
@@ -330,6 +330,7 @@ def test_resume_can_skip_training_states(dummy_config, tmp_path: Path, load_glob
 
     assert global_step == expected_global_step
     assert loaded_path == str(checkpoint_path)
+    assert trainer._dataloader_state_restored is False
     trainer.train_dataloader.load_state_dict.assert_not_called()
     trainer.dispatch.load_checkpoint.assert_called_once_with(
         "policy",
@@ -337,6 +338,38 @@ def test_resume_can_skip_training_states(dummy_config, tmp_path: Path, load_glob
         load_optimizer_states=False,
         load_lr_scheduler_states=False,
     )
+
+
+def test_resume_records_successful_dataloader_state_restore(dummy_config, tmp_path: Path):
+    checkpoint_path = tmp_path / "global_step_7"
+    (checkpoint_path / "policy").mkdir(parents=True)
+    torch.save({"global_step": 7}, checkpoint_path / "trainer_state.pt")
+    torch.save({"position": 5}, checkpoint_path / "data.pt")
+
+    dummy_config.trainer.resume_path = str(checkpoint_path)
+
+    trainer = RayPPOTrainer.__new__(RayPPOTrainer)
+    trainer.cfg = dummy_config
+    trainer.resume_mode = ResumeMode.FROM_PATH
+    trainer.train_dataloader = MagicMock()
+    trainer.dispatch = MagicMock()
+
+    assert trainer.load_checkpoints() == (7, str(checkpoint_path))
+    assert trainer._dataloader_state_restored is True
+    trainer.train_dataloader.load_state_dict.assert_called_once_with({"position": 5})
+
+
+@pytest.mark.parametrize(
+    ("global_step", "state_restored", "expected"),
+    [(7, False, 1), (8, False, 4), (7, True, None), (0, False, None)],
+)
+def test_resumed_epoch_steps_remaining(global_step, state_restored, expected):
+    trainer = RayPPOTrainer.__new__(RayPPOTrainer)
+    trainer.global_step = global_step
+    trainer._dataloader_state_restored = state_restored
+    trainer.train_dataloader = [object()] * 4
+
+    assert trainer._get_resumed_epoch_steps_remaining() == expected
 
 
 def test_resume_without_train_dataloader_skips_cursor_restore(dummy_config, tmp_path: Path):


### PR DESCRIPTION
## Summary

Allow checkpoint weights to seed a new training phase while independently controlling global-step, dataloader, optimizer, and learning-rate scheduler restoration.

Exact resume remains unchanged because every option defaults to `true`.

## Changes

- Add `trainer.resume_load_global_step`, `trainer.resume_load_dataloader_state`, `trainer.resume_load_optimizer_states`, and `trainer.resume_load_lr_scheduler_states`.
- Reset training to step zero when global-step restoration is disabled.
- Skip stale fully-async UID and epoch state for a new training phase.
- Preserve logical epoch progress and epoch-end saves in sync and fully-async trainers when global-step restoration skips the dataloader cursor.
- Bound fully-async producers to the shortened first epoch's remaining groups when the cursor is skipped. Filtered groups return one permit so replacement sampling still works without leaving surplus buffered generation at epoch teardown.
- Pass optimizer and scheduler restore options to policy and critic checkpoint loading.
- Document selective-state resume and separate checkpoint output paths.
- Add focused sync and fully-async regression coverage.

## Testing

- `pytest tests/train/test_trainer.py tests/train/test_config.py tests/train/test_fully_async_trainer.py -q` (`179 passed`)
- Same focused suites on a clean merge with current `upstream/main` at `a6871df` (`183 passed`)
- `pre-commit run --all-files`
- `uv lock --check`
- documentation type check and production build (`66 pages`)
- `git diff --check`

## Megatron dependency

Merge #2149 before using `trainer.resume_load_optimizer_states=false` with Megatron. It refreshes optimizer master parameters from the loaded model; without it, the first optimizer step can overwrite checkpoint weights with stale master values. Default full-state resume is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core checkpoint resume and fully-async epoch/generation bookkeeping; misconfiguration could desync training step vs data or leave stale optimizer state (Megatron caveat noted in PR).
> 
> **Overview**
> Adds four **`trainer.resume_load_*`** flags (global step, dataloader, optimizer, LR scheduler) so runs can load checkpoint **weights** while starting a new phase with fresh step counters, data cursors, or optimizers. Defaults stay **`true`**, so normal resume behavior is unchanged.
> 
> **`load_checkpoints`** honors the flags: optional step reset to 0, conditional **`data.pt`** restore with **`_dataloader_state_restored`**, and optimizer/scheduler restore passed through to policy/critic dispatch. Docs add a YAML example for new-phase resume and recommend a separate **`ckpt_path`**.
> 
> The **sync trainer** limits the first resumed epoch to the logical remainder when global step is kept but the dataloader cursor is not. **Fully-async** skips **`fully_async_state.pt`** when dataloader restore is off, refactors async restore into **`_restore_async_training_state`**, and uses a **generation-group budget** so producers do not overrun a shortened first epoch (including permit release on filtered groups).
> 
> Regression tests cover selective restore, epoch bounding, and async budget behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897d65f306612766640edfe401412124bccf86c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->