### PR TITLE
[security][ci] Restrict privileged GPU jobs to trusted branches

### DIFF
--- a/.github/workflows/gpu_ci_h100.yaml
+++ b/.github/workflows/gpu_ci_h100.yaml
@@ -25,15 +25,15 @@ permissions:
 jobs:
 
   skyrl_train_tests_h100:
-    # Gate on the label that fired this event. `types: [labeled]` delivers one event
-    # per label added, and `contains(...labels.*.name, ...)` tests the whole label
-    # set, so labelling in bulk launched one identical GPU run per label.
+    # Match the label that fired this event to avoid duplicate runs from bulk
+    # labeling. This job executes the PR head with secrets, so reject forks.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.label.name == 'run_h100_gpu_ci'
       )
     runs-on: ubuntu-latest
@@ -47,9 +47,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           # The Anyscale job uploads this working dir, so we need the PR head.
-          # Fork code only reaches here after a maintainer applies the gating
-          # label above; don't leave the base repo token on disk for it.
-          allow-unsafe-pr-checkout: true
+          # Don't leave the base repo token in the uploaded checkout.
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/gpu_skyrl.yaml
+++ b/.github/workflows/gpu_skyrl.yaml
@@ -28,6 +28,11 @@ concurrency:
 
 jobs:
   skyrl_gpu_tests:
+    # Repository secrets are unavailable to fork pull requests, so skip the
+    # remote job instead of reporting a credential failure before tests start.
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -25,15 +25,15 @@ permissions:
 jobs:
   
   skyrl_train_tests:
-    # Gate on the label that fired this event. `types: [labeled]` delivers one event
-    # per label added, and `contains(...labels.*.name, ...)` tests the whole label
-    # set, so labelling in bulk launched one identical GPU run per label.
+    # Match the label that fired this event to avoid duplicate runs from bulk
+    # labeling. This job executes the PR head with secrets, so reject forks.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.label.name == 'run_train_gpu_ci'
       )
     runs-on: ubuntu-latest
@@ -47,9 +47,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           # The Anyscale job uploads this working dir, so we need the PR head.
-          # Fork code only reaches here after a maintainer applies the gating
-          # label above; don't leave the base repo token on disk for it.
-          allow-unsafe-pr-checkout: true
+          # Don't leave the base repo token in the uploaded checkout.
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -27,15 +27,15 @@ permissions:
 jobs:
   
   skyrl_train_tests_megatron:
-    # Gate on the label that fired this event. `types: [labeled]` delivers one event
-    # per label added, and `contains(...labels.*.name, ...)` tests the whole label
-    # set, so labelling in bulk launched one identical GPU run per label.
+    # Match the label that fired this event to avoid duplicate runs from bulk
+    # labeling. This job executes the PR head with secrets, so reject forks.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.label.name == 'run_train_megatron_gpu_ci'
       )
     runs-on: ubuntu-latest
@@ -49,9 +49,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           # The Anyscale job uploads this working dir, so we need the PR head.
-          # Fork code only reaches here after a maintainer applies the gating
-          # label above; don't leave the base repo token on disk for it.
-          allow-unsafe-pr-checkout: true
+          # Don't leave the base repo token in the uploaded checkout.
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/gpu_skyrl_train_megatron_models.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron_models.yaml
@@ -27,15 +27,15 @@ permissions:
 jobs:
   
   skyrl_train_tests_megatron_models:
-    # Gate on the label that fired this event. `types: [labeled]` delivers one event
-    # per label added, and `contains(...labels.*.name, ...)` tests the whole label
-    # set, so labelling in bulk launched one identical GPU run per label.
+    # Match the label that fired this event to avoid duplicate runs from bulk
+    # labeling. This job executes the PR head with secrets, so reject forks.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.label.name == 'run_train_megatron_gpu_ci_models'
       )
     runs-on: ubuntu-latest
@@ -49,9 +49,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           # The Anyscale job uploads this working dir, so we need the PR head.
-          # Fork code only reaches here after a maintainer applies the gating
-          # label above; don't leave the base repo token on disk for it.
-          allow-unsafe-pr-checkout: true
+          # Don't leave the base repo token in the uploaded checkout.
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
+++ b/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
@@ -28,15 +28,15 @@ permissions:
 jobs:
 
   tinker_skyrl_train_backend_gpu_tests:
-    # Gate on the label that fired this event. `types: [labeled]` delivers one event
-    # per label added, and `contains(...labels.*.name, ...)` tests the whole label
-    # set, so labelling in bulk launched one identical GPU run per label.
+    # Match the label that fired this event to avoid duplicate runs from bulk
+    # labeling. This job executes the PR head with secrets, so reject forks.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.label.name == 'run_tinker_skyrl_train_backend_gpu_ci'
       )
     runs-on: ubuntu-latest
@@ -50,9 +50,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           # The Anyscale job uploads this working dir, so we need the PR head.
-          # Fork code only reaches here after a maintainer applies the gating
-          # label above; don't leave the base repo token on disk for it.
-          allow-unsafe-pr-checkout: true
+          # Don't leave the base repo token in the uploaded checkout.
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

- Run secret-bearing `pull_request_target` GPU jobs only for branches in this repository.
- Skip generic remote GPU jobs for fork pull requests, where repository credentials are unavailable.
- Keep push, manual dispatch, maintainer label, and draft gates unchanged.
- Remove the unsafe fork-checkout override from all five privileged workflows.

## Why

The labeled GPU workflows check out and execute the pull request head while exposing repository Anyscale and Hugging Face credentials. A maintainer-applied label limits execution, but an external fork still controls the submitted scripts, config, and remote test payload.

The generic GPU workflow is not privileged on fork pull requests because GitHub withholds secrets, but it still starts and fails before tests with invalid Anyscale credentials. Skipping that job makes the missing GPU signal explicit instead of reporting a code failure.

External contributions must be mirrored to a reviewed branch in this repository before privileged GPU validation. Unprivileged CPU checks continue through their existing workflows.

## Validation

- Parsed all changed workflows with `yq`.
- `actionlint` 1.7.12
- Event predicate truth tables covering push, manual dispatch, same-repo PRs, forks, drafts, and missing labels
- Coverage scan: all five `pull_request_target` GPU workflows guarded; no unsafe checkout override remains
- Generic fork GPU job resolves to skipped instead of submitting without credentials
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI security boundaries for workflows that expose Anyscale and Hugging Face secrets; behavior for fork PRs shifts from failed runs to skipped or blocked GPU checks.
> 
> **Overview**
> **Tightens GPU CI so secret-bearing jobs never run untrusted fork code**, while avoiding misleading failures when forks cannot use repo credentials.
> 
> For five `pull_request_target` workflows (H100, train, Megatron, Megatron models, Tinker backend), labeled runs now require `github.event.pull_request.head.repo.full_name == github.repository` in addition to the existing draft and label gates. Checkout drops `allow-unsafe-pr-checkout: true` and keeps `persist-credentials: false` so uploaded Anyscale payloads do not retain a base-repo token.
> 
> The standard `pull_request` **SkyRL-GPU** workflow skips the job on fork PRs instead of starting and failing on missing Anyscale/HF secrets. Push, `workflow_dispatch`, and same-repo labeled runs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ae732619a567ad3e0c245d6bdf364b214583154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->