### PR TITLE
[Tinker API] Restore variable-length result order

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1254,11 +1254,13 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             torch.cuda.empty_cache()
 
         # Aggregate metrics across micro-batches
-        all_loss_fn_outputs = []  # Handle separately from scalar metrics
+        loss_fn_output_batches = []
         for m_batch, metrics in zip(micro_buffer, metrics_list):
             # Extract loss_fn_outputs before reduce_metrics (it's not a scalar metric)
-            if "loss_fn_outputs" in metrics:
-                all_loss_fn_outputs.extend(metrics.pop("loss_fn_outputs"))
+            if metrics is None:
+                loss_fn_output_batches.append([])
+                continue
+            loss_fn_output_batches.append(metrics.pop("loss_fn_outputs", []))
             # Skip fully-padding microbatches: their metrics (clip_ratio=0, policy_entropy=0,
             # ...) are meaningless and would drag down the mean-reduced metrics. Summed
             # metrics (e.g. policy_loss) are unaffected since padding contributes 0, but
@@ -1302,6 +1304,13 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             if moe_metrics:
                 for k, v in moe_metrics.items():
                     status[k] = v
+
+        if not any(loss_fn_output_batches):
+            all_loss_fn_outputs = []
+        elif isinstance(microbatch_iterator, TokenBasedBatchIterator):
+            all_loss_fn_outputs = microbatch_iterator.reorder_and_combine_items(loss_fn_output_batches)
+        else:
+            all_loss_fn_outputs = [item for batch in loss_fn_output_batches for item in batch]
 
         return WorkerOutput(loss_fn_outputs=all_loss_fn_outputs, metrics=status)
 

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -424,6 +424,18 @@ class TokenBasedBatchIterator(BaseBatchIterator):
         reordered_batch.metadata = ref_microbatch.metadata
         return reordered_batch
 
+    def reorder_and_combine_items(self, batches: List[List[dict]]) -> List[dict]:
+        """Restore per-sample microbatch outputs to input order."""
+        ordered = [None] * self.data.batch_size
+        for original_indices, items in zip(self._microbatches, batches):
+            if len(items) < len(original_indices):
+                raise ValueError("Microbatch output has fewer items than input samples")
+            for original_idx, item in zip(original_indices, items):
+                ordered[original_idx] = item
+        if any(item is None for item in ordered):
+            raise ValueError("Microbatch outputs do not cover every input sample")
+        return ordered
+
 
 def get_microbatch_iterator(
     data: TrainingInputBatch, micro_batch_size: int, max_tokens_per_microbatch: int

--- a/tests/backends/skyrl_train/test_token_based_batching_utils.py
+++ b/tests/backends/skyrl_train/test_token_based_batching_utils.py
@@ -160,6 +160,19 @@ class TestTokenBasedBatchIterator:
         for i in range(batch.batch_size):
             assert torch.equal(reordered["sequences"][i], batch["sequences"][i])
 
+    def test_reorder_and_combine_items_drops_padding(self):
+        batch = self._make_batch([10, 3, 8, 5])
+        iterator = TokenBasedBatchIterator(batch, max_tokens_per_microbatch=12)
+        output_batches = [
+            [{"sample": index} for index in indices] + [{"sample": "padding"}] for indices in iterator._microbatches
+        ]
+        iterator._num_padding_microbatches = 1
+        output_batches.append([{"sample": "padding-microbatch"}])
+
+        reordered = iterator.reorder_and_combine_items(output_batches)
+
+        assert [output["sample"] for output in reordered] == list(range(batch.batch_size))
+
     def test_get_microbatch_iterator_factory(self):
         batch = self._make_batch([10, 10, 5, 5])
 


### PR DESCRIPTION
## Summary

- Return each variable-length training result in the same order as its input example.
- Remove results produced only for padding.

## Before

Token-based batching returned results in packed microbatch order. A client could pair one example's mask with another example's log probabilities and fail before the optimizer step.

## After

SkyRL maps each result back to the original example index before it returns `loss_fn_outputs`. The change applies to Trajectory custom GSPO and any other client that reads per-example results.

## Testing

```bash
uv run --isolated --extra dev --extra tinker --extra skyrl-train \
  pytest tests/backends/skyrl_train/test_token_based_batching_utils.py -q
```

18 passed.
