### PR TITLE
[docs] drop experimental framing from Tinker docs

### DIFF
--- a/docs/content/docs/tinker/configuration.mdx
+++ b/docs/content/docs/tinker/configuration.mdx
@@ -2,10 +2,6 @@
 title: "Configuration"
 ---
 
-<Callout type="warn">
-The backend configuration organization is undergoing a migration to simplify and reorganize these options. The keys and structure described below may change in a future release.
-</Callout>
-
 This page describes how to configure the SkyRL Tinker backend, including GPU allocation, training parameters, and inference settings.
 
 When spinning up the Tinker server, the `--backend-config` flag accepts a JSON dictionary of dot-notation overrides that are applied to the underlying SkyRL-Train configuration. For example:

--- a/docs/content/docs/tinker/limitations.mdx
+++ b/docs/content/docs/tinker/limitations.mdx
@@ -2,7 +2,7 @@
 title: "Limitations & Roadmap"
 ---
 
-The Tinker integration is under active development. This page documents current limitations.
+This page documents the features that are not yet wired through the Tinker integration. Everything listed on the [Overview](./overview) as supported is expected to work; if you hit an issue with one of those paths, please [open an issue](https://github.com/NovaSky-AI/SkyRL/issues).
 
 ## Current Limitations
 

--- a/skyrl-tx/README.md
+++ b/skyrl-tx/README.md
@@ -283,7 +283,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 uv run --extra gpu --extra tinker -m skyrl.tinker.a
 
 ## 🤝 Contributing
 
-We welcome contributions! The project is early and hackable — now is a great time to get involved.
+We welcome contributions! The codebase is small and hackable — it's easy to get involved.
 
 **Ways to contribute:**
 - Try examples from the [Tinker documentation](https://tinker-docs.thinkingmachines.ai/) or [cookbook](https://github.com/thinking-machines-lab/tinker-cookbook)


### PR DESCRIPTION
The Tinker integration is a supported path, but three places still read as experimental. Remove the hedges while keeping the factual content:

- limitations.mdx: replace "under active development" with a pointer to the Overview support matrix and the issue tracker.
- configuration.mdx: drop the "config org is undergoing a migration / keys may change" warn callout.
- skyrl-tx/README.md: "the project is early" -> "the codebase is small".

The concrete limitations (FSDP multi-tenant LoRA, prompt logprobs, KL penalty, RL loss coverage) are unchanged.