### PR TITLE
[fix][train] Reject unsafe MTP prefix caching

### DIFF
--- a/examples/train/spec_decode/run_megatron_dapo_qwen3.5_9b_specdecode.sh
+++ b/examples/train/spec_decode/run_megatron_dapo_qwen3.5_9b_specdecode.sh
@@ -145,6 +145,7 @@ uv run --isolated --extra megatron -m examples.train.algorithms.dapo.main_dapo \
   trainer.policy.optimizer_config.weight_decay=0.1 \
   trainer.policy.optimizer_config.max_grad_norm=1.0 \
   generator.inference_engine.backend=vllm \
+  generator.inference_engine.enable_prefix_caching=false \
   generator.inference_engine.run_engines_locally=true \
   generator.inference_engine.weight_sync_backend=nccl \
   generator.inference_engine.async_engine=true \

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -1193,7 +1193,8 @@ class InferenceEngineConfig(BaseConfig):
     enable_prefix_caching: bool = True
     """Enable vLLM prefix caching.
     Can be left at the default in most cases. With remote inference servers, this must match the setting the remote
-    servers were initialized with."""
+    servers were initialized with. Must be disabled when using MTP speculative decoding with recurrent
+    linear-attention models."""
     enable_chunked_prefill: bool = True
     """Enable vLLM chunked prefill.
     Currently not plumbed through to the engine; set ``engine_init_kwargs.enable_chunked_prefill``

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -337,47 +337,61 @@ def _is_custom_proposer_path(model: str) -> bool:
 def _validate_mtp_prefix_caching(cfg: SkyRLTrainConfig) -> None:
     """Reject vLLM MTP with prefix caching on recurrent linear-attention models."""
     ie_cfg = cfg.generator.inference_engine
-    engine_kwargs = ie_cfg.engine_init_kwargs or {}
-    enable_prefix_caching = engine_kwargs.get("enable_prefix_caching", ie_cfg.enable_prefix_caching)
-    speculative_config = engine_kwargs.get("speculative_config", ie_cfg.speculative_config)
+    engine_kwargs_list = []
 
-    if not enable_prefix_caching or not speculative_config:
-        return
+    if ie_cfg.enable_pd and (ie_cfg.prefill_init_kwargs or ie_cfg.decode_init_kwargs):
+        if ie_cfg.prefill_init_kwargs:
+            engine_kwargs_list.append(get_config_as_dict(ie_cfg.prefill_init_kwargs))
+        if ie_cfg.decode_init_kwargs:
+            engine_kwargs_list.append(get_config_as_dict(ie_cfg.decode_init_kwargs))
+    else:
+        engine_kwargs_list.append(get_config_as_dict(ie_cfg.engine_init_kwargs or {}))
 
-    from transformers import AutoConfig
+    for engine_kwargs in engine_kwargs_list:
+        enable_prefix_caching = engine_kwargs.get("enable_prefix_caching", ie_cfg.enable_prefix_caching)
+        speculative_config = engine_kwargs.get("speculative_config", ie_cfg.speculative_config)
+        if speculative_config is not None:
+            speculative_config = get_config_as_dict(speculative_config)
 
-    method = speculative_config.get("method")
-    uses_mtp = method == "mtp" or (isinstance(method, str) and method.endswith("_mtp"))
-    if method is None and speculative_config.get("model"):
-        draft_model = speculative_config["model"]
-        if draft_model in ("ngram", "[ngram]") or _is_custom_proposer_path(draft_model):
-            return
-        draft_config = AutoConfig.from_pretrained(
-            draft_model,
+        if not enable_prefix_caching or not speculative_config:
+            continue
+
+        from transformers import AutoConfig
+
+        method = speculative_config.get("method")
+        uses_mtp = method == "mtp" or (isinstance(method, str) and method.endswith("_mtp"))
+        if method is None and speculative_config.get("model"):
+            draft_model = speculative_config["model"]
+            if draft_model in ("ngram", "[ngram]") or _is_custom_proposer_path(draft_model):
+                continue
+            draft_config = AutoConfig.from_pretrained(
+                draft_model,
+                trust_remote_code=engine_kwargs.get("trust_remote_code", True),
+                revision=speculative_config.get("revision"),
+                code_revision=speculative_config.get("code_revision"),
+            )
+            uses_mtp = _has_native_mtp_capability(draft_config)
+        if not uses_mtp:
+            continue
+
+        model_config = AutoConfig.from_pretrained(
+            engine_kwargs.get("model", cfg.trainer.policy.model.path),
             trust_remote_code=engine_kwargs.get("trust_remote_code", True),
-            revision=speculative_config.get("revision"),
-            code_revision=speculative_config.get("code_revision"),
+            revision=engine_kwargs.get("revision"),
         )
-        uses_mtp = _has_native_mtp_capability(draft_config)
-    if not uses_mtp:
-        return
+        text_config = model_config.get_text_config(decoder=True)
+        if "linear_attention" not in (getattr(text_config, "layer_types", None) or []):
+            continue
 
-    model_config = AutoConfig.from_pretrained(
-        engine_kwargs.get("model", cfg.trainer.policy.model.path),
-        trust_remote_code=engine_kwargs.get("trust_remote_code", True),
-        revision=engine_kwargs.get("revision"),
-    )
-    text_config = model_config.get_text_config(decoder=True)
-    if "linear_attention" not in (getattr(text_config, "layer_types", None) or []):
-        return
-
-    raise ValueError(
-        "MTP speculative decoding with prefix caching is unsafe for models with recurrent "
-        "linear-attention layers. Set generator.inference_engine.enable_prefix_caching=false "
-        "and remove any engine_init_kwargs.enable_prefix_caching override, or disable MTP "
-        "speculative decoding (SKYRL_DISABLE_SPEC=1 for trainer.mtp, or remove speculative_config). See "
-        "vllm-project/vllm#43559 and vllm-project/vllm#50021."
-    )
+        raise ValueError(
+            "MTP speculative decoding with prefix caching is unsafe for models with recurrent "
+            "linear-attention layers (such as Qwen3.5/Qwen3-Next). Recurrent state cannot be shared across "
+            "different token histories, which causes silent output corruption. Set "
+            "generator.inference_engine.enable_prefix_caching=false or remove MTP speculative decoding. "
+            "and remove any engine_init_kwargs.enable_prefix_caching override, or disable MTP "
+            "speculative decoding (SKYRL_DISABLE_SPEC=1 for trainer.mtp, or remove speculative_config). See "
+            "vllm-project/vllm#43559 and vllm-project/vllm#50021."
+        )
 
 
 def validate_cfg(cfg: SkyRLTrainConfig):

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -363,7 +363,7 @@ def _validate_mtp_prefix_caching(cfg: SkyRLTrainConfig) -> None:
         return
 
     model_config = AutoConfig.from_pretrained(
-        cfg.trainer.policy.model.path,
+        engine_kwargs.get("model", cfg.trainer.policy.model.path),
         trust_remote_code=engine_kwargs.get("trust_remote_code", True),
         revision=engine_kwargs.get("revision"),
     )
@@ -395,14 +395,13 @@ def validate_cfg(cfg: SkyRLTrainConfig):
         if cfg.trainer.max_training_steps <= 0:
             raise ValueError(f"max_training_steps must be > 0, got {cfg.trainer.max_training_steps}")
 
-    # Validate generation config separately
-    validate_generator_cfg(cfg)
-
     # Multi-Token Prediction (MTP): the high-level `trainer.mtp` knob is the single source of truth.
     # Propagate it to the training side (Megatron MTP heads + decoupled draft loss) and the inference
-    # side (vLLM MTP speculative decoding) so both stay consistent.
+    # side (vLLM MTP speculative decoding) before validating the effective inference config.
     _apply_mtp_config(cfg)
-    _validate_mtp_prefix_caching(cfg)
+
+    # Validate generation config separately, including the shared inference-engine checks.
+    validate_generator_cfg(cfg)
 
     from skyrl.backends.skyrl_train.utils.ppo_utils import (
         AdvantageEstimatorRegistry,
@@ -772,6 +771,8 @@ def validate_inference_engine_cfg(cfg: SkyRLTrainConfig):
                 f"invalid `generator.inference_engine.speculative_config.method`: {method!r}. "
                 f"Must be one of {list(SUPPORTED_SPECULATIVE_DECODING_METHODS)}."
             )
+
+    _validate_mtp_prefix_caching(cfg)
 
     # Validate new inference config options
     _validate_new_inference_cfg(cfg)

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -310,6 +310,40 @@ def _apply_mtp_config(cfg: SkyRLTrainConfig):
         }
 
 
+def _validate_mtp_prefix_caching(cfg: SkyRLTrainConfig) -> None:
+    """Reject vLLM MTP with prefix caching on recurrent linear-attention models."""
+    ie_cfg = cfg.generator.inference_engine
+    engine_kwargs = ie_cfg.engine_init_kwargs or {}
+    enable_prefix_caching = engine_kwargs.get("enable_prefix_caching", ie_cfg.enable_prefix_caching)
+    speculative_config = engine_kwargs.get("speculative_config", ie_cfg.speculative_config)
+
+    if not enable_prefix_caching or not speculative_config:
+        return
+
+    method = speculative_config.get("method")
+    if method != "mtp" and not (isinstance(method, str) and method.endswith("_mtp")):
+        return
+
+    from transformers import AutoConfig
+
+    model_config = AutoConfig.from_pretrained(
+        cfg.trainer.policy.model.path,
+        trust_remote_code=engine_kwargs.get("trust_remote_code", True),
+        revision=engine_kwargs.get("revision"),
+    )
+    text_config = model_config.get_text_config(decoder=True)
+    if "linear_attention" not in (getattr(text_config, "layer_types", None) or []):
+        return
+
+    raise ValueError(
+        "MTP speculative decoding with prefix caching is unsafe for models with recurrent "
+        "linear-attention layers. Set generator.inference_engine.enable_prefix_caching=false "
+        "and remove any engine_init_kwargs.enable_prefix_caching override, or disable MTP "
+        "speculative decoding (SKYRL_DISABLE_SPEC=1 for trainer.mtp, or remove speculative_config). See "
+        "vllm-project/vllm#43559 and vllm-project/vllm#50021."
+    )
+
+
 def validate_cfg(cfg: SkyRLTrainConfig):
     if cfg.trainer.strategy == "fsdp2":
         import warnings
@@ -332,6 +366,7 @@ def validate_cfg(cfg: SkyRLTrainConfig):
     # Propagate it to the training side (Megatron MTP heads + decoupled draft loss) and the inference
     # side (vLLM MTP speculative decoding) so both stay consistent.
     _apply_mtp_config(cfg)
+    _validate_mtp_prefix_caching(cfg)
 
     from skyrl.backends.skyrl_train.utils.ppo_utils import (
         AdvantageEstimatorRegistry,

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -310,6 +310,30 @@ def _apply_mtp_config(cfg: SkyRLTrainConfig):
         }
 
 
+def _has_native_mtp_capability(model_config) -> bool:
+    fields = ("mtp_num_hidden_layers", "num_nextn_predict_layers", "num_mtp_modules", "n_predict")
+    text_config = model_config.get_text_config(decoder=True)
+    for candidate in (model_config, text_config):
+        for field in fields:
+            value = getattr(candidate, field, None)
+            if isinstance(value, int) and value > 0:
+                return True
+        mtp_config = getattr(candidate, "mtp_config", None)
+        if isinstance(mtp_config, dict):
+            for field in fields:
+                value = mtp_config.get(field)
+                if isinstance(value, int) and value > 0:
+                    return True
+    return False
+
+
+def _is_custom_proposer_path(model: str) -> bool:
+    if model.startswith(("http://", "https://", "file://")) or "/" in model:
+        return False
+    parts = model.split(".")
+    return len(parts) >= 2 and all(part.isidentifier() for part in parts)
+
+
 def _validate_mtp_prefix_caching(cfg: SkyRLTrainConfig) -> None:
     """Reject vLLM MTP with prefix caching on recurrent linear-attention models."""
     ie_cfg = cfg.generator.inference_engine
@@ -320,11 +344,23 @@ def _validate_mtp_prefix_caching(cfg: SkyRLTrainConfig) -> None:
     if not enable_prefix_caching or not speculative_config:
         return
 
-    method = speculative_config.get("method")
-    if method != "mtp" and not (isinstance(method, str) and method.endswith("_mtp")):
-        return
-
     from transformers import AutoConfig
+
+    method = speculative_config.get("method")
+    uses_mtp = method == "mtp" or (isinstance(method, str) and method.endswith("_mtp"))
+    if method is None and speculative_config.get("model"):
+        draft_model = speculative_config["model"]
+        if draft_model in ("ngram", "[ngram]") or _is_custom_proposer_path(draft_model):
+            return
+        draft_config = AutoConfig.from_pretrained(
+            draft_model,
+            trust_remote_code=engine_kwargs.get("trust_remote_code", True),
+            revision=speculative_config.get("revision"),
+            code_revision=speculative_config.get("code_revision"),
+        )
+        uses_mtp = _has_native_mtp_capability(draft_config)
+    if not uses_mtp:
+        return
 
     model_config = AutoConfig.from_pretrained(
         cfg.trainer.policy.model.path,

--- a/tests/backends/skyrl_train/mtp/test_mtp_config.py
+++ b/tests/backends/skyrl_train/mtp/test_mtp_config.py
@@ -1,6 +1,6 @@
 """CPU unit tests for the MTP config knobs.
 
-uv run --isolated --extra dev pytest tests/train/test_mtp_config.py
+uv run --isolated --extra dev --extra skyrl-train pytest tests/backends/skyrl_train/mtp/test_mtp_config.py
 """
 
 import pytest
@@ -12,7 +12,11 @@ from skyrl.train.config import (
     SkyRLTrainConfig,
 )
 from skyrl.train.config.config import build_nested_dataclass
-from skyrl.train.utils.utils import _apply_mtp_config
+from skyrl.train.utils.utils import (
+    _apply_mtp_config,
+    _validate_mtp_prefix_caching,
+    validate_cfg,
+)
 
 
 def test_megatron_config_mtp_defaults():
@@ -109,3 +113,86 @@ def test_apply_mtp_config_does_not_clobber_explicit_speculative_config():
     cfg.generator.inference_engine.speculative_config = {"method": "mtp", "num_speculative_tokens": 5}
     _apply_mtp_config(cfg)
     assert cfg.generator.inference_engine.speculative_config["num_speculative_tokens"] == 5
+
+
+@pytest.mark.parametrize(
+    ("enable_prefix_caching", "engine_init_kwargs", "should_raise"),
+    [
+        (True, {}, True),
+        (False, {}, False),
+        (False, {"enable_prefix_caching": True}, True),
+        (True, {"enable_prefix_caching": False}, False),
+    ],
+)
+def test_validate_mtp_prefix_caching_for_linear_attention_model(
+    tmp_path, enable_prefix_caching, engine_init_kwargs, should_raise
+):
+    from transformers import Qwen3_5TextConfig
+
+    Qwen3_5TextConfig(
+        num_hidden_layers=4,
+        layer_types=["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+    ).save_pretrained(tmp_path)
+
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.policy.model.path = str(tmp_path)
+    cfg.trainer.mtp.enabled = True
+    cfg.generator.inference_engine.enable_prefix_caching = enable_prefix_caching
+    cfg.generator.inference_engine.engine_init_kwargs = engine_init_kwargs
+    _apply_mtp_config(cfg)
+
+    if should_raise:
+        with pytest.raises(ValueError, match="enable_prefix_caching=false"):
+            _validate_mtp_prefix_caching(cfg)
+    else:
+        _validate_mtp_prefix_caching(cfg)
+
+
+def test_validate_mtp_prefix_caching_allows_full_attention_model(tmp_path):
+    from transformers import Qwen3_5TextConfig
+
+    Qwen3_5TextConfig(num_hidden_layers=2, layer_types=["full_attention", "full_attention"]).save_pretrained(tmp_path)
+
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.policy.model.path = str(tmp_path)
+    cfg.trainer.mtp.enabled = True
+    _apply_mtp_config(cfg)
+
+    _validate_mtp_prefix_caching(cfg)
+
+
+def test_validate_mtp_prefix_caching_allows_effective_non_mtp_override():
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.policy.model.path = "unresolved-linear-attention-model"
+    cfg.trainer.mtp.enabled = True
+    cfg.generator.inference_engine.engine_init_kwargs = {
+        "speculative_config": {
+            "method": "eagle",
+            "num_speculative_tokens": 1,
+        }
+    }
+    _apply_mtp_config(cfg)
+
+    _validate_mtp_prefix_caching(cfg)
+
+
+def test_validate_cfg_rejects_mtp_prefix_caching_after_mtp_propagation(tmp_path):
+    from transformers import Qwen3_5TextConfig
+
+    Qwen3_5TextConfig(
+        num_hidden_layers=2,
+        layer_types=["linear_attention", "full_attention"],
+    ).save_pretrained(tmp_path)
+
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.policy.model.path = str(tmp_path)
+    cfg.trainer.mtp.enabled = True
+    cfg.trainer.logger = "console"
+
+    with pytest.raises(ValueError, match="MTP speculative decoding with prefix caching"):
+        validate_cfg(cfg)
+
+    assert cfg.generator.inference_engine.speculative_config == {
+        "method": "mtp",
+        "num_speculative_tokens": 1,
+    }

--- a/tests/backends/skyrl_train/mtp/test_mtp_config.py
+++ b/tests/backends/skyrl_train/mtp/test_mtp_config.py
@@ -176,6 +176,52 @@ def test_validate_mtp_prefix_caching_allows_effective_non_mtp_override():
     _validate_mtp_prefix_caching(cfg)
 
 
+def test_validate_mtp_prefix_caching_rejects_implicit_native_mtp(tmp_path):
+    from transformers import Qwen3_5Config, Qwen3_5TextConfig
+
+    model_path = tmp_path / "model"
+    Qwen3_5Config(
+        architectures=["Qwen3_5ForConditionalGeneration"],
+        text_config=Qwen3_5TextConfig(
+            num_hidden_layers=2,
+            layer_types=["linear_attention", "full_attention"],
+            mtp_num_hidden_layers=1,
+        ),
+    ).save_pretrained(model_path)
+
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.policy.model.path = str(model_path)
+    cfg.generator.inference_engine.speculative_config = {
+        "model": str(model_path),
+        "num_speculative_tokens": 1,
+    }
+
+    with pytest.raises(ValueError, match="MTP speculative decoding with prefix caching"):
+        _validate_mtp_prefix_caching(cfg)
+
+
+@pytest.mark.parametrize("model", ["draft", "ngram", "package.CustomProposer"])
+def test_validate_mtp_prefix_caching_allows_implicit_non_mtp_model(tmp_path, model):
+    from transformers import GPT2Config, Qwen3_5TextConfig
+
+    target_path = tmp_path / "target"
+    draft_path = tmp_path / "draft"
+    Qwen3_5TextConfig(
+        num_hidden_layers=2,
+        layer_types=["linear_attention", "full_attention"],
+    ).save_pretrained(target_path)
+    GPT2Config().save_pretrained(draft_path)
+
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.policy.model.path = str(target_path)
+    cfg.generator.inference_engine.speculative_config = {
+        "model": str(draft_path) if model == "draft" else model,
+        "num_speculative_tokens": 1,
+    }
+
+    _validate_mtp_prefix_caching(cfg)
+
+
 def test_validate_cfg_rejects_mtp_prefix_caching_after_mtp_propagation(tmp_path):
     from transformers import Qwen3_5TextConfig
 

--- a/tests/backends/skyrl_train/mtp/test_mtp_config.py
+++ b/tests/backends/skyrl_train/mtp/test_mtp_config.py
@@ -16,6 +16,7 @@ from skyrl.train.utils.utils import (
     _apply_mtp_config,
     _validate_mtp_prefix_caching,
     validate_cfg,
+    validate_inference_engine_cfg,
 )
 
 
@@ -242,3 +243,53 @@ def test_validate_cfg_rejects_mtp_prefix_caching_after_mtp_propagation(tmp_path)
         "method": "mtp",
         "num_speculative_tokens": 1,
     }
+
+
+@pytest.mark.parametrize("enable_prefix_caching", [False, True])
+def test_inference_only_validation_checks_mtp_prefix_caching(tmp_path, enable_prefix_caching):
+    from transformers import Qwen3_5TextConfig
+
+    Qwen3_5TextConfig(
+        num_hidden_layers=2,
+        layer_types=["linear_attention", "full_attention"],
+    ).save_pretrained(tmp_path)
+
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.policy.model.path = str(tmp_path)
+    cfg.trainer.placement.colocate_all = False
+    cfg.generator.inference_engine.enable_prefix_caching = enable_prefix_caching
+    cfg.generator.inference_engine.speculative_config = {"method": "mtp", "num_speculative_tokens": 1}
+
+    # The serve entrypoint calls this shared validator without training's MTP propagation.
+    if enable_prefix_caching:
+        with pytest.raises(ValueError, match="MTP speculative decoding with prefix caching"):
+            validate_inference_engine_cfg(cfg)
+    else:
+        validate_inference_engine_cfg(cfg)
+
+
+@pytest.mark.parametrize("hybrid_override", [False, True])
+def test_validate_mtp_prefix_caching_uses_effective_engine_model(tmp_path, hybrid_override):
+    from transformers import Qwen3_5TextConfig
+
+    full_attention_path = tmp_path / "full_attention"
+    hybrid_path = tmp_path / "hybrid"
+    Qwen3_5TextConfig(num_hidden_layers=2, layer_types=["full_attention", "full_attention"]).save_pretrained(
+        full_attention_path
+    )
+    Qwen3_5TextConfig(num_hidden_layers=2, layer_types=["linear_attention", "full_attention"]).save_pretrained(
+        hybrid_path
+    )
+
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.policy.model.path = str(full_attention_path if hybrid_override else hybrid_path)
+    cfg.generator.inference_engine.engine_init_kwargs = {
+        "model": str(hybrid_path if hybrid_override else full_attention_path),
+    }
+    cfg.generator.inference_engine.speculative_config = {"method": "mtp", "num_speculative_tokens": 1}
+
+    if hybrid_override:
+        with pytest.raises(ValueError, match="MTP speculative decoding with prefix caching"):
+            validate_inference_engine_cfg(cfg)
+    else:
+        validate_inference_engine_cfg(cfg)

--- a/tests/backends/skyrl_train/mtp/test_mtp_config.py
+++ b/tests/backends/skyrl_train/mtp/test_mtp_config.py
@@ -293,3 +293,39 @@ def test_validate_mtp_prefix_caching_uses_effective_engine_model(tmp_path, hybri
             validate_inference_engine_cfg(cfg)
     else:
         validate_inference_engine_cfg(cfg)
+
+
+@pytest.mark.parametrize(
+    ("decode_init_kwargs", "should_raise"),
+    [
+        ({"enable_prefix_caching": True}, True),
+        ({"enable_prefix_caching": False}, False),
+        ({"speculative_config": {"method": "mtp", "num_speculative_tokens": 1}}, True),
+        ({"speculative_config": {"method": "eagle", "num_speculative_tokens": 1}}, False),
+    ],
+)
+def test_validate_mtp_prefix_caching_checks_pd_role_kwargs(tmp_path, decode_init_kwargs, should_raise):
+    from transformers import Qwen3_5TextConfig
+
+    Qwen3_5TextConfig(num_hidden_layers=2, layer_types=["linear_attention", "full_attention"]).save_pretrained(tmp_path)
+
+    cfg = SkyRLTrainConfig()
+    cfg.trainer.policy.model.path = str(tmp_path)
+    cfg.generator.inference_engine.enable_pd = True
+    cfg.generator.inference_engine.enable_prefix_caching = decode_init_kwargs.get("enable_prefix_caching", True)
+    if "speculative_config" not in decode_init_kwargs:
+        cfg.generator.inference_engine.speculative_config = {"method": "mtp", "num_speculative_tokens": 1}
+
+    cfg.generator.inference_engine.prefill_init_kwargs = {
+        "enable_prefix_caching": False,
+        "kv_transfer_config": {"kv_connector": "PyTorchConnector"},
+    }
+    decode_kwargs = {"kv_transfer_config": {"kv_connector": "PyTorchConnector"}}
+    decode_kwargs.update(decode_init_kwargs)
+    cfg.generator.inference_engine.decode_init_kwargs = decode_kwargs
+
+    if should_raise:
+        with pytest.raises(ValueError, match="MTP speculative decoding with prefix caching"):
+            _validate_mtp_prefix_caching(cfg)
+    else:
+        _validate_mtp_prefix_caching(cfg)


### PR DESCRIPTION
## Summary

Reject MTP speculative decoding with prefix caching on recurrent linear-attention models during both training and standalone serving. Inspect the effective engine model and respect final `engine_init_kwargs` overrides for model, prefix caching, and speculative decoding. The Qwen3.5 MTP recipe explicitly disables prefix caching.

## Why

Issue #1981 motivated this guard after a Qwen3.6 accuracy collapse with MTP and prefix caching. Current SkyRL main pins vLLM 0.28.0, which includes the fix that closed [vLLM #43559](https://github.com/vllm-project/vllm/issues/43559) through [#51113](https://github.com/vllm-project/vllm/pull/51113). Separate hybrid speculative-state failures remain documented in [#50021](https://github.com/vllm-project/vllm/pull/50021); its proposed fix remains unmerged, and the affected unchecked indexing paths are present in 0.28.0.

This PR conservatively rejects the combined configuration pending validation of that path. Config validation explains how to disable prefix caching or MTP. Full-attention MTP models and non-MTP hybrid models remain allowed.

## Validation

- 171 focused MTP and training-configuration tests pass offline.
- The standalone-serving rejection failed before moving the check into the shared inference validator; its prefix-caching-disabled control passed.
- Both model-override regressions failed before the fix: an overridden hybrid model was accepted, and an overridden full-attention model was incorrectly rejected.
- Independent review verified training propagation order, serving coverage, and override precedence.
- Required Ruff, Black, and gitleaks hooks pass.

These tests verify configuration detection and precedence. They do not reproduce GPU failures or establish numerical parity on vLLM 0.28.0. The original #43559 bug is already fixed in that release.

## Repro command

```bash
uv run --isolated --extra skyrl-train --extra dev pytest --noconftest \
  tests/backends/skyrl_train/mtp/test_mtp_config.py tests/train/test_config.py -q
```

Fixes #1981

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout/inference configuration validation and can block previously accepted MTP+prefix-caching setups on hybrid linear-attention models, but avoids silent generation corruption rather than altering training math.
> 
> **Overview**
> Adds **config validation** that fails fast when **MTP speculative decoding** and **vLLM prefix caching** are both enabled on models with **recurrent linear-attention** layers (e.g. Qwen3.5). The check uses the **effective** inference settings—`engine_init_kwargs` / PD `prefill_init_kwargs` and `decode_init_kwargs` overrides for model, prefix caching, and speculative config—and detects MTP via explicit `method`, implicit draft configs, or native MTP fields on the draft model.
> 
> **Training validation order** is adjusted so `_apply_mtp_config` runs before generator/inference validation, ensuring propagated MTP speculative settings are included. The same guard runs in **`validate_inference_engine_cfg`**, so standalone serving rejects the unsafe combo too. Config docs and the Qwen3.5 MTP example script set **`enable_prefix_caching=false`**. New unit tests cover overrides, full-attention allowlists, PD roles, and serve-only validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bc184c3b31dea2a82432955e7162e33f4a3f665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->