### PR TITLE
[ci] Fix Black formatting in Tinker test

### DIFF
--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -340,6 +340,8 @@ def test_process_batch_requests_per_model_completes_incrementally(scheduling_eng
     assert processed_models == ["model_a", "model_b"]
     with Session(engine.db_engine) as session:
         assert all(f.status == RequestStatus.COMPLETED for f in session.exec(select(FutureDB)).all())
+
+
 def forward_backward_payload() -> dict:
     return types.ForwardBackwardInput(
         data=[


### PR DESCRIPTION
## Summary

Restore Black formatting in `tests/tinker/test_engine.py`. Missing module-level spacing currently makes repository-wide `check_code_quality` fail on otherwise unrelated pull requests.

## Changes

- add required spacing before `forward_backward_payload`
- no behavioral or test logic changes

## Testing

- `uvx pre-commit run --all-files --config .pre-commit-config.yaml`
- Ruff passed
- Black passed
- gitleaks passed
- `git diff --check`