### PR TITLE
[ci] opt in to fork PR checkout in label-gated GPU workflows

### DIFF
--- a/.github/workflows/gpu_ci_h100.yaml
+++ b/.github/workflows/gpu_ci_h100.yaml
@@ -43,6 +43,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # The Anyscale job uploads this working dir, so we need the PR head.
+          # Fork code only reaches here after a maintainer applies the gating
+          # label above; don't leave the base repo token on disk for it.
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -43,6 +43,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # The Anyscale job uploads this working dir, so we need the PR head.
+          # Fork code only reaches here after a maintainer applies the gating
+          # label above; don't leave the base repo token on disk for it.
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -45,6 +45,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # The Anyscale job uploads this working dir, so we need the PR head.
+          # Fork code only reaches here after a maintainer applies the gating
+          # label above; don't leave the base repo token on disk for it.
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/gpu_skyrl_train_megatron_models.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron_models.yaml
@@ -45,6 +45,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # The Anyscale job uploads this working dir, so we need the PR head.
+          # Fork code only reaches here after a maintainer applies the gating
+          # label above; don't leave the base repo token on disk for it.
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
+++ b/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
@@ -46,6 +46,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # The Anyscale job uploads this working dir, so we need the PR head.
+          # Fork code only reaches here after a maintainer applies the gating
+          # label above; don't leave the base repo token on disk for it.
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
actions/checkout now refuses to check out a fork's head SHA from a pull_request_target workflow, so every label-gated GPU CI run on a fork PR fails at the checkout step:

  Error: Refusing to check out fork pull request code from a
  'pull_request_target' workflow.

These workflows need the PR head because the Anyscale job spec uploads the checked-out working dir (working_dir: .). Set the documented opt-in, allow-unsafe-pr-checkout: true. Fork code still only runs after a maintainer applies the gating label, which the job's `if:` enforces.

Also set persist-credentials: false on those checkouts: the base repo's GITHUB_TOKEN would otherwise be left in .git/config inside the directory we ship to the cluster to run fork-authored code. Nothing downstream uses git, so dropping it costs nothing.