### PR TITLE
[fix][tinker] Preserve training order and isolate sample futures

### DIFF
--- a/docs/content/docs/tinker/architecture.mdx
+++ b/docs/content/docs/tinker/architecture.mdx
@@ -8,7 +8,7 @@ This page describes how SkyRL implements the Tinker API, including the system ar
 
 The integration is organized in three high-level layers:
 
-1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests, stores them in a database, and returns future IDs for async polling
+1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests and returns future IDs for async polling. Engine-owned operations use the database; API-forwarded samples use in-memory futures.
 2. **Engine Layer** (`skyrl.tinker.engine`) - Background subprocess that polls the database, batches pending requests, and dispatches them to the backend
 3. **Backend Layer** (`skyrl.backends`) - Translates Tinker operations into training and inference calls, managing Ray workers, FSDP/Megatron training, and vLLM inference
 
@@ -71,6 +71,9 @@ Sampling requests (`sample`) go through the following lifecycle:
 Client calls sample()
     │
     ▼
+API Server (FastAPI)
+    │  Creates an in-memory future
+    ▼
 SkyRL-Train Backend
     │  Converts Tinker SamplingParams → vLLM params
     ▼
@@ -83,10 +86,10 @@ RemoteInferenceClient
 Inference Workers (vLLM)
     │  Generate tokens with logprobs
     ▼
-Results aggregated → GeneratedSequence objects returned
+Results resolve the in-memory future → GeneratedSequence objects returned
 ```
 
-The `sample()` call is a fairly lightweight wrapper around SkyRL-Train's vLLM inference engines. The backend translates Tinker `SamplingParams` to vLLM format (e.g., `stop_strings` → `stop`, `stop_tokens` → `stop_token_ids`) and delegates prompts to the `RemoteInferenceClient`. `RemoteInferenceClient` forwards the requests to an instance of [vLLM Router](https://github.com/vllm-project/router), which handles load balancing and sticky routing across vLLM workers.
+The `sample()` call is a fairly lightweight wrapper around SkyRL-Train's vLLM inference engines. Non-colocated and external inference requests bypass the engine database: the API owns their futures and signals completion with `asyncio.Event`. The backend translates Tinker `SamplingParams` to vLLM format (e.g., `stop_strings` → `stop`, `stop_tokens` → `stop_token_ids`) and delegates prompts to the `RemoteInferenceClient`. `RemoteInferenceClient` forwards the requests to an instance of [vLLM Router](https://github.com/vllm-project/router), which handles load balancing and sticky routing across vLLM workers.
 
 
 ## Weight Sync

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -43,6 +43,7 @@ from skyrl.tinker.db_models import (
 )
 from skyrl.tinker.extra import (
     ExternalInferenceClient,
+    InMemoryFutureStore,
     SkyRLTrainInferenceForwardingClient,
 )
 from skyrl.utils.log import get_uvicorn_log_config, logger
@@ -251,12 +252,17 @@ async def lifespan(app: FastAPI):
     # SkyRL-Train default is colocate_all=True; only opt into forwarding
     # when the operator explicitly sets it to False.
     is_colocated = bool(backend_cfg.get("trainer.placement.colocate_all", True))
+    app.state.external_future_store = InMemoryFutureStore()
     if app.state.engine_config.external_inference_url:
-        app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
+        app.state.external_inference_client = ExternalInferenceClient(
+            app.state.engine_config, app.state.external_future_store
+        )
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
         app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
-            app.state.engine_config, app.state.db_engine
+            app.state.engine_config,
+            app.state.db_engine,
+            app.state.external_future_store,
         )
         logger.info(
             "SkyRL-Train inference forwarding client enabled for non-colocated backend=%s",
@@ -1272,35 +1278,33 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
         # Validate that the checkpoint exists and is ready
         await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
 
-    request_id = await create_future(
-        session=session,
-        request_type=(
-            types.RequestType.EXTERNAL if req.app.state.external_inference_client else types.RequestType.SAMPLE
-        ),
-        model_id=model_id,
-        request_data=types.SampleInput(
-            base_model=base_model,
-            prompt=request.prompt.to_types(),
-            sampling_params=request.sampling_params.to_types(),
-            num_samples=request.num_samples,
-            checkpoint_id=checkpoint_id,
-            # A positive topk implies prompt logprobs: both are read off the same
-            # prompt forward pass, so asking for one asks for the other.
-            prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
-            topk_prompt_logprobs=request.topk_prompt_logprobs,
-            seq_id=request.seq_id,
-            sampling_session_id=request.sampling_session_id,
-        ),
-    )
-
-    await session.commit()
-
     if req.app.state.external_inference_client:
+        request_id = req.app.state.external_future_store.create_future()
         asyncio.create_task(
             req.app.state.external_inference_client.call_and_store_result(
                 request_id, request, model_id, checkpoint_id, base_model=base_model
             )
         )
+    else:
+        request_id = await create_future(
+            session=session,
+            request_type=types.RequestType.SAMPLE,
+            model_id=model_id,
+            request_data=types.SampleInput(
+                base_model=base_model,
+                prompt=request.prompt.to_types(),
+                sampling_params=request.sampling_params.to_types(),
+                num_samples=request.num_samples,
+                checkpoint_id=checkpoint_id,
+                # A positive topk implies prompt logprobs: both are read off the same
+                # prompt forward pass, so asking for one asks for the other.
+                prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
+                topk_prompt_logprobs=request.topk_prompt_logprobs,
+                seq_id=request.seq_id,
+                sampling_session_id=request.sampling_session_id,
+            ),
+        )
+        await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
@@ -1324,7 +1328,10 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     request_id = int(request.request_id)
 
     try:
-        row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        if request_id < 0:
+            row = await req.app.state.external_future_store.wait_for_future(request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        else:
+            row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
     except KeyError:
         raise HTTPException(status_code=404, detail="Future not found")
 

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -761,12 +761,14 @@ class SampleRequest(BaseModel):
 class SaveWeightsRequest(BaseModel):
     model_id: str
     path: str = Field(..., pattern=ID_PATTERN, max_length=ID_MAX_LENGTH)
+    seq_id: int | None = None
     type: Literal["save_weights"] | None = None
 
 
 class LoadWeightsRequest(BaseModel):
     model_id: str
     path: str
+    seq_id: int | None = None
     type: Literal["load_weights"] | None = None
 
 
@@ -1150,6 +1152,7 @@ async def load_weights(request: LoadWeightsRequest, req: Request, session: Async
         request_type=types.RequestType.LOAD_WEIGHTS,
         model_id=request.model_id,
         request_data=types.LoadWeightsInput(source_model_id=source_model_id, checkpoint_id=checkpoint_id),
+        seq_id=request.seq_id,
     )
 
     await session.commit()
@@ -1173,6 +1176,7 @@ async def save_weights(request: SaveWeightsRequest, session: AsyncSession = Depe
         request_type=types.RequestType.SAVE_WEIGHTS,
         model_id=request.model_id,
         request_data=types.SaveWeightsInput(path=request.path),
+        seq_id=request.seq_id,
     )
 
     await session.commit()
@@ -1218,6 +1222,7 @@ async def save_weights_for_sampler(request: SaveWeightsForSamplerRequest, sessio
             seq_id=request.seq_id,
             sampling_session_id=sampling_session_id,
         ),
+        seq_id=request.seq_id,
     )
 
     await session.commit()

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -408,9 +408,7 @@ class TinkerEngine:
             pending_by_model[model_id].append((request_id, request_type, seq_id))
 
         predecessor_keys = {
-            (model_id, requests[0][2] - 1)
-            for model_id, requests in pending_by_model.items()
-            if requests[0][2] > 1
+            (model_id, requests[0][2] - 1) for model_id, requests in pending_by_model.items() if requests[0][2] > 1
         }
         completed_predecessors: set[tuple[str, int]] = set()
         if predecessor_keys:
@@ -473,9 +471,7 @@ class TinkerEngine:
             (request_id, model_id)
             for request_id, model_id, seq_id in ops
             if model_id not in barriers or request_id < barriers[model_id]
-            if ready_sequenced_request_ids is None
-            or seq_id is None
-            or request_id in ready_sequenced_request_ids
+            if ready_sequenced_request_ids is None or seq_id is None or request_id in ready_sequenced_request_ids
         ]
 
         return {
@@ -573,9 +569,7 @@ class TinkerEngine:
             (request_id, model_id, request_type)
             for request_id, model_id, request_type, seq_id in other_futures
             if model_id not in blocked_pass_barriers or request_id < blocked_pass_barriers[model_id]
-            if ready_sequenced_request_ids is None
-            or seq_id is None
-            or request_id in ready_sequenced_request_ids
+            if ready_sequenced_request_ids is None or seq_id is None or request_id in ready_sequenced_request_ids
         ]
 
         return {

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -10,6 +10,7 @@ from typing import Any, Callable
 
 from cloudpathlib import AnyPath
 from pydantic import BaseModel
+from sqlalchemy import tuple_
 from sqlmodel import Session, create_engine, func, select, update
 
 from skyrl.backends.utils import log_timing
@@ -28,6 +29,14 @@ from skyrl.tinker.db_models import (
 from skyrl.utils.log import logger
 
 _MAX_IDS_PER_QUERY = 500
+_SEQUENCED_TRAINING_REQUEST_TYPES = (
+    types.RequestType.FORWARD_BACKWARD,
+    types.RequestType.FORWARD,
+    types.RequestType.OPTIM_STEP,
+    types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER,
+    types.RequestType.SAVE_WEIGHTS,
+    types.RequestType.LOAD_WEIGHTS,
+)
 
 
 def _model_not_found_error(model_id: str) -> types.ErrorResponse:
@@ -377,8 +386,64 @@ class TinkerEngine:
         )
         return dict(session.exec(query).all())
 
+    def _find_ready_sequenced_request_ids(self, session: Session) -> set[int]:
+        """Find the next contiguous training request block for each model.
+
+        The Tinker SDK submits parallel forward/backward chunks out of order: it
+        sends every later chunk first, then sends the first chunk to release the
+        complete batch. Hold those later chunks until their predecessor has
+        completed or is part of the same contiguous pending block.
+        """
+        statement = (
+            select(FutureDB.request_id, FutureDB.model_id, FutureDB.request_type, FutureDB.seq_id)
+            .where(FutureDB.status == RequestStatus.PENDING)
+            .where(FutureDB.seq_id.is_not(None))
+            .where(FutureDB.request_type.in_(_SEQUENCED_TRAINING_REQUEST_TYPES))
+            .order_by(FutureDB.model_id, FutureDB.seq_id)
+        )
+        pending_by_model: dict[str, list[tuple[int, types.RequestType, int]]] = defaultdict(list)
+        for request_id, model_id, request_type, seq_id in session.exec(statement).all():
+            if model_id is None or seq_id is None:
+                raise ValueError("Sequenced training requests require model_id and seq_id")
+            pending_by_model[model_id].append((request_id, request_type, seq_id))
+
+        predecessor_keys = {
+            (model_id, requests[0][2] - 1)
+            for model_id, requests in pending_by_model.items()
+            if requests[0][2] > 1
+        }
+        completed_predecessors: set[tuple[str, int]] = set()
+        if predecessor_keys:
+            predecessor_statement = select(FutureDB.model_id, FutureDB.seq_id, FutureDB.status).where(
+                tuple_(FutureDB.model_id, FutureDB.seq_id).in_(predecessor_keys)
+            )
+            completed_predecessors = {
+                (model_id, seq_id)
+                for model_id, seq_id, status in session.exec(predecessor_statement).all()
+                if model_id is not None and seq_id is not None and status != RequestStatus.PENDING
+            }
+
+        ready: set[int] = set()
+        for model_id, requests in pending_by_model.items():
+            first_seq_id = requests[0][2]
+            if first_seq_id != 1 and (model_id, first_seq_id - 1) not in completed_predecessors:
+                continue
+
+            request_type = requests[0][1]
+            expected_seq_id = first_seq_id
+            for request_id, candidate_type, seq_id in requests:
+                if candidate_type != request_type or seq_id != expected_seq_id:
+                    break
+                ready.add(request_id)
+                expected_seq_id += 1
+
+        return ready
+
     def find_batchable_model_passes(
-        self, session: Session, request_type: types.RequestType
+        self,
+        session: Session,
+        request_type: types.RequestType,
+        ready_sequenced_request_ids: set[int] | None = None,
     ) -> dict[str, tuple[str, types.ForwardBackwardInput]]:
         """Find all requests of the given type that come before any destructive update for their model.
 
@@ -396,7 +461,7 @@ class TinkerEngine:
 
         # Get all pending operations of the requested type ordered by request_id
         query = (
-            select(FutureDB.request_id, FutureDB.model_id)
+            select(FutureDB.request_id, FutureDB.model_id, FutureDB.seq_id)
             .where(FutureDB.request_type == request_type)
             .where(FutureDB.status == RequestStatus.PENDING)
             .order_by(FutureDB.request_id)
@@ -406,8 +471,11 @@ class TinkerEngine:
         # Filter: only include ops that come before their model's barrier
         batchable = [
             (request_id, model_id)
-            for request_id, model_id in ops
+            for request_id, model_id, seq_id in ops
             if model_id not in barriers or request_id < barriers[model_id]
+            if ready_sequenced_request_ids is None
+            or seq_id is None
+            or request_id in ready_sequenced_request_ids
         ]
 
         return {
@@ -458,7 +526,9 @@ class TinkerEngine:
             for request_id, model_id, request_data in self._load_requests(session, batchable)
         }
 
-    def find_single_requests(self, session: Session) -> dict[str, tuple[str, types.RequestType, dict]]:
+    def find_single_requests(
+        self, session: Session, ready_sequenced_request_ids: set[int] | None = None
+    ) -> dict[str, tuple[str, types.RequestType, dict]]:
         """Find all requests that need to be processed individually (not batchable).
 
         Args:
@@ -488,7 +558,7 @@ class TinkerEngine:
                     blocked_pass_barriers.setdefault(model_id, req_id)
 
         statement = (
-            select(FutureDB.request_id, FutureDB.model_id, FutureDB.request_type)
+            select(FutureDB.request_id, FutureDB.model_id, FutureDB.request_type, FutureDB.seq_id)
             .where(FutureDB.status == RequestStatus.PENDING)
             .where(FutureDB.request_type != types.RequestType.FORWARD_BACKWARD)
             .where(FutureDB.request_type != types.RequestType.FORWARD)
@@ -501,8 +571,11 @@ class TinkerEngine:
         # Filter: only include ops that come before the first blocked pass for their model
         other_futures = [
             (request_id, model_id, request_type)
-            for request_id, model_id, request_type in other_futures
+            for request_id, model_id, request_type, seq_id in other_futures
             if model_id not in blocked_pass_barriers or request_id < blocked_pass_barriers[model_id]
+            if ready_sequenced_request_ids is None
+            or seq_id is None
+            or request_id in ready_sequenced_request_ids
         ]
 
         return {
@@ -807,15 +880,18 @@ class TinkerEngine:
         while True:
             # Query for pending requests and extract data within session context
             with Session(self.db_engine) as session:
+                ready_sequenced_request_ids = self._find_ready_sequenced_request_ids(session)
                 # Use look-ahead scheduling to find batchable forward_backward and forward model passes
                 forward_backward_requests = self.find_batchable_model_passes(
-                    session, types.RequestType.FORWARD_BACKWARD
+                    session, types.RequestType.FORWARD_BACKWARD, ready_sequenced_request_ids
                 )
-                forward_requests = self.find_batchable_model_passes(session, types.RequestType.FORWARD)
+                forward_requests = self.find_batchable_model_passes(
+                    session, types.RequestType.FORWARD, ready_sequenced_request_ids
+                )
                 # Find pending sample requests that can be batched
                 sample_requests = self.find_batchable_sample(session)
                 # Get other pending requests (non forward_backward and non sampling)
-                other_requests = self.find_single_requests(session)
+                other_requests = self.find_single_requests(session, ready_sequenced_request_ids)
 
             # Process batches outside of session context
             self.process_batch_requests(

--- a/skyrl/tinker/extra/__init__.py
+++ b/skyrl/tinker/extra/__init__.py
@@ -1,6 +1,11 @@
 from skyrl.tinker.extra.external_inference import ExternalInferenceClient
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
     SkyRLTrainInferenceForwardingClient,
 )
 
-__all__ = ["ExternalInferenceClient", "SkyRLTrainInferenceForwardingClient"]
+__all__ = [
+    "ExternalInferenceClient",
+    "InMemoryFutureStore",
+    "SkyRLTrainInferenceForwardingClient",
+]

--- a/skyrl/tinker/extra/external_inference.py
+++ b/skyrl/tinker/extra/external_inference.py
@@ -1,17 +1,16 @@
 import asyncio
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
 from cloudpathlib import AnyPath
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from skyrl.backends.renderer import render_model_input
 from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
-from skyrl.tinker.db_models import FutureDB, RequestStatus
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.utils.log import logger
 from skyrl.utils.storage import download_and_unpack
 
@@ -41,12 +40,12 @@ def _extract_checkpoint_sync(checkpoint_path: AnyPath, target_dir: Path) -> None
 class ExternalInferenceClient:
     """Client for calling external inference engines (e.g., vLLM)."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(self, engine_config: EngineConfig, future_store: InMemoryFutureStore):
         self.base_url = f"{engine_config.external_inference_url}/v1"
         self.api_key = engine_config.external_inference_api_key
         self.checkpoints_base = engine_config.checkpoints_base
         self.lora_base_dir = engine_config.external_inference_lora_base
-        self.db_engine = db_engine
+        self.future_store = future_store
 
     async def call_and_store_result(
         self,
@@ -57,7 +56,7 @@ class ExternalInferenceClient:
         *,
         base_model: str | None = None,
     ):
-        """Background task to call external engine and store result in database."""
+        """Call the external engine and resolve its API-process-owned future."""
         try:
             async with httpx.AsyncClient(
                 base_url=self.base_url,
@@ -73,13 +72,7 @@ class ExternalInferenceClient:
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
 
-        async with AsyncSession(self.db_engine) as session:
-            future = await session.get(FutureDB, request_id)
-            # `result_data` is a text column holding pre-serialized JSON.
-            future.result_data = result.model_dump_json()
-            future.status = status
-            future.completed_at = datetime.now(timezone.utc)
-            await session.commit()
+        self.future_store.complete_future(request_id, status, result.model_dump_json())
 
     async def _forward_to_engine(
         self,

--- a/skyrl/tinker/extra/in_memory_future_store.py
+++ b/skyrl/tinker/extra/in_memory_future_store.py
@@ -1,6 +1,7 @@
 import asyncio
 import itertools
 import time
+from collections import deque
 from dataclasses import dataclass, field
 
 from skyrl.tinker.db_models import RequestStatus
@@ -22,6 +23,7 @@ class InMemoryFutureStore:
         self._max_terminal_futures = max_terminal_futures
         self._next_id = itertools.count(start=-1, step=-1)
         self._futures: dict[int, _StoredFuture] = {}
+        self._terminal_futures: deque[tuple[float, int]] = deque()
 
     def create_future(self) -> int:
         self._cleanup_terminal_futures()
@@ -34,7 +36,9 @@ class InMemoryFutureStore:
         future.status = status
         future.result_data = result_data
         future.completed_at = time.monotonic()
+        self._terminal_futures.append((future.completed_at, request_id))
         future.event.set()
+        self._cleanup_terminal_futures()
 
     async def wait_for_future(self, request_id: int, timeout: float) -> tuple[RequestStatus, str | None] | None:
         future = self._futures.get(request_id)
@@ -49,19 +53,9 @@ class InMemoryFutureStore:
 
     def _cleanup_terminal_futures(self) -> None:
         now = time.monotonic()
-        expired = [
-            request_id
-            for request_id, future in self._futures.items()
-            if future.completed_at is not None and now - future.completed_at > self._terminal_retention_sec
-        ]
-        for request_id in expired:
-            del self._futures[request_id]
-
-        terminal = sorted(
-            (future.completed_at, request_id)
-            for request_id, future in self._futures.items()
-            if future.completed_at is not None
-        )
-        overflow = len(terminal) - self._max_terminal_futures
-        for _, request_id in terminal[: max(overflow, 0)]:
+        while self._terminal_futures and (
+            now - self._terminal_futures[0][0] > self._terminal_retention_sec
+            or len(self._terminal_futures) > self._max_terminal_futures
+        ):
+            _, request_id = self._terminal_futures.popleft()
             del self._futures[request_id]

--- a/skyrl/tinker/extra/in_memory_future_store.py
+++ b/skyrl/tinker/extra/in_memory_future_store.py
@@ -1,0 +1,67 @@
+import asyncio
+import itertools
+import time
+from dataclasses import dataclass, field
+
+from skyrl.tinker.db_models import RequestStatus
+
+
+@dataclass
+class _StoredFuture:
+    event: asyncio.Event = field(default_factory=asyncio.Event)
+    status: RequestStatus = RequestStatus.PENDING
+    result_data: str | None = None
+    completed_at: float | None = None
+
+
+class InMemoryFutureStore:
+    """Store API-process-owned futures without routing them through the engine database."""
+
+    def __init__(self, *, terminal_retention_sec: float = 600, max_terminal_futures: int = 10_000):
+        self._terminal_retention_sec = terminal_retention_sec
+        self._max_terminal_futures = max_terminal_futures
+        self._next_id = itertools.count(start=-1, step=-1)
+        self._futures: dict[int, _StoredFuture] = {}
+
+    def create_future(self) -> int:
+        self._cleanup_terminal_futures()
+        request_id = next(self._next_id)
+        self._futures[request_id] = _StoredFuture()
+        return request_id
+
+    def complete_future(self, request_id: int, status: RequestStatus, result_data: str) -> None:
+        future = self._futures[request_id]
+        future.status = status
+        future.result_data = result_data
+        future.completed_at = time.monotonic()
+        future.event.set()
+
+    async def wait_for_future(self, request_id: int, timeout: float) -> tuple[RequestStatus, str | None] | None:
+        future = self._futures.get(request_id)
+        if future is None:
+            raise KeyError(request_id)
+        if future.status == RequestStatus.PENDING:
+            try:
+                await asyncio.wait_for(future.event.wait(), timeout)
+            except asyncio.TimeoutError:
+                return None
+        return future.status, future.result_data
+
+    def _cleanup_terminal_futures(self) -> None:
+        now = time.monotonic()
+        expired = [
+            request_id
+            for request_id, future in self._futures.items()
+            if future.completed_at is not None and now - future.completed_at > self._terminal_retention_sec
+        ]
+        for request_id in expired:
+            del self._futures[request_id]
+
+        terminal = sorted(
+            (future.completed_at, request_id)
+            for request_id, future in self._futures.items()
+            if future.completed_at is not None
+        )
+        overflow = len(terminal) - self._max_terminal_futures
+        for _, request_id in terminal[: max(overflow, 0)]:
+            del self._futures[request_id]

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -5,7 +5,6 @@ Pair to :class:`ExternalInferenceClient`; resolves the target URL from
 """
 
 import asyncio
-from datetime import datetime, timezone
 
 import httpx
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -14,16 +13,18 @@ from skyrl.backends.renderer import render_model_input
 from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
-from skyrl.tinker.db_models import EngineStateDB, FutureDB, RequestStatus
+from skyrl.tinker.db_models import EngineStateDB, RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.utils.log import logger
 
 
 class SkyRLTrainInferenceForwardingClient:
     """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(self, engine_config: EngineConfig, db_engine, future_store: InMemoryFutureStore):
         self.engine_config = engine_config
         self.db_engine = db_engine
+        self.future_store = future_store
         self._cached_proxy_url: str | None = None
         self._cache_lock = asyncio.Lock()
         # Backpressure layered: httpx pool -> vllm-router -> vLLM max_num_seqs.
@@ -71,7 +72,7 @@ class SkyRLTrainInferenceForwardingClient:
         *,
         base_model: str | None = None,
     ):
-        """Forward a sample request to vLLM and write the result to FutureDB."""
+        """Forward a sample request to vLLM and resolve its API-process-owned future."""
         try:
             result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
             status = RequestStatus.COMPLETED
@@ -80,18 +81,7 @@ class SkyRLTrainInferenceForwardingClient:
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
 
-        async with AsyncSession(self.db_engine) as session:
-            future = await session.get(FutureDB, request_id)
-            if future is None:
-                # Row was deleted between scheduling and completion (cancelled
-                # request, stale-session GC). Nothing to write back.
-                logger.warning("FutureDB row %s missing on completion write — skipping", request_id)
-                return
-            # `result_data` is a text column holding pre-serialized JSON.
-            future.result_data = result.model_dump_json()
-            future.status = status
-            future.completed_at = datetime.now(timezone.utc)
-            await session.commit()
+        self.future_store.complete_future(request_id, status, result.model_dump_json())
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
         # httpx.RequestError covers ConnectError, ReadError, TimeoutException, etc.

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -9,8 +9,8 @@ bypassing the engine subprocess's serial scheduling loop.
 Coverage:
   - test_engine_state_published: after ``save_weights_for_sampler``, the
     engine's vLLM proxy URL is written to ``EngineStateDB``.
-  - test_sample_uses_external_path: an issued sample creates a future of
-    type ``EXTERNAL`` (not ``SAMPLE``) and resolves successfully.
+  - test_sample_bypasses_future_db: an issued sample resolves without creating
+    a database future.
   - test_sample_concurrent_with_training_is_fast: the central
     parallelism test. While a long-running stream of ``forward_backward``
     + ``optim_step`` calls is in flight, a sample request resolves in
@@ -210,15 +210,14 @@ def test_engine_state_published(server_db_path):
     ), f"expected an http(s) proxy URL, got {row.inference_proxy_url!r}"
 
 
-def test_sample_uses_external_path(server_db_path):
-    """A sample issued through the SDK creates a FutureDB row of type EXTERNAL.
+def test_sample_bypasses_future_db(server_db_path):
+    """A sample issued through the SDK does not use the engine's FutureDB.
 
     This is the "test" half of the design: the API hoists the sample off
-    the engine's serial loop and into the API process's asyncio loop.
+    the engine's serial loop and keeps its future in the API process.
     """
     from sqlmodel import Session, create_engine, func, select
 
-    from skyrl.tinker import types as skyrl_types
     from skyrl.tinker.db_models import FutureDB
 
     proc, db_path, _ = server_db_path
@@ -229,12 +228,11 @@ def test_sample_uses_external_path(server_db_path):
     _train_one_step(tc, tok)
     sampler = tc.save_weights_and_get_sampling_client(name="external_path_a")
 
-    # Snapshot the max future_id before submitting our sample so we can
-    # filter out any EXTERNAL futures from earlier tests.
+    # Snapshot the number of database futures before submitting our sample.
     eng = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(eng) as s:
-            max_before = s.exec(select(func.max(FutureDB.request_id))).one() or 0
+            count_before = s.exec(select(func.count()).select_from(FutureDB)).one()
     finally:
         eng.dispose()
 
@@ -245,24 +243,16 @@ def test_sample_uses_external_path(server_db_path):
     ).result()
     assert len(out.sequences) == 1
 
-    # Look for an EXTERNAL future with id > max_before. If async routing
-    # is on, every sample creates exactly one such row.
+    # API-forwarded samples use negative, in-memory future ids and must not
+    # add database work to the engine's scheduling hot path.
     eng = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(eng) as s:
-            stmt = (
-                select(FutureDB.request_id, FutureDB.request_type)
-                .where(FutureDB.request_id > max_before)
-                .where(FutureDB.request_type == skyrl_types.RequestType.EXTERNAL)
-            )
-            rows = s.exec(stmt).all()
+            count_after = s.exec(select(func.count()).select_from(FutureDB)).one()
     finally:
         eng.dispose()
 
-    assert len(rows) >= 1, (
-        f"expected at least one EXTERNAL future to be created by the sample call, "
-        f"found {len(rows)}; async sample routing may not be active"
-    )
+    assert count_after == count_before
 
 
 def test_sample_concurrent_with_training_is_fast(server_db_path):

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -371,6 +371,101 @@ def add_futures(engine, specs) -> list[int]:
         return [row.request_id for row in rows]
 
 
+def add_sequenced_futures(engine, specs) -> dict[int, int]:
+    """Add sequenced futures and return their database IDs keyed by sequence ID."""
+    with Session(engine.db_engine) as session:
+        rows = [
+            FutureDB(
+                request_type=request_type,
+                model_id=model_id,
+                seq_id=seq_id,
+                request_data=data,
+                status=status,
+            )
+            for request_type, model_id, seq_id, data, status in specs
+        ]
+        for row in rows:
+            session.add(row)
+        session.commit()
+        return {row.seq_id: row.request_id for row in rows}
+
+
+def test_sequenced_model_passes_wait_for_first_parallel_chunk(scheduling_engine):
+    """Later SDK chunks wait until the first chunk arrives, then batch together."""
+    engine = scheduling_engine
+    payload = forward_backward_payload()
+    request_ids = add_sequenced_futures(
+        engine,
+        [
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 2, payload, RequestStatus.PENDING),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 3, payload, RequestStatus.PENDING),
+        ],
+    )
+
+    with Session(engine.db_engine) as session:
+        assert engine._find_ready_sequenced_request_ids(session) == set()
+
+    request_ids.update(
+        add_sequenced_futures(
+            engine,
+            [(types.RequestType.FORWARD_BACKWARD, "model_a", 1, payload, RequestStatus.PENDING)],
+        )
+    )
+    with Session(engine.db_engine) as session:
+        ready = engine._find_ready_sequenced_request_ids(session)
+        batchable = engine.find_batchable_model_passes(session, types.RequestType.FORWARD_BACKWARD, ready)
+
+    assert ready == set(request_ids.values())
+    assert set(batchable) == {str(request_id) for request_id in request_ids.values()}
+
+
+def test_sequenced_requests_stop_at_operation_boundary(scheduling_engine):
+    """Only one contiguous request type is released per model in an engine iteration."""
+    engine = scheduling_engine
+    request_ids = add_sequenced_futures(
+        engine,
+        [
+            (types.RequestType.FORWARD, "model_a", 1, {}, RequestStatus.PENDING),
+            (types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER, "model_a", 2, {}, RequestStatus.PENDING),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 3, {}, RequestStatus.PENDING),
+        ],
+    )
+
+    with Session(engine.db_engine) as session:
+        assert engine._find_ready_sequenced_request_ids(session) == {request_ids[1]}
+        first = session.get(FutureDB, request_ids[1])
+        first.status = RequestStatus.COMPLETED
+        session.add(first)
+        session.commit()
+        assert engine._find_ready_sequenced_request_ids(session) == {request_ids[2]}
+
+        second = session.get(FutureDB, request_ids[2])
+        second.status = RequestStatus.COMPLETED
+        session.add(second)
+        session.commit()
+        assert engine._find_ready_sequenced_request_ids(session) == {request_ids[3]}
+
+
+def test_sequenced_requests_resume_after_completed_predecessor(scheduling_engine):
+    """A later parallel block is released when its immediately preceding block completed."""
+    engine = scheduling_engine
+    payload = forward_backward_payload()
+    request_ids = add_sequenced_futures(
+        engine,
+        [
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 1, payload, RequestStatus.COMPLETED),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 2, payload, RequestStatus.COMPLETED),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 4, payload, RequestStatus.PENDING),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 3, payload, RequestStatus.PENDING),
+        ],
+    )
+
+    with Session(engine.db_engine) as session:
+        ready = engine._find_ready_sequenced_request_ids(session)
+
+    assert ready == {request_ids[3], request_ids[4]}
+
+
 def test_find_batchable_model_passes_stops_at_barrier(scheduling_engine):
     """Passes behind an optim_step must not batch with earlier ones, and payloads still parse."""
     engine = scheduling_engine

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -179,10 +179,18 @@ async def test_query_count_does_not_scale_with_waiters(waiters, sync_engine, asy
     assert 0 < len(statements) < 50
 
 
-def _stub_request(async_engine, waiters):
+def _stub_request(async_engine, waiters, external_future_store=None):
     from types import SimpleNamespace
 
-    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(db_engine=async_engine, future_waiters=waiters)))
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                db_engine=async_engine,
+                external_future_store=external_future_store,
+                future_waiters=waiters,
+            )
+        )
+    )
 
 
 @pytest.mark.asyncio
@@ -204,6 +212,24 @@ async def test_retrieve_future_returns_completed_result(waiters, async_engine, s
     )
 
     # The stored JSON text is returned as-is rather than re-encoded by FastAPI.
+    assert response.media_type == "application/json"
+    assert response.body == SAMPLE_RESULT.model_dump_json().encode()
+
+
+@pytest.mark.asyncio
+async def test_retrieve_future_returns_in_memory_external_result(waiters, async_engine):
+    from skyrl.tinker import api
+    from skyrl.tinker.extra import InMemoryFutureStore
+
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+    store.complete_future(request_id, RequestStatus.COMPLETED, SAMPLE_RESULT.model_dump_json())
+
+    response = await api.retrieve_future(
+        api.RetrieveFutureRequest(request_id=str(request_id)),
+        _stub_request(async_engine, waiters, store),
+    )
+
     assert response.media_type == "application/json"
     assert response.body == SAMPLE_RESULT.model_dump_json().encode()
 

--- a/tests/tinker/test_in_memory_future_store.py
+++ b/tests/tinker/test_in_memory_future_store.py
@@ -1,0 +1,61 @@
+import asyncio
+
+import pytest
+
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
+
+
+@pytest.mark.asyncio
+async def test_concurrent_waiters_receive_completed_result():
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+    waiters = [asyncio.create_task(store.wait_for_future(request_id, 1)) for _ in range(3)]
+
+    store.complete_future(request_id, RequestStatus.COMPLETED, '{"value":1}')
+
+    assert await asyncio.gather(*waiters) == [
+        (RequestStatus.COMPLETED, '{"value":1}'),
+        (RequestStatus.COMPLETED, '{"value":1}'),
+        (RequestStatus.COMPLETED, '{"value":1}'),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_timed_out_waiter_does_not_cancel_future():
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+
+    assert await store.wait_for_future(request_id, 0) is None
+    store.complete_future(request_id, RequestStatus.FAILED, '{"error":"boom"}')
+
+    assert await store.wait_for_future(request_id, 1) == (
+        RequestStatus.FAILED,
+        '{"error":"boom"}',
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_future_raises_key_error():
+    store = InMemoryFutureStore()
+
+    with pytest.raises(KeyError):
+        await store.wait_for_future(-1, 1)
+
+
+@pytest.mark.asyncio
+async def test_terminal_future_retention_is_bounded():
+    store = InMemoryFutureStore(max_terminal_futures=1)
+    first_id = store.create_future()
+    store.complete_future(first_id, RequestStatus.COMPLETED, "{}")
+    second_id = store.create_future()
+    store.complete_future(second_id, RequestStatus.COMPLETED, "{}")
+
+    store.create_future()
+
+    with pytest.raises(KeyError):
+        await store.wait_for_future(first_id, 1)
+    assert await store.wait_for_future(second_id, 1) == (
+        RequestStatus.COMPLETED,
+        "{}",
+    )


### PR DESCRIPTION
## Summary

- preserve Tinker SDK per-model sequence IDs for save and load requests
- hold out-of-order training requests until the next contiguous sequence block is complete
- keep API-forwarded sample futures in memory instead of routing their high-QPS completion path through the engine database
- retain existing durable database scheduling for training, checkpoint, and internally sampled requests

## Problem

Two independent control-plane bugs surface under large RL batches.

First, the Tinker SDK intentionally submits parallel forward/backward chunks 2 through N before chunk 1. Its server contract expects later chunks to remain queued until chunk 1 arrives so the complete logical batch can run together. SkyRL persisted `seq_id` for retry deduplication, but scheduled pending requests by database insertion order. It could therefore begin GPU work on the tail of a logical batch while chunk 1 and other large requests were still being admitted. Save and load requests also consumed the same SDK sequence, but SkyRL discarded those sequence IDs.

Second, non-colocated sampling is owned by the API process, but every forwarded sample still created, polled, and completed a `FutureDB` row. Large rollout bursts exhausted SQLAlchemy's connection pool and starved `/asample`, heartbeats, and training submissions. Increasing the pool only delayed the failure.

## Design

- Sequenced training operations are released only when sequence 1 arrives or the prior sequence is terminal, and only as a contiguous block of one operation type.
- Forwarded samples receive negative request IDs from an API-local future store, so they cannot collide with database-generated IDs.
- Completion uses `asyncio.Event`, supports concurrent and retrying waiters, and retains terminal results for bounded time and count limits.
- Pending futures are never evicted. Training and checkpoint futures remain durable in the database and continue through the background engine.

## Testing

```text
uv run --isolated --extra tinker --extra jax --with pytest --with pytest-asyncio pytest -q \
  tests/tinker/test_api.py \
  tests/tinker/test_api_validation.py \
  tests/tinker/test_future_waiting.py \
  tests/tinker/test_in_memory_future_store.py \
  tests/tinker/test_engine.py \
  tests/tinker/test_training_request_idempotency.py
# 71 passed

uv run --isolated --extra dev ruff check <touched Python files>
# passed

uv run --isolated --with black black --check <touched Python files>
# passed
```

The existing GPU-gated async-sampling test now verifies that forwarded samples do not add `FutureDB` rows; GPU CI runs that test.
