### PR TITLE
[bug] patch transformer engine logic to allow fa2 on sm103

### DIFF
--- a/skyrl/backends/skyrl_train/patches/te/README.md
+++ b/skyrl/backends/skyrl_train/patches/te/README.md
@@ -1,0 +1,83 @@
+# TE FlashAttention 2 head_dim patch
+
+Backport of [NVIDIA/TransformerEngine#3360](https://github.com/NVIDIA/TransformerEngine/pull/3360)
+for the `transformer-engine==2.16.0` pin.
+
+## The bug
+
+`utils.py:750` in TE 2.16.0 rejects FA2 for `head_dim_qk > 192` unless the
+compute capability is `(8,0), (9,0), (10,0), (12,0)`:
+
+```python
+or (
+    head_dim_qk > 192
+    and device_compute_capability not in ((8, 0), (9, 0), (10, 0), (12, 0))
+)
+```
+
+Upstream removed this allowlist in #2836, #2629 reintroduced it by accident, and
+#3360 removes it again, keeping only FA2's real limits (`<= 256`, `% 8 == 0`).
+Consequence on an excluded arch: a head_dim of 256 (Gemma 2/3) drops to unfused
+attention, which materializes the quadratic attention matrix — upstream reported
+a 202 GiB allocation and OOM at 65k tokens.
+
+## Minimal repro
+
+Needs a GPU whose compute capability is **not** sm80/90/100/120 — sm103
+(B300/GB300) is upstream's case; sm89 (L40S, L4) and sm86 (A10G, A40) hit the
+identical branch, since the gate keys on compute capability alone.
+
+```bash
+nvidia-smi --query-gpu=name,compute_cap --format=csv   # must not be 8.0/9.0/10.0/12.0
+uv run --isolated --extra megatron python \
+    skyrl/backends/skyrl_train/patches/te/verify_fa2_head_dim.py
+```
+
+Phase A (backend selection) should show:
+
+```
+ head_dim    FA2 before     FA2 after
+      128         2.8.3         2.8.3
+      192         2.8.3         2.8.3
+      200          None         2.8.3   <- fixed
+      256          None         2.8.3   <- fixed
+      264          None          None   <- still rejected, correctly
+```
+
+Phase B forces FA2 and diffs fwd+bwd against TE's unfused reference. This is the
+part that proves the allowlist was stale rather than protecting a broken kernel.
+Reference from a validated H100 run (`--force`, bf16, 4k causal): `max |out
+diff| = 0.01562`, `max |dq diff| = 0.01562`, PASS. A crash or CUDA error instead
+means #3360 itself is unsafe on that arch — report it upstream, don't ship.
+
+On an allowlisted GPU the gate is dead code, so phase A shows no change; that
+run only confirms the no-op guard.
+
+## Why a Python patch
+
+TE ships as a prebuilt wheel, and `uv run --isolated` builds a fresh venv per
+invocation, so a site-packages edit does not survive a run (nor reach other Ray
+nodes). The gate is an inline clause in a ~1000-line function, but
+`get_attention_backend` is undecorated and its only caller resolves it as a
+module attribute (`dpa_utils.get_attention_backend`) — so recompiling that one
+function into TE's own `__dict__` is enough, with no reference chasing. The patch
+also invalidates `_attention_backends`, which memoizes backend selection.
+
+Guarded to no-op on sm80/90/100/120, idempotent, and matches the literal 2.16.0
+source so it self-disables on a newer TE instead of misfiring.
+
+## Wired in at
+
+`MegatronWorker.make_megatron_module()`, before `provide_distributed_model()` —
+the choke point both the policy and ref workers pass through, and the last hook
+before any TE attention layer exists. Megatron only; FSDP uses HF transformers.
+Inert on H100.
+
+## Delete this when
+
+The `transformer-engine` pin moves to a release containing #3360. It is a
+temporary backport, and a stale copy goes quiet rather than loud — nothing will
+remind you, so check this directory when bumping TE.
+
+#3360 was approved but not yet merged as of 2026-08-13; re-check its final form
+against this backport.

--- a/skyrl/backends/skyrl_train/patches/te/patch_fa2_head_dim.py
+++ b/skyrl/backends/skyrl_train/patches/te/patch_fa2_head_dim.py
@@ -1,0 +1,119 @@
+"""Backport of NVIDIA/TransformerEngine#3360 for transformer-engine 2.16.0.
+
+TE 2.16.0 gates FlashAttention 2 for ``head_dim > 192`` behind a compute
+capability allowlist of ``(8, 0), (9, 0), (10, 0), (12, 0)``. Upstream removed
+that allowlist in #2836, #2629 accidentally reintroduced it, and #3360 removes
+it again -- keeping only the real FA2 constraints (``head_dim <= 256`` and
+``head_dim % 8 == 0``).
+
+On an architecture outside the allowlist -- notably sm103 (B300/GB300) -- a
+head_dim of 256 (Gemma 2/3, for example) makes TE reject FA2. If cuDNN fused
+attention is also unavailable for the config, TE drops to unfused attention,
+which materializes the quadratic attention matrix; upstream reported a 202 GiB
+allocation and an OOM at 65k tokens.
+
+This is applied as a source-level rebind rather than an edit to the installed
+wheel: TE ships as a prebuilt wheel from Astral's CUDA index, and
+``uv run --isolated`` builds a throwaway environment per invocation, so a
+site-packages edit would not survive a run (nor reach other Ray nodes).
+``get_attention_backend`` is a single ~1000 line function and the gate is an
+inline boolean clause, so there is no sub-function seam to override -- we
+recompile that one function with the clause removed and rebind it on its
+module. Its only caller resolves it as a module attribute
+(``dpa_utils.get_attention_backend``), so the rebind is picked up.
+"""
+
+import inspect
+
+from loguru import logger
+
+# The allowlist clause as it appears in TE 2.16.0. Newer TE expresses the same
+# check against `fa2_padded_head_dim`; this patch deliberately does not match
+# that form, so it no-ops instead of misfiring after a TE upgrade.
+_SM_ALLOWLIST_CLAUSE = """        and (
+            head_dim_qk > 256
+            or head_dim_qk % 8 != 0
+            or (
+                head_dim_qk > 192
+                and device_compute_capability not in ((8, 0), (9, 0), (10, 0), (12, 0))
+            )
+        )
+"""
+
+_REPLACEMENT_CLAUSE = """        and (head_dim_qk > 256 or head_dim_qk % 8 != 0)
+"""
+
+# Architectures TE 2.16.0 already allows; on these the gate is dead code.
+_UNAFFECTED_COMPUTE_CAPABILITIES = ((8, 0), (9, 0), (10, 0), (12, 0))
+
+_PATCHED_FLAG = "_skyrl_fa2_head_dim_patched"
+
+
+def patch_fa2_head_dim_allowlist(force: bool = False) -> bool:
+    """Remove TE's compute-capability gate on FlashAttention 2 for head_dim > 192.
+
+    No-ops (returning False) when the current GPU is one TE already allows, when
+    TE is not importable, or when TE's source does not match the 2.16.0 form.
+    Pass ``force=True`` to patch regardless of the detected compute capability.
+
+    Safe to call more than once; the second call is a no-op returning True.
+    """
+    try:
+        from transformer_engine.pytorch.attention.dot_product_attention import (
+            dot_product_attention as dpa,
+        )
+        from transformer_engine.pytorch.attention.dot_product_attention import (
+            utils as dpa_utils,
+        )
+    except ImportError:
+        logger.debug("transformer_engine not importable; skipping FA2 head_dim patch")
+        return False
+
+    target = getattr(dpa_utils, "get_attention_backend", None)
+    if target is None:
+        logger.warning("TE has no get_attention_backend; skipping FA2 head_dim patch")
+        return False
+
+    if getattr(target, _PATCHED_FLAG, False):
+        return True
+
+    if not force:
+        compute_capability = dpa_utils.get_device_compute_capability()
+        if compute_capability in _UNAFFECTED_COMPUTE_CAPABILITIES:
+            logger.debug(
+                "sm{} is already allowed by TE; skipping FA2 head_dim patch",
+                ".".join(str(i) for i in compute_capability),
+            )
+            return False
+
+    try:
+        source = inspect.getsource(target)
+    except (OSError, TypeError):
+        logger.warning("Cannot read TE get_attention_backend source; skipping FA2 head_dim patch")
+        return False
+
+    if _SM_ALLOWLIST_CLAUSE not in source:
+        logger.info(
+            "TE get_attention_backend does not contain the sm allowlist for head_dim > 192 "
+            "(likely fixed or refactored upstream); skipping FA2 head_dim patch"
+        )
+        return False
+
+    patched_source = source.replace(_SM_ALLOWLIST_CLAUSE, _REPLACEMENT_CLAUSE)
+    # Execute in TE's own module namespace so the recompiled function keeps the
+    # live module globals it depends on, and so the rebind lands on the module.
+    exec(compile(patched_source, dpa_utils.__file__, "exec"), dpa_utils.__dict__)  # noqa: S102
+
+    patched = dpa_utils.get_attention_backend
+    if patched is target:
+        logger.warning("Failed to rebind TE get_attention_backend; FA2 head_dim patch not applied")
+        return False
+    setattr(patched, _PATCHED_FLAG, True)
+
+    # Backend selection is memoized per attention config; drop any entry chosen
+    # by the unpatched function.
+    dpa._attention_backends["attention_params"] = None
+    dpa._attention_backends["backend_selection_requires_update"] = True
+
+    logger.info("Applied TE FA2 head_dim patch (NVIDIA/TransformerEngine#3360 backport)")
+    return True

--- a/skyrl/backends/skyrl_train/patches/te/patch_fa2_head_dim.py
+++ b/skyrl/backends/skyrl_train/patches/te/patch_fa2_head_dim.py
@@ -114,7 +114,8 @@ def patch_fa2_head_dim_allowlist(force: bool = False) -> bool:
     patched_source = source.replace(_SM_ALLOWLIST_CLAUSE, _REPLACEMENT_CLAUSE)
     # Execute in TE's own module namespace so the recompiled function keeps the
     # live module globals it depends on, and so the rebind lands on the module.
-    exec(compile(patched_source, dpa_utils.__file__, "exec"), dpa_utils.__dict__)  # noqa: S102
+    fn = getattr(dpa_utils, "__file__", None) or "<string>"
+    exec(compile(patched_source, fn, "exec"), dpa_utils.__dict__)  # noqa: S102
 
     patched = dpa_utils.get_attention_backend
     if patched is target:
@@ -124,8 +125,10 @@ def patch_fa2_head_dim_allowlist(force: bool = False) -> bool:
 
     # Backend selection is memoized per attention config; drop any entry chosen
     # by the unpatched function.
-    dpa._attention_backends["attention_params"] = None
-    dpa._attention_backends["backend_selection_requires_update"] = True
+    backends = getattr(dpa, "_attention_backends", None)
+    if isinstance(backends, dict):
+        backends["attention_params"] = None
+        backends["backend_selection_requires_update"] = True
 
     logger.info("Applied TE FA2 head_dim patch (NVIDIA/TransformerEngine#3360 backport)")
     return True

--- a/skyrl/backends/skyrl_train/patches/te/patch_fa2_head_dim.py
+++ b/skyrl/backends/skyrl_train/patches/te/patch_fa2_head_dim.py
@@ -21,6 +21,15 @@ inline boolean clause, so there is no sub-function seam to override -- we
 recompile that one function with the clause removed and rebind it on its
 module. Its only caller resolves it as a module attribute
 (``dpa_utils.get_attention_backend``), so the rebind is picked up.
+
+DELETE THIS PATCH once the transformer-engine pin moves to a release that
+contains #3360. This is a temporary backport of an upstream fix, not a SkyRL
+behavior change, and it has no reason to outlive the pin it works around.
+It fails safe in the meantime: the match below is against the literal 2.16.0
+source text, and TE expresses the same check against ``fa2_padded_head_dim``
+after the padding refactor, so on a newer TE this logs and no-ops rather than
+misfiring. That means a stale copy is quiet rather than harmful -- which also
+means nothing will alert you to remove it. Check this file when bumping TE.
 """
 
 import inspect
@@ -93,9 +102,12 @@ def patch_fa2_head_dim_allowlist(force: bool = False) -> bool:
         return False
 
     if _SM_ALLOWLIST_CLAUSE not in source:
+        # Most likely the TE pin moved past 2.16.0 and picked up #3360, in which
+        # case this whole module should be deleted rather than left to no-op.
         logger.info(
             "TE get_attention_backend does not contain the sm allowlist for head_dim > 192 "
-            "(likely fixed or refactored upstream); skipping FA2 head_dim patch"
+            "(likely fixed or refactored upstream); skipping FA2 head_dim patch. "
+            "If TE now includes NVIDIA/TransformerEngine#3360, delete this patch module."
         )
         return False
 

--- a/skyrl/backends/skyrl_train/patches/te/patch_fa2_head_dim.py
+++ b/skyrl/backends/skyrl_train/patches/te/patch_fa2_head_dim.py
@@ -87,13 +87,20 @@ def patch_fa2_head_dim_allowlist(force: bool = False) -> bool:
         return True
 
     if not force:
-        compute_capability = dpa_utils.get_device_compute_capability()
-        if compute_capability in _UNAFFECTED_COMPUTE_CAPABILITIES:
-            logger.debug(
-                "sm{} is already allowed by TE; skipping FA2 head_dim patch",
-                ".".join(str(i) for i in compute_capability),
-            )
-            return False
+        # Looked up defensively: this guard only narrows the blast radius, so if TE
+        # ever renames it we fall through to the source match below, which is the
+        # real version gate.
+        get_compute_capability = getattr(dpa_utils, "get_device_compute_capability", None)
+        if get_compute_capability is None:
+            logger.debug("TE has no get_device_compute_capability; skipping the sm guard")
+        else:
+            compute_capability = get_compute_capability()
+            if compute_capability in _UNAFFECTED_COMPUTE_CAPABILITIES:
+                logger.debug(
+                    "sm{} is already allowed by TE; skipping FA2 head_dim patch",
+                    ".".join(str(i) for i in compute_capability),
+                )
+                return False
 
     try:
         source = inspect.getsource(target)

--- a/skyrl/backends/skyrl_train/patches/te/verify_fa2_head_dim.py
+++ b/skyrl/backends/skyrl_train/patches/te/verify_fa2_head_dim.py
@@ -1,0 +1,132 @@
+"""Verification harness for the TE FA2 head_dim patch (NVIDIA/TransformerEngine#3360).
+
+Run this on a GPU whose compute capability is OUTSIDE TE 2.16.0's allowlist of
+sm80 / sm90 / sm100 / sm120 -- e.g. sm103 (B300/GB300), or sm86/sm89
+(A10, A40, L4, L40S, RTX 4090). On an allowlisted GPU the gate is dead code and
+the patch is a deliberate no-op, so phase A shows no change; pass --force to
+exercise the mechanics anyway.
+
+    uv run --isolated --extra megatron python \
+        skyrl/backends/skyrl_train/patches/te/verify_fa2_head_dim.py
+
+Phase A checks backend *selection* (pure logic, no kernels).
+Phase B actually runs FlashAttention 2 forward+backward at head_dim=256 and
+compares against TE's unfused reference -- this is the part that proves the
+allowlist was over-restrictive rather than protecting against a broken kernel.
+"""
+
+import argparse
+import importlib.metadata
+import os
+
+import torch
+import transformer_engine.pytorch as te
+from transformer_engine.pytorch.attention.dot_product_attention import (
+    dot_product_attention as dpa,
+)
+from transformer_engine.pytorch.attention.dot_product_attention import (
+    utils as dpa_utils,
+)
+
+from skyrl.backends.skyrl_train.patches.te.patch_fa2_head_dim import (
+    patch_fa2_head_dim_allowlist,
+)
+
+ALLOWLISTED = ((8, 0), (9, 0), (10, 0), (12, 0))
+HEAD_DIMS = (128, 192, 200, 256, 264)
+
+
+def fa2_backend(head_dim):
+    """Return the FA backend version TE would allow, or None if it rejects FA2."""
+    params = dpa_utils.AttentionParams(
+        head_dim_qk=head_dim,
+        head_dim_v=head_dim,
+        max_seqlen_q=4096,
+        max_seqlen_kv=4096,
+        core_attention_bias_shape=None,  # the '1hss' default disables FA on its own
+    )
+    return dpa_utils.get_attention_backend(params)[1]
+
+
+def run_attention(head_dim, force_backend, seqlen=4096, batch=1, heads=8):
+    """Run one fwd+bwd through TE with a specific backend forced. Returns (out, dq)."""
+    os.environ["NVTE_FLASH_ATTN"] = "1" if force_backend == "flash" else "0"
+    os.environ["NVTE_FUSED_ATTN"] = "1" if force_backend == "fused" else "0"
+    os.environ["NVTE_UNFUSED_ATTN"] = "1" if force_backend == "unfused" else "0"
+    # Invalidate TE's memoized backend choice so the env change takes effect.
+    dpa._attention_backends["attention_params"] = None
+    dpa._attention_backends["backend_selection_requires_update"] = True
+
+    torch.manual_seed(0)
+    shape = (batch, seqlen, heads, head_dim)
+    q, k, v = (torch.randn(shape, device="cuda", dtype=torch.bfloat16, requires_grad=True) for _ in range(3))
+    layer = te.DotProductAttention(
+        num_attention_heads=heads,
+        kv_channels=head_dim,
+        attention_dropout=0.0,
+        qkv_format="bshd",
+        attn_mask_type="causal",
+    )
+    out = layer(q, k, v)
+    out.sum().backward()
+    selected = {
+        "flash": dpa._attention_backends["use_flash_attention"],
+        "fused": dpa._attention_backends["use_fused_attention"],
+        "unfused": dpa._attention_backends["use_unfused_attention"],
+    }
+    return out.detach().float(), q.grad.detach().float(), selected
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--force", action="store_true", help="patch even on an allowlisted GPU")
+    parser.add_argument("--skip-numerics", action="store_true", help="phase A only")
+    args = parser.parse_args()
+
+    cc = dpa_utils.get_device_compute_capability()
+    name = torch.cuda.get_device_name(0)
+    affected = cc not in ALLOWLISTED
+    print(f"GPU: {name}  compute capability: sm{'.'.join(map(str, cc))}")
+    te_version = importlib.metadata.version("transformer_engine")
+    print(f"TE: {te_version}   affected by the allowlist: {affected}")
+    if not affected and not args.force:
+        print("\nThis GPU is already allowlisted by TE 2.16.0 -- the patch is a no-op here.")
+        print("Re-run with --force to exercise the mechanics, or use an sm103/sm86/sm89 box.")
+
+    print("\n--- phase A: backend selection ---")
+    before = {hd: fa2_backend(hd) for hd in HEAD_DIMS}
+    applied = patch_fa2_head_dim_allowlist(force=args.force)
+    after = {hd: fa2_backend(hd) for hd in HEAD_DIMS}
+    print(f"patch applied: {applied}")
+    print(f"{'head_dim':>9}  {'FA2 before':>12}  {'FA2 after':>12}")
+    for hd in HEAD_DIMS:
+        print(f"{hd:>9}  {str(before[hd]):>12}  {str(after[hd]):>12}")
+    print("\nExpected on an affected GPU: 128/192 unchanged, 200 and 256 go None -> 2.8.3,")
+    print("264 stays None (still above FA2's real limit).")
+
+    if args.skip_numerics:
+        return
+    if after[256] is None:
+        print("\nFA2 still rejected at head_dim=256; skipping numerics.")
+        return
+
+    print("\n--- phase B: FA2 fwd+bwd numerics at head_dim=256 ---")
+    flash_out, flash_dq, flash_sel = run_attention(256, "flash")
+    print(f"forced flash -> selection {flash_sel}")
+    if not flash_sel["flash"]:
+        print("FA2 was not actually selected; numerics comparison is meaningless. Investigate.")
+        return
+    ref_out, ref_dq, ref_sel = run_attention(256, "unfused")
+    print(f"forced unfused -> selection {ref_sel}")
+
+    out_err = (flash_out - ref_out).abs().max().item()
+    dq_err = (flash_dq - ref_dq).abs().max().item()
+    print(f"max |out  diff| vs unfused: {out_err:.5f}")
+    print(f"max |dq   diff| vs unfused: {dq_err:.5f}")
+    # bf16 attention at 4k context: differences here are accumulation-order noise.
+    tol = 0.05
+    print(f"PASS: {out_err < tol and dq_err < tol}  (tolerance {tol}, bf16)")
+
+
+if __name__ == "__main__":
+    main()

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -39,6 +39,9 @@ from skyrl.backends.skyrl_train.distributed.megatron.optimizer import (
 from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
     SKYRL_LORA_ADAPTER_NAME,
 )
+from skyrl.backends.skyrl_train.patches.te.patch_fa2_head_dim import (
+    patch_fa2_head_dim_allowlist,
+)
 from skyrl.backends.skyrl_train.training_batch import (
     TrainingInputBatch,
     TrainingOutputBatch,
@@ -594,6 +597,10 @@ class MegatronWorker:
         from megatron.core.distributed.distributed_data_parallel_config import (
             DistributedDataParallelConfig,
         )
+
+        # TE patch to allow FA2 for head_dim 256 on SM103 (B300)
+        # Delete along with the patch module once the TE pin includes NVIDIA/TransformerEngine#3360.
+        patch_fa2_head_dim_allowlist()
 
         if lora_config is not None:
             self.configure_lora(lora_config, lora_type)


### PR DESCRIPTION
applying https://github.com/NVIDIA/TransformerEngine/pull/3360 to TE 2.16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes attention backend selection at Megatron init via `exec` on TE internals; mitigated by SM guards, literal 2.16.0 source matching, and idempotent no-ops on unaffected GPUs, but wrong TE versions or arch-specific FA2 issues could still affect training memory or numerics.
> 
> **Overview**
> Backports **NVIDIA/TransformerEngine#3360** for the pinned **transformer-engine 2.16.0** so Megatron training can select **FlashAttention 2** for **head_dim 256** (e.g. Gemma 2/3) on GPUs outside TE’s SM allowlist (notably **sm103** B300/GB300, also sm86/sm89).
> 
> A runtime patch **recompiles and rebinds** TE’s `get_attention_backend` to drop the erroneous `head_dim > 192` + compute-capability gate, keeping only FA2’s real limits (`<= 256`, `% 8 == 0`). It **no-ops** on sm80/90/100/120, when TE isn’t importable, or when TE source no longer matches 2.16.0, and clears TE’s memoized `_attention_backends` after apply.
> 
> **Megatron only:** `patch_fa2_head_dim_allowlist()` runs in `make_megatron_module()` before `provide_distributed_model()` (policy and ref workers). A **verify script** and README document repro and numerics vs unfused attention.
> 
> Remove this patch when the TE pin includes upstream #3360.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d9d8c97e5e63056010ac4172decc64f96e53064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->