### PR TITLE
Fix hybrid FP8 KV-cache wake on vLLM 0.26

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -30,6 +30,11 @@ from skyrl.backends.skyrl_train.inference_servers.layerwise_reload import (
     LayerwiseReloadWorkerMixin,
     _empty_cuda_cache_rocm,
 )
+from skyrl.backends.skyrl_train.patches.vllm.patch_hybrid_fp8_kv_wake import (
+    patch_hybrid_fp8_kv_wake,
+)
+
+patch_hybrid_fp8_kv_wake()
 
 try:
     from skyrl.backends.skyrl_train.weight_sync.delta_engine import (

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
@@ -9,7 +9,6 @@ The upstream fix handles both entry shapes. Remove this backport when the vLLM
 pin includes https://github.com/vllm-project/vllm/pull/41602.
 """
 
-import importlib.util
 import inspect
 import textwrap
 

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
@@ -39,9 +39,6 @@ _PATCHED_FLAG = "_skyrl_hybrid_fp8_kv_wake_patched"
 
 def patch_hybrid_fp8_kv_wake() -> bool:
     """Teach the pinned vLLM wake path to zero hybrid KV-cache entries."""
-    if importlib.util.find_spec("vllm") is None:
-def patch_hybrid_fp8_kv_wake() -> bool:
-    """Teach the pinned vLLM wake path to zero hybrid KV-cache entries."""
     try:
         from vllm.v1.worker import gpu_model_runner
     except ModuleNotFoundError:

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
@@ -40,9 +40,12 @@ _PATCHED_FLAG = "_skyrl_hybrid_fp8_kv_wake_patched"
 def patch_hybrid_fp8_kv_wake() -> bool:
     """Teach the pinned vLLM wake path to zero hybrid KV-cache entries."""
     if importlib.util.find_spec("vllm") is None:
+def patch_hybrid_fp8_kv_wake() -> bool:
+    """Teach the pinned vLLM wake path to zero hybrid KV-cache entries."""
+    try:
+        from vllm.v1.worker import gpu_model_runner
+    except ModuleNotFoundError:
         return False
-
-    from vllm.v1.worker import gpu_model_runner
 
     runner_cls = gpu_model_runner.GPUModelRunner
     target = runner_cls.init_fp8_kv_scales

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
@@ -1,0 +1,73 @@
+"""Backport vllm-project/vllm#41602 for vLLM 0.26.0.
+
+vLLM 0.26.0 assumes each quantized KV-cache entry is one tensor when it
+reinitializes the cache after sleep. Hybrid models such as Qwen3.6 and Qwen3.8
+also store recurrent state as lists of tensors, so ``wake_up(tags=["kv_cache"])``
+fails with ``AttributeError: 'list' object has no attribute 'zero_'``.
+
+The upstream fix handles both entry shapes. Remove this backport when the vLLM
+pin includes https://github.com/vllm-project/vllm/pull/41602.
+"""
+
+import inspect
+import textwrap
+
+from loguru import logger
+
+_OLD_LOOP = """    kv_caches = getattr(self, \"kv_caches\", [])
+    for cache_tensor in kv_caches:
+        if cache_tensor is not None:
+            cache_tensor.zero_()
+"""
+
+_UPSTREAM_LOOP = """    kv_caches = getattr(self, \"kv_caches\", [])
+    for cache_entry in kv_caches:
+        if cache_entry is None:
+            continue
+        # Hybrid models (Mamba, DeltaNet) store per-layer state as a
+        # list of tensors rather than a single tensor.
+        if isinstance(cache_entry, list):
+            for tensor in cache_entry:
+                tensor.zero_()
+        else:
+            cache_entry.zero_()
+"""
+
+_PATCHED_FLAG = "_skyrl_hybrid_fp8_kv_wake_patched"
+
+
+def patch_hybrid_fp8_kv_wake() -> bool:
+    """Teach the pinned vLLM wake path to zero hybrid KV-cache entries."""
+    from vllm.v1.worker import gpu_model_runner
+
+    runner_cls = gpu_model_runner.GPUModelRunner
+    target = runner_cls.init_fp8_kv_scales
+    if getattr(target, _PATCHED_FLAG, False):
+        return True
+
+    try:
+        source = textwrap.dedent(inspect.getsource(target))
+    except (OSError, TypeError):
+        logger.warning(
+            "Cannot read vLLM init_fp8_kv_scales source; skipping hybrid KV wake patch"
+        )
+        return False
+
+    if _OLD_LOOP not in source:
+        logger.info(
+            "vLLM init_fp8_kv_scales no longer matches 0.26.0; skipping hybrid KV wake patch. "
+            "If the vLLM pin includes vllm-project/vllm#41602, delete this patch module."
+        )
+        return False
+
+    patched_source = source.replace(_OLD_LOOP, _UPSTREAM_LOOP)
+    namespace = gpu_model_runner.__dict__
+    exec(compile(patched_source, gpu_model_runner.__file__, "exec"), namespace)  # noqa: S102
+    patched = namespace["init_fp8_kv_scales"]
+    setattr(patched, _PATCHED_FLAG, True)
+    runner_cls.init_fp8_kv_scales = patched
+
+    logger.info(
+        "Applied hybrid FP8 KV-cache wake patch (vllm-project/vllm#41602 backport)"
+    )
+    return True

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
@@ -9,6 +9,7 @@ The upstream fix handles both entry shapes. Remove this backport when the vLLM
 pin includes https://github.com/vllm-project/vllm/pull/41602.
 """
 
+import importlib.util
 import inspect
 import textwrap
 
@@ -38,6 +39,9 @@ _PATCHED_FLAG = "_skyrl_hybrid_fp8_kv_wake_patched"
 
 def patch_hybrid_fp8_kv_wake() -> bool:
     """Teach the pinned vLLM wake path to zero hybrid KV-cache entries."""
+    if importlib.util.find_spec("vllm") is None:
+        return False
+
     from vllm.v1.worker import gpu_model_runner
 
     runner_cls = gpu_model_runner.GPUModelRunner

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
@@ -48,9 +48,7 @@ def patch_hybrid_fp8_kv_wake() -> bool:
     try:
         source = textwrap.dedent(inspect.getsource(target))
     except (OSError, TypeError):
-        logger.warning(
-            "Cannot read vLLM init_fp8_kv_scales source; skipping hybrid KV wake patch"
-        )
+        logger.warning("Cannot read vLLM init_fp8_kv_scales source; skipping hybrid KV wake patch")
         return False
 
     if _OLD_LOOP not in source:
@@ -67,7 +65,5 @@ def patch_hybrid_fp8_kv_wake() -> bool:
     setattr(patched, _PATCHED_FLAG, True)
     runner_cls.init_fp8_kv_scales = patched
 
-    logger.info(
-        "Applied hybrid FP8 KV-cache wake patch (vllm-project/vllm#41602 backport)"
-    )
+    logger.info("Applied hybrid FP8 KV-cache wake patch (vllm-project/vllm#41602 backport)")
     return True


### PR DESCRIPTION
## Summary

- Backport vllm-project/vllm#41602 for the pinned vLLM 0.26.0 release.
- Handle hybrid-model KV-cache entries that contain a list of tensors.
- Apply the patch only when the vLLM method matches the affected source. A future vLLM update can remove this patch.

## Before and after

| Check | Before | After |
| --- | --- | --- |
| Qwen3.6-27B B300 lifecycle | KV-cache wake failed with `AttributeError: list object has no attribute zero_` | Four engines woke the KV cache in 1.21-1.25 s. The full create, sample, and unload check passed. |
| Qwen3.8-27B B300 lifecycle | Same KV-cache wake failure | Four engines woke the KV cache in 1.12-1.15 s. The full create, sample, and unload check passed. |

## Testing

`uv run ruff check skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py`

`git diff --check upstream/main...HEAD`

Both checks passed. The patched image also passed the two B300 lifecycle checks above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runtime `exec` patching of vLLM's `init_fp8_kv_scales` affects inference worker lifecycle and KV-cache reinit; scope is narrow and gated on source matching, but wrong patch application could break wake/sleep for FP8 hybrid models.
> 
> **Overview**
> Adds a **vLLM 0.26.0 backport** of upstream **vllm#41602** so `wake_up(tags=["kv_cache"])` can zero FP8 KV-cache state for **hybrid models** (e.g. Qwen3.6/3.8) whose cache entries are **lists of tensors**, not single tensors—avoiding `AttributeError: 'list' object has no attribute 'zero_'`.
> 
> The patch replaces the loop in `GPUModelRunner.init_fp8_kv_scales` only when the pinned vLLM source still matches the old 0.26.0 shape; otherwise it skips and logs. **`patch_hybrid_fp8_kv_wake()`** runs at import in **`new_inference_worker_wrap`** so inference workers get the fix before serving.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304ef5527d4458ae54063b84ad2c9033b5596fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->