### PR TITLE
[fix][tinker] Make retried training requests idempotent

### DIFF
--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -341,14 +341,13 @@ async def create_future(
             return None
         statement = select(TrainingRequestDB).where(
             TrainingRequestDB.model_id == model_id,
-            TrainingRequestDB.request_type == request_type,
             TrainingRequestDB.seq_id == seq_id,
         )
         existing = (await session.exec(statement)).first()
         if existing is None:
             return None
         future = await session.get(FutureDB, existing.request_id)
-        if future is None or future.request_data != serialized_request:
+        if future is None or future.request_type != request_type or future.request_data != serialized_request:
             raise HTTPException(status_code=409, detail="Training request sequence number was reused")
         return existing.request_id
 
@@ -369,7 +368,6 @@ async def create_future(
         session.add(
             TrainingRequestDB(
                 model_id=model_id,
-                request_type=request_type,
                 seq_id=seq_id,
                 request_id=future_db.request_id,
             )

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -333,7 +333,7 @@ async def create_future(
     request_data: BaseModel,
     seq_id: int | None = None,
 ) -> int:
-    """Create a future, returning the original one when an SDK request is retried."""
+    """Create a future, returning the original request_id when an SDK request is retried."""
     serialized_request = request_data.model_dump(mode="json")
 
     async def existing_request_id() -> int | None:

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -37,6 +37,7 @@ from skyrl.tinker.db_models import (
     RequestStatus,
     SamplingSessionDB,
     SessionDB,
+    TrainingRequestDB,
     enable_sqlite_wal,
     get_async_database_url,
 )
@@ -330,17 +331,58 @@ async def create_future(
     request_type: types.RequestType,
     model_id: str | None,
     request_data: BaseModel,
+    seq_id: int | None = None,
 ) -> int:
-    """Create a FutureDB entry and return its auto-generated request_id."""
+    """Create a future, returning the original one when an SDK request is retried."""
+    serialized_request = request_data.model_dump(mode="json")
+
+    async def existing_request_id() -> int | None:
+        if model_id is None or seq_id is None:
+            return None
+        statement = select(TrainingRequestDB).where(
+            TrainingRequestDB.model_id == model_id,
+            TrainingRequestDB.request_type == request_type,
+            TrainingRequestDB.seq_id == seq_id,
+        )
+        existing = (await session.exec(statement)).first()
+        if existing is None:
+            return None
+        future = await session.get(FutureDB, existing.request_id)
+        if future is None or future.request_data != serialized_request:
+            raise HTTPException(status_code=409, detail="Training request sequence number was reused")
+        return existing.request_id
+
+    if request_id := await existing_request_id():
+        return request_id
+
     future_db = FutureDB(
         request_type=request_type,
         model_id=model_id,
-        request_data=request_data.model_dump(mode="json"),
+        request_data=serialized_request,
         status=RequestStatus.PENDING,
     )
     session.add(future_db)
     await session.flush()  # Flush to generate auto-increment request_id
     assert future_db.request_id
+
+    if model_id is not None and seq_id is not None:
+        session.add(
+            TrainingRequestDB(
+                model_id=model_id,
+                request_type=request_type,
+                seq_id=seq_id,
+                request_id=future_db.request_id,
+            )
+        )
+        try:
+            await session.flush()
+        except IntegrityError:
+            # A concurrent retry inserted the sequence mapping first.
+            await session.rollback()
+            request_id = await existing_request_id()
+            if request_id is None:
+                raise
+            return request_id
     return future_db.request_id
 
 
@@ -587,11 +629,13 @@ class ForwardBackwardInput(BaseModel):
 class ForwardBackwardRequest(BaseModel):
     model_id: str
     forward_backward_input: ForwardBackwardInput
+    seq_id: int | None = None
 
 
 class ForwardRequest(BaseModel):
     model_id: str
     forward_input: ForwardBackwardInput
+    seq_id: int | None = None
 
 
 class AdamParams(BaseModel):
@@ -614,6 +658,7 @@ class AdamParams(BaseModel):
 class OptimStepRequest(BaseModel):
     model_id: str
     adam_params: AdamParams
+    seq_id: int | None = None
 
 
 class SaveWeightsForSamplerRequest(BaseModel):
@@ -1026,6 +1071,7 @@ async def forward_backward(request: ForwardBackwardRequest, session: AsyncSessio
         request_type=types.RequestType.FORWARD_BACKWARD,
         model_id=request.model_id,
         request_data=request.forward_backward_input.to_types(),
+        seq_id=request.seq_id,
     )
 
     await session.commit()
@@ -1043,6 +1089,7 @@ async def forward(request: ForwardRequest, session: AsyncSession = Depends(get_s
         request_type=types.RequestType.FORWARD,
         model_id=request.model_id,
         request_data=request.forward_input.to_types(),
+        seq_id=request.seq_id,
     )
 
     await session.commit()
@@ -1060,6 +1107,7 @@ async def optim_step(request: OptimStepRequest, session: AsyncSession = Depends(
         request_type=types.RequestType.OPTIM_STEP,
         model_id=request.model_id,
         request_data=types.OptimStepInput(adam_params=request.adam_params.to_types()),
+        seq_id=request.seq_id,
     )
 
     await session.commit()

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -37,7 +37,6 @@ from skyrl.tinker.db_models import (
     RequestStatus,
     SamplingSessionDB,
     SessionDB,
-    TrainingRequestDB,
     enable_sqlite_wal,
     get_async_database_url,
 )
@@ -337,50 +336,41 @@ async def create_future(
     serialized_request = request_data.model_dump(mode="json")
 
     async def existing_request_id() -> int | None:
+        """The request_id already recorded for this (model_id, seq_id), if there is one."""
         if model_id is None or seq_id is None:
             return None
-        statement = select(TrainingRequestDB).where(
-            TrainingRequestDB.model_id == model_id,
-            TrainingRequestDB.seq_id == seq_id,
-        )
+        statement = select(FutureDB).where(FutureDB.model_id == model_id, FutureDB.seq_id == seq_id)
         existing = (await session.exec(statement)).first()
         if existing is None:
             return None
-        future = await session.get(FutureDB, existing.request_id)
-        if future is None or future.request_type != request_type or future.request_data != serialized_request:
+        if existing.request_type != request_type or existing.request_data != serialized_request:
             raise HTTPException(status_code=409, detail="Training request sequence number was reused")
         return existing.request_id
 
-    if request_id := await existing_request_id():
+    if (request_id := await existing_request_id()) is not None:
         return request_id
 
     future_db = FutureDB(
         request_type=request_type,
         model_id=model_id,
+        seq_id=seq_id,
         request_data=serialized_request,
         status=RequestStatus.PENDING,
     )
-    session.add(future_db)
-    await session.flush()  # Flush to generate auto-increment request_id
+    try:
+        # Savepoint rather than a plain flush: losing the insert race must roll back
+        # only this row. Callers stage other writes before getting here (save_weights
+        # adds a pending checkpoint), and a session-wide rollback would discard them.
+        async with session.begin_nested():
+            session.add(future_db)
+            await session.flush()  # Flush to generate auto-increment request_id
+    except IntegrityError:
+        # A concurrent retry inserted the same (model_id, seq_id) first; return its future.
+        request_id = await existing_request_id()
+        if request_id is None:
+            raise
+        return request_id
     assert future_db.request_id
-
-    if model_id is not None and seq_id is not None:
-        session.add(
-            TrainingRequestDB(
-                model_id=model_id,
-                seq_id=seq_id,
-                request_id=future_db.request_id,
-            )
-        )
-        try:
-            await session.flush()
-        except IntegrityError:
-            # A concurrent retry inserted the sequence mapping first.
-            await session.rollback()
-            request_id = await existing_request_id()
-            if request_id is None:
-                raise
-            return request_id
     return future_db.request_id
 
 

--- a/skyrl/tinker/db_models.py
+++ b/skyrl/tinker/db_models.py
@@ -100,6 +100,17 @@ class FutureDB(SQLModel, table=True):
     completed_at: datetime | None = Field(default=None, sa_type=DateTime(timezone=True))
 
 
+class TrainingRequestDB(SQLModel, table=True):
+    """Maps an SDK training sequence number to its single server-side future."""
+
+    __tablename__ = "training_requests"
+
+    model_id: str = Field(primary_key=True)
+    request_type: types.RequestType = Field(primary_key=True)
+    seq_id: int = Field(primary_key=True)
+    request_id: int = Field(foreign_key="futures.request_id", unique=True)
+
+
 class CheckpointDB(SQLModel, table=True):
     __tablename__ = "checkpoints"
 

--- a/skyrl/tinker/db_models.py
+++ b/skyrl/tinker/db_models.py
@@ -101,12 +101,11 @@ class FutureDB(SQLModel, table=True):
 
 
 class TrainingRequestDB(SQLModel, table=True):
-    """Maps an SDK training sequence number to its single server-side future."""
+    """Maps a model-global SDK training sequence number to one future."""
 
     __tablename__ = "training_requests"
 
     model_id: str = Field(primary_key=True)
-    request_type: types.RequestType = Field(primary_key=True)
     seq_id: int = Field(primary_key=True)
     request_id: int = Field(foreign_key="futures.request_id", unique=True)
 

--- a/skyrl/tinker/db_models.py
+++ b/skyrl/tinker/db_models.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from enum import Enum
 
-from sqlalchemy import DateTime, event
+from sqlalchemy import DateTime, UniqueConstraint, event
 from sqlalchemy.engine import url as sqlalchemy_url
 from sqlmodel import JSON, Field, SQLModel
 
@@ -90,24 +90,22 @@ class ModelDB(SQLModel, table=True):
 class FutureDB(SQLModel, table=True):
     __tablename__ = "futures"
 
+    # The SDK stamps each training request with a model-global sequence number, so
+    # (model_id, seq_id) identifies one logical request and a retry of it carries the
+    # same pair. The constraint is what makes the dedup in `create_future` safe under
+    # concurrent retries. SQL treats NULLs as distinct, so requests that carry no
+    # seq_id are unconstrained and still get a fresh future each time.
+    __table_args__ = (UniqueConstraint("model_id", "seq_id", name="uq_futures_model_id_seq_id"),)
+
     request_id: int | None = Field(default=None, primary_key=True, sa_column_kwargs={"autoincrement": True})
     request_type: types.RequestType
     model_id: str | None = Field(default=None, index=True)
+    seq_id: int | None = Field(default=None)
     request_data: dict = Field(sa_type=JSON)  # this is of type types.{request_type}Input
     result_data: dict | None = Field(default=None, sa_type=JSON)  # this is of type types.{request_type}Output
     status: RequestStatus = Field(default=RequestStatus.PENDING, index=True)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), sa_type=DateTime(timezone=True))
     completed_at: datetime | None = Field(default=None, sa_type=DateTime(timezone=True))
-
-
-class TrainingRequestDB(SQLModel, table=True):
-    """Maps a model-global SDK training sequence number to one future."""
-
-    __tablename__ = "training_requests"
-
-    model_id: str = Field(primary_key=True)
-    seq_id: int = Field(primary_key=True)
-    request_id: int = Field(foreign_key="futures.request_id", unique=True)
 
 
 class CheckpointDB(SQLModel, table=True):

--- a/tests/tinker/test_training_request_idempotency.py
+++ b/tests/tinker/test_training_request_idempotency.py
@@ -10,7 +10,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from skyrl.tinker import types
 from skyrl.tinker.api import create_future
-from skyrl.tinker.db_models import FutureDB, TrainingRequestDB, enable_sqlite_wal
+from skyrl.tinker.db_models import FutureDB, enable_sqlite_wal
 
 
 def optim_input(learning_rate: float = 1e-4) -> types.OptimStepInput:
@@ -42,6 +42,7 @@ async def test_training_request_retry_returns_original_future(tmp_path):
 
     assert retry_id == original_id
     assert len(futures) == 1
+    assert futures[0].seq_id == 7
     await engine.dispose()
 
 
@@ -103,10 +104,9 @@ async def test_concurrent_training_request_types_cannot_reuse_sequence(tmp_path)
 
     async with AsyncSession(engine) as session:
         futures = (await session.exec(select(FutureDB))).all()
-        mappings = (await session.exec(select(TrainingRequestDB))).all()
     assert len(futures) == 1
-    assert len(mappings) == 1
-    assert futures[0].request_id == successes[0] == mappings[0].request_id
+    assert futures[0].request_id == successes[0]
+    assert futures[0].seq_id == 7
     await engine.dispose()
 
 
@@ -120,6 +120,12 @@ async def test_training_requests_without_sequence_numbers_remain_distinct(tmp_pa
         first_id = await create_future(session, types.RequestType.OPTIM_STEP, "model_1", optim_input())
         second_id = await create_future(session, types.RequestType.OPTIM_STEP, "model_1", optim_input())
         await session.commit()
+        futures = (await session.exec(select(FutureDB))).all()
 
+    # Two identical requests for one model, both with seq_id NULL, must not collide on
+    # the futures (model_id, seq_id) constraint: SQL counts NULLs as distinct. That is
+    # what keeps clients which send no seq_id on the pre-idempotency behaviour.
     assert second_id != first_id
+    assert len(futures) == 2
+    assert [future.seq_id for future in futures] == [None, None]
     await engine.dispose()

--- a/tests/tinker/test_training_request_idempotency.py
+++ b/tests/tinker/test_training_request_idempotency.py
@@ -1,5 +1,7 @@
 """Tests that retried training writes execute only once."""
 
+import asyncio
+
 import pytest
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -8,7 +10,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from skyrl.tinker import types
 from skyrl.tinker.api import create_future
-from skyrl.tinker.db_models import FutureDB
+from skyrl.tinker.db_models import FutureDB, TrainingRequestDB, enable_sqlite_wal
 
 
 def optim_input(learning_rate: float = 1e-4) -> types.OptimStepInput:
@@ -66,6 +68,53 @@ async def test_training_request_sequence_reuse_with_new_payload_fails(tmp_path):
             )
 
     assert error.value.status_code == 409
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_training_request_types_cannot_reuse_sequence(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'tinker.db'}")
+    enable_sqlite_wal(engine.sync_engine)
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    start = asyncio.Event()
+
+    async def create(request_type, request_data):
+        async with AsyncSession(engine) as session:
+            await start.wait()
+            try:
+                request_id = await create_future(session, request_type, "model_1", request_data, seq_id=7)
+                await session.commit()
+                return request_id
+            except HTTPException as error:
+                return error
+
+    requests = [
+        asyncio.create_task(
+            create(
+                types.RequestType.FORWARD_BACKWARD,
+                types.ForwardBackwardInput(data=[], loss_fn="cross_entropy"),
+            )
+        ),
+        asyncio.create_task(create(types.RequestType.OPTIM_STEP, optim_input())),
+    ]
+    start.set()
+    results = await asyncio.gather(*requests)
+
+    successes = [result for result in results if isinstance(result, int)]
+    conflicts = [result for result in results if isinstance(result, HTTPException)]
+    assert len(successes) == 1
+    assert len(conflicts) == 1
+    assert conflicts[0].status_code == 409
+    assert "sequence number was reused" in conflicts[0].detail
+
+    async with AsyncSession(engine) as session:
+        futures = (await session.exec(select(FutureDB))).all()
+        mappings = (await session.exec(select(TrainingRequestDB))).all()
+    assert len(futures) == 1
+    assert len(mappings) == 1
+    assert futures[0].request_id == successes[0] == mappings[0].request_id
     await engine.dispose()
 
 

--- a/tests/tinker/test_training_request_idempotency.py
+++ b/tests/tinker/test_training_request_idempotency.py
@@ -1,0 +1,84 @@
+"""Tests that retried training writes execute only once."""
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from skyrl.tinker import types
+from skyrl.tinker.api import create_future
+from skyrl.tinker.db_models import FutureDB
+
+
+def optim_input(learning_rate: float = 1e-4) -> types.OptimStepInput:
+    return types.OptimStepInput(
+        adam_params=types.AdamParams(
+            learning_rate=learning_rate,
+            beta1=0.9,
+            beta2=0.95,
+            eps=1e-12,
+            weight_decay=0.0,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_training_request_retry_returns_original_future(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'tinker.db'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    async with AsyncSession(engine) as session:
+        original_id = await create_future(
+            session, types.RequestType.OPTIM_STEP, "model_1", optim_input(), seq_id=7
+        )
+        await session.commit()
+
+    async with AsyncSession(engine) as session:
+        retry_id = await create_future(
+            session, types.RequestType.OPTIM_STEP, "model_1", optim_input(), seq_id=7
+        )
+        await session.commit()
+        futures = (await session.exec(select(FutureDB))).all()
+
+    assert retry_id == original_id
+    assert len(futures) == 1
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_training_request_sequence_reuse_with_new_payload_fails(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'tinker.db'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    async with AsyncSession(engine) as session:
+        await create_future(
+            session, types.RequestType.OPTIM_STEP, "model_1", optim_input(), seq_id=7
+        )
+        await session.commit()
+
+    async with AsyncSession(engine) as session:
+        with pytest.raises(HTTPException, match="sequence number was reused") as error:
+            await create_future(
+                session, types.RequestType.OPTIM_STEP, "model_1", optim_input(2e-4), seq_id=7
+            )
+
+    assert error.value.status_code == 409
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_training_requests_without_sequence_numbers_remain_distinct(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'tinker.db'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    async with AsyncSession(engine) as session:
+        first_id = await create_future(session, types.RequestType.OPTIM_STEP, "model_1", optim_input())
+        second_id = await create_future(session, types.RequestType.OPTIM_STEP, "model_1", optim_input())
+        await session.commit()
+
+    assert second_id != first_id
+    await engine.dispose()

--- a/tests/tinker/test_training_request_idempotency.py
+++ b/tests/tinker/test_training_request_idempotency.py
@@ -32,15 +32,11 @@ async def test_training_request_retry_returns_original_future(tmp_path):
         await connection.run_sync(SQLModel.metadata.create_all)
 
     async with AsyncSession(engine) as session:
-        original_id = await create_future(
-            session, types.RequestType.OPTIM_STEP, "model_1", optim_input(), seq_id=7
-        )
+        original_id = await create_future(session, types.RequestType.OPTIM_STEP, "model_1", optim_input(), seq_id=7)
         await session.commit()
 
     async with AsyncSession(engine) as session:
-        retry_id = await create_future(
-            session, types.RequestType.OPTIM_STEP, "model_1", optim_input(), seq_id=7
-        )
+        retry_id = await create_future(session, types.RequestType.OPTIM_STEP, "model_1", optim_input(), seq_id=7)
         await session.commit()
         futures = (await session.exec(select(FutureDB))).all()
 
@@ -56,16 +52,12 @@ async def test_training_request_sequence_reuse_with_new_payload_fails(tmp_path):
         await connection.run_sync(SQLModel.metadata.create_all)
 
     async with AsyncSession(engine) as session:
-        await create_future(
-            session, types.RequestType.OPTIM_STEP, "model_1", optim_input(), seq_id=7
-        )
+        await create_future(session, types.RequestType.OPTIM_STEP, "model_1", optim_input(), seq_id=7)
         await session.commit()
 
     async with AsyncSession(engine) as session:
         with pytest.raises(HTTPException, match="sequence number was reused") as error:
-            await create_future(
-                session, types.RequestType.OPTIM_STEP, "model_1", optim_input(2e-4), seq_id=7
-            )
+            await create_future(session, types.RequestType.OPTIM_STEP, "model_1", optim_input(2e-4), seq_id=7)
 
     assert error.value.status_code == 409
     await engine.dispose()


### PR DESCRIPTION
## Problem

The Tinker SDK wraps every training HTTP send in `execute_with_retries`, which retries for up to 5 minutes on any retryable exception. So when a `forward_backward` / `forward` / `optim_step` reaches the server but its response is lost — connection reset, 5xx, timeout — the SDK resends the identical request.

The server creates a fresh future for every POST, so that resend is executed a second time:

- a duplicated `forward_backward` adds its gradients to the pending accumulation twice
- a duplicated `optim_step` takes two optimizer steps

Both corrupt training silently. Nothing surfaces an error, and the client can't tell the difference — it just sees a successful response to its retry.

## Fix

The SDK already stamps every one of these requests with a per-request `seq_id` (`seq_id=request_id + 1`, drawn from one counter shared across request types on the training client). This PR threads that value through to `create_future` and uses it as an idempotency key:

- New `training_requests` table maps `(model_id, seq_id) -> request_id`, keyed on the pair, with `request_id` unique.
- A repeat POST carrying a `(model_id, seq_id)` already on file returns the **original** `request_id` instead of enqueueing new work. The client polls the original future and receives the original result, so a retry is observationally identical to the first attempt succeeding.
- The same `(model_id, seq_id)` arriving with a different request type or a different payload is a **409** rather than a silent aliasing of unrelated work.
- The mapping insert is guarded by the table's primary key. If a concurrent retry inserts first, the `IntegrityError` is caught, the session rolls back, and the winner's `request_id` is returned — so two racing retries still produce exactly one future.

`request_type` is deliberately *not* part of the key: the SDK's counter is shared across request types for a given training client, so `seq_id` alone is already unique per model. Keying on the pair and *verifying* the type gives a 409 on a genuine reuse instead of quietly partitioning it into a separate namespace.

## Backwards compatibility

`seq_id` is optional throughout. Requests that arrive without one — older clients, hand-built requests, endpoints not yet wired up — take the original path and get a fresh future every time. No mapping row is written, so nothing is deduplicated that wasn't before. Covered by `test_training_requests_without_sequence_numbers_remain_distinct`.

## Tests

`tests/tinker/test_training_request_idempotency.py`, 4 new tests against a real SQLite-backed session:

| Test | Asserts |
|---|---|
| `test_training_request_retry_returns_original_future` | A replayed request returns the first `request_id`; exactly one `FutureDB` row exists |
| `test_training_request_sequence_reuse_with_new_payload_fails` | Same `seq_id` + changed payload → `HTTPException` 409 |
| `test_concurrent_training_request_types_cannot_reuse_sequence` | Two concurrent requests racing on one `seq_id` (WAL enabled) → exactly one success, one 409, one future, one mapping |
| `test_training_requests_without_sequence_numbers_remain_distinct` | `seq_id=None` still yields distinct futures |

```bash
uv run --isolated --extra tinker --extra jax --extra dev pytest --forked -s \
  tests/tinker/test_training_request_idempotency.py
```

4 passed.

## Known limitation

The uniqueness of `(model_id, seq_id)` rests on one model_id being driven by a single SDK `TrainingClient` instance. `TrainingClient._request_id_counter` is per-instance and starts at 0, so two clients addressing the same model_id would both replay `seq_id` 1, 2, 3… — an identical payload would be treated as a retry and its work dropped, and a differing one would 409. Note that the SDK's *sampling* client guards against exactly this by seeding its counter with a random offset, while the training client does not.

This is a pre-existing property of the SDK's request numbering rather than something this PR introduces, and it is not reachable through the normal `create_lora_training_client` flow (each call gets a distinct model_id). Worth revisiting if we ever support attaching a second client to a live model.

## Note

Split out of #2008, which now carries only the Megatron cross-request gradient accumulation change. The two are independent and can merge in either order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how training futures are created and can affect gradient accumulation and optimizer steps on retries; behavior is well-tested but touches core training request handling.
> 
> **Overview**
> **Makes retried training requests idempotent** so SDK `execute_with_retries` cannot silently corrupt training when a request reaches the server but the response is lost.
> 
> Adds a `training_requests` table mapping `(model_id, seq_id)` to a single `request_id`. `create_future` accepts optional `seq_id`; a replay with the same model, sequence, request type, and payload returns the **original** `request_id` instead of a new future. The same `seq_id` with a different payload or type yields **409**. Concurrent retries race on the primary key; the loser rolls back and returns the winner’s id.
> 
> Optional `seq_id` is threaded through `forward_backward`, `forward`, and `optim_step` request models and handlers. Requests without `seq_id` keep the old behavior (distinct futures every time).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e98fcb503bc9b014c91ba59844c81fbea074816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->