### PR TITLE
Fix CI thresholds after fully async changes

### DIFF
--- a/tests/train/gpu_e2e_test/gsm8k_fully_async.sh
+++ b/tests/train/gpu_e2e_test/gsm8k_fully_async.sh
@@ -11,8 +11,7 @@ SCRIPT_DIR=$(dirname $(realpath $0))
 # 18th Aug 2026). The window starts at #1929 (eval metrics logged at the right step), which
 # is the last change to shift these numbers. Rebaselined after the async codepath changes:
 # stale KV cache reuse on weight sync (#1798), policy_loss_type=rollout_is (#1850), and the
-# per-step cache salt (#1836). `loss/avg_final_rewards` in particular dropped from ~0.36 to
-# ~0.24 once the fully async scripts moved to rollout_is, while eval accuracy stayed flat.
+# per-step cache salt (#1836).
 EVAL_ACC_MIN_VALUE=0.50
 TRAIN_ACC_MIN_VALUE=0.198
 AVG_NUM_TOKENS_MAX_VALUE=285

--- a/tests/train/gpu_e2e_test/gsm8k_fully_async.sh
+++ b/tests/train/gpu_e2e_test/gsm8k_fully_async.sh
@@ -7,11 +7,16 @@ set -euo pipefail
 RUN_NAME="run_$(date +%Y%m%d%H%M%S)_$$"
 
 SCRIPT_DIR=$(dirname $(realpath $0))
-# Thresholds: 5% allowance from min/max of last 10 CI runs as of 23rd Feb 2026
-EVAL_ACC_MIN_VALUE=0.56
-TRAIN_ACC_MIN_VALUE=0.32
-AVG_NUM_TOKENS_MAX_VALUE=283
-LOGPROBS_DIFF_MAX_VALUE=0.040
+# Thresholds: 5% allowance from min/max of every CI run since 20th Jul 2026 (69 runs as of
+# 18th Aug 2026). The window starts at #1929 (eval metrics logged at the right step), which
+# is the last change to shift these numbers. Rebaselined after the async codepath changes:
+# stale KV cache reuse on weight sync (#1798), policy_loss_type=rollout_is (#1850), and the
+# per-step cache salt (#1836). `loss/avg_final_rewards` in particular dropped from ~0.36 to
+# ~0.24 once the fully async scripts moved to rollout_is, while eval accuracy stayed flat.
+EVAL_ACC_MIN_VALUE=0.50
+TRAIN_ACC_MIN_VALUE=0.198
+AVG_NUM_TOKENS_MAX_VALUE=285
+LOGPROBS_DIFF_MAX_VALUE=0.0193
 
 # The anyscale job's working_dir is the repo root, so we can use relative paths.
 bash examples/train/fully_async/fully_async_run_gsm8k.sh \


### PR DESCRIPTION
# What does this PR do?

Fixes E2E Fully Async CI failures. 

Rebaselined after the async codepath changes:
1. stale KV cache reuse on weight sync (#1798),
2.  policy_loss_type=rollout_is (#1850), and the
3. per-step cache salt (#1836). 

`loss/avg_final_rewards` in particular dropped from ~0.36 to ~0.24 once the fully async scripts moved to rollout_is, while eval accuracy stayed flat.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only threshold and comment updates; no production training or inference logic changed.
> 
> **Overview**
> Updates **wandb metric gates** in `gsm8k_fully_async.sh` so the fully async GSM8K GPU E2E job passes after recent async training changes, without altering the training script invocation.
> 
> **Threshold shifts** (5% allowance from CI runs since Jul 2026): eval min **0.56 → 0.50**, train reward min **0.32 → 0.198**, max tokens **283 → 285**, rollout/train logprob diff max **0.040 → 0.0193**. Comments now document the wider baseline window and tie the rebaseline to stale KV on weight sync (#1798), `rollout_is` policy loss (#1850), and per-step cache salt (#1836).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d589aac26de9aa42c7d9000a24ad177cfe9b4ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->