### PR TITLE
Add watchdog for stalled Ray initialization

### DIFF
--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -1,3 +1,4 @@
+import faulthandler
 import functools
 import ipaddress
 import logging
@@ -5,6 +6,7 @@ import math
 import os
 import socket
 import sys
+import threading
 import time
 from copy import deepcopy
 from datetime import datetime
@@ -27,6 +29,23 @@ from skyrl.env_vars import (
     SKYRL_RAY_PG_TIMEOUT_IN_S,
 )
 from skyrl.train.config.config import SkyRLTrainConfig
+
+
+def _start_ray_init_watchdog(timeout_s: float) -> threading.Event:
+    """Exit the driver if Ray initialization stops making progress."""
+    completed = threading.Event()
+    if timeout_s <= 0:
+        return completed
+
+    def watchdog() -> None:
+        if completed.wait(timeout_s):
+            return
+        logger.error(f"ray.init() did not complete within {timeout_s:g}s; terminating the driver")
+        faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+        os._exit(1)
+
+    threading.Thread(target=watchdog, name="skyrl-ray-init-watchdog", daemon=True).start()
+    return completed
 
 
 class Timer:
@@ -918,7 +937,15 @@ def initialize_ray(cfg: SkyRLTrainConfig):
 
     # log_to_driver=True allows training progress from skyrl_entrypoint to reach stdout.
     # Infrastructure logs (vLLM, workers) are redirected to log file via os.dup2 in their init.
-    ray.init(runtime_env={"env_vars": env_vars}, log_to_driver=True)
+    ray_init_timeout_s = float(os.environ.get("SKYRL_RAY_INIT_TIMEOUT_IN_S", "0"))
+    logger.info(f"Starting ray.init() (timeout={ray_init_timeout_s:g}s; 0 disables the watchdog)")
+    started_at = time.monotonic()
+    ray_init_completed = _start_ray_init_watchdog(ray_init_timeout_s)
+    try:
+        ray.init(runtime_env={"env_vars": env_vars}, log_to_driver=True)
+    finally:
+        ray_init_completed.set()
+    logger.info(f"ray.init() completed in {time.monotonic() - started_at:.1f}s")
 
     if not verbose_logging:
         logger.info(f"Infrastructure logs will be written to: {log_file}")

--- a/tests/train/utils/test_initialize_ray.py
+++ b/tests/train/utils/test_initialize_ray.py
@@ -1,0 +1,29 @@
+import threading
+
+from skyrl.train.utils import utils
+
+
+def test_ray_init_watchdog_exits_after_timeout(monkeypatch):
+    exited = threading.Event()
+    exit_codes = []
+
+    def fake_exit(code):
+        exit_codes.append(code)
+        exited.set()
+
+    monkeypatch.setattr(utils.faulthandler, "dump_traceback", lambda **kwargs: None)
+    monkeypatch.setattr(utils.os, "_exit", fake_exit)
+
+    completed = utils._start_ray_init_watchdog(0.01)
+
+    assert exited.wait(timeout=1)
+    assert exit_codes == [1]
+    completed.set()
+
+
+def test_ray_init_watchdog_can_be_disabled(monkeypatch):
+    monkeypatch.setattr(utils.os, "_exit", lambda code: (_ for _ in ()).throw(AssertionError(code)))
+
+    completed = utils._start_ray_init_watchdog(0)
+
+    assert not completed.is_set()


### PR DESCRIPTION
## Summary

- add an opt-in watchdog around Ray driver initialization
- log the configured deadline and successful initialization duration
- dump all Python thread stacks and terminate the driver when initialization exceeds the deadline

## Motivation

Trajectory TCLI cold starts XIDs 1042972 and 1042974 both blocked indefinitely while the driver CoreWorker registered with the local raylet. The API process stayed healthy and create_model remained pending until its caller timed out after 3600 seconds. Because ray.init is synchronous, timing out only the caller leaves the unusable engine alive.

Set SKYRL_RAY_INIT_TIMEOUT_IN_S to enable the watchdog. The default remains disabled so existing deployments do not change behavior.

## Test plan

- uvx --from ruff==0.11.9 ruff check skyrl/train/utils/utils.py tests/train/utils/test_initialize_ray.py
- uvx --from black==24.10.0 black --check skyrl/train/utils/utils.py tests/train/utils/test_initialize_ray.py
- uv run --isolated --extra dev --extra fsdp pytest -q tests/train/utils/test_initialize_ray.py