### PR TITLE
[tinker] Support tinker SDK proto wire format for fwd_bwd and sample

### DIFF
--- a/.claude/docs/tinker.md
+++ b/.claude/docs/tinker.md
@@ -5,6 +5,7 @@ SkyRL's implementation of the [Tinker API](https://tinker-docs.thinkingmachines.
 ## Code Layout
 
 - **`skyrl/tinker/api.py`** -- FastAPI HTTP server. Receives Tinker SDK requests, writes them to SQLite/Postgres, returns future IDs.
+- **`skyrl/tinker/proto_serialization.py`** -- Proto wire-format conversion. SDK >= 0.25.0 sends `forward_backward` request bodies as protobuf (with forward-only passes routed to `/forward_backward` via a `forward_only` flag instead of `/forward`) and requires proto-serialized `SampleResponse`/`ForwardBackwardOutput` results from `retrieve_future`. Mirrors the SDK's `tinker/proto/{request,response}_conv.py`; round-trip tested in `tests/tinker/test_proto_serialization.py`.
 - **`skyrl/tinker/engine.py`** -- Background subprocess (`TinkerEngine`). Polls DB, batches compatible requests, dispatches to backend.
 - **`skyrl/tinker/types.py`** -- Internal Pydantic models (distinct from API request/response models in `api.py`). `LOSS_TYPES` dict defines valid loss functions.
 - **`skyrl/tinker/config.py`** -- `EngineConfig` Pydantic model. `add_model()` auto-generates argparse flags from Pydantic fields.

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1083,15 +1083,15 @@ async def get_training_run(model_id: str, session: AsyncSession = Depends(get_se
     )
 
 
-async def _read_forward_backward_request(req: Request) -> tuple[ForwardBackwardRequest, bool]:
+async def _read_forward_backward_request(request: Request) -> tuple[ForwardBackwardRequest, bool]:
     """Read a forward_backward body in either wire format.
 
     tinker SDK >= 0.25.0 submits the body as protobuf and routes forward-only
     passes here via the proto's ``forward_only`` flag instead of calling
     ``/api/v1/forward``; older SDKs keep sending JSON with forward_only False.
     """
-    body = await req.body()
-    if PROTO_CONTENT_TYPE in req.headers.get("content-type", ""):
+    body = await request.body()
+    if PROTO_CONTENT_TYPE in request.headers.get("content-type", ""):
         try:
             request_dict, forward_only = parse_forward_backward_request(body)
         except (DecodeError, ValueError) as e:
@@ -1108,17 +1108,17 @@ async def _read_forward_backward_request(req: Request) -> tuple[ForwardBackwardR
 
 
 @app.post("/api/v1/forward_backward", response_model=FutureResponse)
-async def forward_backward(req: Request, session: AsyncSession = Depends(get_session)):
+async def forward_backward(request: Request, session: AsyncSession = Depends(get_session)):
     """Compute and accumulate gradients (or run forward-only when the proto body asks for it)."""
-    request, forward_only = await _read_forward_backward_request(req)
-    await get_model(session, request.model_id)
+    req, forward_only = await _read_forward_backward_request(request)
+    await get_model(session, req.model_id)
 
     request_id = await create_future(
         session=session,
         request_type=types.RequestType.FORWARD if forward_only else types.RequestType.FORWARD_BACKWARD,
-        model_id=request.model_id,
-        request_data=request.forward_backward_input.to_types(),
-        seq_id=request.seq_id,
+        model_id=req.model_id,
+        request_data=req.forward_backward_input.to_types(),
+        seq_id=req.seq_id,
     )
 
     await session.commit()

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import random
 import re
@@ -13,7 +14,9 @@ from uuid import uuid4
 import fastapi
 import psutil
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi.exceptions import RequestValidationError as FastAPIRequestValidationError
 from fastapi.responses import RedirectResponse, StreamingResponse
+from google.protobuf.message import DecodeError
 from pydantic import (
     Base64Bytes,
     BaseModel,
@@ -44,6 +47,12 @@ from skyrl.tinker.db_models import (
 from skyrl.tinker.extra import (
     ExternalInferenceClient,
     SkyRLTrainInferenceForwardingClient,
+)
+from skyrl.tinker.proto_serialization import (
+    PROTO_CONTENT_TYPE,
+    PROTO_SERIALIZABLE_REQUEST_TYPES,
+    parse_forward_backward_request,
+    serialize_result,
 )
 from skyrl.utils.log import get_uvicorn_log_config, logger
 from skyrl.utils.storage import download_file
@@ -85,8 +94,8 @@ def raw_json_response(payload: str | None) -> Response:
 
 async def wait_for_future(
     waiters: dict[int, set[asyncio.Future]], request_id: int, timeout: float
-) -> tuple[RequestStatus, str | None] | None:
-    """Wait for ``request_id`` to finish, returning its ``(status, result_data)``.
+) -> tuple[RequestStatus, types.RequestType, str | None] | None:
+    """Wait for ``request_id`` to finish, returning its ``(status, request_type, result_data)``.
 
     ``result_data`` is the JSON text stored for the request, not a decoded
     object -- see :class:`FutureDB`.
@@ -142,15 +151,15 @@ async def poll_futures(
                     # The awaited ids go in as bound parameters, capped at 32766
                     # by SQLite (since 3.32) and 65535 by Postgres -- far above
                     # any plausible number of in-flight requests.
-                    statement = select(FutureDB.request_id, FutureDB.status, FutureDB.result_data).where(
-                        FutureDB.request_id.in_(awaited)
-                    )
+                    statement = select(
+                        FutureDB.request_id, FutureDB.status, FutureDB.request_type, FutureDB.result_data
+                    ).where(FutureDB.request_id.in_(awaited))
                     rows = (await session.exec(statement)).all()
 
                 # Pending requests are left alone to be picked up on a later tick.
-                outcomes: dict[int, tuple[RequestStatus, str | None] | KeyError] = {
-                    request_id: (status, result_data)
-                    for request_id, status, result_data in rows
+                outcomes: dict[int, tuple[RequestStatus, types.RequestType, str | None] | KeyError] = {
+                    request_id: (status, request_type, result_data)
+                    for request_id, status, request_type, result_data in rows
                     if status in TERMINAL_STATUSES
                 }
                 for request_id in set(awaited) - {request_id for request_id, *_ in rows}:
@@ -1074,14 +1083,39 @@ async def get_training_run(model_id: str, session: AsyncSession = Depends(get_se
     )
 
 
+async def _read_forward_backward_request(req: Request) -> tuple[ForwardBackwardRequest, bool]:
+    """Read a forward_backward body in either wire format.
+
+    tinker SDK >= 0.25.0 submits the body as protobuf and routes forward-only
+    passes here via the proto's ``forward_only`` flag instead of calling
+    ``/api/v1/forward``; older SDKs keep sending JSON with forward_only False.
+    """
+    body = await req.body()
+    if PROTO_CONTENT_TYPE in req.headers.get("content-type", ""):
+        try:
+            request_dict, forward_only = parse_forward_backward_request(body)
+        except (DecodeError, ValueError) as e:
+            raise HTTPException(status_code=422, detail=f"Invalid proto forward_backward body: {e}")
+    else:
+        request_dict, forward_only = None, False
+    try:
+        if request_dict is not None:
+            return ForwardBackwardRequest.model_validate(request_dict), forward_only
+        return ForwardBackwardRequest.model_validate_json(body), forward_only
+    except ValidationError as e:
+        # Match FastAPI's native body validation error shape (422).
+        raise FastAPIRequestValidationError(e.errors())
+
+
 @app.post("/api/v1/forward_backward", response_model=FutureResponse)
-async def forward_backward(request: ForwardBackwardRequest, session: AsyncSession = Depends(get_session)):
-    """Compute and accumulate gradients."""
+async def forward_backward(req: Request, session: AsyncSession = Depends(get_session)):
+    """Compute and accumulate gradients (or run forward-only when the proto body asks for it)."""
+    request, forward_only = await _read_forward_backward_request(req)
     await get_model(session, request.model_id)
 
     request_id = await create_future(
         session=session,
-        request_type=types.RequestType.FORWARD_BACKWARD,
+        request_type=types.RequestType.FORWARD if forward_only else types.RequestType.FORWARD_BACKWARD,
         model_id=request.model_id,
         request_data=request.forward_backward_input.to_types(),
         seq_id=request.seq_id,
@@ -1327,8 +1361,18 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     if row is None:
         raise HTTPException(status_code=408, detail="Timeout waiting for result")
 
-    status, result_data = row
+    status, request_type, result_data = row
     if status == RequestStatus.COMPLETED:
+        # The SDK retrieves sample/forward/forward_backward results in proto
+        # wire format when it advertises support; SDK >= 0.25.0 rejects JSON
+        # for these types. Errors and other result types stay JSON.
+        if types.RequestType(
+            request_type
+        ) in PROTO_SERIALIZABLE_REQUEST_TYPES and PROTO_CONTENT_TYPE in req.headers.get("accept", ""):
+            return Response(
+                content=serialize_result(types.RequestType(request_type), json.loads(result_data)),
+                media_type=PROTO_CONTENT_TYPE,
+            )
         return raw_json_response(result_data)
 
     # Return 400 for handled errors (validation, etc.), 500 for unexpected failures.

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1091,7 +1091,7 @@ async def _read_forward_backward_request(request: Request) -> tuple[ForwardBackw
     ``/api/v1/forward``; older SDKs keep sending JSON with forward_only False.
     """
     body = await request.body()
-    if PROTO_CONTENT_TYPE in request.headers.get("content-type", ""):
+    if PROTO_CONTENT_TYPE in request.headers.get("content-type", "").lower():
         try:
             request_dict, forward_only = parse_forward_backward_request(body)
         except (DecodeError, ValueError) as e:
@@ -1366,9 +1366,10 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
         # The SDK retrieves sample/forward/forward_backward results in proto
         # wire format when it advertises support; SDK >= 0.25.0 rejects JSON
         # for these types. Errors and other result types stay JSON.
-        if types.RequestType(
-            request_type
-        ) in PROTO_SERIALIZABLE_REQUEST_TYPES and PROTO_CONTENT_TYPE in req.headers.get("accept", ""):
+        if (
+            types.RequestType(request_type) in PROTO_SERIALIZABLE_REQUEST_TYPES
+            and PROTO_CONTENT_TYPE in req.headers.get("accept", "").lower()
+        ):
             return Response(
                 content=serialize_result(types.RequestType(request_type), json.loads(result_data)),
                 media_type=PROTO_CONTENT_TYPE,

--- a/skyrl/tinker/proto_serialization.py
+++ b/skyrl/tinker/proto_serialization.py
@@ -1,0 +1,203 @@
+"""Proto wire-format conversion for the Tinker SDK's binary paths.
+
+Two directions, both required by tinker SDK >= 0.25.0 (older SDKs negotiate
+these via server-side client_config flags and fall back to JSON):
+
+- **Responses**: the SDK retrieves ``sample``, ``forward``, and
+  ``forward_backward`` results as protobuf (``Accept: application/x-protobuf``
+  on ``retrieve_future``) and rejects JSON for these types. Serializers here
+  are the inverse of the SDK's ``tinker/proto/response_conv.py``: tokens as
+  little-endian int32 bytes, logprobs as float32 bytes, undefined
+  ``prompt_logprobs`` entries as NaN, undefined top-k entries sentinel-filled
+  (token_id=0, logprob=-99999.0), and each ``BatchedTensor`` concatenating
+  per-datum arrays with int64 byte offsets.
+
+- **Requests**: the SDK submits ``forward_backward`` bodies as protobuf
+  (``Content-Type: application/x-protobuf``), with forward-only passes sent to
+  the same endpoint via the ``forward_only`` flag instead of ``/api/v1/forward``.
+  The parser here is the inverse of the SDK's ``tinker/proto/request_conv.py``.
+"""
+
+import base64
+
+import numpy as np
+from tinker.proto import tinker_public_pb2 as pb
+
+from skyrl.tinker import types
+
+PROTO_CONTENT_TYPE = "application/x-protobuf"
+
+# Request types whose results the SDK can retrieve in proto form. All other
+# results are only ever served as JSON.
+PROTO_SERIALIZABLE_REQUEST_TYPES = frozenset(
+    {types.RequestType.SAMPLE, types.RequestType.FORWARD, types.RequestType.FORWARD_BACKWARD}
+)
+
+# Sentinel fill for undefined top-k positions; must match the SDK's
+# MASK_LOGPROB in tinker/types/sample_response.py.
+_TOPK_MASK_TOKEN_ID = 0
+_TOPK_MASK_LOGPROB = -99999.0
+
+_STOP_REASON_TO_PROTO = {
+    "stop": pb.STOP_REASON_STOP,
+    "length": pb.STOP_REASON_LENGTH,
+}
+
+_TENSOR_DTYPE_TO_PROTO = {"float32": pb.DTYPE_FLOAT32, "int64": pb.DTYPE_INT64}
+_TENSOR_DTYPE_TO_NUMPY = {"float32": np.float32, "int64": np.int64}
+
+# Request tensors only arrive as the public dtypes (the SDK collapses to
+# {float32, int64} on the write path).
+_PROTO_DTYPE_TO_NUMPY = {pb.DTYPE_FLOAT32: np.float32, pb.DTYPE_INT64: np.int64}
+
+
+def parse_forward_backward_request(body: bytes) -> tuple[dict, bool]:
+    """Parse a proto ForwardBackwardRequest body into the JSON-equivalent
+    request dict (ready for the API's ``ForwardBackwardRequest`` model) and
+    the ``forward_only`` flag."""
+    msg = pb.ForwardBackwardRequest()
+    msg.ParseFromString(body)
+
+    data = []
+    for datum in msg.data:
+        chunks = []
+        for chunk in datum.model_input:
+            which = chunk.WhichOneof("chunk")
+            if which == "encoded_text":
+                chunks.append(
+                    {
+                        "type": "encoded_text",
+                        "tokens": np.frombuffer(chunk.encoded_text.tokens, dtype=np.int32).tolist(),
+                    }
+                )
+            elif which == "image":
+                image_chunk = {
+                    "type": "image",
+                    "data": base64.b64encode(chunk.image.data).decode(),
+                    "format": chunk.image.format,
+                }
+                if chunk.image.HasField("expected_tokens"):
+                    image_chunk["expected_tokens"] = chunk.image.expected_tokens
+                chunks.append(image_chunk)
+            else:
+                raise ValueError(f"Unsupported model input chunk type: {which}")
+        loss_fn_inputs = {name: _tensor_from_proto(tensor) for name, tensor in datum.loss_fn_inputs.items()}
+        data.append({"model_input": {"chunks": chunks}, "loss_fn_inputs": loss_fn_inputs})
+
+    request_dict = {
+        "model_id": msg.model_id,
+        "forward_backward_input": {
+            "data": data,
+            "loss_fn": msg.loss_fn,
+            "loss_fn_config": dict(msg.loss_fn_config) or None,
+        },
+    }
+    return request_dict, msg.forward_only
+
+
+def _tensor_from_proto(tensor: pb.Tensor) -> dict:
+    np_dtype = _PROTO_DTYPE_TO_NUMPY.get(tensor.dtype)
+    if np_dtype is None:
+        raise ValueError(f"Unsupported tensor dtype value in request: {tensor.dtype}")
+    if tensor.WhichOneof("encoding") != "dense":
+        raise ValueError("Sparse loss_fn_input tensors are not supported")
+    return {"data": np.frombuffer(tensor.dense, dtype=np_dtype).tolist()}
+
+
+def serialize_result(request_type: types.RequestType, result_data: dict) -> bytes:
+    """Serialize a completed future's result_data dict to proto wire bytes."""
+    if request_type == types.RequestType.SAMPLE:
+        return _serialize_sample_output(result_data)
+    if request_type in (types.RequestType.FORWARD, types.RequestType.FORWARD_BACKWARD):
+        return _serialize_forward_backward_output(result_data)
+    raise ValueError(f"No proto serialization for request type: {request_type}")
+
+
+def _serialize_sample_output(result_data: dict) -> bytes:
+    output = types.SampleOutput.model_validate(result_data)
+    proto = pb.SampleResponse()
+
+    for seq in output.sequences:
+        proto.sequences.append(
+            pb.SampledSequence(
+                stop_reason=_STOP_REASON_TO_PROTO[seq.stop_reason],
+                tokens=np.asarray(seq.tokens, dtype=np.int32).tobytes(),
+                logprobs=np.asarray(seq.logprobs, dtype=np.float32).tobytes(),
+            )
+        )
+
+    if output.prompt_logprobs is not None:
+        proto.prompt_logprobs = np.array(
+            [np.nan if lp is None else lp for lp in output.prompt_logprobs], dtype=np.float32
+        ).tobytes()
+
+    if output.topk_prompt_logprobs is not None:
+        rows = output.topk_prompt_logprobs
+        # k is not recorded in the result, so recover it from the widest row.
+        # With every row undefined, use k=1 so prompt_length stays encoded
+        # (the client maps fully-masked rows back to None).
+        k = max((len(row) for row in rows if row), default=1)
+        token_ids = np.full((len(rows), k), _TOPK_MASK_TOKEN_ID, dtype=np.int32)
+        logprobs = np.full((len(rows), k), _TOPK_MASK_LOGPROB, dtype=np.float32)
+        for i, row in enumerate(rows):
+            for j, (token_id, logprob) in enumerate(row or ()):
+                token_ids[i, j] = token_id
+                logprobs[i, j] = logprob
+        proto.topk_prompt_logprobs.CopyFrom(
+            pb.TopkPromptLogprobs(
+                prompt_length=len(rows),
+                k=k,
+                token_ids=token_ids.tobytes(),
+                logprobs=logprobs.tobytes(),
+            )
+        )
+
+    return proto.SerializeToString()
+
+
+def _serialize_forward_backward_output(result_data: dict) -> bytes:
+    output = types.ForwardBackwardOutput.model_validate(result_data)
+    proto = pb.ForwardBackwardOutput()
+    proto.loss_fn_output_type = output.loss_fn_output_type
+    for name, value in output.metrics.items():
+        proto.metrics[name] = float(value)
+
+    if not output.loss_fn_outputs:
+        return proto.SerializeToString()
+
+    record = proto.loss_fn_outputs.add()
+    record.num_datums = len(output.loss_fn_outputs)
+
+    # Union of field names across datums, in first-seen order. Backends emit
+    # the same fields for every datum in a request, but a missing field still
+    # encodes cleanly as an empty slice (equal adjacent offsets).
+    field_names = list(dict.fromkeys(name for datum in output.loss_fn_outputs for name in datum))
+    for name in field_names:
+        tensors = [datum.get(name) for datum in output.loss_fn_outputs]
+        dtypes = {t["dtype"] for t in tensors if t is not None}
+        if len(dtypes) > 1:
+            raise ValueError(f"Field {name} has mixed dtypes across datums: {dtypes}")
+        dtype = dtypes.pop() if dtypes else "float32"
+
+        # The SDK slices one BatchedTensor with a single trailing shape, so
+        # datums may only be ragged in the leading dimension.
+        trailing_shapes = {tuple(t["shape"][1:]) for t in tensors if t is not None}
+        if len(trailing_shapes) > 1:
+            raise ValueError(f"Field {name} has mixed trailing shapes across datums: {trailing_shapes}")
+        trailing_shape = trailing_shapes.pop() if trailing_shapes else ()
+
+        np_dtype = _TENSOR_DTYPE_TO_NUMPY[dtype]
+        arrays = [np.asarray(t["data"] if t is not None else [], dtype=np_dtype).ravel() for t in tensors]
+        offsets = np.zeros(len(arrays) + 1, dtype=np.int64)
+        np.cumsum([a.nbytes for a in arrays], out=offsets[1:])
+
+        record.fields[name].CopyFrom(
+            pb.BatchedTensor(
+                data=b"".join(a.tobytes() for a in arrays),
+                offsets=offsets.tobytes(),
+                dtype=_TENSOR_DTYPE_TO_PROTO[dtype],
+                trailing_shape=trailing_shape,
+            )
+        )
+
+    return proto.SerializeToString()

--- a/skyrl/tinker/proto_serialization.py
+++ b/skyrl/tinker/proto_serialization.py
@@ -92,6 +92,9 @@ def parse_forward_backward_request(body: bytes) -> tuple[dict, bool]:
 
     request_dict = {
         "model_id": msg.model_id,
+        # seq_id is non-optional on the wire; the SDK encodes a caller-supplied
+        # None as 0.
+        "seq_id": msg.seq_id or None,
         "forward_backward_input": {
             "data": data,
             "loss_fn": msg.loss_fn,

--- a/skyrl/tinker/proto_serialization.py
+++ b/skyrl/tinker/proto_serialization.py
@@ -28,9 +28,15 @@ from skyrl.tinker import types
 PROTO_CONTENT_TYPE = "application/x-protobuf"
 
 # Request types whose results the SDK can retrieve in proto form. All other
-# results are only ever served as JSON.
+# results are only ever served as JSON. EXTERNAL is a sample forwarded to
+# external/backend inference engines; its result_data is a SampleOutput dump.
 PROTO_SERIALIZABLE_REQUEST_TYPES = frozenset(
-    {types.RequestType.SAMPLE, types.RequestType.FORWARD, types.RequestType.FORWARD_BACKWARD}
+    {
+        types.RequestType.SAMPLE,
+        types.RequestType.EXTERNAL,
+        types.RequestType.FORWARD,
+        types.RequestType.FORWARD_BACKWARD,
+    }
 )
 
 # Sentinel fill for undefined top-k positions; must match the SDK's
@@ -106,7 +112,7 @@ def _tensor_from_proto(tensor: pb.Tensor) -> dict:
 
 def serialize_result(request_type: types.RequestType, result_data: dict) -> bytes:
     """Serialize a completed future's result_data dict to proto wire bytes."""
-    if request_type == types.RequestType.SAMPLE:
+    if request_type in (types.RequestType.SAMPLE, types.RequestType.EXTERNAL):
         return _serialize_sample_output(result_data)
     if request_type in (types.RequestType.FORWARD, types.RequestType.FORWARD_BACKWARD):
         return _serialize_forward_backward_output(result_data)

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -252,7 +252,9 @@ async def test_retrieve_future_serves_proto_when_accepted(waiters, async_engine,
     mark_completed(
         sync_engine,
         request_id,
-        types.SampleOutput(sequences=[types.GeneratedSequence(stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0])]),
+        types.SampleOutput(
+            sequences=[types.GeneratedSequence(stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0])]
+        ),
     )
 
     result = await api.retrieve_future(

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -105,11 +105,15 @@ async def test_resolves_once_the_request_completes(waiters, sync_engine):
         mark_completed(sync_engine, request_id, SAMPLE_RESULT)
 
     asyncio.create_task(complete_soon())
-    status, result_data = await wait_for_future(waiters, request_id, timeout=5)
+    status, request_type, result_data = await wait_for_future(waiters, request_id, timeout=5)
 
     # result_data is the stored JSON text, not a decoded object, so it takes a
     # parse to compare against the result that was stored.
-    assert (status, types.SampleOutput.model_validate_json(result_data)) == (RequestStatus.COMPLETED, SAMPLE_RESULT)
+    assert (status, request_type, types.SampleOutput.model_validate_json(result_data)) == (
+        RequestStatus.COMPLETED,
+        types.RequestType.SAMPLE,
+        SAMPLE_RESULT,
+    )
 
 
 @pytest.mark.asyncio
@@ -118,9 +122,13 @@ async def test_surfaces_failed_status(waiters, sync_engine):
     error = types.ErrorResponse(error="boom", status="failed")
     mark_completed(sync_engine, request_id, error, status=RequestStatus.FAILED)
 
-    status, result_data = await wait_for_future(waiters, request_id, timeout=5)
+    status, request_type, result_data = await wait_for_future(waiters, request_id, timeout=5)
 
-    assert (status, types.ErrorResponse.model_validate_json(result_data)) == (RequestStatus.FAILED, error)
+    assert (status, request_type, types.ErrorResponse.model_validate_json(result_data)) == (
+        RequestStatus.FAILED,
+        types.RequestType.SAMPLE,
+        error,
+    )
 
 
 @pytest.mark.asyncio
@@ -150,7 +158,7 @@ async def test_one_waiter_giving_up_does_not_strand_the_others(waiters, sync_eng
     result = types.OptimStepOutput(metrics={"loss": 1.5})
     mark_completed(sync_engine, request_id, result)
 
-    status, result_data = await patient
+    status, _, result_data = await patient
     assert (status, types.OptimStepOutput.model_validate_json(result_data)) == (RequestStatus.COMPLETED, result)
 
 
@@ -179,10 +187,13 @@ async def test_query_count_does_not_scale_with_waiters(waiters, sync_engine, asy
     assert 0 < len(statements) < 50
 
 
-def _stub_request(async_engine, waiters):
+def _stub_request(async_engine, waiters, headers: dict | None = None):
     from types import SimpleNamespace
 
-    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(db_engine=async_engine, future_waiters=waiters)))
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(db_engine=async_engine, future_waiters=waiters)),
+        headers=headers or {},
+    )
 
 
 @pytest.mark.asyncio
@@ -226,6 +237,32 @@ async def test_retrieve_future_400s_with_the_stored_error(waiters, async_engine,
 
     assert excinfo.value.status_code == 400
     assert excinfo.value.detail == "boom"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_future_serves_proto_when_accepted(waiters, async_engine, sync_engine):
+    """A completed sample future is served as proto bytes when the client's
+    Accept header asks for it (the JSON test above covers the default path)."""
+    from tinker import SampleResponse
+    from tinker.proto.response_conv import deserialize_proto_response
+
+    from skyrl.tinker import api
+
+    request_id = insert_pending(sync_engine)[0]
+    mark_completed(
+        sync_engine,
+        request_id,
+        types.SampleOutput(sequences=[types.GeneratedSequence(stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0])]),
+    )
+
+    result = await api.retrieve_future(
+        api.RetrieveFutureRequest(request_id=str(request_id)),
+        _stub_request(async_engine, waiters, headers={"accept": "application/x-protobuf, application/json"}),
+    )
+
+    assert result.media_type == "application/x-protobuf"
+    response = deserialize_proto_response(result.body, SampleResponse)
+    assert response.sequences[0].tokens == [1, 2]
 
 
 @pytest.mark.asyncio

--- a/tests/tinker/test_proto_serialization.py
+++ b/tests/tinker/test_proto_serialization.py
@@ -147,6 +147,15 @@ def test_forward_uses_forward_backward_wire_type():
     np.testing.assert_allclose(output.loss_fn_outputs[0]["logprobs"].tolist(), [-0.5])
 
 
+def test_external_sample_serializes_as_sample_response():
+    """EXTERNAL futures (samples forwarded to external inference engines) must
+    serialize as SampleResponse like SAMPLE ones."""
+    result_data = {"sequences": [{"stop_reason": "stop", "tokens": [5, 6], "logprobs": [-0.5, -1.0]}]}
+    proto_bytes = serialize_result(types.RequestType.EXTERNAL, result_data)
+    response = deserialize_proto_response(proto_bytes, SampleResponse)
+    assert response.sequences[0].tokens == [5, 6]
+
+
 def test_unsupported_request_type_raises():
     with pytest.raises(ValueError, match="No proto serialization"):
         serialize_result(types.RequestType.OPTIM_STEP, {})

--- a/tests/tinker/test_proto_serialization.py
+++ b/tests/tinker/test_proto_serialization.py
@@ -1,0 +1,204 @@
+"""Round-trip tests for proto serialization of retrieve_future results.
+
+Each test serializes a result_data dict the way the API server does and
+deserializes it with the installed tinker SDK's own proto deserializers,
+so the wire conventions (byte layouts, NaN/sentinel fills) are checked
+against the exact code the client runs.
+"""
+
+import math
+
+import numpy as np
+import pytest
+import tinker.types as sdk_types
+from tinker import ForwardBackwardOutput, SampleResponse
+from tinker.proto.request_conv import forward_backward_request_to_proto
+from tinker.proto.response_conv import deserialize_proto_response
+
+from skyrl.tinker import api, types
+from skyrl.tinker.proto_serialization import (
+    parse_forward_backward_request,
+    serialize_result,
+)
+
+
+def roundtrip_sample(result_data: dict) -> SampleResponse:
+    return deserialize_proto_response(serialize_result(types.RequestType.SAMPLE, result_data), SampleResponse)
+
+
+def roundtrip_forward_backward(result_data: dict) -> ForwardBackwardOutput:
+    return deserialize_proto_response(
+        serialize_result(types.RequestType.FORWARD_BACKWARD, result_data), ForwardBackwardOutput
+    )
+
+
+def test_sample_sequences():
+    result_data = {
+        "sequences": [
+            {"stop_reason": "stop", "tokens": [1, 2, 3], "logprobs": [-0.5, -1.25, -2.0]},
+            {"stop_reason": "length", "tokens": [7], "logprobs": [-0.125]},
+        ]
+    }
+    response = roundtrip_sample(result_data)
+    assert len(response.sequences) == 2
+    assert response.sequences[0].stop_reason == "stop"
+    assert response.sequences[0].tokens == [1, 2, 3]
+    assert response.sequences[0].logprobs == [-0.5, -1.25, -2.0]
+    assert response.sequences[1].stop_reason == "length"
+    assert response.sequences[1].tokens == [7]
+    assert response.prompt_logprobs is None
+    assert response.topk_prompt_logprobs is None
+
+
+def test_sample_prompt_logprobs_none_becomes_nan_wire_none_client():
+    result_data = {
+        "sequences": [{"stop_reason": "stop", "tokens": [1], "logprobs": [-0.5]}],
+        "prompt_logprobs": [None, -0.25, -0.75],
+    }
+    response = roundtrip_sample(result_data)
+    assert response.prompt_logprobs == [None, pytest.approx(-0.25), pytest.approx(-0.75)]
+    assert math.isnan(response.prompt_logprobs_np[0])
+
+
+def test_sample_topk_prompt_logprobs():
+    result_data = {
+        "sequences": [{"stop_reason": "stop", "tokens": [1], "logprobs": [-0.5]}],
+        # First position undefined, second full width, third narrower (ragged).
+        "topk_prompt_logprobs": [
+            None,
+            [(11, -0.1), (12, -0.2)],
+            [(13, -0.3)],
+        ],
+    }
+    response = roundtrip_sample(result_data)
+    topk = response.topk_prompt_logprobs
+    assert topk[0] is None
+    assert topk[1] == [(11, pytest.approx(-0.1)), (12, pytest.approx(-0.2))]
+    assert topk[2] == [(13, pytest.approx(-0.3))]
+
+
+def test_sample_topk_all_rows_undefined():
+    result_data = {
+        "sequences": [{"stop_reason": "stop", "tokens": [1], "logprobs": [-0.5]}],
+        "topk_prompt_logprobs": [None, None],
+    }
+    response = roundtrip_sample(result_data)
+    assert response.topk_prompt_logprobs == [None, None]
+
+
+def test_forward_backward_ragged_datums_and_metrics():
+    result_data = {
+        "loss_fn_output_type": "scalar",
+        "loss_fn_outputs": [
+            {
+                "elementwise_loss": {"data": [1.0, 2.0, 3.0], "dtype": "float32", "shape": [3]},
+                "logprobs": {"data": [-0.1, -0.2, -0.3], "dtype": "float32", "shape": [3]},
+            },
+            {
+                "elementwise_loss": {"data": [4.0], "dtype": "float32", "shape": [1]},
+                "logprobs": {"data": [-0.4], "dtype": "float32", "shape": [1]},
+            },
+        ],
+        "metrics": {"loss:sum": 10.5, "clip_fraction": 0.25},
+    }
+    output = roundtrip_forward_backward(result_data)
+    assert output.loss_fn_output_type == "scalar"
+    assert output.metrics == {"loss:sum": 10.5, "clip_fraction": 0.25}
+    assert len(output.loss_fn_outputs) == 2
+    first, second = output.loss_fn_outputs
+    np.testing.assert_allclose(first["elementwise_loss"].tolist(), [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(first["logprobs"].tolist(), [-0.1, -0.2, -0.3], rtol=1e-6)
+    assert first["logprobs"].dtype == "float32"
+    assert first["logprobs"].shape == [3]
+    np.testing.assert_allclose(second["elementwise_loss"].tolist(), [4.0])
+    assert second["logprobs"].shape == [1]
+
+
+def test_forward_backward_empty_outputs():
+    result_data = {"loss_fn_output_type": "scalar", "loss_fn_outputs": [], "metrics": {"loss:sum": 0.0}}
+    output = roundtrip_forward_backward(result_data)
+    assert output.loss_fn_outputs == []
+    assert output.metrics == {"loss:sum": 0.0}
+
+
+def test_forward_backward_field_missing_in_one_datum():
+    result_data = {
+        "loss_fn_output_type": "scalar",
+        "loss_fn_outputs": [
+            {"logprobs": {"data": [-0.1, -0.2], "dtype": "float32", "shape": [2]}},
+            {},
+        ],
+        "metrics": {},
+    }
+    output = roundtrip_forward_backward(result_data)
+    assert len(output.loss_fn_outputs) == 2
+    np.testing.assert_allclose(output.loss_fn_outputs[0]["logprobs"].tolist(), [-0.1, -0.2], rtol=1e-6)
+    assert output.loss_fn_outputs[1]["logprobs"].tolist() == []
+
+
+def test_forward_uses_forward_backward_wire_type():
+    result_data = {
+        "loss_fn_output_type": "scalar",
+        "loss_fn_outputs": [{"logprobs": {"data": [-0.5], "dtype": "float32", "shape": [1]}}],
+        "metrics": {},
+    }
+    proto_bytes = serialize_result(types.RequestType.FORWARD, result_data)
+    output = deserialize_proto_response(proto_bytes, ForwardBackwardOutput)
+    np.testing.assert_allclose(output.loss_fn_outputs[0]["logprobs"].tolist(), [-0.5])
+
+
+def test_unsupported_request_type_raises():
+    with pytest.raises(ValueError, match="No proto serialization"):
+        serialize_result(types.RequestType.OPTIM_STEP, {})
+
+
+def encode_sdk_fwd_bwd_request(loss_fn_config=None, forward_only=False) -> bytes:
+    """Build a fwd_bwd request with the SDK's own proto encoder."""
+    request = sdk_types.ForwardBackwardRequest(
+        model_id="model_abc",
+        seq_id=1,
+        forward_backward_input=sdk_types.ForwardBackwardInput(
+            data=[
+                sdk_types.Datum(
+                    model_input=sdk_types.ModelInput.from_ints([1, 2, 3, 4]),
+                    loss_fn_inputs={
+                        "target_tokens": sdk_types.TensorData(data=[2, 3, 4, 5], dtype="int64", shape=[4]),
+                        "weights": sdk_types.TensorData(data=[1.0, 0.5, 1.0, 0.0], dtype="float32", shape=[4]),
+                    },
+                )
+            ],
+            loss_fn="cross_entropy",
+            loss_fn_config=loss_fn_config,
+        ),
+    )
+    proto_msg = forward_backward_request_to_proto(request)
+    proto_msg.forward_only = forward_only
+    return proto_msg.SerializeToString()
+
+
+def test_parse_forward_backward_request():
+    request_dict, forward_only = parse_forward_backward_request(encode_sdk_fwd_bwd_request())
+    assert not forward_only
+
+    # The dict must validate against the API's JSON request model.
+    request = api.ForwardBackwardRequest.model_validate(request_dict)
+    assert request.model_id == "model_abc"
+    assert request.forward_backward_input.loss_fn == "cross_entropy"
+    assert request.forward_backward_input.loss_fn_config is None
+    (datum,) = request.forward_backward_input.data
+    (chunk,) = datum.model_input.chunks
+    assert chunk.tokens == [1, 2, 3, 4]
+    assert datum.loss_fn_inputs["target_tokens"].data == [2, 3, 4, 5]
+    assert datum.loss_fn_inputs["weights"].data == [1.0, 0.5, 1.0, 0.0]
+
+
+def test_parse_forward_backward_request_forward_only_and_config():
+    body = encode_sdk_fwd_bwd_request(loss_fn_config={"clip_low_threshold": 0.2}, forward_only=True)
+    request_dict, forward_only = parse_forward_backward_request(body)
+    assert forward_only
+    assert request_dict["forward_backward_input"]["loss_fn_config"] == {"clip_low_threshold": 0.2}
+
+
+def test_parse_forward_backward_request_garbage_raises():
+    with pytest.raises(Exception):
+        parse_forward_backward_request(b"\xff\xfe not a proto")

--- a/tests/tinker/test_proto_serialization.py
+++ b/tests/tinker/test_proto_serialization.py
@@ -192,6 +192,7 @@ def test_parse_forward_backward_request():
     # The dict must validate against the API's JSON request model.
     request = api.ForwardBackwardRequest.model_validate(request_dict)
     assert request.model_id == "model_abc"
+    assert request.seq_id == 1
     assert request.forward_backward_input.loss_fn == "cross_entropy"
     assert request.forward_backward_input.loss_fn_config is None
     (datum,) = request.forward_backward_input.data


### PR DESCRIPTION
## What does this PR do?

Fixes the nightly tinker cookbook e2e failures that started 2026-08-12:

```
ValueError: Server returned a JSON payload for self.model_cls=<class 'tinker.SampleResponse'> ...,
which this SDK version only supports as proto.
```

The e2e scripts install the tinker SDK unpinned, and **tinker 0.25.0 (released 2026-08-08) made its proto wire paths mandatory**:

1. **Responses**: `retrieve_future` results for `sample` / `forward` / `forward_backward` must be proto-serialized when the client sends `Accept: application/x-protobuf`. Since 0.18.0 the SDK has sent `Accept: application/x-protobuf, application/json` and deserialized whichever format the server returned — JSON was a true client-side fallback, which is why our JSON-only server worked. 0.25.0 removed that fallback for these two response types. (SDKs <0.18.0 have no proto module at all and speak pure JSON.)
2. **Requests**: `forward_backward` bodies are submitted as proto (`Content-Type: application/x-protobuf`), and forward-only passes are routed to `/api/v1/forward_backward` via the proto `forward_only` flag instead of `/api/v1/forward`. Unlike the response path, this was never a fallback arrangement before 0.25.0: the proto write path (present since ~0.22) was gated by the server-supplied `client_config` flag `proto_write_fwdbwd` (default false), and our stub `client_config` never opted in, so JSON requests were simply the default. 0.25.0 removed the flag and made proto requests unconditional.

## Changes

- **`skyrl/tinker/proto_serialization.py`** (new): mirrors the SDK's `tinker/proto/{request,response}_conv.py`. Serializers for `SampleResponse` / `ForwardBackwardOutput` (NaN encodes undefined prompt logprobs, `token_id=0 / logprob=-99999.0` sentinel fill for undefined top-k entries, batched int64 byte offsets for per-datum tensors), plus a parser for proto `ForwardBackwardRequest` bodies. The proto schema ships inside the `tinker` package, which the `tinker` extra already depends on -- no new dependency.
- **`skyrl/tinker/api.py`**: `retrieve_future` content-negotiates on the `Accept` header (errors and all other result types stay JSON); `forward_backward` accepts both wire formats and maps `forward_only=true` to the `FORWARD` request type. `poll_futures`/`wait_for_future` now carry `request_type` alongside `(status, result_data)`.
- Old JSON paths (including `/api/v1/forward`) are unchanged, so SDKs <=0.24.x keep working.

## Testing

- New `tests/tinker/test_proto_serialization.py` round-trips the server encoding through the installed SDK's own proto codecs (12 tests), plus a proto-path test in `test_future_waiting.py`.
- Manually verified a full loop (`forward_backward` -> `forward` -> `optim_step` -> `save_weights_for_sampler` -> `sample`) against a local JAX-backend server with **12 SDK versions spanning the supported range** (`tinker>=0.3.0`) -- all pass with this change; before it, 0.25.0 failed exactly like the nightly:

  | SDK versions | Wire behavior | Result |
  |---|---|---|
  | 0.3.0, 0.8.1, 0.13.1, 0.16.1 | pure JSON (no proto module) | ✅ |
  | 0.18.2, 0.20.0, 0.21.0, 0.22.0, 0.22.4, 0.23.4, 0.24.1 | proto responses (JSON-fallback), JSON requests | ✅ |
  | 0.25.0 | proto responses + proto requests, no fallback | ✅ |
- `tests/tinker/` CPU suite passes (`skyrl_train/` GPU-cluster tests excluded -- they fail in my workspace with a pre-existing Ray version mismatch unrelated to this change).

Notes for reviewers:
- SDK >=0.18.0 sends `Accept: application/x-protobuf, application/json` on `retrieve_future` and understands proto responses, so the existing `test_api.py` integration tests (locked SDK 0.22.4) now exercise the proto response path end-to-end.
- The SDK's zstd request compression (`proto_compress_fwdbwd`) is negotiated via `client_config`, which our server does not advertise, so compressed bodies never arrive.
- I left the e2e scripts' `--with tinker` unpinned on purpose: catching SDK/server incompatibilities is exactly what those nightlies are for. Happy to pin to `tinker==0.25.0` instead if determinism is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Tinker API wire contract on hot training paths (forward/backward and sampling) with binary encoding; mistakes could break all 0.25.0 clients while JSON fallbacks must stay correct for older SDKs.
> 
> **Overview**
> Fixes nightly cookbook failures against **tinker SDK 0.25.0**, which requires protobuf for `sample` / `forward` / `forward_backward` results on `retrieve_future` and sends `forward_backward` bodies as protobuf (including forward-only via a `forward_only` flag).
> 
> A new **`proto_serialization`** module mirrors the SDK’s proto codecs: it parses proto `ForwardBackwardRequest` bodies and serializes stored JSON results into `SampleResponse` and `ForwardBackwardOutput` wire bytes (tokens, logprobs, top-k sentinels, batched tensors).
> 
> **`retrieve_future`** negotiates on `Accept: application/x-protobuf` for SAMPLE, EXTERNAL, FORWARD, and FORWARD_BACKWARD; errors and other futures stay JSON. **`forward_backward`** reads JSON or protobuf and maps `forward_only=true` to the FORWARD request type. Future polling now passes **`request_type`** through waiters. JSON **`/forward`** and legacy SDK paths are unchanged.
> 
> Round-trip tests use the installed tinker SDK deserializers; **`EXTERNAL`** sample futures (external inference) serialize like **`SAMPLE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8043b979ce787ba6decb404e9bec0b61500a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## GPU e2e validation (2026-08-17)

Both CI e2e tests were run as Anyscale jobs on this branch (4xL4, exact CI configs, cookbook client installing the **unpinned** tinker SDK -> 0.25.0, the strict proto-only client):

- `gsm8k_tinker` (colocated, FSDP backend): **SUCCEEDED** (55m50s)
- `gsm8k_tinker_fully_async` (non-colocated): **SUCCEEDED** (56m28s)

The first attempt surfaced a real gap the local JAX-backend testing missed: `/asample` stores futures as `request_type=EXTERNAL` (not `SAMPLE`) whenever an external inference client is configured -- which is how the fsdp/megatron backends run sampling -- and those results bypassed the proto gate, reproducing the original failure. Fixed in `7c72fff0` (EXTERNAL results serialize as `SampleResponse`; failures still return JSON errors), with a regression unit test. Both jobs passed on the fixed commit, including the wandb reward assertions.


## Performance

Microbenchmark of the response paths at CI-realistic payload shapes (single CPU core, round-tripped through the SDK's own deserializers; script: `serialize_result` vs the raw-JSON passthrough):

| Payload | Wire size (JSON -> proto) | Server cost per result | Client parse (JSON -> proto) |
|---|---|---|---|
| sample, 4 seqs x 512 tokens (CI shape) | 51.5 KiB -> 16 KiB (3.2x) | +0.78 ms | 0.57 ms -> 0.02 ms |
| sample + top-20 prompt logprobs, 2048-token prompt | 1.17 MiB -> 344 KiB (3.5x) | +34 ms | 21.9 ms -> 0.07 ms |
| fwd_bwd, 512 datums x 600 tokens x 2 float fields | 11.4 MiB -> 2.4 MiB (4.8x) | +170 ms | 144.9 ms -> 2.8 ms |

- **Client + wire: strictly faster.** Proto payloads are 3-5x smaller and client-side deserialization is `np.frombuffer` over binary instead of JSON-parsing decimal floats (~50x faster on large payloads; the JSON column above is `json.loads` only, a lower bound -- the SDK adds model construction on top).
- **Server: a bounded regression vs the current JSON path, which #2017 made a zero-copy passthrough.** The proto path pays `json.loads(stored text) + validate + proto encode` per result: sub-millisecond for typical samples, ~170 ms worst-case for a full 512-datum fwd_bwd result. ~85% of that is the `json.loads` of the stored JSON text (a storage-format artifact, not a proto cost); the pre-#2017 baseline (`jsonable_encoder` + `json.dumps`) was ~300 ms on the same payload class, so this is still cheaper than the JSON path of two weeks ago. The SDK also chunks fwd_bwd requests (~5 MB estimated per chunk), so single results near the worst case are uncommon.
- **End-to-end: indistinguishable.** The GPU e2e runs are GPU-bound; proto-client (0.25.0) and JSON-client (0.24.x) runs both complete in 55-56 min.

Possible follow-ups (not in this PR): offload `json.loads + serialize` to a thread in `retrieve_future` so a worst-case result doesn't stall the event loop; longer term, store proto bytes in `FutureDB.result_data` for the four proto-serializable request types, which removes the parse entirely and makes every SDK >= 0.18.0 (all of which prefer proto via the Accept header) a zero-copy read.
