### PR TITLE
Run GSPO natively and harden Tinker transport

### DIFF
--- a/.claude/docs/tinker.md
+++ b/.claude/docs/tinker.md
@@ -5,6 +5,7 @@ SkyRL's implementation of the [Tinker API](https://tinker-docs.thinkingmachines.
 ## Code Layout
 
 - **`skyrl/tinker/api.py`** -- FastAPI HTTP server. Receives Tinker SDK requests, writes them to SQLite/Postgres, returns future IDs.
+- **`skyrl/tinker/proto_serialization.py`** -- Proto wire-format conversion. SDK >= 0.25.0 sends `forward_backward` request bodies as protobuf (with forward-only passes routed to `/forward_backward` via a `forward_only` flag instead of `/forward`) and requires proto-serialized `SampleResponse`/`ForwardBackwardOutput` results from `retrieve_future`. Mirrors the SDK's `tinker/proto/{request,response}_conv.py`; round-trip tested in `tests/tinker/test_proto_serialization.py`.
 - **`skyrl/tinker/engine.py`** -- Background subprocess (`TinkerEngine`). Polls DB, batches compatible requests, dispatches to backend.
 - **`skyrl/tinker/types.py`** -- Internal Pydantic models (distinct from API request/response models in `api.py`). `LOSS_TYPES` dict defines valid loss functions.
 - **`skyrl/tinker/config.py`** -- `EngineConfig` Pydantic model. `add_model()` auto-generates argparse flags from Pydantic fields.

--- a/.claude/docs/tinker.md
+++ b/.claude/docs/tinker.md
@@ -5,7 +5,7 @@ SkyRL's implementation of the [Tinker API](https://tinker-docs.thinkingmachines.
 ## Code Layout
 
 - **`skyrl/tinker/api.py`** -- FastAPI HTTP server. Receives Tinker SDK requests, writes them to SQLite/Postgres, returns future IDs.
-- **`skyrl/tinker/proto_serialization.py`** -- Proto wire-format conversion. SDK >= 0.25.0 sends `forward_backward` request bodies as protobuf (with forward-only passes routed to `/forward_backward` via a `forward_only` flag instead of `/forward`) and requires proto-serialized `SampleResponse`/`ForwardBackwardOutput` results from `retrieve_future`. Mirrors the SDK's `tinker/proto/{request,response}_conv.py`; round-trip tested in `tests/tinker/test_proto_serialization.py`.
+- **`skyrl/tinker/proto_serialization.py`** -- Proto wire-format conversion negotiated through the SDK client-config handshake. Supports compressed `forward_backward` request bodies and proto-serialized `SampleResponse`/`ForwardBackwardOutput` results from `retrieve_future`. Mirrors the SDK's `tinker/proto/{request,response}_conv.py`; round-trip tested in `tests/tinker/test_proto_serialization.py`.
 - **`skyrl/tinker/engine.py`** -- Background subprocess (`TinkerEngine`). Polls DB, batches compatible requests, dispatches to backend.
 - **`skyrl/tinker/types.py`** -- Internal Pydantic models (distinct from API request/response models in `api.py`). `LOSS_TYPES` dict defines valid loss functions.
 - **`skyrl/tinker/config.py`** -- `EngineConfig` Pydantic model. `add_model()` auto-generates argparse flags from Pydantic fields.

--- a/docs/content/docs/tinker/architecture.mdx
+++ b/docs/content/docs/tinker/architecture.mdx
@@ -152,6 +152,8 @@ The following loss functions are validated through the Tinker API:
 
 Native GSPO requires both `clip_low_threshold` and `clip_high_threshold` in `loss_fn_config`. The API normalizes raw advantages over the complete request batch before data-parallel sharding, matching Tinker's sequence-mean custom-loss semantics while executing a single forward-backward pass.
 
+Clients can discover this support from `supported_loss_fns` in `GET /api/v1/get_server_capabilities`; this allows clients to retain their custom-loss fallback against older SkyRL services.
+
 SkyRL-Train's `PolicyLossRegistry` also contains additional loss functions that are not yet part of the Tinker-compatible API.
 
 ## Concurrency Model

--- a/docs/content/docs/tinker/architecture.mdx
+++ b/docs/content/docs/tinker/architecture.mdx
@@ -8,7 +8,7 @@ This page describes how SkyRL implements the Tinker API, including the system ar
 
 The integration is organized in three high-level layers:
 
-1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests, stores them in a database, and returns future IDs for async polling
+1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests and returns future IDs for async polling. Engine-owned operations use the database; API-forwarded samples use in-memory futures.
 2. **Engine Layer** (`skyrl.tinker.engine`) - Background subprocess that polls the database, batches pending requests, and dispatches them to the backend
 3. **Backend Layer** (`skyrl.backends`) - Translates Tinker operations into training and inference calls, managing Ray workers, FSDP/Megatron training, and vLLM inference
 
@@ -71,6 +71,9 @@ Sampling requests (`sample`) go through the following lifecycle:
 Client calls sample()
     │
     ▼
+API Server (FastAPI)
+    │  Creates an in-memory future
+    ▼
 SkyRL-Train Backend
     │  Converts Tinker SamplingParams → vLLM params
     ▼
@@ -83,10 +86,10 @@ RemoteInferenceClient
 Inference Workers (vLLM)
     │  Generate tokens with logprobs
     ▼
-Results aggregated → GeneratedSequence objects returned
+Results resolve the in-memory future → GeneratedSequence objects returned
 ```
 
-The `sample()` call is a fairly lightweight wrapper around SkyRL-Train's vLLM inference engines. The backend translates Tinker `SamplingParams` to vLLM format (e.g., `stop_strings` → `stop`, `stop_tokens` → `stop_token_ids`) and delegates prompts to the `RemoteInferenceClient`. `RemoteInferenceClient` forwards the requests to an instance of [vLLM Router](https://github.com/vllm-project/router), which handles load balancing and sticky routing across vLLM workers.
+The `sample()` call is a fairly lightweight wrapper around SkyRL-Train's vLLM inference engines. Non-colocated and external inference requests bypass the engine database: the API owns their futures and signals completion with `asyncio.Event`. The backend translates Tinker `SamplingParams` to vLLM format (e.g., `stop_strings` → `stop`, `stop_tokens` → `stop_token_ids`) and delegates prompts to the `RemoteInferenceClient`. `RemoteInferenceClient` forwards the requests to an instance of [vLLM Router](https://github.com/vllm-project/router), which handles load balancing and sticky routing across vLLM workers.
 
 
 ## Weight Sync

--- a/docs/content/docs/tinker/architecture.mdx
+++ b/docs/content/docs/tinker/architecture.mdx
@@ -148,8 +148,11 @@ The following loss functions are validated through the Tinker API:
 |--------------|-------------|----------|
 | `cross_entropy` | Standard next-token prediction loss | Supervised fine-tuning |
 | `importance_sampling` | Off-policy policy gradient: `-(exp(logp - old_logp) * advantage)` | RL training (GRPO, REINFORCE) |
+| `gspo` | Sequence-level importance-ratio clipping with equal weight per trainable sequence | GSPO training without a separate client-side logprob pass |
 
-SkyRL-Train's `PolicyLossRegistry` also contains additional loss functions (`regular`, `dual_clip`, `gspo`, `sapo`, `cispo`, `clip_cov`, `kl_cov`) used by SkyRL's native trainer. These are not yet wired through the Tinker data conversion path, which does not currently populate the required `advantages` and `old_log_probs` fields in the training batch for these loss types.
+Native GSPO requires both `clip_low_threshold` and `clip_high_threshold` in `loss_fn_config`. The API normalizes raw advantages over the complete request batch before data-parallel sharding, matching Tinker's sequence-mean custom-loss semantics while executing a single forward-backward pass.
+
+SkyRL-Train's `PolicyLossRegistry` also contains additional loss functions that are not yet part of the Tinker-compatible API.
 
 ## Concurrency Model
 

--- a/docs/content/docs/tinker/limitations.mdx
+++ b/docs/content/docs/tinker/limitations.mdx
@@ -22,5 +22,4 @@ KL penalty (`kl_penalty_coef > 0`) is not yet supported. This requires prompt lo
 
 ### RL Loss Functions
 
-Only `cross_entropy` and `importance_sampling` are currently wired through the Tinker data conversion path. SkyRL's `PolicyLossRegistry` contains implementations for PPO (`regular`), `cispo`, and others, but these are not yet validated through the Tinker API.
-
+The Tinker API exposes `importance_sampling`, PPO, CISPO, DPPO, and GSPO in addition to `cross_entropy`. Other losses in SkyRL's `PolicyLossRegistry` are not yet part of the Tinker-compatible API.

--- a/docs/content/docs/tinker/overview.mdx
+++ b/docs/content/docs/tinker/overview.mdx
@@ -33,6 +33,7 @@ SkyRL brings the Tinker API to your own hardware. By utilizing the fully Tinker 
 |---------|--------|
 | Supervised fine-tuning (`cross_entropy` loss) | Supported |
 | RL training (`importance_sampling` loss) | Supported |
+| Native GSPO training (`gspo` loss) | Supported |
 | Forward-only pass (logprobs without gradients) | Supported |
 | Sampling with logprobs | Supported |
 | LoRA adapters | Supported |

--- a/skyrl/backends/jax.py
+++ b/skyrl/backends/jax.py
@@ -634,8 +634,9 @@ class JaxBackendImpl(AbstractBackend):
         """
         if not prepared_batch.all_model_inputs:
             return {}
-        if "ppo_critic" in prepared_batch.all_loss_fns:
-            raise ValueError("ppo_critic is only supported by the SkyRL-Train backend")
+        unsupported_loss_fns = sorted(set(prepared_batch.all_loss_fns) - LOSS_TYPES.keys())
+        if unsupported_loss_fns:
+            raise ValueError(f"{', '.join(unsupported_loss_fns)} is only supported by the SkyRL-Train backend")
 
         results = {}
 

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1247,11 +1247,10 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             torch.cuda.empty_cache()
 
         # Aggregate metrics across micro-batches
-        all_loss_fn_outputs = []  # Handle separately from scalar metrics
+        loss_fn_output_batches = []
         for m_batch, metrics in zip(micro_buffer, metrics_list):
             # Extract loss_fn_outputs before reduce_metrics (it's not a scalar metric)
-            if "loss_fn_outputs" in metrics:
-                all_loss_fn_outputs.extend(metrics.pop("loss_fn_outputs"))
+            loss_fn_output_batches.append(metrics.pop("loss_fn_outputs", []))
             # Skip fully-padding microbatches: their metrics (clip_ratio=0, policy_entropy=0,
             # ...) are meaningless and would drag down the mean-reduced metrics. Summed
             # metrics (e.g. policy_loss) are unaffected since padding contributes 0, but
@@ -1295,6 +1294,13 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             if moe_metrics:
                 for k, v in moe_metrics.items():
                     status[k] = v
+
+        if not any(loss_fn_output_batches):
+            all_loss_fn_outputs = []
+        elif isinstance(microbatch_iterator, TokenBasedBatchIterator):
+            all_loss_fn_outputs = microbatch_iterator.reorder_and_combine_items(loss_fn_output_batches)
+        else:
+            all_loss_fn_outputs = [item for batch in loss_fn_output_batches for item in batch]
 
         return WorkerOutput(loss_fn_outputs=all_loss_fn_outputs, metrics=status)
 

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -424,6 +424,18 @@ class TokenBasedBatchIterator(BaseBatchIterator):
         reordered_batch.metadata = ref_microbatch.metadata
         return reordered_batch
 
+    def reorder_and_combine_items(self, batches: List[List[dict]]) -> List[dict]:
+        """Restore per-sample microbatch outputs to input order."""
+        ordered = [None] * self.data.batch_size
+        for original_indices, items in zip(self._microbatches, batches):
+            if len(items) < len(original_indices):
+                raise ValueError("Microbatch output has fewer items than input samples")
+            for original_idx, item in zip(original_indices, items):
+                ordered[original_idx] = item
+        if any(item is None for item in ordered):
+            raise ValueError("Microbatch outputs do not cover every input sample")
+        return ordered
+
 
 def get_microbatch_iterator(
     data: TrainingInputBatch, micro_batch_size: int, max_tokens_per_microbatch: int

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -805,6 +805,21 @@ class SkyRLTrainBackend(AbstractBackend):
         if role == "critic":
             return loss_fn, loss_fn_config
 
+        if loss_fn == "gspo":
+            normalized_config = dict(loss_fn_config or {})
+            clip_low_threshold = normalized_config.pop("clip_low_threshold", None)
+            clip_high_threshold = normalized_config.pop("clip_high_threshold", None)
+            if clip_low_threshold is None or clip_high_threshold is None:
+                raise ValueError("loss_fn='gspo' requires clip_low_threshold and clip_high_threshold")
+            normalized_config.update(
+                eps_clip_low=1.0 - clip_low_threshold,
+                eps_clip_high=clip_high_threshold - 1.0,
+                loss_reduction="sequence_mean",
+                use_entropy_loss=False,
+                use_kl_loss=False,
+            )
+            return loss_fn, normalized_config
+
         if loss_fn == "dppo":
             # DPPO thresholds live in the nested `algorithm.dppo` sub-config, but
             # Tinker's loss_fn_config is a flat float dict. Re-nest so the
@@ -828,6 +843,28 @@ class SkyRLTrainBackend(AbstractBackend):
         if clip_high_threshold is not None:
             normalized_config["eps_clip_high"] = clip_high_threshold - 1.0
         return "regular", normalized_config or None
+
+    @staticmethod
+    def _normalize_gspo_batch(batch: TrainingInputBatch) -> None:
+        """Match Tinker's sequence-mean GSPO reduction before DP sharding.
+
+        The Tinker API receives raw per-token advantages. SkyRL's native RL
+        trainer normally pre-scales those advantages before dispatch, but the
+        API backend bypasses that trainer. Normalize once over the complete
+        request batch so each trainable sequence has equal weight and each of
+        its trainable tokens shares that sequence's weight.
+
+        A zero advantage is the Tinker custom-GSPO mask convention. Excluding
+        those tokens here also makes the sequence importance ratio identical
+        to the custom-loss path being replaced.
+        """
+        advantages = batch["advantages"]
+        loss_mask = advantages.ne(0).to(batch["loss_mask"].dtype)
+        token_counts = loss_mask.sum(dim=-1, keepdim=True)
+        trainable_sequences = token_counts.squeeze(-1).gt(0)
+        num_trainable_sequences = trainable_sequences.sum().clamp(min=1)
+        batch["advantages"] = advantages / token_counts.clamp(min=1) / num_trainable_sequences
+        batch["loss_mask"] = loss_mask
 
     def forward_backward(
         self,
@@ -857,6 +894,8 @@ class SkyRLTrainBackend(AbstractBackend):
         ):
             raise ValueError("Critic forward_backward requires values and returns for every response token")
         batch = self._to_training_batch(prepared_batch, role)
+        if loss_fn == "gspo":
+            self._normalize_gspo_batch(batch)
         micro_bs = (
             self._cfg.trainer.micro_train_batch_size_per_gpu if self._cfg.trainer.strategy == "megatron" else None
         )

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -866,6 +866,24 @@ class SkyRLTrainBackend(AbstractBackend):
         batch["advantages"] = advantages / token_counts.clamp(min=1) / num_trainable_sequences
         batch["loss_mask"] = loss_mask
 
+    @staticmethod
+    def _select_trainable_gspo_rows(batch: TrainingInputBatch) -> tuple[TrainingInputBatch, list[int]]:
+        """Drop rows that cannot contribute to a GSPO gradient.
+
+        Keep an entirely inactive batch unchanged. Its backward pass materializes
+        zero gradients, preserving the optimizer semantics of the existing API.
+        """
+        trainable_rows = batch["loss_mask"].ne(0).any(dim=-1)
+        trainable_indices = trainable_rows.nonzero(as_tuple=False).flatten()
+        if trainable_indices.numel() == 0 or trainable_indices.numel() == batch.batch_size:
+            return batch, list(range(batch.batch_size))
+
+        selected = TrainingInputBatch(
+            {key: None if value is None else value[trainable_indices] for key, value in batch.items()}
+        )
+        selected.metadata = batch.metadata
+        return selected, trainable_indices.tolist()
+
     def forward_backward(
         self,
         prepared_batch: types.PreparedModelPassBatch,
@@ -894,8 +912,13 @@ class SkyRLTrainBackend(AbstractBackend):
         ):
             raise ValueError("Critic forward_backward requires values and returns for every response token")
         batch = self._to_training_batch(prepared_batch, role)
+        original_batch_size = batch.batch_size
+        original_token_count = int(batch["attention_mask"].sum().item())
+        submitted_indices = list(range(original_batch_size))
         if loss_fn == "gspo":
             self._normalize_gspo_batch(batch)
+            batch, submitted_indices = self._select_trainable_gspo_rows(batch)
+        submitted_token_count = int(batch["attention_mask"].sum().item())
         micro_bs = (
             self._cfg.trainer.micro_train_batch_size_per_gpu if self._cfg.trainer.strategy == "megatron" else None
         )
@@ -933,7 +956,24 @@ class SkyRLTrainBackend(AbstractBackend):
         if pad_size > 0 and per_sample_outputs:
             per_sample_outputs = per_sample_outputs[:-pad_size]
 
+        if len(submitted_indices) != original_batch_size:
+            restored_outputs = [
+                {"logprobs": list(logprobs)} for logprobs in prepared_batch.all_sampling_logprobs
+            ]
+            for index, output in zip(submitted_indices, per_sample_outputs, strict=True):
+                restored_outputs[index] = output
+            per_sample_outputs = restored_outputs
+
         metrics = self._extract_metrics(data.metrics)
+        if loss_fn == "gspo":
+            metrics.update(
+                {
+                    "skyrl.ai/submitted_datums:sum": float(len(submitted_indices)),
+                    "skyrl.ai/skipped_datums:sum": float(original_batch_size - len(submitted_indices)),
+                    "skyrl.ai/submitted_tokens:sum": float(submitted_token_count),
+                    "skyrl.ai/skipped_tokens:sum": float(original_token_count - submitted_token_count),
+                }
+            )
 
         results = {}
         for request_id, _, start_idx, end_idx in prepared_batch.request_batch_slices:

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -864,6 +864,7 @@ class SupportedModel(BaseModel):
 
 class GetServerCapabilitiesResponse(BaseModel):
     supported_models: list[SupportedModel]
+    supported_loss_fns: list[str]
 
 
 class ListCheckpointsResponse(BaseModel):
@@ -1321,7 +1322,10 @@ async def get_server_capabilities(request: Request):
     supported_models = [
         SupportedModel(model_name=request.app.state.engine_config.base_model),
     ]
-    return GetServerCapabilitiesResponse(supported_models=supported_models)
+    return GetServerCapabilitiesResponse(
+        supported_models=supported_models,
+        supported_loss_fns=sorted(types.SUPPORTED_LOSS_FNS),
+    )
 
 
 class RetrieveFutureRequest(BaseModel):

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1125,9 +1125,10 @@ async def get_training_run(model_id: str, session: AsyncSession = Depends(get_se
 
 
 def _decode_forward_backward_request(
-    body: bytes, content_type: str, content_encoding: str
+    body: bytes | bytearray, content_type: str, content_encoding: str
 ) -> tuple[ForwardBackwardRequest, bool]:
     """Decode and validate a forward_backward body in either wire format."""
+    body = bytes(body)
     if content_encoding:
         if content_encoding != "zstd" or PROTO_CONTENT_TYPE not in content_type:
             raise HTTPException(status_code=415, detail=f"Unsupported content encoding: {content_encoding}")
@@ -1154,6 +1155,17 @@ def _decode_forward_backward_request(
         raise FastAPIRequestValidationError(e.errors())
 
 
+async def _read_streaming_body(req: Request) -> bytearray:
+    """Read an upload cooperatively so other API requests remain responsive."""
+    body = bytearray()
+    async for chunk in req.stream():
+        body.extend(chunk)
+        # Uvicorn can have the next upload chunk ready immediately, so awaiting
+        # receive alone does not guarantee that other requests get scheduled.
+        await asyncio.sleep(0)
+    return body
+
+
 async def _read_forward_backward_request(req: Request) -> tuple[ForwardBackwardRequest, bool]:
     """Read a forward_backward body without blocking the API event loop.
 
@@ -1161,7 +1173,7 @@ async def _read_forward_backward_request(req: Request) -> tuple[ForwardBackwardR
     Forward-only passes use the proto's ``forward_only`` flag; clients that do
     not support the negotiated path keep sending JSON to the legacy endpoints.
     """
-    body = await req.body()
+    body = await _read_streaming_body(req)
     content_type = req.headers.get("content-type", "").lower()
     content_encoding = req.headers.get("content-encoding", "").lower().strip()
     return await asyncio.to_thread(_decode_forward_backward_request, body, content_type, content_encoding)

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -776,12 +776,14 @@ class SampleRequest(BaseModel):
 class SaveWeightsRequest(BaseModel):
     model_id: str
     path: str = Field(..., pattern=ID_PATTERN, max_length=ID_MAX_LENGTH)
+    seq_id: int | None = None
     type: Literal["save_weights"] | None = None
 
 
 class LoadWeightsRequest(BaseModel):
     model_id: str
     path: str
+    seq_id: int | None = None
     type: Literal["load_weights"] | None = None
 
 
@@ -1166,6 +1168,7 @@ async def load_weights(request: LoadWeightsRequest, req: Request, session: Async
         request_type=types.RequestType.LOAD_WEIGHTS,
         model_id=request.model_id,
         request_data=types.LoadWeightsInput(source_model_id=source_model_id, checkpoint_id=checkpoint_id),
+        seq_id=request.seq_id,
     )
 
     await session.commit()
@@ -1189,6 +1192,7 @@ async def save_weights(request: SaveWeightsRequest, session: AsyncSession = Depe
         request_type=types.RequestType.SAVE_WEIGHTS,
         model_id=request.model_id,
         request_data=types.SaveWeightsInput(path=request.path),
+        seq_id=request.seq_id,
     )
 
     await session.commit()
@@ -1234,6 +1238,7 @@ async def save_weights_for_sampler(request: SaveWeightsForSamplerRequest, sessio
             seq_id=request.seq_id,
             sampling_session_id=sampling_session_id,
         ),
+        seq_id=request.seq_id,
     )
 
     await session.commit()

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -602,19 +602,22 @@ class ForwardBackwardInput(BaseModel):
         "cross_entropy": set(),
         "importance_sampling": set(),
         "ppo": {"clip_low_threshold", "clip_high_threshold", "value_clip"},
+        "gspo": {"clip_low_threshold", "clip_high_threshold"},
         "cispo": {"clip_low_threshold", "clip_high_threshold"},
         "ppo_critic": {"value_clip"},
         "dppo": {"delta_low", "delta_high"},
     }
 
     data: list[Datum]
-    loss_fn: Literal["cross_entropy", "importance_sampling", "ppo", "cispo", "ppo_critic", "dppo"]
+    loss_fn: Literal["cross_entropy", "importance_sampling", "ppo", "gspo", "cispo", "ppo_critic", "dppo"]
     loss_fn_config: dict[str, float] | None = None
 
     @model_validator(mode="after")
     def validate_loss_fn_config_keys(self):
         """Validate loss_fn_config keys based on the selected loss function."""
         if self.loss_fn_config is None:
+            if self.loss_fn == "gspo":
+                raise ValueError("loss_fn='gspo' requires clip_low_threshold and clip_high_threshold.")
             return self
 
         allowed_keys = self._ALLOWED_KEYS_BY_LOSS_FN[self.loss_fn]
@@ -628,6 +631,18 @@ class ForwardBackwardInput(BaseModel):
             raise ValueError(
                 f"loss_fn='{self.loss_fn}' does not accept loss_fn_config keys. " f"Received: {invalid_keys}."
             )
+        if self.loss_fn == "gspo":
+            required_keys = {"clip_low_threshold", "clip_high_threshold"}
+            missing_keys = sorted(required_keys - self.loss_fn_config.keys())
+            if missing_keys:
+                raise ValueError(f"loss_fn='gspo' is missing required loss_fn_config keys: {missing_keys}.")
+            clip_low = self.loss_fn_config["clip_low_threshold"]
+            clip_high = self.loss_fn_config["clip_high_threshold"]
+            if not 0.0 <= clip_low <= 1.0 <= clip_high:
+                raise ValueError(
+                    "loss_fn='gspo' requires 0 <= clip_low_threshold <= 1 <= clip_high_threshold; "
+                    f"got {clip_low=} and {clip_high=}."
+                )
         return self
 
     def to_types(self) -> types.ForwardBackwardInput:

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1124,21 +1124,15 @@ async def get_training_run(model_id: str, session: AsyncSession = Depends(get_se
     )
 
 
-async def _read_forward_backward_request(req: Request) -> tuple[ForwardBackwardRequest, bool]:
-    """Read a forward_backward body in either wire format.
-
-    SDKs use protobuf and zstd when the client-config handshake enables them.
-    Forward-only passes use the proto's ``forward_only`` flag; clients that do
-    not support the negotiated path keep sending JSON to the legacy endpoints.
-    """
-    body = await req.body()
-    content_type = req.headers.get("content-type", "").lower()
-    content_encoding = req.headers.get("content-encoding", "").lower().strip()
+def _decode_forward_backward_request(
+    body: bytes, content_type: str, content_encoding: str
+) -> tuple[ForwardBackwardRequest, bool]:
+    """Decode and validate a forward_backward body in either wire format."""
     if content_encoding:
         if content_encoding != "zstd" or PROTO_CONTENT_TYPE not in content_type:
             raise HTTPException(status_code=415, detail=f"Unsupported content encoding: {content_encoding}")
         try:
-            body = await asyncio.to_thread(_decompress_forward_backward_body, body)
+            body = _decompress_forward_backward_body(body)
         except OverflowError:
             raise HTTPException(status_code=413, detail="Decompressed forward_backward body is too large")
         except zstd.ZstdError as e:
@@ -1160,17 +1154,31 @@ async def _read_forward_backward_request(req: Request) -> tuple[ForwardBackwardR
         raise FastAPIRequestValidationError(e.errors())
 
 
+async def _read_forward_backward_request(req: Request) -> tuple[ForwardBackwardRequest, bool]:
+    """Read a forward_backward body without blocking the API event loop.
+
+    SDKs use protobuf and zstd when the client-config handshake enables them.
+    Forward-only passes use the proto's ``forward_only`` flag; clients that do
+    not support the negotiated path keep sending JSON to the legacy endpoints.
+    """
+    body = await req.body()
+    content_type = req.headers.get("content-type", "").lower()
+    content_encoding = req.headers.get("content-encoding", "").lower().strip()
+    return await asyncio.to_thread(_decode_forward_backward_request, body, content_type, content_encoding)
+
+
 @app.post("/api/v1/forward_backward", response_model=FutureResponse)
 async def forward_backward(req: Request, session: AsyncSession = Depends(get_session)):
     """Compute and accumulate gradients (or run forward-only when the proto body asks for it)."""
     request, forward_only = await _read_forward_backward_request(req)
     await get_model(session, request.model_id)
+    request_data = await asyncio.to_thread(request.forward_backward_input.to_types)
 
     request_id = await create_future(
         session=session,
         request_type=types.RequestType.FORWARD if forward_only else types.RequestType.FORWARD_BACKWARD,
         model_id=request.model_id,
-        request_data=request.forward_backward_input.to_types(),
+        request_data=request_data,
         seq_id=request.seq_id,
     )
 

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 import os
 import random
 import re
@@ -12,8 +13,11 @@ from uuid import uuid4
 
 import fastapi
 import psutil
+import zstandard as zstd
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi.exceptions import RequestValidationError as FastAPIRequestValidationError
 from fastapi.responses import RedirectResponse, StreamingResponse
+from google.protobuf.message import DecodeError
 from pydantic import (
     Base64Bytes,
     BaseModel,
@@ -46,6 +50,12 @@ from skyrl.tinker.extra import (
     InMemoryFutureStore,
     SkyRLTrainInferenceForwardingClient,
 )
+from skyrl.tinker.proto_serialization import (
+    PROTO_CONTENT_TYPE,
+    PROTO_SERIALIZABLE_REQUEST_TYPES,
+    parse_forward_backward_request,
+    serialize_result,
+)
 from skyrl.utils.log import get_uvicorn_log_config, logger
 from skyrl.utils.storage import download_file
 
@@ -69,6 +79,19 @@ FUTURE_POLL_INTERVAL_SECONDS = 0.05
 # Statuses a request never moves out of, i.e. the ones a waiter resolves on.
 TERMINAL_STATUSES = (RequestStatus.COMPLETED, RequestStatus.FAILED)
 
+# The SDK limits each uncompressed forward/backward chunk to roughly 5 MB.
+# Leave room for estimation error and future tensor fields while bounding
+# decompression so a malformed request cannot expand without limit.
+MAX_FORWARD_BACKWARD_BODY_BYTES = 64 * 1024 * 1024
+
+
+def _decompress_forward_backward_body(body: bytes) -> bytes:
+    with zstd.ZstdDecompressor().stream_reader(io.BytesIO(body)) as reader:
+        decompressed = reader.read(MAX_FORWARD_BACKWARD_BODY_BYTES + 1)
+    if len(decompressed) > MAX_FORWARD_BACKWARD_BODY_BYTES:
+        raise OverflowError
+    return decompressed
+
 
 def raw_json_response(payload: str | None) -> Response:
     """Return already-serialized JSON without routing it through FastAPI's encoder.
@@ -86,8 +109,8 @@ def raw_json_response(payload: str | None) -> Response:
 
 async def wait_for_future(
     waiters: dict[int, set[asyncio.Future]], request_id: int, timeout: float
-) -> tuple[RequestStatus, str | None] | None:
-    """Wait for ``request_id`` to finish, returning its ``(status, result_data)``.
+) -> tuple[RequestStatus, types.RequestType, str | None] | None:
+    """Wait for ``request_id`` to finish, returning its ``(status, request_type, result_data)``.
 
     ``result_data`` is the JSON text stored for the request, not a decoded
     object -- see :class:`FutureDB`.
@@ -143,15 +166,15 @@ async def poll_futures(
                     # The awaited ids go in as bound parameters, capped at 32766
                     # by SQLite (since 3.32) and 65535 by Postgres -- far above
                     # any plausible number of in-flight requests.
-                    statement = select(FutureDB.request_id, FutureDB.status, FutureDB.result_data).where(
-                        FutureDB.request_id.in_(awaited)
-                    )
+                    statement = select(
+                        FutureDB.request_id, FutureDB.status, FutureDB.request_type, FutureDB.result_data
+                    ).where(FutureDB.request_id.in_(awaited))
                     rows = (await session.exec(statement)).all()
 
                 # Pending requests are left alone to be picked up on a later tick.
-                outcomes: dict[int, tuple[RequestStatus, str | None] | KeyError] = {
-                    request_id: (status, result_data)
-                    for request_id, status, result_data in rows
+                outcomes: dict[int, tuple[RequestStatus, types.RequestType, str | None] | KeyError] = {
+                    request_id: (status, request_type, result_data)
+                    for request_id, status, request_type, result_data in rows
                     if status in TERMINAL_STATUSES
                 }
                 for request_id in set(awaited) - {request_id for request_id, *_ in rows}:
@@ -905,6 +928,8 @@ class WeightsInfoResponse(BaseModel):
 
 class ClientConfigResponse(BaseModel):
     pjwt_auth_enabled: bool = False
+    proto_write_fwdbwd: bool = True
+    proto_compress_fwdbwd: bool = True
 
 
 @app.post("/api/v1/client/config", response_model=ClientConfigResponse)
@@ -1097,14 +1122,51 @@ async def get_training_run(model_id: str, session: AsyncSession = Depends(get_se
     )
 
 
+async def _read_forward_backward_request(req: Request) -> tuple[ForwardBackwardRequest, bool]:
+    """Read a forward_backward body in either wire format.
+
+    tinker SDK >= 0.25.0 submits the body as protobuf and routes forward-only
+    passes here via the proto's ``forward_only`` flag instead of calling
+    ``/api/v1/forward``; older SDKs keep sending JSON with forward_only False.
+    """
+    body = await req.body()
+    content_type = req.headers.get("content-type", "").lower()
+    content_encoding = req.headers.get("content-encoding", "").lower().strip()
+    if content_encoding:
+        if content_encoding != "zstd" or PROTO_CONTENT_TYPE not in content_type:
+            raise HTTPException(status_code=415, detail=f"Unsupported content encoding: {content_encoding}")
+        try:
+            body = await asyncio.to_thread(_decompress_forward_backward_body, body)
+        except OverflowError:
+            raise HTTPException(status_code=413, detail="Decompressed forward_backward body is too large")
+        except zstd.ZstdError as e:
+            raise HTTPException(status_code=422, detail=f"Invalid zstd forward_backward body: {e}")
+
+    if PROTO_CONTENT_TYPE in content_type:
+        try:
+            request_dict, forward_only = parse_forward_backward_request(body)
+        except (DecodeError, ValueError) as e:
+            raise HTTPException(status_code=422, detail=f"Invalid proto forward_backward body: {e}")
+    else:
+        request_dict, forward_only = None, False
+    try:
+        if request_dict is not None:
+            return ForwardBackwardRequest.model_validate(request_dict), forward_only
+        return ForwardBackwardRequest.model_validate_json(body), forward_only
+    except ValidationError as e:
+        # Match FastAPI's native body validation error shape (422).
+        raise FastAPIRequestValidationError(e.errors())
+
+
 @app.post("/api/v1/forward_backward", response_model=FutureResponse)
-async def forward_backward(request: ForwardBackwardRequest, session: AsyncSession = Depends(get_session)):
-    """Compute and accumulate gradients."""
+async def forward_backward(req: Request, session: AsyncSession = Depends(get_session)):
+    """Compute and accumulate gradients (or run forward-only when the proto body asks for it)."""
+    request, forward_only = await _read_forward_backward_request(req)
     await get_model(session, request.model_id)
 
     request_id = await create_future(
         session=session,
-        request_type=types.RequestType.FORWARD_BACKWARD,
+        request_type=types.RequestType.FORWARD if forward_only else types.RequestType.FORWARD_BACKWARD,
         model_id=request.model_id,
         request_data=request.forward_backward_input.to_types(),
         seq_id=request.seq_id,
@@ -1348,7 +1410,10 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
 
     try:
         if request_id < 0:
-            row = await req.app.state.external_future_store.wait_for_future(request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+            external_row = await req.app.state.external_future_store.wait_for_future(
+                request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS
+            )
+            row = None if external_row is None else (external_row[0], types.RequestType.SAMPLE, external_row[1])
         else:
             row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
     except KeyError:
@@ -1357,8 +1422,18 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     if row is None:
         raise HTTPException(status_code=408, detail="Timeout waiting for result")
 
-    status, result_data = row
+    status, request_type, result_data = row
     if status == RequestStatus.COMPLETED:
+        # The SDK retrieves sample/forward/forward_backward results in proto
+        # wire format when it advertises support; SDK >= 0.25.0 rejects JSON
+        # for these types. Errors and other result types stay JSON.
+        if request_type in PROTO_SERIALIZABLE_REQUEST_TYPES and PROTO_CONTENT_TYPE in req.headers.get(
+            "accept", ""
+        ).lower():
+            return Response(
+                content=serialize_result(request_type, result_data),
+                media_type=PROTO_CONTENT_TYPE,
+            )
         return raw_json_response(result_data)
 
     # Return 400 for handled errors (validation, etc.), 500 for unexpected failures.

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -930,6 +930,7 @@ class ClientConfigResponse(BaseModel):
     pjwt_auth_enabled: bool = False
     proto_write_fwdbwd: bool = True
     proto_compress_fwdbwd: bool = True
+    fwd_via_fwdbwd: bool = True
 
 
 @app.post("/api/v1/client/config", response_model=ClientConfigResponse)
@@ -1125,9 +1126,9 @@ async def get_training_run(model_id: str, session: AsyncSession = Depends(get_se
 async def _read_forward_backward_request(req: Request) -> tuple[ForwardBackwardRequest, bool]:
     """Read a forward_backward body in either wire format.
 
-    tinker SDK >= 0.25.0 submits the body as protobuf and routes forward-only
-    passes here via the proto's ``forward_only`` flag instead of calling
-    ``/api/v1/forward``; older SDKs keep sending JSON with forward_only False.
+    SDKs use protobuf and zstd when the client-config handshake enables them.
+    Forward-only passes use the proto's ``forward_only`` flag; clients that do
+    not support the negotiated path keep sending JSON to the legacy endpoints.
     """
     body = await req.body()
     content_type = req.headers.get("content-type", "").lower()
@@ -1425,11 +1426,12 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     status, request_type, result_data = row
     if status == RequestStatus.COMPLETED:
         # The SDK retrieves sample/forward/forward_backward results in proto
-        # wire format when it advertises support; SDK >= 0.25.0 rejects JSON
-        # for these types. Errors and other result types stay JSON.
-        if request_type in PROTO_SERIALIZABLE_REQUEST_TYPES and PROTO_CONTENT_TYPE in req.headers.get(
-            "accept", ""
-        ).lower():
+        # wire format when it advertises support. Errors and other result types
+        # stay JSON.
+        if (
+            request_type in PROTO_SERIALIZABLE_REQUEST_TYPES
+            and PROTO_CONTENT_TYPE in req.headers.get("accept", "").lower()
+        ):
             return Response(
                 content=serialize_result(request_type, result_data),
                 media_type=PROTO_CONTENT_TYPE,

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -928,6 +928,7 @@ class WeightsInfoResponse(BaseModel):
 
 class ClientConfigResponse(BaseModel):
     pjwt_auth_enabled: bool = False
+    parallel_fwdbwd_chunks: bool = False
     proto_write_fwdbwd: bool = True
     proto_compress_fwdbwd: bool = True
     fwd_via_fwdbwd: bool = True

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -43,6 +43,7 @@ from skyrl.tinker.db_models import (
 )
 from skyrl.tinker.extra import (
     ExternalInferenceClient,
+    InMemoryFutureStore,
     SkyRLTrainInferenceForwardingClient,
 )
 from skyrl.utils.log import get_uvicorn_log_config, logger
@@ -251,12 +252,17 @@ async def lifespan(app: FastAPI):
     # SkyRL-Train default is colocate_all=True; only opt into forwarding
     # when the operator explicitly sets it to False.
     is_colocated = bool(backend_cfg.get("trainer.placement.colocate_all", True))
+    app.state.external_future_store = InMemoryFutureStore()
     if app.state.engine_config.external_inference_url:
-        app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
+        app.state.external_inference_client = ExternalInferenceClient(
+            app.state.engine_config, app.state.external_future_store
+        )
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
         app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
-            app.state.engine_config, app.state.db_engine
+            app.state.engine_config,
+            app.state.db_engine,
+            app.state.external_future_store,
         )
         logger.info(
             "SkyRL-Train inference forwarding client enabled for non-colocated backend=%s",
@@ -1288,35 +1294,33 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
         # Validate that the checkpoint exists and is ready
         await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
 
-    request_id = await create_future(
-        session=session,
-        request_type=(
-            types.RequestType.EXTERNAL if req.app.state.external_inference_client else types.RequestType.SAMPLE
-        ),
-        model_id=model_id,
-        request_data=types.SampleInput(
-            base_model=base_model,
-            prompt=request.prompt.to_types(),
-            sampling_params=request.sampling_params.to_types(),
-            num_samples=request.num_samples,
-            checkpoint_id=checkpoint_id,
-            # A positive topk implies prompt logprobs: both are read off the same
-            # prompt forward pass, so asking for one asks for the other.
-            prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
-            topk_prompt_logprobs=request.topk_prompt_logprobs,
-            seq_id=request.seq_id,
-            sampling_session_id=request.sampling_session_id,
-        ),
-    )
-
-    await session.commit()
-
     if req.app.state.external_inference_client:
+        request_id = req.app.state.external_future_store.create_future()
         asyncio.create_task(
             req.app.state.external_inference_client.call_and_store_result(
                 request_id, request, model_id, checkpoint_id, base_model=base_model
             )
         )
+    else:
+        request_id = await create_future(
+            session=session,
+            request_type=types.RequestType.SAMPLE,
+            model_id=model_id,
+            request_data=types.SampleInput(
+                base_model=base_model,
+                prompt=request.prompt.to_types(),
+                sampling_params=request.sampling_params.to_types(),
+                num_samples=request.num_samples,
+                checkpoint_id=checkpoint_id,
+                # A positive topk implies prompt logprobs: both are read off the same
+                # prompt forward pass, so asking for one asks for the other.
+                prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
+                topk_prompt_logprobs=request.topk_prompt_logprobs,
+                seq_id=request.seq_id,
+                sampling_session_id=request.sampling_session_id,
+            ),
+        )
+        await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
@@ -1343,7 +1347,10 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     request_id = int(request.request_id)
 
     try:
-        row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        if request_id < 0:
+            row = await req.app.state.external_future_store.wait_for_future(request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        else:
+            row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
     except KeyError:
         raise HTTPException(status_code=404, detail="Future not found")
 

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -408,9 +408,7 @@ class TinkerEngine:
             pending_by_model[model_id].append((request_id, request_type, seq_id))
 
         predecessor_keys = {
-            (model_id, requests[0][2] - 1)
-            for model_id, requests in pending_by_model.items()
-            if requests[0][2] > 1
+            (model_id, requests[0][2] - 1) for model_id, requests in pending_by_model.items() if requests[0][2] > 1
         }
         completed_predecessors: set[tuple[str, int]] = set()
         if predecessor_keys:
@@ -473,9 +471,7 @@ class TinkerEngine:
             (request_id, model_id)
             for request_id, model_id, seq_id in ops
             if model_id not in barriers or request_id < barriers[model_id]
-            if ready_sequenced_request_ids is None
-            or seq_id is None
-            or request_id in ready_sequenced_request_ids
+            if ready_sequenced_request_ids is None or seq_id is None or request_id in ready_sequenced_request_ids
         ]
 
         return {
@@ -573,9 +569,7 @@ class TinkerEngine:
             (request_id, model_id, request_type)
             for request_id, model_id, request_type, seq_id in other_futures
             if model_id not in blocked_pass_barriers or request_id < blocked_pass_barriers[model_id]
-            if ready_sequenced_request_ids is None
-            or seq_id is None
-            or request_id in ready_sequenced_request_ids
+            if ready_sequenced_request_ids is None or seq_id is None or request_id in ready_sequenced_request_ids
         ]
 
         return {

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -10,6 +10,7 @@ from typing import Any, Callable
 
 from cloudpathlib import AnyPath
 from pydantic import BaseModel
+from sqlalchemy import tuple_
 from sqlmodel import Session, create_engine, func, select, update
 
 from skyrl.backends.utils import log_timing
@@ -28,6 +29,14 @@ from skyrl.tinker.db_models import (
 from skyrl.utils.log import logger
 
 _MAX_IDS_PER_QUERY = 500
+_SEQUENCED_TRAINING_REQUEST_TYPES = (
+    types.RequestType.FORWARD_BACKWARD,
+    types.RequestType.FORWARD,
+    types.RequestType.OPTIM_STEP,
+    types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER,
+    types.RequestType.SAVE_WEIGHTS,
+    types.RequestType.LOAD_WEIGHTS,
+)
 
 
 def _model_not_found_error(model_id: str) -> types.ErrorResponse:
@@ -377,8 +386,64 @@ class TinkerEngine:
         )
         return dict(session.exec(query).all())
 
+    def _find_ready_sequenced_request_ids(self, session: Session) -> set[int]:
+        """Find the next contiguous training request block for each model.
+
+        The Tinker SDK submits parallel forward/backward chunks out of order: it
+        sends every later chunk first, then sends the first chunk to release the
+        complete batch. Hold those later chunks until their predecessor has
+        completed or is part of the same contiguous pending block.
+        """
+        statement = (
+            select(FutureDB.request_id, FutureDB.model_id, FutureDB.request_type, FutureDB.seq_id)
+            .where(FutureDB.status == RequestStatus.PENDING)
+            .where(FutureDB.seq_id.is_not(None))
+            .where(FutureDB.request_type.in_(_SEQUENCED_TRAINING_REQUEST_TYPES))
+            .order_by(FutureDB.model_id, FutureDB.seq_id)
+        )
+        pending_by_model: dict[str, list[tuple[int, types.RequestType, int]]] = defaultdict(list)
+        for request_id, model_id, request_type, seq_id in session.exec(statement).all():
+            if model_id is None or seq_id is None:
+                raise ValueError("Sequenced training requests require model_id and seq_id")
+            pending_by_model[model_id].append((request_id, request_type, seq_id))
+
+        predecessor_keys = {
+            (model_id, requests[0][2] - 1)
+            for model_id, requests in pending_by_model.items()
+            if requests[0][2] > 1
+        }
+        completed_predecessors: set[tuple[str, int]] = set()
+        if predecessor_keys:
+            predecessor_statement = select(FutureDB.model_id, FutureDB.seq_id, FutureDB.status).where(
+                tuple_(FutureDB.model_id, FutureDB.seq_id).in_(predecessor_keys)
+            )
+            completed_predecessors = {
+                (model_id, seq_id)
+                for model_id, seq_id, status in session.exec(predecessor_statement).all()
+                if model_id is not None and seq_id is not None and status != RequestStatus.PENDING
+            }
+
+        ready: set[int] = set()
+        for model_id, requests in pending_by_model.items():
+            first_seq_id = requests[0][2]
+            if first_seq_id != 1 and (model_id, first_seq_id - 1) not in completed_predecessors:
+                continue
+
+            request_type = requests[0][1]
+            expected_seq_id = first_seq_id
+            for request_id, candidate_type, seq_id in requests:
+                if candidate_type != request_type or seq_id != expected_seq_id:
+                    break
+                ready.add(request_id)
+                expected_seq_id += 1
+
+        return ready
+
     def find_batchable_model_passes(
-        self, session: Session, request_type: types.RequestType
+        self,
+        session: Session,
+        request_type: types.RequestType,
+        ready_sequenced_request_ids: set[int] | None = None,
     ) -> dict[str, tuple[str, types.ForwardBackwardInput]]:
         """Find all requests of the given type that come before any destructive update for their model.
 
@@ -396,7 +461,7 @@ class TinkerEngine:
 
         # Get all pending operations of the requested type ordered by request_id
         query = (
-            select(FutureDB.request_id, FutureDB.model_id)
+            select(FutureDB.request_id, FutureDB.model_id, FutureDB.seq_id)
             .where(FutureDB.request_type == request_type)
             .where(FutureDB.status == RequestStatus.PENDING)
             .order_by(FutureDB.request_id)
@@ -406,8 +471,11 @@ class TinkerEngine:
         # Filter: only include ops that come before their model's barrier
         batchable = [
             (request_id, model_id)
-            for request_id, model_id in ops
+            for request_id, model_id, seq_id in ops
             if model_id not in barriers or request_id < barriers[model_id]
+            if ready_sequenced_request_ids is None
+            or seq_id is None
+            or request_id in ready_sequenced_request_ids
         ]
 
         return {
@@ -458,7 +526,9 @@ class TinkerEngine:
             for request_id, model_id, request_data in self._load_requests(session, batchable)
         }
 
-    def find_single_requests(self, session: Session) -> dict[str, tuple[str, types.RequestType, dict]]:
+    def find_single_requests(
+        self, session: Session, ready_sequenced_request_ids: set[int] | None = None
+    ) -> dict[str, tuple[str, types.RequestType, dict]]:
         """Find all requests that need to be processed individually (not batchable).
 
         Args:
@@ -488,7 +558,7 @@ class TinkerEngine:
                     blocked_pass_barriers.setdefault(model_id, req_id)
 
         statement = (
-            select(FutureDB.request_id, FutureDB.model_id, FutureDB.request_type)
+            select(FutureDB.request_id, FutureDB.model_id, FutureDB.request_type, FutureDB.seq_id)
             .where(FutureDB.status == RequestStatus.PENDING)
             .where(FutureDB.request_type != types.RequestType.FORWARD_BACKWARD)
             .where(FutureDB.request_type != types.RequestType.FORWARD)
@@ -501,8 +571,11 @@ class TinkerEngine:
         # Filter: only include ops that come before the first blocked pass for their model
         other_futures = [
             (request_id, model_id, request_type)
-            for request_id, model_id, request_type in other_futures
+            for request_id, model_id, request_type, seq_id in other_futures
             if model_id not in blocked_pass_barriers or request_id < blocked_pass_barriers[model_id]
+            if ready_sequenced_request_ids is None
+            or seq_id is None
+            or request_id in ready_sequenced_request_ids
         ]
 
         return {
@@ -807,15 +880,18 @@ class TinkerEngine:
         while True:
             # Query for pending requests and extract data within session context
             with Session(self.db_engine) as session:
+                ready_sequenced_request_ids = self._find_ready_sequenced_request_ids(session)
                 # Use look-ahead scheduling to find batchable forward_backward and forward model passes
                 forward_backward_requests = self.find_batchable_model_passes(
-                    session, types.RequestType.FORWARD_BACKWARD
+                    session, types.RequestType.FORWARD_BACKWARD, ready_sequenced_request_ids
                 )
-                forward_requests = self.find_batchable_model_passes(session, types.RequestType.FORWARD)
+                forward_requests = self.find_batchable_model_passes(
+                    session, types.RequestType.FORWARD, ready_sequenced_request_ids
+                )
                 # Find pending sample requests that can be batched
                 sample_requests = self.find_batchable_sample(session)
                 # Get other pending requests (non forward_backward and non sampling)
-                other_requests = self.find_single_requests(session)
+                other_requests = self.find_single_requests(session, ready_sequenced_request_ids)
 
             # Process batches outside of session context
             self.process_batch_requests(

--- a/skyrl/tinker/extra/__init__.py
+++ b/skyrl/tinker/extra/__init__.py
@@ -1,6 +1,11 @@
 from skyrl.tinker.extra.external_inference import ExternalInferenceClient
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
     SkyRLTrainInferenceForwardingClient,
 )
 
-__all__ = ["ExternalInferenceClient", "SkyRLTrainInferenceForwardingClient"]
+__all__ = [
+    "ExternalInferenceClient",
+    "InMemoryFutureStore",
+    "SkyRLTrainInferenceForwardingClient",
+]

--- a/skyrl/tinker/extra/external_inference.py
+++ b/skyrl/tinker/extra/external_inference.py
@@ -1,17 +1,16 @@
 import asyncio
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
 from cloudpathlib import AnyPath
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from skyrl.backends.renderer import render_model_input
 from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
-from skyrl.tinker.db_models import FutureDB, RequestStatus
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.utils.log import logger
 from skyrl.utils.storage import download_and_unpack
 
@@ -41,12 +40,12 @@ def _extract_checkpoint_sync(checkpoint_path: AnyPath, target_dir: Path) -> None
 class ExternalInferenceClient:
     """Client for calling external inference engines (e.g., vLLM)."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(self, engine_config: EngineConfig, future_store: InMemoryFutureStore):
         self.base_url = f"{engine_config.external_inference_url}/v1"
         self.api_key = engine_config.external_inference_api_key
         self.checkpoints_base = engine_config.checkpoints_base
         self.lora_base_dir = engine_config.external_inference_lora_base
-        self.db_engine = db_engine
+        self.future_store = future_store
 
     async def call_and_store_result(
         self,
@@ -57,7 +56,7 @@ class ExternalInferenceClient:
         *,
         base_model: str | None = None,
     ):
-        """Background task to call external engine and store result in database."""
+        """Call the external engine and resolve its API-process-owned future."""
         try:
             async with httpx.AsyncClient(
                 base_url=self.base_url,
@@ -73,13 +72,7 @@ class ExternalInferenceClient:
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
 
-        async with AsyncSession(self.db_engine) as session:
-            future = await session.get(FutureDB, request_id)
-            # `result_data` is a text column holding pre-serialized JSON.
-            future.result_data = result.model_dump_json()
-            future.status = status
-            future.completed_at = datetime.now(timezone.utc)
-            await session.commit()
+        self.future_store.complete_future(request_id, status, result.model_dump_json())
 
     async def _forward_to_engine(
         self,

--- a/skyrl/tinker/extra/in_memory_future_store.py
+++ b/skyrl/tinker/extra/in_memory_future_store.py
@@ -1,6 +1,7 @@
 import asyncio
 import itertools
 import time
+from collections import deque
 from dataclasses import dataclass, field
 
 from skyrl.tinker.db_models import RequestStatus
@@ -22,6 +23,7 @@ class InMemoryFutureStore:
         self._max_terminal_futures = max_terminal_futures
         self._next_id = itertools.count(start=-1, step=-1)
         self._futures: dict[int, _StoredFuture] = {}
+        self._terminal_futures: deque[tuple[float, int]] = deque()
 
     def create_future(self) -> int:
         self._cleanup_terminal_futures()
@@ -34,7 +36,9 @@ class InMemoryFutureStore:
         future.status = status
         future.result_data = result_data
         future.completed_at = time.monotonic()
+        self._terminal_futures.append((future.completed_at, request_id))
         future.event.set()
+        self._cleanup_terminal_futures()
 
     async def wait_for_future(self, request_id: int, timeout: float) -> tuple[RequestStatus, str | None] | None:
         future = self._futures.get(request_id)
@@ -49,19 +53,9 @@ class InMemoryFutureStore:
 
     def _cleanup_terminal_futures(self) -> None:
         now = time.monotonic()
-        expired = [
-            request_id
-            for request_id, future in self._futures.items()
-            if future.completed_at is not None and now - future.completed_at > self._terminal_retention_sec
-        ]
-        for request_id in expired:
-            del self._futures[request_id]
-
-        terminal = sorted(
-            (future.completed_at, request_id)
-            for request_id, future in self._futures.items()
-            if future.completed_at is not None
-        )
-        overflow = len(terminal) - self._max_terminal_futures
-        for _, request_id in terminal[: max(overflow, 0)]:
+        while self._terminal_futures and (
+            now - self._terminal_futures[0][0] > self._terminal_retention_sec
+            or len(self._terminal_futures) > self._max_terminal_futures
+        ):
+            _, request_id = self._terminal_futures.popleft()
             del self._futures[request_id]

--- a/skyrl/tinker/extra/in_memory_future_store.py
+++ b/skyrl/tinker/extra/in_memory_future_store.py
@@ -1,0 +1,67 @@
+import asyncio
+import itertools
+import time
+from dataclasses import dataclass, field
+
+from skyrl.tinker.db_models import RequestStatus
+
+
+@dataclass
+class _StoredFuture:
+    event: asyncio.Event = field(default_factory=asyncio.Event)
+    status: RequestStatus = RequestStatus.PENDING
+    result_data: str | None = None
+    completed_at: float | None = None
+
+
+class InMemoryFutureStore:
+    """Store API-process-owned futures without routing them through the engine database."""
+
+    def __init__(self, *, terminal_retention_sec: float = 600, max_terminal_futures: int = 10_000):
+        self._terminal_retention_sec = terminal_retention_sec
+        self._max_terminal_futures = max_terminal_futures
+        self._next_id = itertools.count(start=-1, step=-1)
+        self._futures: dict[int, _StoredFuture] = {}
+
+    def create_future(self) -> int:
+        self._cleanup_terminal_futures()
+        request_id = next(self._next_id)
+        self._futures[request_id] = _StoredFuture()
+        return request_id
+
+    def complete_future(self, request_id: int, status: RequestStatus, result_data: str) -> None:
+        future = self._futures[request_id]
+        future.status = status
+        future.result_data = result_data
+        future.completed_at = time.monotonic()
+        future.event.set()
+
+    async def wait_for_future(self, request_id: int, timeout: float) -> tuple[RequestStatus, str | None] | None:
+        future = self._futures.get(request_id)
+        if future is None:
+            raise KeyError(request_id)
+        if future.status == RequestStatus.PENDING:
+            try:
+                await asyncio.wait_for(future.event.wait(), timeout)
+            except asyncio.TimeoutError:
+                return None
+        return future.status, future.result_data
+
+    def _cleanup_terminal_futures(self) -> None:
+        now = time.monotonic()
+        expired = [
+            request_id
+            for request_id, future in self._futures.items()
+            if future.completed_at is not None and now - future.completed_at > self._terminal_retention_sec
+        ]
+        for request_id in expired:
+            del self._futures[request_id]
+
+        terminal = sorted(
+            (future.completed_at, request_id)
+            for request_id, future in self._futures.items()
+            if future.completed_at is not None
+        )
+        overflow = len(terminal) - self._max_terminal_futures
+        for _, request_id in terminal[: max(overflow, 0)]:
+            del self._futures[request_id]

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -5,7 +5,6 @@ Pair to :class:`ExternalInferenceClient`; resolves the target URL from
 """
 
 import asyncio
-from datetime import datetime, timezone
 
 import httpx
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -14,16 +13,18 @@ from skyrl.backends.renderer import render_model_input
 from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
-from skyrl.tinker.db_models import EngineStateDB, FutureDB, RequestStatus
+from skyrl.tinker.db_models import EngineStateDB, RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.utils.log import logger
 
 
 class SkyRLTrainInferenceForwardingClient:
     """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(self, engine_config: EngineConfig, db_engine, future_store: InMemoryFutureStore):
         self.engine_config = engine_config
         self.db_engine = db_engine
+        self.future_store = future_store
         self._cached_proxy_url: str | None = None
         self._cache_lock = asyncio.Lock()
         # Backpressure layered: httpx pool -> vllm-router -> vLLM max_num_seqs.
@@ -71,7 +72,7 @@ class SkyRLTrainInferenceForwardingClient:
         *,
         base_model: str | None = None,
     ):
-        """Forward a sample request to vLLM and write the result to FutureDB."""
+        """Forward a sample request to vLLM and resolve its API-process-owned future."""
         try:
             result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
             status = RequestStatus.COMPLETED
@@ -80,18 +81,7 @@ class SkyRLTrainInferenceForwardingClient:
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
 
-        async with AsyncSession(self.db_engine) as session:
-            future = await session.get(FutureDB, request_id)
-            if future is None:
-                # Row was deleted between scheduling and completion (cancelled
-                # request, stale-session GC). Nothing to write back.
-                logger.warning("FutureDB row %s missing on completion write — skipping", request_id)
-                return
-            # `result_data` is a text column holding pre-serialized JSON.
-            future.result_data = result.model_dump_json()
-            future.status = status
-            future.completed_at = datetime.now(timezone.utc)
-            await session.commit()
+        self.future_store.complete_future(request_id, status, result.model_dump_json())
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
         # httpx.RequestError covers ConnectError, ReadError, TimeoutException, etc.

--- a/skyrl/tinker/proto_serialization.py
+++ b/skyrl/tinker/proto_serialization.py
@@ -1,0 +1,211 @@
+"""Proto wire-format conversion for the Tinker SDK's binary paths.
+
+Two directions, negotiated through the Tinker client-config endpoint:
+
+- **Responses**: the SDK retrieves ``sample``, ``forward``, and
+  ``forward_backward`` results as protobuf (``Accept: application/x-protobuf``
+  on ``retrieve_future``) and rejects JSON for these types. Serializers here
+  are the inverse of the SDK's ``tinker/proto/response_conv.py``: tokens as
+  little-endian int32 bytes, logprobs as float32 bytes, undefined
+  ``prompt_logprobs`` entries as NaN, undefined top-k entries sentinel-filled
+  (token_id=0, logprob=-99999.0), and each ``BatchedTensor`` concatenating
+  per-datum arrays with int64 byte offsets.
+
+- **Requests**: the SDK submits ``forward_backward`` bodies as protobuf
+  (``Content-Type: application/x-protobuf``), with forward-only passes sent to
+  the same endpoint via the ``forward_only`` flag instead of ``/api/v1/forward``.
+  The parser here is the inverse of the SDK's ``tinker/proto/request_conv.py``.
+"""
+
+import base64
+
+import numpy as np
+from tinker.proto import tinker_public_pb2 as pb
+
+from skyrl.tinker import types
+
+PROTO_CONTENT_TYPE = "application/x-protobuf"
+
+# Request types whose results the SDK can retrieve in proto form. All other
+# results are only ever served as JSON.
+PROTO_SERIALIZABLE_REQUEST_TYPES = frozenset(
+    {types.RequestType.SAMPLE, types.RequestType.FORWARD, types.RequestType.FORWARD_BACKWARD}
+)
+
+# Sentinel fill for undefined top-k positions; must match the SDK's
+# MASK_LOGPROB in tinker/types/sample_response.py.
+_TOPK_MASK_TOKEN_ID = 0
+_TOPK_MASK_LOGPROB = -99999.0
+
+_STOP_REASON_TO_PROTO = {
+    "stop": pb.STOP_REASON_STOP,
+    "length": pb.STOP_REASON_LENGTH,
+}
+
+_TENSOR_DTYPE_TO_PROTO = {"float32": pb.DTYPE_FLOAT32, "int64": pb.DTYPE_INT64}
+_TENSOR_DTYPE_TO_NUMPY = {"float32": np.float32, "int64": np.int64}
+
+# Request tensors only arrive as the public dtypes (the SDK collapses to
+# {float32, int64} on the write path).
+_PROTO_DTYPE_TO_NUMPY = {pb.DTYPE_FLOAT32: np.float32, pb.DTYPE_INT64: np.int64}
+
+
+def parse_forward_backward_request(body: bytes) -> tuple[dict, bool]:
+    """Parse a proto ForwardBackwardRequest body into the JSON-equivalent
+    request dict (ready for the API's ``ForwardBackwardRequest`` model) and
+    the ``forward_only`` flag."""
+    msg = pb.ForwardBackwardRequest()
+    msg.ParseFromString(body)
+
+    data = []
+    for datum in msg.data:
+        chunks = []
+        for chunk in datum.model_input:
+            which = chunk.WhichOneof("chunk")
+            if which == "encoded_text":
+                chunks.append(
+                    {
+                        "type": "encoded_text",
+                        "tokens": np.frombuffer(chunk.encoded_text.tokens, dtype=np.int32).tolist(),
+                    }
+                )
+            elif which == "image":
+                image_chunk = {
+                    "type": "image",
+                    "data": base64.b64encode(chunk.image.data).decode(),
+                    "format": chunk.image.format,
+                }
+                if chunk.image.HasField("expected_tokens"):
+                    image_chunk["expected_tokens"] = chunk.image.expected_tokens
+                chunks.append(image_chunk)
+            else:
+                raise ValueError(f"Unsupported model input chunk type: {which}")
+        loss_fn_inputs = {name: _tensor_from_proto(tensor) for name, tensor in datum.loss_fn_inputs.items()}
+        data.append({"model_input": {"chunks": chunks}, "loss_fn_inputs": loss_fn_inputs})
+
+    request_dict = {
+        "model_id": msg.model_id,
+        "seq_id": msg.seq_id,
+        "forward_backward_input": {
+            "data": data,
+            "loss_fn": msg.loss_fn,
+            "loss_fn_config": dict(msg.loss_fn_config) or None,
+        },
+    }
+    return request_dict, msg.forward_only
+
+
+def _tensor_from_proto(tensor: pb.Tensor) -> dict:
+    np_dtype = _PROTO_DTYPE_TO_NUMPY.get(tensor.dtype)
+    if np_dtype is None:
+        raise ValueError(f"Unsupported tensor dtype value in request: {tensor.dtype}")
+    if tensor.WhichOneof("encoding") != "dense":
+        raise ValueError("Sparse loss_fn_input tensors are not supported")
+    return {"data": np.frombuffer(tensor.dense, dtype=np_dtype).tolist()}
+
+
+def serialize_result(request_type: types.RequestType, result_data: dict | str) -> bytes:
+    """Serialize a completed future's result data to proto wire bytes."""
+    if request_type == types.RequestType.SAMPLE:
+        return _serialize_sample_output(result_data)
+    if request_type in (types.RequestType.FORWARD, types.RequestType.FORWARD_BACKWARD):
+        return _serialize_forward_backward_output(result_data)
+    raise ValueError(f"No proto serialization for request type: {request_type}")
+
+
+def _serialize_sample_output(result_data: dict | str) -> bytes:
+    output = (
+        types.SampleOutput.model_validate_json(result_data)
+        if isinstance(result_data, str)
+        else types.SampleOutput.model_validate(result_data)
+    )
+    proto = pb.SampleResponse()
+
+    for seq in output.sequences:
+        proto.sequences.append(
+            pb.SampledSequence(
+                stop_reason=_STOP_REASON_TO_PROTO[seq.stop_reason],
+                tokens=np.asarray(seq.tokens, dtype=np.int32).tobytes(),
+                logprobs=np.asarray(seq.logprobs, dtype=np.float32).tobytes(),
+            )
+        )
+
+    if output.prompt_logprobs is not None:
+        proto.prompt_logprobs = np.array(
+            [np.nan if lp is None else lp for lp in output.prompt_logprobs], dtype=np.float32
+        ).tobytes()
+
+    if output.topk_prompt_logprobs is not None:
+        rows = output.topk_prompt_logprobs
+        # k is not recorded in the result, so recover it from the widest row.
+        # With every row undefined, use k=1 so prompt_length stays encoded
+        # (the client maps fully-masked rows back to None).
+        k = max((len(row) for row in rows if row), default=1)
+        token_ids = np.full((len(rows), k), _TOPK_MASK_TOKEN_ID, dtype=np.int32)
+        logprobs = np.full((len(rows), k), _TOPK_MASK_LOGPROB, dtype=np.float32)
+        for i, row in enumerate(rows):
+            for j, (token_id, logprob) in enumerate(row or ()):
+                token_ids[i, j] = token_id
+                logprobs[i, j] = logprob
+        proto.topk_prompt_logprobs.CopyFrom(
+            pb.TopkPromptLogprobs(
+                prompt_length=len(rows),
+                k=k,
+                token_ids=token_ids.tobytes(),
+                logprobs=logprobs.tobytes(),
+            )
+        )
+
+    return proto.SerializeToString()
+
+
+def _serialize_forward_backward_output(result_data: dict | str) -> bytes:
+    output = (
+        types.ForwardBackwardOutput.model_validate_json(result_data)
+        if isinstance(result_data, str)
+        else types.ForwardBackwardOutput.model_validate(result_data)
+    )
+    proto = pb.ForwardBackwardOutput()
+    proto.loss_fn_output_type = output.loss_fn_output_type
+    for name, value in output.metrics.items():
+        proto.metrics[name] = float(value)
+
+    if not output.loss_fn_outputs:
+        return proto.SerializeToString()
+
+    record = proto.loss_fn_outputs.add()
+    record.num_datums = len(output.loss_fn_outputs)
+
+    # Union of field names across datums, in first-seen order. Backends emit
+    # the same fields for every datum in a request, but a missing field still
+    # encodes cleanly as an empty slice (equal adjacent offsets).
+    field_names = list(dict.fromkeys(name for datum in output.loss_fn_outputs for name in datum))
+    for name in field_names:
+        tensors = [datum.get(name) for datum in output.loss_fn_outputs]
+        dtypes = {t["dtype"] for t in tensors if t is not None}
+        if len(dtypes) > 1:
+            raise ValueError(f"Field {name} has mixed dtypes across datums: {dtypes}")
+        dtype = dtypes.pop() if dtypes else "float32"
+
+        # The SDK slices one BatchedTensor with a single trailing shape, so
+        # datums may only be ragged in the leading dimension.
+        trailing_shapes = {tuple(t["shape"][1:]) for t in tensors if t is not None}
+        if len(trailing_shapes) > 1:
+            raise ValueError(f"Field {name} has mixed trailing shapes across datums: {trailing_shapes}")
+        trailing_shape = trailing_shapes.pop() if trailing_shapes else ()
+
+        np_dtype = _TENSOR_DTYPE_TO_NUMPY[dtype]
+        arrays = [np.asarray(t["data"] if t is not None else [], dtype=np_dtype).ravel() for t in tensors]
+        offsets = np.zeros(len(arrays) + 1, dtype=np.int64)
+        np.cumsum([a.nbytes for a in arrays], out=offsets[1:])
+
+        record.fields[name].CopyFrom(
+            pb.BatchedTensor(
+                data=b"".join(a.tobytes() for a in arrays),
+                offsets=offsets.tobytes(),
+                dtype=_TENSOR_DTYPE_TO_PROTO[dtype],
+                trailing_shape=trailing_shape,
+            )
+        )
+
+    return proto.SerializeToString()

--- a/skyrl/tinker/types.py
+++ b/skyrl/tinker/types.py
@@ -160,7 +160,7 @@ class Datum(BaseModel):
 
 class ForwardBackwardInput(BaseModel):
     data: list[Datum]
-    loss_fn: Literal["cross_entropy", "importance_sampling", "ppo", "cispo", "ppo_critic", "dppo"]
+    loss_fn: Literal["cross_entropy", "importance_sampling", "ppo", "gspo", "cispo", "ppo_critic", "dppo"]
     loss_fn_config: dict[str, float] | None = None
 
 
@@ -341,6 +341,7 @@ SUPPORTED_LOSS_FNS = {
     "cross_entropy",
     "importance_sampling",
     "ppo",
+    "gspo",
     "cispo",
     "ppo_critic",
     "dppo",

--- a/tests/backends/skyrl_train/test_token_based_batching_utils.py
+++ b/tests/backends/skyrl_train/test_token_based_batching_utils.py
@@ -160,6 +160,19 @@ class TestTokenBasedBatchIterator:
         for i in range(batch.batch_size):
             assert torch.equal(reordered["sequences"][i], batch["sequences"][i])
 
+    def test_reorder_and_combine_items_drops_padding(self):
+        batch = self._make_batch([10, 3, 8, 5])
+        iterator = TokenBasedBatchIterator(batch, max_tokens_per_microbatch=12)
+        output_batches = [
+            [{"sample": index} for index in indices] + [{"sample": "padding"}] for indices in iterator._microbatches
+        ]
+        iterator._num_padding_microbatches = 1
+        output_batches.append([{"sample": "padding-microbatch"}])
+
+        reordered = iterator.reorder_and_combine_items(output_batches)
+
+        assert [output["sample"] for output in reordered] == list(range(batch.batch_size))
+
     def test_get_microbatch_iterator_factory(self):
         batch = self._make_batch([10, 10, 5, 5])
 

--- a/tests/backends/test_jax_backend.py
+++ b/tests/backends/test_jax_backend.py
@@ -496,6 +496,31 @@ def test_ppo_loss_fn_config_is_applied():
     np.testing.assert_allclose(tight_losses, -1.01, atol=1e-4)
 
 
+@pytest.mark.parametrize("loss_fn", ["dppo", "gspo", "ppo_critic"])
+def test_skyrl_train_losses_are_rejected_by_jax(loss_fn):
+    backend = JaxBackend(BASE_MODEL, JaxBackendConfig(max_lora_adapters=2, max_lora_rank=8))
+    model_id = "unsupported_loss_adapter"
+    backend.create_model(model_id, LoraConfig(rank=8, alpha=16, seed=0))
+    datum = types.Datum(
+        model_input=types.ModelInput(chunks=[types.EncodedTextChunk(tokens=[1, 2])]),
+        loss_fn_inputs=types.LossFnInputs(
+            target_tokens=types.TensorData(data=[2, 0]),
+            weights=types.TensorData(data=[1.0, 1.0]),
+            logprobs=types.TensorData(data=[-1.0, -1.0]),
+            advantages=types.TensorData(data=[1.0, 1.0]),
+        ),
+    )
+    requests = {
+        "unsupported_loss": (
+            model_id,
+            types.ForwardBackwardInput(data=[datum], loss_fn=loss_fn),
+        )
+    }
+
+    with pytest.raises(ValueError, match=f"{loss_fn} is only supported by the SkyRL-Train backend"):
+        backend.forward(prepare_model_pass_batch(requests))
+
+
 def test_sample_max_num_sequences():
     """
     Verify sampling with sample_max_num_sequences constraint.

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -9,8 +9,8 @@ bypassing the engine subprocess's serial scheduling loop.
 Coverage:
   - test_engine_state_published: after ``save_weights_for_sampler``, the
     engine's vLLM proxy URL is written to ``EngineStateDB``.
-  - test_sample_uses_external_path: an issued sample creates a future of
-    type ``EXTERNAL`` (not ``SAMPLE``) and resolves successfully.
+  - test_sample_bypasses_future_db: an issued sample resolves without creating
+    a database future.
   - test_sample_concurrent_with_training_is_fast: the central
     parallelism test. While a long-running stream of ``forward_backward``
     + ``optim_step`` calls is in flight, a sample request resolves in
@@ -210,15 +210,14 @@ def test_engine_state_published(server_db_path):
     ), f"expected an http(s) proxy URL, got {row.inference_proxy_url!r}"
 
 
-def test_sample_uses_external_path(server_db_path):
-    """A sample issued through the SDK creates a FutureDB row of type EXTERNAL.
+def test_sample_bypasses_future_db(server_db_path):
+    """A sample issued through the SDK does not use the engine's FutureDB.
 
     This is the "test" half of the design: the API hoists the sample off
-    the engine's serial loop and into the API process's asyncio loop.
+    the engine's serial loop and keeps its future in the API process.
     """
     from sqlmodel import Session, create_engine, func, select
 
-    from skyrl.tinker import types as skyrl_types
     from skyrl.tinker.db_models import FutureDB
 
     proc, db_path, _ = server_db_path
@@ -229,12 +228,11 @@ def test_sample_uses_external_path(server_db_path):
     _train_one_step(tc, tok)
     sampler = tc.save_weights_and_get_sampling_client(name="external_path_a")
 
-    # Snapshot the max future_id before submitting our sample so we can
-    # filter out any EXTERNAL futures from earlier tests.
+    # Snapshot the number of database futures before submitting our sample.
     eng = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(eng) as s:
-            max_before = s.exec(select(func.max(FutureDB.request_id))).one() or 0
+            count_before = s.exec(select(func.count()).select_from(FutureDB)).one()
     finally:
         eng.dispose()
 
@@ -245,24 +243,16 @@ def test_sample_uses_external_path(server_db_path):
     ).result()
     assert len(out.sequences) == 1
 
-    # Look for an EXTERNAL future with id > max_before. If async routing
-    # is on, every sample creates exactly one such row.
+    # API-forwarded samples use negative, in-memory future ids and must not
+    # add database work to the engine's scheduling hot path.
     eng = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(eng) as s:
-            stmt = (
-                select(FutureDB.request_id, FutureDB.request_type)
-                .where(FutureDB.request_id > max_before)
-                .where(FutureDB.request_type == skyrl_types.RequestType.EXTERNAL)
-            )
-            rows = s.exec(stmt).all()
+            count_after = s.exec(select(func.count()).select_from(FutureDB)).one()
     finally:
         eng.dispose()
 
-    assert len(rows) >= 1, (
-        f"expected at least one EXTERNAL future to be created by the sample call, "
-        f"found {len(rows)}; async sample routing may not be active"
-    )
+    assert count_after == count_before
 
 
 def test_sample_concurrent_with_training_is_fast(server_db_path):

--- a/tests/tinker/skyrl_train/test_loss_normalization.py
+++ b/tests/tinker/skyrl_train/test_loss_normalization.py
@@ -8,6 +8,7 @@ SkyRL-Train backend deps (ray/vllm) to be importable. Run:
 from __future__ import annotations
 
 import pytest
+import torch
 
 # Skip if skyrl_train_backend.py cannot be imported
 skyrl_train_backend = pytest.importorskip("skyrl.backends.skyrl_train_backend")
@@ -19,6 +20,37 @@ def test_ppo_thresholds_map_to_eps_clip():
     loss_fn, config = _normalize(None, "policy", "ppo", {"clip_low_threshold": 0.8, "clip_high_threshold": 1.28})
     assert loss_fn == "regular"
     assert config == pytest.approx({"eps_clip_low": 0.2, "eps_clip_high": 0.28})
+
+
+def test_gspo_thresholds_map_to_native_sequence_loss():
+    loss_fn, config = _normalize(
+        None,
+        "policy",
+        "gspo",
+        {"clip_low_threshold": 0.98, "clip_high_threshold": 1.03},
+    )
+    assert loss_fn == "gspo"
+    assert config == {
+        "eps_clip_low": pytest.approx(0.02),
+        "eps_clip_high": pytest.approx(0.03),
+        "loss_reduction": "sequence_mean",
+        "use_entropy_loss": False,
+        "use_kl_loss": False,
+    }
+
+
+def test_gspo_batch_normalization_gives_each_trainable_sequence_equal_weight():
+    batch = skyrl_train_backend.TrainingInputBatch(
+        {
+            "advantages": torch.tensor([[2.0, 2.0, 0.0, 0.0], [-1.0, -1.0, -1.0, 0.0], [0.0] * 4]),
+            "loss_mask": torch.ones(3, 4),
+        }
+    )
+
+    skyrl_train_backend.SkyRLTrainBackend._normalize_gspo_batch(batch)
+
+    assert batch["loss_mask"].tolist() == [[1.0, 1.0, 0.0, 0.0], [1.0, 1.0, 1.0, 0.0], [0.0] * 4]
+    assert (batch["advantages"] * batch["loss_mask"]).sum(dim=-1).tolist() == pytest.approx([1.0, -0.5, 0.0])
 
 
 def test_dppo_deltas_are_nested_under_dppo():

--- a/tests/tinker/skyrl_train/test_loss_normalization.py
+++ b/tests/tinker/skyrl_train/test_loss_normalization.py
@@ -53,6 +53,37 @@ def test_gspo_batch_normalization_gives_each_trainable_sequence_equal_weight():
     assert (batch["advantages"] * batch["loss_mask"]).sum(dim=-1).tolist() == pytest.approx([1.0, -0.5, 0.0])
 
 
+def test_gspo_selects_only_rows_with_gradient_contributions():
+    batch = skyrl_train_backend.TrainingInputBatch(
+        {
+            "sequences": torch.tensor([[1, 2], [3, 0], [4, 5]]),
+            "attention_mask": torch.tensor([[1, 1], [1, 0], [1, 1]]),
+            "loss_mask": torch.tensor([[1.0, 0.0], [0.0, 0.0], [0.0, 1.0]]),
+        }
+    )
+    batch.metadata = {"response_length": 2}
+
+    selected, indices = skyrl_train_backend.SkyRLTrainBackend._select_trainable_gspo_rows(batch)
+
+    assert indices == [0, 2]
+    assert selected["sequences"].tolist() == [[1, 2], [4, 5]]
+    assert selected.metadata == batch.metadata
+
+
+def test_gspo_keeps_entirely_inactive_batch_for_zero_gradient_backward():
+    batch = skyrl_train_backend.TrainingInputBatch(
+        {
+            "sequences": torch.tensor([[1, 2], [3, 4]]),
+            "loss_mask": torch.zeros(2, 2),
+        }
+    )
+
+    selected, indices = skyrl_train_backend.SkyRLTrainBackend._select_trainable_gspo_rows(batch)
+
+    assert selected is batch
+    assert indices == [0, 1]
+
+
 def test_dppo_deltas_are_nested_under_dppo():
     loss_fn, config = _normalize(None, "policy", "dppo", {"delta_low": 0.2, "delta_high": 0.3})
     assert loss_fn == "dppo"

--- a/tests/tinker/test_api_validation.py
+++ b/tests/tinker/test_api_validation.py
@@ -1,4 +1,5 @@
 import base64
+from types import SimpleNamespace
 
 import pytest
 from pydantic import TypeAdapter, ValidationError
@@ -43,6 +44,16 @@ def test_forward_backward_input_accepts_gspo_threshold_keys():
 def test_forward_backward_input_rejects_incomplete_or_invalid_gspo_thresholds(loss_fn_config):
     with pytest.raises(ValidationError, match="loss_fn='gspo'"):
         api.ForwardBackwardInput(data=[_make_datum()], loss_fn="gspo", loss_fn_config=loss_fn_config)
+
+
+@pytest.mark.asyncio
+async def test_server_capabilities_advertise_native_gspo():
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(engine_config=SimpleNamespace(base_model="test-model")))
+    )
+    capabilities = await api.get_server_capabilities(request)
+
+    assert "gspo" in capabilities.supported_loss_fns
 
 
 def test_forward_backward_input_accepts_ppo_value_clip():

--- a/tests/tinker/test_api_validation.py
+++ b/tests/tinker/test_api_validation.py
@@ -56,6 +56,13 @@ async def test_server_capabilities_advertise_native_gspo():
     assert "gspo" in capabilities.supported_loss_fns
 
 
+@pytest.mark.asyncio
+async def test_client_config_serializes_forward_backward_chunks():
+    config = await api.client_config()
+
+    assert config.parallel_fwdbwd_chunks is False
+
+
 def test_forward_backward_input_accepts_ppo_value_clip():
     req = api.ForwardBackwardInput(
         data=[_make_datum()],

--- a/tests/tinker/test_api_validation.py
+++ b/tests/tinker/test_api_validation.py
@@ -27,6 +27,24 @@ def test_forward_backward_input_accepts_ppo_threshold_keys():
     assert req.loss_fn_config == {"clip_low_threshold": 0.9, "clip_high_threshold": 1.1}
 
 
+def test_forward_backward_input_accepts_gspo_threshold_keys():
+    req = api.ForwardBackwardInput(
+        data=[_make_datum()],
+        loss_fn="gspo",
+        loss_fn_config={"clip_low_threshold": 0.98, "clip_high_threshold": 1.03},
+    )
+    assert req.to_types().loss_fn == "gspo"
+
+
+@pytest.mark.parametrize(
+    "loss_fn_config",
+    [None, {"clip_low_threshold": 0.98}, {"clip_low_threshold": 1.01, "clip_high_threshold": 1.03}],
+)
+def test_forward_backward_input_rejects_incomplete_or_invalid_gspo_thresholds(loss_fn_config):
+    with pytest.raises(ValidationError, match="loss_fn='gspo'"):
+        api.ForwardBackwardInput(data=[_make_datum()], loss_fn="gspo", loss_fn_config=loss_fn_config)
+
+
 def test_forward_backward_input_accepts_ppo_value_clip():
     req = api.ForwardBackwardInput(
         data=[_make_datum()],

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -380,6 +380,101 @@ def add_futures(engine, specs) -> list[int]:
         return [row.request_id for row in rows]
 
 
+def add_sequenced_futures(engine, specs) -> dict[int, int]:
+    """Add sequenced futures and return their database IDs keyed by sequence ID."""
+    with Session(engine.db_engine) as session:
+        rows = [
+            FutureDB(
+                request_type=request_type,
+                model_id=model_id,
+                seq_id=seq_id,
+                request_data=data,
+                status=status,
+            )
+            for request_type, model_id, seq_id, data, status in specs
+        ]
+        for row in rows:
+            session.add(row)
+        session.commit()
+        return {row.seq_id: row.request_id for row in rows}
+
+
+def test_sequenced_model_passes_wait_for_first_parallel_chunk(scheduling_engine):
+    """Later SDK chunks wait until the first chunk arrives, then batch together."""
+    engine = scheduling_engine
+    payload = forward_backward_payload()
+    request_ids = add_sequenced_futures(
+        engine,
+        [
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 2, payload, RequestStatus.PENDING),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 3, payload, RequestStatus.PENDING),
+        ],
+    )
+
+    with Session(engine.db_engine) as session:
+        assert engine._find_ready_sequenced_request_ids(session) == set()
+
+    request_ids.update(
+        add_sequenced_futures(
+            engine,
+            [(types.RequestType.FORWARD_BACKWARD, "model_a", 1, payload, RequestStatus.PENDING)],
+        )
+    )
+    with Session(engine.db_engine) as session:
+        ready = engine._find_ready_sequenced_request_ids(session)
+        batchable = engine.find_batchable_model_passes(session, types.RequestType.FORWARD_BACKWARD, ready)
+
+    assert ready == set(request_ids.values())
+    assert set(batchable) == {str(request_id) for request_id in request_ids.values()}
+
+
+def test_sequenced_requests_stop_at_operation_boundary(scheduling_engine):
+    """Only one contiguous request type is released per model in an engine iteration."""
+    engine = scheduling_engine
+    request_ids = add_sequenced_futures(
+        engine,
+        [
+            (types.RequestType.FORWARD, "model_a", 1, {}, RequestStatus.PENDING),
+            (types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER, "model_a", 2, {}, RequestStatus.PENDING),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 3, {}, RequestStatus.PENDING),
+        ],
+    )
+
+    with Session(engine.db_engine) as session:
+        assert engine._find_ready_sequenced_request_ids(session) == {request_ids[1]}
+        first = session.get(FutureDB, request_ids[1])
+        first.status = RequestStatus.COMPLETED
+        session.add(first)
+        session.commit()
+        assert engine._find_ready_sequenced_request_ids(session) == {request_ids[2]}
+
+        second = session.get(FutureDB, request_ids[2])
+        second.status = RequestStatus.COMPLETED
+        session.add(second)
+        session.commit()
+        assert engine._find_ready_sequenced_request_ids(session) == {request_ids[3]}
+
+
+def test_sequenced_requests_resume_after_completed_predecessor(scheduling_engine):
+    """A later parallel block is released when its immediately preceding block completed."""
+    engine = scheduling_engine
+    payload = forward_backward_payload()
+    request_ids = add_sequenced_futures(
+        engine,
+        [
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 1, payload, RequestStatus.COMPLETED),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 2, payload, RequestStatus.COMPLETED),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 4, payload, RequestStatus.PENDING),
+            (types.RequestType.FORWARD_BACKWARD, "model_a", 3, payload, RequestStatus.PENDING),
+        ],
+    )
+
+    with Session(engine.db_engine) as session:
+        ready = engine._find_ready_sequenced_request_ids(session)
+
+    assert ready == {request_ids[3], request_ids[4]}
+
+
 def test_find_batchable_model_passes_stops_at_barrier(scheduling_engine):
     """Passes behind an optim_step must not batch with earlier ones, and payloads still parse."""
     engine = scheduling_engine

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -109,6 +109,15 @@ def test_cleanup_stale_sessions():
             [],
             id="cispo",
         ),
+        pytest.param(
+            "gspo",
+            {"clip_low_threshold": 0.98, "clip_high_threshold": 1.03},
+            [0.1, 0.2, 0.3],
+            [-1.1, -1.0, -0.9],
+            [],
+            [],
+            id="gspo",
+        ),
         pytest.param("ppo_critic", {"value_clip": 0.2}, [], [], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9], id="ppo_critic"),
         pytest.param(
             "dppo",

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -179,10 +179,18 @@ async def test_query_count_does_not_scale_with_waiters(waiters, sync_engine, asy
     assert 0 < len(statements) < 50
 
 
-def _stub_request(async_engine, waiters):
+def _stub_request(async_engine, waiters, external_future_store=None):
     from types import SimpleNamespace
 
-    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(db_engine=async_engine, future_waiters=waiters)))
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                db_engine=async_engine,
+                external_future_store=external_future_store,
+                future_waiters=waiters,
+            )
+        )
+    )
 
 
 @pytest.mark.asyncio
@@ -204,6 +212,24 @@ async def test_retrieve_future_returns_completed_result(waiters, async_engine, s
     )
 
     # The stored JSON text is returned as-is rather than re-encoded by FastAPI.
+    assert response.media_type == "application/json"
+    assert response.body == SAMPLE_RESULT.model_dump_json().encode()
+
+
+@pytest.mark.asyncio
+async def test_retrieve_future_returns_in_memory_external_result(waiters, async_engine):
+    from skyrl.tinker import api
+    from skyrl.tinker.extra import InMemoryFutureStore
+
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+    store.complete_future(request_id, RequestStatus.COMPLETED, SAMPLE_RESULT.model_dump_json())
+
+    response = await api.retrieve_future(
+        api.RetrieveFutureRequest(request_id=str(request_id)),
+        _stub_request(async_engine, waiters, store),
+    )
+
     assert response.media_type == "application/json"
     assert response.body == SAMPLE_RESULT.model_dump_json().encode()
 

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -105,10 +105,11 @@ async def test_resolves_once_the_request_completes(waiters, sync_engine):
         mark_completed(sync_engine, request_id, SAMPLE_RESULT)
 
     asyncio.create_task(complete_soon())
-    status, result_data = await wait_for_future(waiters, request_id, timeout=5)
+    status, request_type, result_data = await wait_for_future(waiters, request_id, timeout=5)
 
     # result_data is the stored JSON text, not a decoded object, so it takes a
     # parse to compare against the result that was stored.
+    assert request_type == types.RequestType.SAMPLE
     assert (status, types.SampleOutput.model_validate_json(result_data)) == (RequestStatus.COMPLETED, SAMPLE_RESULT)
 
 
@@ -118,8 +119,9 @@ async def test_surfaces_failed_status(waiters, sync_engine):
     error = types.ErrorResponse(error="boom", status="failed")
     mark_completed(sync_engine, request_id, error, status=RequestStatus.FAILED)
 
-    status, result_data = await wait_for_future(waiters, request_id, timeout=5)
+    status, request_type, result_data = await wait_for_future(waiters, request_id, timeout=5)
 
+    assert request_type == types.RequestType.SAMPLE
     assert (status, types.ErrorResponse.model_validate_json(result_data)) == (RequestStatus.FAILED, error)
 
 
@@ -150,7 +152,8 @@ async def test_one_waiter_giving_up_does_not_strand_the_others(waiters, sync_eng
     result = types.OptimStepOutput(metrics={"loss": 1.5})
     mark_completed(sync_engine, request_id, result)
 
-    status, result_data = await patient
+    status, request_type, result_data = await patient
+    assert request_type == types.RequestType.SAMPLE
     assert (status, types.OptimStepOutput.model_validate_json(result_data)) == (RequestStatus.COMPLETED, result)
 
 
@@ -179,7 +182,7 @@ async def test_query_count_does_not_scale_with_waiters(waiters, sync_engine, asy
     assert 0 < len(statements) < 50
 
 
-def _stub_request(async_engine, waiters, external_future_store=None):
+def _stub_request(async_engine, waiters, external_future_store=None, headers: dict | None = None):
     from types import SimpleNamespace
 
     return SimpleNamespace(
@@ -189,7 +192,8 @@ def _stub_request(async_engine, waiters, external_future_store=None):
                 external_future_store=external_future_store,
                 future_waiters=waiters,
             )
-        )
+        ),
+        headers=headers or {},
     )
 
 
@@ -252,6 +256,31 @@ async def test_retrieve_future_400s_with_the_stored_error(waiters, async_engine,
 
     assert excinfo.value.status_code == 400
     assert excinfo.value.detail == "boom"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_future_serves_proto_when_accepted(waiters, async_engine, sync_engine):
+    """A completed sample future is served as proto bytes when the client's
+    Accept header asks for it (the JSON test above covers the default path)."""
+    from tinker import SampleResponse
+    from tinker.proto.response_conv import deserialize_proto_response
+
+    from skyrl.tinker import api
+
+    request_id = insert_pending(sync_engine)[0]
+    sample_result = types.SampleOutput(
+        sequences=[types.GeneratedSequence(stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0])]
+    )
+    mark_completed(sync_engine, request_id, sample_result)
+
+    result = await api.retrieve_future(
+        api.RetrieveFutureRequest(request_id=str(request_id)),
+        _stub_request(async_engine, waiters, headers={"accept": "Application/X-Protobuf, application/json"}),
+    )
+
+    assert result.media_type == "application/x-protobuf"
+    response = deserialize_proto_response(result.body, SampleResponse)
+    assert response.sequences[0].tokens == [1, 2]
 
 
 @pytest.mark.asyncio

--- a/tests/tinker/test_in_memory_future_store.py
+++ b/tests/tinker/test_in_memory_future_store.py
@@ -1,0 +1,61 @@
+import asyncio
+
+import pytest
+
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
+
+
+@pytest.mark.asyncio
+async def test_concurrent_waiters_receive_completed_result():
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+    waiters = [asyncio.create_task(store.wait_for_future(request_id, 1)) for _ in range(3)]
+
+    store.complete_future(request_id, RequestStatus.COMPLETED, '{"value":1}')
+
+    assert await asyncio.gather(*waiters) == [
+        (RequestStatus.COMPLETED, '{"value":1}'),
+        (RequestStatus.COMPLETED, '{"value":1}'),
+        (RequestStatus.COMPLETED, '{"value":1}'),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_timed_out_waiter_does_not_cancel_future():
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+
+    assert await store.wait_for_future(request_id, 0) is None
+    store.complete_future(request_id, RequestStatus.FAILED, '{"error":"boom"}')
+
+    assert await store.wait_for_future(request_id, 1) == (
+        RequestStatus.FAILED,
+        '{"error":"boom"}',
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_future_raises_key_error():
+    store = InMemoryFutureStore()
+
+    with pytest.raises(KeyError):
+        await store.wait_for_future(-1, 1)
+
+
+@pytest.mark.asyncio
+async def test_terminal_future_retention_is_bounded():
+    store = InMemoryFutureStore(max_terminal_futures=1)
+    first_id = store.create_future()
+    store.complete_future(first_id, RequestStatus.COMPLETED, "{}")
+    second_id = store.create_future()
+    store.complete_future(second_id, RequestStatus.COMPLETED, "{}")
+
+    store.create_future()
+
+    with pytest.raises(KeyError):
+        await store.wait_for_future(first_id, 1)
+    assert await store.wait_for_future(second_id, 1) == (
+        RequestStatus.COMPLETED,
+        "{}",
+    )

--- a/tests/tinker/test_proto_serialization.py
+++ b/tests/tinker/test_proto_serialization.py
@@ -1,0 +1,251 @@
+"""Round-trip tests for proto serialization of retrieve_future results.
+
+Each test serializes a result_data dict the way the API server does and
+deserializes it with the installed tinker SDK's own proto deserializers,
+so the wire conventions (byte layouts, NaN/sentinel fills) are checked
+against the exact code the client runs.
+"""
+
+import math
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import tinker.types as sdk_types
+import zstandard as zstd
+from fastapi import HTTPException
+from tinker import ForwardBackwardOutput, SampleResponse
+from tinker.proto.request_conv import forward_backward_request_to_proto
+from tinker.proto.response_conv import deserialize_proto_response
+
+from skyrl.tinker import api, types
+from skyrl.tinker.proto_serialization import (
+    parse_forward_backward_request,
+    serialize_result,
+)
+
+
+def roundtrip_sample(result_data: dict) -> SampleResponse:
+    return deserialize_proto_response(serialize_result(types.RequestType.SAMPLE, result_data), SampleResponse)
+
+
+def roundtrip_forward_backward(result_data: dict) -> ForwardBackwardOutput:
+    return deserialize_proto_response(
+        serialize_result(types.RequestType.FORWARD_BACKWARD, result_data), ForwardBackwardOutput
+    )
+
+
+def test_sample_sequences():
+    result_data = {
+        "sequences": [
+            {"stop_reason": "stop", "tokens": [1, 2, 3], "logprobs": [-0.5, -1.25, -2.0]},
+            {"stop_reason": "length", "tokens": [7], "logprobs": [-0.125]},
+        ]
+    }
+    response = roundtrip_sample(result_data)
+    assert len(response.sequences) == 2
+    assert response.sequences[0].stop_reason == "stop"
+    assert response.sequences[0].tokens == [1, 2, 3]
+    assert response.sequences[0].logprobs == [-0.5, -1.25, -2.0]
+    assert response.sequences[1].stop_reason == "length"
+    assert response.sequences[1].tokens == [7]
+    assert response.prompt_logprobs is None
+    assert response.topk_prompt_logprobs is None
+
+
+def test_sample_prompt_logprobs_none_becomes_nan_wire_none_client():
+    result_data = {
+        "sequences": [{"stop_reason": "stop", "tokens": [1], "logprobs": [-0.5]}],
+        "prompt_logprobs": [None, -0.25, -0.75],
+    }
+    response = roundtrip_sample(result_data)
+    assert response.prompt_logprobs == [None, pytest.approx(-0.25), pytest.approx(-0.75)]
+    assert math.isnan(response.prompt_logprobs_np[0])
+
+
+def test_sample_topk_prompt_logprobs():
+    result_data = {
+        "sequences": [{"stop_reason": "stop", "tokens": [1], "logprobs": [-0.5]}],
+        # First position undefined, second full width, third narrower (ragged).
+        "topk_prompt_logprobs": [
+            None,
+            [(11, -0.1), (12, -0.2)],
+            [(13, -0.3)],
+        ],
+    }
+    response = roundtrip_sample(result_data)
+    topk = response.topk_prompt_logprobs
+    assert topk[0] is None
+    assert topk[1] == [(11, pytest.approx(-0.1)), (12, pytest.approx(-0.2))]
+    assert topk[2] == [(13, pytest.approx(-0.3))]
+
+
+def test_sample_topk_all_rows_undefined():
+    result_data = {
+        "sequences": [{"stop_reason": "stop", "tokens": [1], "logprobs": [-0.5]}],
+        "topk_prompt_logprobs": [None, None],
+    }
+    response = roundtrip_sample(result_data)
+    assert response.topk_prompt_logprobs == [None, None]
+
+
+def test_forward_backward_ragged_datums_and_metrics():
+    result_data = {
+        "loss_fn_output_type": "scalar",
+        "loss_fn_outputs": [
+            {
+                "elementwise_loss": {"data": [1.0, 2.0, 3.0], "dtype": "float32", "shape": [3]},
+                "logprobs": {"data": [-0.1, -0.2, -0.3], "dtype": "float32", "shape": [3]},
+            },
+            {
+                "elementwise_loss": {"data": [4.0], "dtype": "float32", "shape": [1]},
+                "logprobs": {"data": [-0.4], "dtype": "float32", "shape": [1]},
+            },
+        ],
+        "metrics": {"loss:sum": 10.5, "clip_fraction": 0.25},
+    }
+    output = roundtrip_forward_backward(result_data)
+    assert output.loss_fn_output_type == "scalar"
+    assert output.metrics == {"loss:sum": 10.5, "clip_fraction": 0.25}
+    assert len(output.loss_fn_outputs) == 2
+    first, second = output.loss_fn_outputs
+    np.testing.assert_allclose(first["elementwise_loss"].tolist(), [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(first["logprobs"].tolist(), [-0.1, -0.2, -0.3], rtol=1e-6)
+    assert first["logprobs"].dtype == "float32"
+    assert first["logprobs"].shape == [3]
+    np.testing.assert_allclose(second["elementwise_loss"].tolist(), [4.0])
+    assert second["logprobs"].shape == [1]
+
+
+def test_forward_backward_empty_outputs():
+    result_data = {"loss_fn_output_type": "scalar", "loss_fn_outputs": [], "metrics": {"loss:sum": 0.0}}
+    output = roundtrip_forward_backward(result_data)
+    assert output.loss_fn_outputs == []
+    assert output.metrics == {"loss:sum": 0.0}
+
+
+def test_forward_backward_field_missing_in_one_datum():
+    result_data = {
+        "loss_fn_output_type": "scalar",
+        "loss_fn_outputs": [
+            {"logprobs": {"data": [-0.1, -0.2], "dtype": "float32", "shape": [2]}},
+            {},
+        ],
+        "metrics": {},
+    }
+    output = roundtrip_forward_backward(result_data)
+    assert len(output.loss_fn_outputs) == 2
+    np.testing.assert_allclose(output.loss_fn_outputs[0]["logprobs"].tolist(), [-0.1, -0.2], rtol=1e-6)
+    assert output.loss_fn_outputs[1]["logprobs"].tolist() == []
+
+
+def test_forward_uses_forward_backward_wire_type():
+    result_data = {
+        "loss_fn_output_type": "scalar",
+        "loss_fn_outputs": [{"logprobs": {"data": [-0.5], "dtype": "float32", "shape": [1]}}],
+        "metrics": {},
+    }
+    proto_bytes = serialize_result(types.RequestType.FORWARD, result_data)
+    output = deserialize_proto_response(proto_bytes, ForwardBackwardOutput)
+    np.testing.assert_allclose(output.loss_fn_outputs[0]["logprobs"].tolist(), [-0.5])
+
+
+def test_unsupported_request_type_raises():
+    with pytest.raises(ValueError, match="No proto serialization"):
+        serialize_result(types.RequestType.OPTIM_STEP, {})
+
+
+def encode_sdk_fwd_bwd_request(loss_fn_config=None, forward_only=False) -> bytes:
+    """Build a fwd_bwd request with the SDK's own proto encoder."""
+    request = sdk_types.ForwardBackwardRequest(
+        model_id="model_abc",
+        seq_id=1,
+        forward_backward_input=sdk_types.ForwardBackwardInput(
+            data=[
+                sdk_types.Datum(
+                    model_input=sdk_types.ModelInput.from_ints([1, 2, 3, 4]),
+                    loss_fn_inputs={
+                        "target_tokens": sdk_types.TensorData(data=[2, 3, 4, 5], dtype="int64", shape=[4]),
+                        "weights": sdk_types.TensorData(data=[1.0, 0.5, 1.0, 0.0], dtype="float32", shape=[4]),
+                    },
+                )
+            ],
+            loss_fn="cross_entropy",
+            loss_fn_config=loss_fn_config,
+        ),
+    )
+    proto_msg = forward_backward_request_to_proto(request)
+    proto_msg.forward_only = forward_only
+    return proto_msg.SerializeToString()
+
+
+def test_parse_forward_backward_request():
+    request_dict, forward_only = parse_forward_backward_request(encode_sdk_fwd_bwd_request())
+    assert not forward_only
+
+    # The dict must validate against the API's JSON request model.
+    request = api.ForwardBackwardRequest.model_validate(request_dict)
+    assert request.model_id == "model_abc"
+    assert request.seq_id == 1
+    assert request.forward_backward_input.loss_fn == "cross_entropy"
+    assert request.forward_backward_input.loss_fn_config is None
+    (datum,) = request.forward_backward_input.data
+    (chunk,) = datum.model_input.chunks
+    assert chunk.tokens == [1, 2, 3, 4]
+    assert datum.loss_fn_inputs["target_tokens"].data == [2, 3, 4, 5]
+    assert datum.loss_fn_inputs["weights"].data == [1.0, 0.5, 1.0, 0.0]
+
+
+def test_parse_forward_backward_request_forward_only_and_config():
+    body = encode_sdk_fwd_bwd_request(loss_fn_config={"clip_low_threshold": 0.2}, forward_only=True)
+    request_dict, forward_only = parse_forward_backward_request(body)
+    assert forward_only
+    assert request_dict["forward_backward_input"]["loss_fn_config"] == {"clip_low_threshold": 0.2}
+
+
+def test_parse_forward_backward_request_garbage_raises():
+    with pytest.raises(Exception):
+        parse_forward_backward_request(b"\xff\xfe not a proto")
+
+
+def _request_with_body(body: bytes, headers: dict[str, str]):
+    async def get_body():
+        return body
+
+    return SimpleNamespace(body=get_body, headers=headers)
+
+
+@pytest.mark.asyncio
+async def test_read_compressed_forward_backward_request():
+    body = zstd.ZstdCompressor().compress(encode_sdk_fwd_bwd_request())
+    request, forward_only = await api._read_forward_backward_request(
+        _request_with_body(
+            body,
+            {"content-type": "Application/X-Protobuf", "content-encoding": "ZSTD"},
+        )
+    )
+
+    assert not forward_only
+    assert request.model_id == "model_abc"
+    assert request.seq_id == 1
+
+
+@pytest.mark.asyncio
+async def test_read_rejects_invalid_compressed_forward_backward_request():
+    with pytest.raises(HTTPException) as excinfo:
+        await api._read_forward_backward_request(
+            _request_with_body(
+                b"not zstd",
+                {"content-type": "application/x-protobuf", "content-encoding": "zstd"},
+            )
+        )
+
+    assert excinfo.value.status_code == 422
+
+
+def test_decompression_is_bounded(monkeypatch):
+    monkeypatch.setattr(api, "MAX_FORWARD_BACKWARD_BODY_BYTES", 10)
+    body = zstd.ZstdCompressor().compress(b"a" * 11)
+
+    with pytest.raises(OverflowError):
+        api._decompress_forward_backward_body(body)

--- a/tests/tinker/test_proto_serialization.py
+++ b/tests/tinker/test_proto_serialization.py
@@ -14,6 +14,7 @@ import pytest
 import tinker.types as sdk_types
 import zstandard as zstd
 from fastapi import HTTPException
+from google.protobuf.message import DecodeError
 from tinker import ForwardBackwardOutput, SampleResponse
 from tinker.proto.request_conv import forward_backward_request_to_proto
 from tinker.proto.response_conv import deserialize_proto_response
@@ -204,7 +205,7 @@ def test_parse_forward_backward_request_forward_only_and_config():
 
 
 def test_parse_forward_backward_request_garbage_raises():
-    with pytest.raises(Exception):
+    with pytest.raises(DecodeError):
         parse_forward_backward_request(b"\xff\xfe not a proto")
 
 

--- a/tests/tinker/test_proto_serialization.py
+++ b/tests/tinker/test_proto_serialization.py
@@ -7,6 +7,7 @@ against the exact code the client runs.
 """
 
 import math
+import threading
 from types import SimpleNamespace
 
 import numpy as np
@@ -229,6 +230,25 @@ async def test_read_compressed_forward_backward_request():
     assert not forward_only
     assert request.model_id == "model_abc"
     assert request.seq_id == 1
+
+
+@pytest.mark.asyncio
+async def test_read_forward_backward_request_decodes_off_event_loop(monkeypatch):
+    event_loop_thread = threading.get_ident()
+    decoder_thread = None
+    decode = api._decode_forward_backward_request
+
+    def record_decoder_thread(*args):
+        nonlocal decoder_thread
+        decoder_thread = threading.get_ident()
+        return decode(*args)
+
+    monkeypatch.setattr(api, "_decode_forward_backward_request", record_decoder_thread)
+    await api._read_forward_backward_request(
+        _request_with_body(encode_sdk_fwd_bwd_request(), {"content-type": "application/x-protobuf"})
+    )
+
+    assert decoder_thread != event_loop_thread
 
 
 @pytest.mark.asyncio

--- a/tests/tinker/test_proto_serialization.py
+++ b/tests/tinker/test_proto_serialization.py
@@ -6,6 +6,7 @@ so the wire conventions (byte layouts, NaN/sentinel fills) are checked
 against the exact code the client runs.
 """
 
+import asyncio
 import math
 import threading
 from types import SimpleNamespace
@@ -211,10 +212,10 @@ def test_parse_forward_backward_request_garbage_raises():
 
 
 def _request_with_body(body: bytes, headers: dict[str, str]):
-    async def get_body():
-        return body
+    async def stream():
+        yield body
 
-    return SimpleNamespace(body=get_body, headers=headers)
+    return SimpleNamespace(stream=stream, headers=headers)
 
 
 @pytest.mark.asyncio
@@ -249,6 +250,20 @@ async def test_read_forward_backward_request_decodes_off_event_loop(monkeypatch)
     )
 
     assert decoder_thread != event_loop_thread
+
+
+@pytest.mark.asyncio
+async def test_read_forward_backward_request_yields_while_streaming():
+    side_task_ran = False
+
+    async def run_side_task():
+        nonlocal side_task_ran
+        side_task_ran = True
+
+    side_task = asyncio.create_task(run_side_task())
+    await api._read_streaming_body(_request_with_body(b"body", {}))
+    assert side_task_ran
+    await side_task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- execute GSPO through SkyRL’s native loss path, avoiding the custom-loss extra forward pass
- preserve packed output order and inactive-sequence semantics
- make large Tinker training updates ordered, compressed, and protobuf-backed
- keep sampling futures bounded and keep the API event loop responsive while decoding large training uploads

## Motivation

Tau 27B uses 512 long, variable-length trajectories per optimizer update. The legacy custom GSPO path performs an extra forward pass, while parallel JSON chunk uploads can reorder training requests and starve the single API event loop long enough to break heartbeats.

## Validation

- `uv run pytest -q tests/tinker/test_proto_serialization.py tests/tinker/test_api_validation.py` (39 passed)
- `uv run ruff check skyrl/tinker/api.py tests/tinker/test_proto_serialization.py`
- B300 end-to-end validation is in progress; this draft will be updated with the proof XID.