### PR TITLE
[tinker] Cap tinker SDK at 0.24.1 and resolve the nightly client from SkyRL's lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ tpu = [
 ]
 
 tinker = [
-    "tinker>=0.3.0",
+    "tinker>=0.3.0,<=0.24.1",
     "fastapi[standard]",
     "sqlmodel",
     "sqlalchemy[asyncio]",

--- a/tests/train/gpu_e2e_test/gsm8k_tinker.sh
+++ b/tests/train/gpu_e2e_test/gsm8k_tinker.sh
@@ -50,7 +50,9 @@ COOKBOOK_COMMIT="016468b0f214f30492f9f8eb001f9094970b3ad5"
 cd "$COOKBOOK_DIR"
 git fetch --depth 1 origin "$COOKBOOK_COMMIT"
 git checkout --detach "$COOKBOOK_COMMIT"
-TINKER_API_KEY=tml-dummy uv run --extra math-rl --extra wandb --with tinker --with datasets --with torch \
+# Run the client from SkyRL's project so the tinker SDK resolves from SkyRL's uv.lock.
+cd "$SKYRL_REPO_ROOT"
+TINKER_API_KEY=tml-dummy uv run --extra tinker --with-editable "$COOKBOOK_DIR[math-rl,wandb]" --with datasets --with torch \
   python -m tinker_cookbook.recipes.math_rl.train \
   base_url=http://localhost:8000 \
   model_name="Qwen/Qwen3-0.6B" \

--- a/tests/train/gpu_e2e_test/gsm8k_tinker_fully_async.sh
+++ b/tests/train/gpu_e2e_test/gsm8k_tinker_fully_async.sh
@@ -55,7 +55,9 @@ COOKBOOK_COMMIT="016468b0f214f30492f9f8eb001f9094970b3ad5"
 cd "$COOKBOOK_DIR"
 git fetch --depth 1 origin "$COOKBOOK_COMMIT"
 git checkout --detach "$COOKBOOK_COMMIT"
-TINKER_API_KEY=tml-dummy uv run --extra math-rl --extra wandb --with tinker --with datasets --with torch \
+# Run the client from SkyRL's project so the tinker SDK resolves from SkyRL's uv.lock.
+cd "$SKYRL_REPO_ROOT"
+TINKER_API_KEY=tml-dummy uv run --extra tinker --with-editable "$COOKBOOK_DIR[math-rl,wandb]" --with datasets --with torch \
   python -m tinker_cookbook.recipes.math_rl.train \
   base_url=http://localhost:8000 \
   model_name="Qwen/Qwen3-0.6B" \

--- a/uv.lock
+++ b/uv.lock
@@ -9129,7 +9129,7 @@ requires-dist = [
     { name = "sqlmodel", marker = "extra == 'tinker'" },
     { name = "tensorboard", marker = "extra == 'skyrl-train'" },
     { name = "tensordict", marker = "extra == 'skyrl-train'" },
-    { name = "tinker", marker = "extra == 'tinker'", specifier = ">=0.3.0" },
+    { name = "tinker", marker = "extra == 'tinker'", specifier = ">=0.3.0,<=0.24.1" },
     { name = "tokenizers", specifier = ">=0.21.2" },
     { name = "torch", marker = "sys_platform == 'darwin' and extra == 'dev'", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch", marker = "sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'dev'" },


### PR DESCRIPTION
## What does this PR do?

Fixes the nightly `gsm8k_tinker` / `gsm8k_tinker_fully_async` failures that started 2026-08-12:

```
ValueError: Server returned a JSON payload for self.model_cls=<class 'tinker.SampleResponse'> ...,
which this SDK version only supports as proto.
```

**tinker 0.25.0 (released 2026-08-08) made its proto wire format mandatory**: it submits `forward_backward` request bodies as protobuf and rejects JSON `retrieve_future` results for `SampleResponse`/`ForwardBackwardOutput`. The SkyRL tinker server only speaks JSON today. The nightlies install the SDK unpinned into tinker-cookbook's own environment (which ships no lockfile), so every run floated to 0.25.0 and died at the first sample retrieval.

Per review feedback, the version constraint lives in `pyproject.toml` rather than hardcoded in the CI scripts. Two commits:

1. **Cap the tinker SDK in the `tinker` extra** at `<=0.24.1` (the newest release that negotiates down to JSON: it sends `Accept: application/x-protobuf, application/json`, falls back to JSON responses, and its proto request path stays off because it is gated by a server-supplied `client_config` flag our server does not enable). The lock keeps main's tinker 0.24.0, which satisfies the cap; only the recorded requirement specifier changes. (Bumping the locked version to 0.24.1 requires a resolver run, which is currently blocked on main by an unrelated py3.14 megatron-split conflict between `vllm 0.26.0+cu129` and `mamba-ssm` over `apache-tvm-ffi` -- any full `uv lock` fails on main today. `uv lock --check` validates the updated lock.)

2. **Make the nightlies resolve the SDK from SkyRL's lock.** The scripts previously ran the cookbook client from `~/tinker-cookbook`'s own project with an unpinned `--with tinker`, so SkyRL's `pyproject.toml` never reached that environment. They now run the client from SkyRL's project, overlaying the cookbook checkout with `--with-editable "$COOKBOOK_DIR[math-rl,wandb]"`: the cookbook's `tinker>=0.9.0` requirement is already satisfied by the base environment's locked SDK, so uv does not fetch a newer one. The SDK version now has a single source of truth and moves only when `pyproject.toml`/`uv.lock` move.

Once server-side proto support (#2021) lands, the cap can be lifted and the nightlies will follow the lock to newer SDKs automatically.

## Testing

- Resolution verified locally at the pinned cookbook commit: the old invocation (`cd ~/tinker-cookbook && uv run --extra math-rl --with tinker ...`) resolves tinker 0.25.0; the new invocation resolves the locked 0.24.0 from SkyRL's lock, and the `math_rl.train` recipe plus wandb/datasets/torch all import cleanly in that environment.
- `tests/tinker/` CPU suite (68 tests on the rebased branch, including the `test_api.py` integration tests that run the real SDK against a real server subprocess) passes with the locked SDK.
- SDK 0.24.x's compatibility with the current JSON-only server was verified manually with a full `forward_backward` -> `forward` -> `optim_step` -> `save_weights_for_sampler` -> `sample` loop (JAX backend); the same loop on 0.25.0 reproduces the nightly failure exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
