### PR TITLE
Add Fireworks reserved capacity configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ tinker = [
 
 fireworks = [
     "skyrl[skyrl-train]",
-    "fireworks-ai[training]>=1.2.0a87,<2; python_version < '3.14'",
+    "fireworks-ai[training]>=1.2.7,<2; python_version < '3.14'",
     "tinker>=0.3.0",
 ]
 

--- a/skyrl/backends/fireworks/runtime.py
+++ b/skyrl/backends/fireworks/runtime.py
@@ -91,25 +91,18 @@ class FireworksRuntime:
         if not api_key:
             raise RuntimeError("FIREWORKS_API_KEY is required for Fireworks training")
         if not config.base_model or not config.training_shape_id:
-            raise ValueError(
-                "Dedicated Fireworks training requires base_model and training_shape_id"
-            )
+            raise ValueError("Dedicated Fireworks training requires base_model and training_shape_id")
         if not config.trainer_job_id or not config.deployment_id:
-            raise ValueError(
-                "Dedicated Fireworks training requires stable trainer_job_id and deployment_id"
-            )
+            raise ValueError("Dedicated Fireworks training requires stable trainer_job_id and deployment_id")
 
         try:
             from fireworks.training.sdk import FiretitanServiceClient
         except ImportError as exc:
             raise ImportError(
-                "The Fireworks backend requires fireworks-ai[training]; "
-                "install SkyRL with --extra fireworks"
+                "The Fireworks backend requires fireworks-ai[training]; " "install SkyRL with --extra fireworks"
             ) from exc
 
-        cleanup_deployment = (
-            config.cleanup_deployment_on_close if config.cleanup_on_exit else None
-        )
+        cleanup_deployment = config.cleanup_deployment_on_close if config.cleanup_on_exit else None
         service = FiretitanServiceClient.from_firetitan_config(
             api_key=api_key,
             base_url=config.base_url,
@@ -120,6 +113,7 @@ class FireworksRuntime:
             trainer_job_id=config.trainer_job_id,
             deployment_id=config.deployment_id,
             create_deployment=True,
+            use_reservation=config.use_reservation,
             max_context_length=config.max_seq_len,
             learning_rate=learning_rate,
             trainer_replica_count=config.trainer_replica_count,
@@ -190,10 +184,7 @@ class FireworksRuntime:
 
     def _snapshot_name(self, version: int) -> str:
         # Dedicated checkpoint names are lowercase DNS labels.
-        prefix = (
-            re.sub(r"[^a-z0-9-]+", "-", self.config.snapshot_prefix.lower()).strip("-")
-            or "skyrl"
-        )
+        prefix = re.sub(r"[^a-z0-9-]+", "-", self.config.snapshot_prefix.lower()).strip("-") or "skyrl"
         suffix = f"-v{version:08d}-{uuid.uuid4().hex[:8]}"
         # Fireworks appends another ``-<8 hex>`` suffix. Keep our input at 54
         # characters so the provider-side name remains at most 63 characters.
@@ -216,15 +207,11 @@ class FireworksRuntime:
                 result = future.result(timeout=self.config.request_timeout_s)
                 path = getattr(result, "path", None)
                 if not path:
-                    raise RuntimeError(
-                        f"Fireworks save_weights_for_sampler({name!r}) returned no path"
-                    )
+                    raise RuntimeError(f"Fireworks save_weights_for_sampler({name!r}) returned no path")
                 return str(path)
 
             snapshot_path = await asyncio.to_thread(_save)
-            await asyncio.to_thread(
-                self.service.hotload_sampler_snapshot, snapshot_path
-            )
+            await asyncio.to_thread(self.service.hotload_sampler_snapshot, snapshot_path)
 
             # The client is created once, after the first snapshot is ready.
             with self._state_lock:
@@ -251,9 +238,7 @@ class FireworksRuntime:
             if self._closed:
                 raise RuntimeError("Fireworks runtime is closed")
             if self._sampler is None or self._sampler_identity is None:
-                raise RuntimeError(
-                    "Fireworks sampler weights have not been published yet"
-                )
+                raise RuntimeError("Fireworks sampler weights have not been published yet")
             sampler = self._sampler
             identity = self._sampler_identity
             self._active_samples += 1
@@ -279,9 +264,7 @@ class FireworksRuntime:
         with self._use_sampler() as (sampler, identity):
             native_sample = getattr(sampler, "sample_async", None)
             if native_sample is None:
-                raise RuntimeError(
-                    "The dedicated Fireworks sampler must expose sample_async()"
-                )
+                raise RuntimeError("The dedicated Fireworks sampler must expose sample_async()")
             result = await asyncio.wait_for(
                 native_sample(
                     prompt=prompt,

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -928,6 +928,7 @@ class FireworksConfig(BaseConfig):
     """Training shape resource name."""
     trainer_job_id: Optional[str] = None
     """Stable trainer ID, used for audit and failure cleanup."""
+    use_reservation: bool = False
     trainer_replica_count: int = 1
     """Number of data-parallel HSDP trainer replicas for dedicated training.
 

--- a/tests/backends/fireworks/test_config.py
+++ b/tests/backends/fireworks/test_config.py
@@ -37,7 +37,9 @@ def _valid_fireworks_cfg() -> SkyRLTrainConfig:
 
 
 def test_validate_fireworks_grpo_config() -> None:
-    validate_cfg(_valid_fireworks_cfg())
+    cfg = _valid_fireworks_cfg()
+    assert cfg.trainer.fireworks.use_reservation is False
+    validate_cfg(cfg)
 
 
 def test_validate_fireworks_fully_async_grpo_config() -> None:
@@ -60,9 +62,7 @@ def test_validate_dedicated_fireworks_grpo_config() -> None:
 
 def test_validate_dedicated_full_parameter_fireworks_grpo_config() -> None:
     cfg = _valid_fireworks_cfg()
-    cfg.trainer.fireworks.training_shape_id = (
-        "accounts/fireworks/trainingShapes/qwen3-4b-minimum"
-    )
+    cfg.trainer.fireworks.training_shape_id = "accounts/fireworks/trainingShapes/qwen3-4b-minimum"
     cfg.trainer.fireworks.replica_count = 4
     cfg.trainer.policy.model.lora.rank = 0
 
@@ -131,9 +131,7 @@ def test_validate_dedicated_requires_auditable_resource_ids() -> None:
         ),
     ],
 )
-def test_validate_fireworks_rejects_out_of_scope_algorithms(
-    mutate, message: str
-) -> None:
+def test_validate_fireworks_rejects_out_of_scope_algorithms(mutate, message: str) -> None:
     cfg = _valid_fireworks_cfg()
     mutate(cfg)
 

--- a/tests/backends/fireworks/test_runtime.py
+++ b/tests/backends/fireworks/test_runtime.py
@@ -92,9 +92,7 @@ def test_connect_uses_managed_dedicated_resources(monkeypatch) -> None:
         return service
 
     monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
-    monkeypatch.setattr(
-        FiretitanServiceClient, "from_firetitan_config", staticmethod(_factory)
-    )
+    monkeypatch.setattr(FiretitanServiceClient, "from_firetitan_config", staticmethod(_factory))
     config = FireworksConfig(
         base_model="accounts/fireworks/models/qwen3-4b",
         max_seq_len=32768,
@@ -103,6 +101,7 @@ def test_connect_uses_managed_dedicated_resources(monkeypatch) -> None:
         deployment_id="skyrl-smoke-test-rollout",
         cleanup_deployment_on_close="delete",
         trainer_replica_count=2,
+        use_reservation=True,
     )
 
     runtime = FireworksRuntime.connect(
@@ -118,6 +117,7 @@ def test_connect_uses_managed_dedicated_resources(monkeypatch) -> None:
     assert captured["service"]["cleanup_deployment_on_close"] == "delete"
     assert captured["service"]["trainer_replica_count"] == 2
     assert captured["service"]["replica_count"] == 1
+    assert captured["service"]["use_reservation"] is True
     assert captured["training_client"] == {
         "base_model": config.base_model,
         "lora_rank": 8,
@@ -128,12 +128,24 @@ def test_connect_uses_managed_dedicated_resources(monkeypatch) -> None:
     assert service.closed is True
 
 
+def test_sdk_serializes_reserved_capacity_request() -> None:
+    from fireworks.training.sdk.trainer import TrainerJobConfig, TrainerJobManager
+
+    config = TrainerJobConfig(
+        base_model="accounts/fireworks/models/qwen3p6-35b-a3b",
+        training_shape_ref="accounts/fireworks/trainingShapes/qwen3p6-35b-a3b-256k-lora/versions/1",
+        use_reservation=True,
+    )
+
+    payload = TrainerJobManager._build_trainer_create_payload(config)
+
+    assert payload["useReservation"] is True
+
+
 def test_runtime_exposes_native_inference_endpoint() -> None:
     service = _Service()
     service._managed_handle = SimpleNamespace(
-        deployment=SimpleNamespace(
-            inference_model="accounts/test/deployments/skyrl-rollout"
-        ),
+        deployment=SimpleNamespace(inference_model="accounts/test/deployments/skyrl-rollout"),
         deployment_manager=SimpleNamespace(inference_url="https://api.fireworks.ai/"),
     )
     runtime = _runtime(service=service)
@@ -194,9 +206,7 @@ async def test_active_sample_spans_hotload_on_same_client() -> None:
         config=FireworksConfig(sampling_timeout_s=1),
     )
     first = await runtime.publish_sampler_weights()
-    sample_task = asyncio.create_task(
-        runtime.sample_async(prompt="prompt", sampling_params="params")
-    )
+    sample_task = asyncio.create_task(runtime.sample_async(prompt="prompt", sampling_params="params"))
     await asyncio.wait_for(started.wait(), timeout=1)
 
     second = await runtime.publish_sampler_weights()
@@ -235,9 +245,7 @@ async def test_failed_hotload_preserves_published_identity_and_client() -> None:
 
 
 def test_snapshot_name_leaves_room_for_provider_suffix() -> None:
-    runtime = _runtime(
-        config=FireworksConfig(snapshot_prefix="skyrl-smoke-" + "long-prefix-" * 8)
-    )
+    runtime = _runtime(config=FireworksConfig(snapshot_prefix="skyrl-smoke-" + "long-prefix-" * 8))
 
     name = runtime._snapshot_name(42)
     prefix, version, random_suffix = name.rsplit("-", 2)
@@ -250,9 +258,7 @@ def test_snapshot_name_leaves_room_for_provider_suffix() -> None:
 
 
 def test_snapshot_name_is_a_lowercase_dns_label() -> None:
-    runtime = _runtime(
-        config=FireworksConfig(snapshot_prefix="My Run_with.dots / and spaces")
-    )
+    runtime = _runtime(config=FireworksConfig(snapshot_prefix="My Run_with.dots / and spaces"))
 
     name = runtime._snapshot_name(0)
 
@@ -282,9 +288,7 @@ async def test_close_waits_for_active_sample() -> None:
         config=FireworksConfig(sampling_timeout_s=1),
     )
     await runtime.publish_sampler_weights()
-    sample_task = asyncio.create_task(
-        runtime.sample_async(prompt="prompt", sampling_params="params")
-    )
+    sample_task = asyncio.create_task(runtime.sample_async(prompt="prompt", sampling_params="params"))
     await asyncio.wait_for(started.wait(), timeout=1)
 
     close_task = asyncio.create_task(runtime.close())


### PR DESCRIPTION
## Summary

- add a backward-compatible `trainer.fireworks.use_reservation` configuration flag
- pass the flag through `FireworksRuntime` to the managed FireTitan SDK
- raise the Fireworks SDK minimum to 1.2.7, which serializes `useReservation` on RLOR trainer creation
- test both the SkyRL-to-SDK boundary and the exact provider request payload

## Test plan

- [x] `tests/backends/fireworks/test_runtime.py`
- [x] `tests/backends/fireworks/test_config.py`
- [x] 23 focused tests passed with `fireworks-ai==1.2.7`
- [x] pre-commit Ruff, Black, and secret detection passed on changed files

Generated with [Devin](https://devin.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible default and narrow wiring to Fireworks trainer provisioning; risk is mainly when users explicitly enable reserved capacity (capacity/billing behavior on the provider side).
> 
> **Overview**
> Adds an opt-in **`trainer.fireworks.use_reservation`** flag (default **`False`**) so dedicated Fireworks RLOR trainer provisioning can request **reserved capacity** instead of on-demand only.
> 
> **`FireworksRuntime.connect`** forwards the flag to **`FiretitanServiceClient.from_firetitan_config`** as **`use_reservation`**. The **`fireworks`** extra now requires **`fireworks-ai[training]>=1.2.7`**, which serializes **`useReservation`** on trainer create payloads (covered by a new SDK payload test and runtime connect wiring test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52cef7ebc5b12338317db81ffdc2039a887cd1d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->