### PR TITLE
[ci] retry CI if state RUNNING is never reached

### DIFF
--- a/.github/workflows/gpu_ci_h100.yaml
+++ b/.github/workflows/gpu_ci_h100.yaml
@@ -65,6 +65,5 @@ jobs:
           envsubst < ci/anyscale_gpu_ci_h100.yaml > ci/anyscale_gpu_ci_h100_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-train-gpu-ci-h100-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_ci_h100_envsubst.yaml --name "$JOB_NAME" --timeout 5400
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 5400
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_h100_envsubst.yaml "$JOB_NAME" 5400
           rm -f ci/anyscale_gpu_ci_h100_envsubst.yaml

--- a/.github/workflows/gpu_ci_h100.yaml
+++ b/.github/workflows/gpu_ci_h100.yaml
@@ -64,6 +64,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_ci_h100.yaml > ci/anyscale_gpu_ci_h100_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-train-gpu-ci-h100-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-train-gpu-ci-h100-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_h100_envsubst.yaml "$JOB_NAME" 5400
           rm -f ci/anyscale_gpu_ci_h100_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci.yaml
+++ b/.github/workflows/gpu_e2e_ci.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_e2e_test.yaml > ci/anyscale_gpu_e2e_test_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-train-gpu-e2e-test-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_envsubst.yaml "$JOB_NAME" 5000
           rm -f ci/anyscale_gpu_e2e_test_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci.yaml
+++ b/.github/workflows/gpu_e2e_ci.yaml
@@ -45,6 +45,5 @@ jobs:
           envsubst < ci/anyscale_gpu_e2e_test.yaml > ci/anyscale_gpu_e2e_test_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-train-gpu-e2e-test-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_envsubst.yaml --name "$JOB_NAME" --timeout 5000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 5000
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_envsubst.yaml "$JOB_NAME" 5000
           rm -f ci/anyscale_gpu_e2e_test_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_fully_async.yaml
+++ b/.github/workflows/gpu_e2e_ci_fully_async.yaml
@@ -45,6 +45,5 @@ jobs:
           envsubst < ci/anyscale_gpu_e2e_test_fully_async.yaml > ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-train-gpu-e2e-test-fully-async-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml --name "$JOB_NAME" --timeout 5000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 5000
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml "$JOB_NAME" 5000
           rm -f ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_fully_async.yaml
+++ b/.github/workflows/gpu_e2e_ci_fully_async.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_fully_async.yaml > ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-train-gpu-e2e-test-fully-async-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-fully-async-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml "$JOB_NAME" 5000
           rm -f ci/anyscale_gpu_e2e_test_fully_async_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_megatron.yaml
+++ b/.github/workflows/gpu_e2e_ci_megatron.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_megatron.yaml > ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-train-gpu-e2e-test-megatron-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-megatron-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml "$JOB_NAME" 4500
           rm -f ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_megatron.yaml
+++ b/.github/workflows/gpu_e2e_ci_megatron.yaml
@@ -45,6 +45,5 @@ jobs:
           envsubst < ci/anyscale_gpu_e2e_test_megatron.yaml > ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-train-gpu-e2e-test-megatron-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml --name "$JOB_NAME" --timeout 4500
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 4500
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml "$JOB_NAME" 4500
           rm -f ci/anyscale_gpu_e2e_test_megatron_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_sft.yaml
+++ b/.github/workflows/gpu_e2e_ci_sft.yaml
@@ -45,6 +45,5 @@ jobs:
           envsubst < ci/anyscale_gpu_e2e_test_sft.yaml > ci/anyscale_gpu_e2e_test_sft_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-train-gpu-e2e-test-sft-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_sft_envsubst.yaml --name "$JOB_NAME" --timeout 4500
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 4500
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_sft_envsubst.yaml "$JOB_NAME" 4500
           rm -f ci/anyscale_gpu_e2e_test_sft_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_sft.yaml
+++ b/.github/workflows/gpu_e2e_ci_sft.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_sft.yaml > ci/anyscale_gpu_e2e_test_sft_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-train-gpu-e2e-test-sft-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-sft-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_sft_envsubst.yaml "$JOB_NAME" 4500
           rm -f ci/anyscale_gpu_e2e_test_sft_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_tinker.yaml
+++ b/.github/workflows/gpu_e2e_ci_tinker.yaml
@@ -45,6 +45,5 @@ jobs:
           envsubst < ci/anyscale_gpu_e2e_test_tinker.yaml > ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-train-gpu-e2e-test-tinker-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml --name "$JOB_NAME" --timeout 12000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 12000
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml "$JOB_NAME" 12000
           rm -f ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_tinker.yaml
+++ b/.github/workflows/gpu_e2e_ci_tinker.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_tinker.yaml > ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-train-gpu-e2e-test-tinker-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-tinker-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml "$JOB_NAME" 12000
           rm -f ci/anyscale_gpu_e2e_test_tinker_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_tinker_fully_async.yaml
+++ b/.github/workflows/gpu_e2e_ci_tinker_fully_async.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_e2e_test_tinker_fully_async.yaml > ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-train-gpu-e2e-test-tinker-fully-async-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-train-gpu-e2e-test-tinker-fully-async-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml "$JOB_NAME" 12000
           rm -f ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml

--- a/.github/workflows/gpu_e2e_ci_tinker_fully_async.yaml
+++ b/.github/workflows/gpu_e2e_ci_tinker_fully_async.yaml
@@ -45,6 +45,5 @@ jobs:
           envsubst < ci/anyscale_gpu_e2e_test_tinker_fully_async.yaml > ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-train-gpu-e2e-test-tinker-fully-async-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml --name "$JOB_NAME" --timeout 12000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 12000
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml "$JOB_NAME" 12000
           rm -f ci/anyscale_gpu_e2e_test_tinker_fully_async_envsubst.yaml

--- a/.github/workflows/gpu_skyrl.yaml
+++ b/.github/workflows/gpu_skyrl.yaml
@@ -58,6 +58,5 @@ jobs:
           envsubst < ci/anyscale_gpu_ci.yaml > ci/anyscale_gpu_ci_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-tx-gpu-ci-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_ci_envsubst.yaml --name "$JOB_NAME" --timeout 10000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 10000
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_envsubst.yaml "$JOB_NAME" 10000
           rm -f ci/anyscale_gpu_ci_envsubst.yaml

--- a/.github/workflows/gpu_skyrl.yaml
+++ b/.github/workflows/gpu_skyrl.yaml
@@ -57,6 +57,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_ci.yaml > ci/anyscale_gpu_ci_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-tx-gpu-ci-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-tx-gpu-ci-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_envsubst.yaml "$JOB_NAME" 10000
           rm -f ci/anyscale_gpu_ci_envsubst.yaml

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -65,6 +65,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_ci_skyrl_train.yaml > ci/anyscale_gpu_ci_skyrl_train_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-train-gpu-ci-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-train-gpu-ci-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_skyrl_train_envsubst.yaml "$JOB_NAME" 12000
           rm -f ci/anyscale_gpu_ci_skyrl_train_envsubst.yaml

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -66,6 +66,5 @@ jobs:
           envsubst < ci/anyscale_gpu_ci_skyrl_train.yaml > ci/anyscale_gpu_ci_skyrl_train_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-train-gpu-ci-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train_envsubst.yaml --name "$JOB_NAME" --timeout 12000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 12000
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_skyrl_train_envsubst.yaml "$JOB_NAME" 12000
           rm -f ci/anyscale_gpu_ci_skyrl_train_envsubst.yaml

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -68,6 +68,5 @@ jobs:
           envsubst < ci/anyscale_gpu_ci_skyrl_train_megatron.yaml > ci/anyscale_gpu_ci_skyrl_train_megatron_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-train-gpu-ci-megatron-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train_megatron_envsubst.yaml --name "$JOB_NAME" --timeout 12000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 12000
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_skyrl_train_megatron_envsubst.yaml "$JOB_NAME" 12000
           rm -f ci/anyscale_gpu_ci_skyrl_train_megatron_envsubst.yaml

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -67,6 +67,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_ci_skyrl_train_megatron.yaml > ci/anyscale_gpu_ci_skyrl_train_megatron_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-train-gpu-ci-megatron-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-train-gpu-ci-megatron-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_skyrl_train_megatron_envsubst.yaml "$JOB_NAME" 12000
           rm -f ci/anyscale_gpu_ci_skyrl_train_megatron_envsubst.yaml

--- a/.github/workflows/gpu_skyrl_train_megatron_models.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron_models.yaml
@@ -67,6 +67,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_gpu_ci_skyrl_train_megatron_models.yaml > ci/anyscale_gpu_ci_skyrl_train_megatron_models_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="skyrl-train-gpu-ci-megatron-models-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="skyrl-train-gpu-ci-megatron-models-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_skyrl_train_megatron_models_envsubst.yaml "$JOB_NAME" 2500
           rm -f ci/anyscale_gpu_ci_skyrl_train_megatron_models_envsubst.yaml

--- a/.github/workflows/gpu_skyrl_train_megatron_models.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron_models.yaml
@@ -68,6 +68,5 @@ jobs:
           envsubst < ci/anyscale_gpu_ci_skyrl_train_megatron_models.yaml > ci/anyscale_gpu_ci_skyrl_train_megatron_models_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="skyrl-train-gpu-ci-megatron-models-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_gpu_ci_skyrl_train_megatron_models_envsubst.yaml --name "$JOB_NAME" --timeout 2500
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 2500
+          bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_skyrl_train_megatron_models_envsubst.yaml "$JOB_NAME" 2500
           rm -f ci/anyscale_gpu_ci_skyrl_train_megatron_models_envsubst.yaml

--- a/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
+++ b/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
@@ -69,6 +69,5 @@ jobs:
           envsubst < ci/anyscale_tinker_skyrl_train_backend_gpu.yaml > ci/anyscale_tinker_skyrl_train_backend_gpu_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           JOB_NAME="tinker-skyrl-train-backend-gpu-${COMMIT_SHA:0:7}-${{ github.run_id }}"
-          anyscale job submit -f ci/anyscale_tinker_skyrl_train_backend_gpu_envsubst.yaml --name "$JOB_NAME" --timeout 5000
-          anyscale job wait --cloud sky-anyscale-aws-us-east-1 --name "$JOB_NAME" --timeout 5000
+          bash ci/submit_anyscale_job.sh ci/anyscale_tinker_skyrl_train_backend_gpu_envsubst.yaml "$JOB_NAME" 5000
           rm -f ci/anyscale_tinker_skyrl_train_backend_gpu_envsubst.yaml

--- a/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
+++ b/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
@@ -68,6 +68,6 @@ jobs:
         run: |
           envsubst < ci/anyscale_tinker_skyrl_train_backend_gpu.yaml > ci/anyscale_tinker_skyrl_train_backend_gpu_envsubst.yaml
           COMMIT_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
-          JOB_NAME="tinker-skyrl-train-backend-gpu-${COMMIT_SHA:0:7}-${{ github.run_id }}"
+          JOB_NAME="tinker-skyrl-train-backend-gpu-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_tinker_skyrl_train_backend_gpu_envsubst.yaml "$JOB_NAME" 5000
           rm -f ci/anyscale_tinker_skyrl_train_backend_gpu_envsubst.yaml

--- a/ci/submit_anyscale_job.sh
+++ b/ci/submit_anyscale_job.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Submit an Anyscale job, retrying only when the cluster never acquired its GPUs.
+#
+# On-demand 4xL4 (g6.12xlarge) capacity in us-east-1 is frequently exhausted. When
+# that happens the Anyscale control plane cycles availability zones, gives up, and
+# terminates the cluster with "failed to acquire min nodes" -- the job goes from
+# STARTING straight to FAILED without the entrypoint ever executing. That is a
+# capacity problem, not a test problem, so we resubmit instead of failing CI.
+#
+# Reaching RUNNING is the signal that provisioning succeeded, so `anyscale job wait
+# --state RUNNING` is the gate: it exits 0 on RUNNING, and non-zero if the job hits
+# a terminal state first. Anything that fails *after* RUNNING is a real test failure
+# and is reported as-is.
+#
+# Usage: ci/submit_anyscale_job.sh <config-file> <job-name> <run-timeout-s> [start-timeout-s]
+#
+# Env overrides:
+#   ANYSCALE_CLOUD           cloud to submit to (default sky-anyscale-aws-us-east-1)
+#   CAPACITY_MAX_ATTEMPTS    submissions before giving up (default 10)
+#   CAPACITY_RETRY_DELAY_S   sleep between attempts (default 300)
+
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+    echo "usage: $0 <config-file> <job-name> <run-timeout-s> [start-timeout-s]" >&2
+    exit 2
+fi
+
+CONFIG_FILE="$1"
+JOB_NAME="$2"
+RUN_TIMEOUT_S="$3"
+# How long to wait for GPUs before writing the attempt off as a capacity failure.
+START_TIMEOUT_S="${4:-2700}"
+
+CLOUD="${ANYSCALE_CLOUD:-sky-anyscale-aws-us-east-1}"
+MAX_ATTEMPTS="${CAPACITY_MAX_ATTEMPTS:-10}"
+RETRY_DELAY_S="${CAPACITY_RETRY_DELAY_S:-300}"
+
+# Current state of a job by name. `job status` resolves the most recently created
+# job with that name, which is why each attempt gets a unique name below.
+job_state() {
+    anyscale job status --cloud "$CLOUD" --name "$1" --json 2>/dev/null \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state", "UNKNOWN"))' 2>/dev/null \
+        || echo "UNKNOWN"
+}
+
+# True when the entrypoint produced output, i.e. the cluster really did come up.
+# Guards against misreading a fast entrypoint crash as a capacity failure.
+entrypoint_produced_logs() {
+    local logs
+    logs="$(anyscale job logs --cloud "$CLOUD" --name "$1" --head --max-lines 5 2>/dev/null || true)"
+    [[ -n "${logs//[[:space:]]/}" ]]
+}
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    run_name="$JOB_NAME"
+    if [[ "$attempt" -gt 1 ]]; then
+        run_name="${JOB_NAME}-retry${attempt}"
+    fi
+
+    echo "--- Anyscale job attempt ${attempt}/${MAX_ATTEMPTS}: ${run_name}"
+    anyscale job submit -f "$CONFIG_FILE" --name "$run_name" --timeout "$RUN_TIMEOUT_S"
+
+    started=1
+    anyscale job wait --cloud "$CLOUD" --name "$run_name" \
+        --state RUNNING --timeout "$START_TIMEOUT_S" || started=0
+
+    state="$(job_state "$run_name")"
+
+    if [[ "$started" -eq 0 ]]; then
+        # A job can pass through RUNNING between two 10s `job wait` polls, so a
+        # missed RUNNING with a terminal SUCCEEDED still means we got GPUs.
+        if [[ "$state" == "SUCCEEDED" ]]; then
+            echo "Job ${run_name} succeeded before RUNNING was observed."
+            exit 0
+        fi
+        if entrypoint_produced_logs "$run_name"; then
+            echo "Job ${run_name} failed (state: ${state}) but the entrypoint ran -- real failure, not retrying." >&2
+            exit 1
+        fi
+        echo "Job ${run_name} never reached RUNNING (state: ${state}) and the entrypoint never ran:" >&2
+        echo "treating this as a GPU capacity failure." >&2
+        if [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
+            echo "Resubmitting in ${RETRY_DELAY_S}s ..." >&2
+            sleep "$RETRY_DELAY_S"
+        fi
+        continue
+    fi
+
+    echo "Job ${run_name} reached RUNNING -- GPUs acquired, waiting for the tests to finish."
+    anyscale job wait --cloud "$CLOUD" --name "$run_name" --timeout "$RUN_TIMEOUT_S"
+    exit 0
+done
+
+echo "Gave up after ${MAX_ATTEMPTS} attempts without ever acquiring GPUs." >&2
+exit 1

--- a/ci/submit_anyscale_job.sh
+++ b/ci/submit_anyscale_job.sh
@@ -37,7 +37,7 @@ RUN_TIMEOUT_S="$3"
 START_TIMEOUT_S="${4:-$RUN_TIMEOUT_S}"
 
 CLOUD="${ANYSCALE_CLOUD:-sky-anyscale-aws-us-east-1}"
-MAX_ATTEMPTS="${CAPACITY_MAX_ATTEMPTS:-10}"
+MAX_ATTEMPTS="${CAPACITY_MAX_ATTEMPTS:-5}"
 RETRY_DELAY_S="${CAPACITY_RETRY_DELAY_S:-300}"
 
 # Current state of a job by name. `job status` resolves the most recently created

--- a/ci/submit_anyscale_job.sh
+++ b/ci/submit_anyscale_job.sh
@@ -14,6 +14,12 @@
 #
 # Usage: ci/submit_anyscale_job.sh <config-file> <job-name> <run-timeout-s> [start-timeout-s]
 #
+# <job-name> must be unique to the invocation. `job status` and `job wait` resolve a
+# name to the most recently created job carrying it, so a name shared with a
+# concurrent run would let the two poll each other's jobs. The CI workflows get this
+# from `github.run_id` plus `github.run_attempt`; anything else calling this script
+# is responsible for its own unique suffix.
+#
 # Env overrides:
 #   ANYSCALE_CLOUD           cloud to submit to (default sky-anyscale-aws-us-east-1)
 #   CAPACITY_MAX_ATTEMPTS    submissions before giving up (default 10)
@@ -56,7 +62,7 @@ entrypoint_produced_logs() {
     [[ -n "${logs//[[:space:]]/}" ]]
 }
 
-for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
     run_name="$JOB_NAME"
     if [[ "$attempt" -gt 1 ]]; then
         run_name="${JOB_NAME}-retry${attempt}"

--- a/ci/submit_anyscale_job.sh
+++ b/ci/submit_anyscale_job.sh
@@ -29,8 +29,12 @@ fi
 CONFIG_FILE="$1"
 JOB_NAME="$2"
 RUN_TIMEOUT_S="$3"
-# How long to wait for GPUs before writing the attempt off as a capacity failure.
-START_TIMEOUT_S="${4:-2700}"
+# Ceiling on time spent in STARTING. Defaults to the run timeout, i.e. no deadline
+# of its own, because the failure we retry for terminates the cluster by itself --
+# `job wait` sees the terminal state and returns immediately, well under any bound
+# set here. A job still in STARTING is instead waiting on an autoscaler node or an
+# image pull, and resubmitting neither conjures capacity nor un-restarts the pull.
+START_TIMEOUT_S="${4:-$RUN_TIMEOUT_S}"
 
 CLOUD="${ANYSCALE_CLOUD:-sky-anyscale-aws-us-east-1}"
 MAX_ATTEMPTS="${CAPACITY_MAX_ATTEMPTS:-10}"
@@ -80,6 +84,14 @@ for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
         fi
         echo "Job ${run_name} never reached RUNNING (state: ${state}) and the entrypoint never ran:" >&2
         echo "treating this as a GPU capacity failure." >&2
+        # A `job wait` timeout leaves the job running -- it only stops the client
+        # polling. Terminate before resubmitting so we never leave a second cluster
+        # competing for the same scarce instance type (or silently running tests
+        # whose result nobody reads).
+        case "$state" in
+            SUCCEEDED | FAILED | TERMINATED) ;;
+            *) anyscale job terminate --cloud "$CLOUD" --name "$run_name" || true ;;
+        esac
         if [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
             echo "Resubmitting in ${RETRY_DELAY_S}s ..." >&2
             sleep "$RETRY_DELAY_S"


### PR DESCRIPTION
Add retries for CI if we are unable to acquire compute.

Previously we would just fail the test even if we did not acquire min nodes. Now we will retry after 5 mins up to 10 attempts. Behavior if we reach state `RUNNING` is the same - if we fail, then the test fails, and a pass is a pass.