### PR TITLE
[tinker] 7/n towards Kimi K2.6: apply client LoRA config before config validation

### DIFF
--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -91,6 +91,14 @@ def _build_skyrl_train_config(
         "megatron",
     ), f"Only fsdp and megatron are supported for SkyRL-Train backend, got {overrides.strategy!r}"
     user_overrides["trainer.strategy"] = overrides.strategy
+    # LoRA rank/alpha must also be on the override dict so post_init validation
+    # sees them — e.g. fake_int4_qat.enabled requires lora.rank > 0, which
+    # would spuriously fail for LoRA clients if the rank were applied after
+    # from_cli_overrides. The client-requested LoRA config wins over any
+    # backend_config value (matching the previous post-assignment behaviour).
+    if lora_config is not None and lora_config.rank > 0:
+        user_overrides["trainer.policy.model.lora.rank"] = lora_config.rank
+        user_overrides["trainer.policy.model.lora.alpha"] = int(lora_config.alpha)
     cfg = SkyRLTrainConfig.from_cli_overrides(user_overrides)
 
     # Disable scheduler - Tinker manages learning rate externally via set_lr()
@@ -101,11 +109,6 @@ def _build_skyrl_train_config(
 
     # TODO(tyler): Support KL Loss
     cfg.trainer.algorithm.use_kl_loss = False
-
-    # Apply LoRA configuration
-    if lora_config is not None and lora_config.rank > 0:
-        cfg.trainer.policy.model.lora.rank = lora_config.rank
-        cfg.trainer.policy.model.lora.alpha = int(lora_config.alpha)
 
     logger.info("SkyRL-Train config:\n%s", get_config_as_yaml_str(cfg))
     return cfg


### PR DESCRIPTION
## What

Injects the client-requested LoRA rank/alpha into the override dict passed to `from_cli_overrides` instead of assigning them onto the config afterwards (client wins over backend_config, matching the previous post-assignment semantics).

## Why

`create_lora_training_client` requests were rejected whenever the backend config enables `trainer.policy.model.fake_int4_qat`: `TrainerConfig.__post_init__` validated `fake_int4_qat` against the default `lora.rank=0` and raised "fake_int4_qat requires LoRA" even for LoRA clients, because the client's rank/alpha arrived after validation.

Part of the Kimi K2.x series (follow-up to #1862). Independent of the other PRs in the series.

Made with [Cursor](https://cursor.com)