### PR TITLE
[Tinker API] Store forwarded sample results in memory

### DIFF
--- a/docs/content/docs/tinker/architecture.mdx
+++ b/docs/content/docs/tinker/architecture.mdx
@@ -8,7 +8,7 @@ This page describes how SkyRL implements the Tinker API, including the system ar
 
 The integration is organized in three high-level layers:
 
-1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests, stores them in a database, and returns future IDs for async polling
+1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests and returns future IDs for async polling. Engine-owned operations use the database; API-forwarded samples use in-memory futures.
 2. **Engine Layer** (`skyrl.tinker.engine`) - Background subprocess that polls the database, batches pending requests, and dispatches them to the backend
 3. **Backend Layer** (`skyrl.backends`) - Translates Tinker operations into training and inference calls, managing Ray workers, FSDP/Megatron training, and vLLM inference
 
@@ -71,6 +71,9 @@ Sampling requests (`sample`) go through the following lifecycle:
 Client calls sample()
     │
     ▼
+API Server (FastAPI)
+    │  Creates an in-memory future
+    ▼
 SkyRL-Train Backend
     │  Converts Tinker SamplingParams → vLLM params
     ▼
@@ -83,10 +86,10 @@ RemoteInferenceClient
 Inference Workers (vLLM)
     │  Generate tokens with logprobs
     ▼
-Results aggregated → GeneratedSequence objects returned
+Results resolve the in-memory future → GeneratedSequence objects returned
 ```
 
-The `sample()` call is a fairly lightweight wrapper around SkyRL-Train's vLLM inference engines. The backend translates Tinker `SamplingParams` to vLLM format (e.g., `stop_strings` → `stop`, `stop_tokens` → `stop_token_ids`) and delegates prompts to the `RemoteInferenceClient`. `RemoteInferenceClient` forwards the requests to an instance of [vLLM Router](https://github.com/vllm-project/router), which handles load balancing and sticky routing across vLLM workers.
+The `sample()` call is a fairly lightweight wrapper around SkyRL-Train's vLLM inference engines. Non-colocated and external inference requests bypass the engine database: the API owns their futures and signals completion with `asyncio.Event`. The backend translates Tinker `SamplingParams` to vLLM format (e.g., `stop_strings` → `stop`, `stop_tokens` → `stop_token_ids`) and delegates prompts to the `RemoteInferenceClient`. `RemoteInferenceClient` forwards the requests to an instance of [vLLM Router](https://github.com/vllm-project/router), which handles load balancing and sticky routing across vLLM workers.
 
 
 ## Weight Sync

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1394,9 +1394,10 @@ class RetrieveFutureRequest(BaseModel):
 async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     """Retrieve the result of an async operation, waiting until it's available."""
     request_id = int(request.request_id)
+    is_external_future = request_id < 0
 
     try:
-        if request_id < 0:
+        if is_external_future:
             row = await req.app.state.external_future_store.wait_for_future(request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
         else:
             row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
@@ -1406,13 +1407,18 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     if row is None:
         raise HTTPException(status_code=408, detail="Timeout waiting for result")
 
-    status, request_type, result_data = row
+    if is_external_future:
+        status, result_data = row
+        request_type = None
+    else:
+        status, request_type, result_data = row
     if status == RequestStatus.COMPLETED:
         # The SDK retrieves sample/forward/forward_backward results in proto
         # wire format when it advertises support; SDK >= 0.25.0 rejects JSON
         # for these types. Errors and other result types stay JSON.
         if (
-            types.RequestType(request_type) in PROTO_SERIALIZABLE_REQUEST_TYPES
+            request_type is not None
+            and types.RequestType(request_type) in PROTO_SERIALIZABLE_REQUEST_TYPES
             and PROTO_CONTENT_TYPE in req.headers.get("accept", "").lower()
         ):
             return Response(

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -47,6 +47,7 @@ from skyrl.tinker.db_models import (
 )
 from skyrl.tinker.extra import (
     ExternalInferenceClient,
+    InMemoryFutureStore,
     SkyRLTrainInferenceForwardingClient,
 )
 from skyrl.tinker.proto_serialization import (
@@ -261,12 +262,17 @@ async def lifespan(app: FastAPI):
     # SkyRL-Train default is colocate_all=True; only opt into forwarding
     # when the operator explicitly sets it to False.
     is_colocated = bool(backend_cfg.get("trainer.placement.colocate_all", True))
+    app.state.external_future_store = InMemoryFutureStore()
     if app.state.engine_config.external_inference_url:
-        app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
+        app.state.external_inference_client = ExternalInferenceClient(
+            app.state.engine_config, app.state.external_future_store
+        )
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
         app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
-            app.state.engine_config, app.state.db_engine
+            app.state.engine_config,
+            app.state.db_engine,
+            app.state.external_future_store,
         )
         logger.info(
             "SkyRL-Train inference forwarding client enabled for non-colocated backend=%s",
@@ -1340,35 +1346,33 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
         # Validate that the checkpoint exists and is ready
         await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
 
-    request_id = await create_future(
-        session=session,
-        request_type=(
-            types.RequestType.EXTERNAL if req.app.state.external_inference_client else types.RequestType.SAMPLE
-        ),
-        model_id=model_id,
-        request_data=types.SampleInput(
-            base_model=base_model,
-            prompt=request.prompt.to_types(),
-            sampling_params=request.sampling_params.to_types(),
-            num_samples=request.num_samples,
-            checkpoint_id=checkpoint_id,
-            # A positive topk implies prompt logprobs: both are read off the same
-            # prompt forward pass, so asking for one asks for the other.
-            prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
-            topk_prompt_logprobs=request.topk_prompt_logprobs,
-            seq_id=request.seq_id,
-            sampling_session_id=request.sampling_session_id,
-        ),
-    )
-
-    await session.commit()
-
     if req.app.state.external_inference_client:
+        request_id = req.app.state.external_future_store.create_future()
         asyncio.create_task(
             req.app.state.external_inference_client.call_and_store_result(
                 request_id, request, model_id, checkpoint_id, base_model=base_model
             )
         )
+    else:
+        request_id = await create_future(
+            session=session,
+            request_type=types.RequestType.SAMPLE,
+            model_id=model_id,
+            request_data=types.SampleInput(
+                base_model=base_model,
+                prompt=request.prompt.to_types(),
+                sampling_params=request.sampling_params.to_types(),
+                num_samples=request.num_samples,
+                checkpoint_id=checkpoint_id,
+                # A positive topk implies prompt logprobs: both are read off the same
+                # prompt forward pass, so asking for one asks for the other.
+                prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
+                topk_prompt_logprobs=request.topk_prompt_logprobs,
+                seq_id=request.seq_id,
+                sampling_session_id=request.sampling_session_id,
+            ),
+        )
+        await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
@@ -1392,7 +1396,10 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     request_id = int(request.request_id)
 
     try:
-        row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        if request_id < 0:
+            row = await req.app.state.external_future_store.wait_for_future(request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        else:
+            row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
     except KeyError:
         raise HTTPException(status_code=404, detail="Future not found")
 

--- a/skyrl/tinker/extra/__init__.py
+++ b/skyrl/tinker/extra/__init__.py
@@ -1,6 +1,11 @@
 from skyrl.tinker.extra.external_inference import ExternalInferenceClient
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
     SkyRLTrainInferenceForwardingClient,
 )
 
-__all__ = ["ExternalInferenceClient", "SkyRLTrainInferenceForwardingClient"]
+__all__ = [
+    "ExternalInferenceClient",
+    "InMemoryFutureStore",
+    "SkyRLTrainInferenceForwardingClient",
+]

--- a/skyrl/tinker/extra/external_inference.py
+++ b/skyrl/tinker/extra/external_inference.py
@@ -1,17 +1,16 @@
 import asyncio
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
 from cloudpathlib import AnyPath
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from skyrl.backends.renderer import render_model_input
 from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
-from skyrl.tinker.db_models import FutureDB, RequestStatus
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.utils.log import logger
 from skyrl.utils.storage import download_and_unpack
 
@@ -41,12 +40,12 @@ def _extract_checkpoint_sync(checkpoint_path: AnyPath, target_dir: Path) -> None
 class ExternalInferenceClient:
     """Client for calling external inference engines (e.g., vLLM)."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(self, engine_config: EngineConfig, future_store: InMemoryFutureStore):
         self.base_url = f"{engine_config.external_inference_url}/v1"
         self.api_key = engine_config.external_inference_api_key
         self.checkpoints_base = engine_config.checkpoints_base
         self.lora_base_dir = engine_config.external_inference_lora_base
-        self.db_engine = db_engine
+        self.future_store = future_store
 
     async def call_and_store_result(
         self,
@@ -57,7 +56,7 @@ class ExternalInferenceClient:
         *,
         base_model: str | None = None,
     ):
-        """Background task to call external engine and store result in database."""
+        """Call the external engine and resolve its API-process-owned future."""
         try:
             async with httpx.AsyncClient(
                 base_url=self.base_url,
@@ -73,13 +72,7 @@ class ExternalInferenceClient:
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
 
-        async with AsyncSession(self.db_engine) as session:
-            future = await session.get(FutureDB, request_id)
-            # `result_data` is a text column holding pre-serialized JSON.
-            future.result_data = result.model_dump_json()
-            future.status = status
-            future.completed_at = datetime.now(timezone.utc)
-            await session.commit()
+        self.future_store.complete_future(request_id, status, result.model_dump_json())
 
     async def _forward_to_engine(
         self,

--- a/skyrl/tinker/extra/in_memory_future_store.py
+++ b/skyrl/tinker/extra/in_memory_future_store.py
@@ -1,6 +1,7 @@
 import asyncio
 import itertools
 import time
+from collections import deque
 from dataclasses import dataclass, field
 
 from skyrl.tinker.db_models import RequestStatus
@@ -22,6 +23,7 @@ class InMemoryFutureStore:
         self._max_terminal_futures = max_terminal_futures
         self._next_id = itertools.count(start=-1, step=-1)
         self._futures: dict[int, _StoredFuture] = {}
+        self._terminal_futures: deque[tuple[float, int]] = deque()
 
     def create_future(self) -> int:
         self._cleanup_terminal_futures()
@@ -34,7 +36,9 @@ class InMemoryFutureStore:
         future.status = status
         future.result_data = result_data
         future.completed_at = time.monotonic()
+        self._terminal_futures.append((future.completed_at, request_id))
         future.event.set()
+        self._cleanup_terminal_futures()
 
     async def wait_for_future(self, request_id: int, timeout: float) -> tuple[RequestStatus, str | None] | None:
         future = self._futures.get(request_id)
@@ -49,19 +53,9 @@ class InMemoryFutureStore:
 
     def _cleanup_terminal_futures(self) -> None:
         now = time.monotonic()
-        expired = [
-            request_id
-            for request_id, future in self._futures.items()
-            if future.completed_at is not None and now - future.completed_at > self._terminal_retention_sec
-        ]
-        for request_id in expired:
-            del self._futures[request_id]
-
-        terminal = sorted(
-            (future.completed_at, request_id)
-            for request_id, future in self._futures.items()
-            if future.completed_at is not None
-        )
-        overflow = len(terminal) - self._max_terminal_futures
-        for _, request_id in terminal[: max(overflow, 0)]:
+        while self._terminal_futures and (
+            now - self._terminal_futures[0][0] > self._terminal_retention_sec
+            or len(self._terminal_futures) > self._max_terminal_futures
+        ):
+            _, request_id = self._terminal_futures.popleft()
             del self._futures[request_id]

--- a/skyrl/tinker/extra/in_memory_future_store.py
+++ b/skyrl/tinker/extra/in_memory_future_store.py
@@ -1,0 +1,67 @@
+import asyncio
+import itertools
+import time
+from dataclasses import dataclass, field
+
+from skyrl.tinker.db_models import RequestStatus
+
+
+@dataclass
+class _StoredFuture:
+    event: asyncio.Event = field(default_factory=asyncio.Event)
+    status: RequestStatus = RequestStatus.PENDING
+    result_data: str | None = None
+    completed_at: float | None = None
+
+
+class InMemoryFutureStore:
+    """Store API-process-owned futures without routing them through the engine database."""
+
+    def __init__(self, *, terminal_retention_sec: float = 600, max_terminal_futures: int = 10_000):
+        self._terminal_retention_sec = terminal_retention_sec
+        self._max_terminal_futures = max_terminal_futures
+        self._next_id = itertools.count(start=-1, step=-1)
+        self._futures: dict[int, _StoredFuture] = {}
+
+    def create_future(self) -> int:
+        self._cleanup_terminal_futures()
+        request_id = next(self._next_id)
+        self._futures[request_id] = _StoredFuture()
+        return request_id
+
+    def complete_future(self, request_id: int, status: RequestStatus, result_data: str) -> None:
+        future = self._futures[request_id]
+        future.status = status
+        future.result_data = result_data
+        future.completed_at = time.monotonic()
+        future.event.set()
+
+    async def wait_for_future(self, request_id: int, timeout: float) -> tuple[RequestStatus, str | None] | None:
+        future = self._futures.get(request_id)
+        if future is None:
+            raise KeyError(request_id)
+        if future.status == RequestStatus.PENDING:
+            try:
+                await asyncio.wait_for(future.event.wait(), timeout)
+            except asyncio.TimeoutError:
+                return None
+        return future.status, future.result_data
+
+    def _cleanup_terminal_futures(self) -> None:
+        now = time.monotonic()
+        expired = [
+            request_id
+            for request_id, future in self._futures.items()
+            if future.completed_at is not None and now - future.completed_at > self._terminal_retention_sec
+        ]
+        for request_id in expired:
+            del self._futures[request_id]
+
+        terminal = sorted(
+            (future.completed_at, request_id)
+            for request_id, future in self._futures.items()
+            if future.completed_at is not None
+        )
+        overflow = len(terminal) - self._max_terminal_futures
+        for _, request_id in terminal[: max(overflow, 0)]:
+            del self._futures[request_id]

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -5,7 +5,6 @@ Pair to :class:`ExternalInferenceClient`; resolves the target URL from
 """
 
 import asyncio
-from datetime import datetime, timezone
 
 import httpx
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -14,16 +13,18 @@ from skyrl.backends.renderer import render_model_input
 from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
-from skyrl.tinker.db_models import EngineStateDB, FutureDB, RequestStatus
+from skyrl.tinker.db_models import EngineStateDB, RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.utils.log import logger
 
 
 class SkyRLTrainInferenceForwardingClient:
     """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(self, engine_config: EngineConfig, db_engine, future_store: InMemoryFutureStore):
         self.engine_config = engine_config
         self.db_engine = db_engine
+        self.future_store = future_store
         self._cached_proxy_url: str | None = None
         self._cache_lock = asyncio.Lock()
         # Backpressure layered: httpx pool -> vllm-router -> vLLM max_num_seqs.
@@ -71,7 +72,7 @@ class SkyRLTrainInferenceForwardingClient:
         *,
         base_model: str | None = None,
     ):
-        """Forward a sample request to vLLM and write the result to FutureDB."""
+        """Forward a sample request to vLLM and resolve its API-process-owned future."""
         try:
             result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
             status = RequestStatus.COMPLETED
@@ -80,18 +81,7 @@ class SkyRLTrainInferenceForwardingClient:
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
 
-        async with AsyncSession(self.db_engine) as session:
-            future = await session.get(FutureDB, request_id)
-            if future is None:
-                # Row was deleted between scheduling and completion (cancelled
-                # request, stale-session GC). Nothing to write back.
-                logger.warning("FutureDB row %s missing on completion write — skipping", request_id)
-                return
-            # `result_data` is a text column holding pre-serialized JSON.
-            future.result_data = result.model_dump_json()
-            future.status = status
-            future.completed_at = datetime.now(timezone.utc)
-            await session.commit()
+        self.future_store.complete_future(request_id, status, result.model_dump_json())
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
         # httpx.RequestError covers ConnectError, ReadError, TimeoutException, etc.

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -9,8 +9,8 @@ bypassing the engine subprocess's serial scheduling loop.
 Coverage:
   - test_engine_state_published: after ``save_weights_for_sampler``, the
     engine's vLLM proxy URL is written to ``EngineStateDB``.
-  - test_sample_uses_external_path: an issued sample creates a future of
-    type ``EXTERNAL`` (not ``SAMPLE``) and resolves successfully.
+  - test_sample_bypasses_future_db: an issued sample resolves without creating
+    a database future.
   - test_sample_concurrent_with_training_is_fast: the central
     parallelism test. While a long-running stream of ``forward_backward``
     + ``optim_step`` calls is in flight, a sample request resolves in
@@ -210,15 +210,14 @@ def test_engine_state_published(server_db_path):
     ), f"expected an http(s) proxy URL, got {row.inference_proxy_url!r}"
 
 
-def test_sample_uses_external_path(server_db_path):
-    """A sample issued through the SDK creates a FutureDB row of type EXTERNAL.
+def test_sample_bypasses_future_db(server_db_path):
+    """A sample issued through the SDK does not use the engine's FutureDB.
 
     This is the "test" half of the design: the API hoists the sample off
-    the engine's serial loop and into the API process's asyncio loop.
+    the engine's serial loop and keeps its future in the API process.
     """
     from sqlmodel import Session, create_engine, func, select
 
-    from skyrl.tinker import types as skyrl_types
     from skyrl.tinker.db_models import FutureDB
 
     proc, db_path, _ = server_db_path
@@ -229,12 +228,11 @@ def test_sample_uses_external_path(server_db_path):
     _train_one_step(tc, tok)
     sampler = tc.save_weights_and_get_sampling_client(name="external_path_a")
 
-    # Snapshot the max future_id before submitting our sample so we can
-    # filter out any EXTERNAL futures from earlier tests.
+    # Snapshot the number of database futures before submitting our sample.
     eng = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(eng) as s:
-            max_before = s.exec(select(func.max(FutureDB.request_id))).one() or 0
+            count_before = s.exec(select(func.count()).select_from(FutureDB)).one()
     finally:
         eng.dispose()
 
@@ -245,24 +243,16 @@ def test_sample_uses_external_path(server_db_path):
     ).result()
     assert len(out.sequences) == 1
 
-    # Look for an EXTERNAL future with id > max_before. If async routing
-    # is on, every sample creates exactly one such row.
+    # API-forwarded samples use negative, in-memory future ids and must not
+    # add database work to the engine's scheduling hot path.
     eng = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(eng) as s:
-            stmt = (
-                select(FutureDB.request_id, FutureDB.request_type)
-                .where(FutureDB.request_id > max_before)
-                .where(FutureDB.request_type == skyrl_types.RequestType.EXTERNAL)
-            )
-            rows = s.exec(stmt).all()
+            count_after = s.exec(select(func.count()).select_from(FutureDB)).one()
     finally:
         eng.dispose()
 
-    assert len(rows) >= 1, (
-        f"expected at least one EXTERNAL future to be created by the sample call, "
-        f"found {len(rows)}; async sample routing may not be active"
-    )
+    assert count_after == count_before
 
 
 def test_sample_concurrent_with_training_is_fast(server_db_path):

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -187,11 +187,17 @@ async def test_query_count_does_not_scale_with_waiters(waiters, sync_engine, asy
     assert 0 < len(statements) < 50
 
 
-def _stub_request(async_engine, waiters, headers: dict | None = None):
+def _stub_request(async_engine, waiters, external_future_store=None, headers: dict | None = None):
     from types import SimpleNamespace
 
     return SimpleNamespace(
-        app=SimpleNamespace(state=SimpleNamespace(db_engine=async_engine, future_waiters=waiters)),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                db_engine=async_engine,
+                external_future_store=external_future_store,
+                future_waiters=waiters,
+            )
+        ),
         headers=headers or {},
     )
 
@@ -215,6 +221,24 @@ async def test_retrieve_future_returns_completed_result(waiters, async_engine, s
     )
 
     # The stored JSON text is returned as-is rather than re-encoded by FastAPI.
+    assert response.media_type == "application/json"
+    assert response.body == SAMPLE_RESULT.model_dump_json().encode()
+
+
+@pytest.mark.asyncio
+async def test_retrieve_future_returns_in_memory_external_result(waiters, async_engine):
+    from skyrl.tinker import api
+    from skyrl.tinker.extra import InMemoryFutureStore
+
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+    store.complete_future(request_id, RequestStatus.COMPLETED, SAMPLE_RESULT.model_dump_json())
+
+    response = await api.retrieve_future(
+        api.RetrieveFutureRequest(request_id=str(request_id)),
+        _stub_request(async_engine, waiters, store),
+    )
+
     assert response.media_type == "application/json"
     assert response.body == SAMPLE_RESULT.model_dump_json().encode()
 

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -236,9 +236,10 @@ async def test_retrieve_future_returns_in_memory_external_result(waiters, async_
 
     response = await api.retrieve_future(
         api.RetrieveFutureRequest(request_id=str(request_id)),
-        _stub_request(async_engine, waiters, store),
+        _stub_request(async_engine, waiters, store, headers={"accept": api.PROTO_CONTENT_TYPE}),
     )
 
+    # Forwarded samples use the Tinker JSON response even when the client also accepts proto.
     assert response.media_type == "application/json"
     assert response.body == SAMPLE_RESULT.model_dump_json().encode()
 

--- a/tests/tinker/test_in_memory_future_store.py
+++ b/tests/tinker/test_in_memory_future_store.py
@@ -1,0 +1,61 @@
+import asyncio
+
+import pytest
+
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
+
+
+@pytest.mark.asyncio
+async def test_concurrent_waiters_receive_completed_result():
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+    waiters = [asyncio.create_task(store.wait_for_future(request_id, 1)) for _ in range(3)]
+
+    store.complete_future(request_id, RequestStatus.COMPLETED, '{"value":1}')
+
+    assert await asyncio.gather(*waiters) == [
+        (RequestStatus.COMPLETED, '{"value":1}'),
+        (RequestStatus.COMPLETED, '{"value":1}'),
+        (RequestStatus.COMPLETED, '{"value":1}'),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_timed_out_waiter_does_not_cancel_future():
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+
+    assert await store.wait_for_future(request_id, 0) is None
+    store.complete_future(request_id, RequestStatus.FAILED, '{"error":"boom"}')
+
+    assert await store.wait_for_future(request_id, 1) == (
+        RequestStatus.FAILED,
+        '{"error":"boom"}',
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_future_raises_key_error():
+    store = InMemoryFutureStore()
+
+    with pytest.raises(KeyError):
+        await store.wait_for_future(-1, 1)
+
+
+@pytest.mark.asyncio
+async def test_terminal_future_retention_is_bounded():
+    store = InMemoryFutureStore(max_terminal_futures=1)
+    first_id = store.create_future()
+    store.complete_future(first_id, RequestStatus.COMPLETED, "{}")
+    second_id = store.create_future()
+    store.complete_future(second_id, RequestStatus.COMPLETED, "{}")
+
+    store.create_future()
+
+    with pytest.raises(KeyError):
+        await store.wait_for_future(first_id, 1)
+    assert await store.wait_for_future(second_id, 1) == (
+        RequestStatus.COMPLETED,
+        "{}",
+    )


### PR DESCRIPTION
## Summary

- Keep forwarded sample results in a bounded in-process store.
- Keep training and checkpoint records in SQLite.
- Preserve JSON and protobuf future-result behavior.

## Context

SkyRL's Tinker-compatible API represents asynchronous sampling operations as futures. A forwarded
sample is short-lived: the API accepts it, external inference produces a result, and the client
retrieves that result. SQLite remains appropriate for durable training and checkpoint records, but
storing every forwarded sample future there makes the database connection pool absorb rollout
concurrency and completion bursts.

## Before

Every forwarded sample request created a SQLite row and updated that row when inference completed.
With 512 concurrent samples, many completions attempted to use the SQLAlchemy pool at the same
time. The pool had 5 regular connections and 10 overflow connections.

The run below used SkyRL through its Tinker-compatible API and recorded the resulting API behavior.

| XID | SkyRL workload | Previous behavior |
| ---: | --- | --- |
| `1045590` | 512 concurrent forwarded samples | The run stalled before its first optimizer update while sample completions competed for database connections. |

## After

Forwarded samples receive negative future IDs, and completed results remain in process memory until
the client retrieves them or they expire. Capacity and lifetime limits bound memory use, and
completed-result eviction runs in constant time. Training and checkpoint operations keep their
existing SQLite storage.

This fixes the sample-result write burst. It does not change training-request body storage; #2061
addresses that separate source of database pressure.

## Testing

```bash
uv run --isolated --extra dev --extra tinker --extra jax pytest \
  tests/tinker/test_future_waiting.py \
  tests/tinker/test_in_memory_future_store.py \
  tests/tinker/test_proto_serialization.py \
  tests/tinker/skyrl_train/test_async_sample_routing.py -q
```

31 passed, 4 skipped.
