### PR TITLE
[Tinker API] Serialize SQLite training writes

### DIFF
--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -234,6 +234,9 @@ async def lifespan(app: FastAPI):
     db_url = get_async_database_url(app.state.engine_config.database_url)
     app.state.db_engine = create_async_engine(db_url, echo=False)
     enable_sqlite_wal(app.state.db_engine.sync_engine)
+    app.state.training_request_write_lock = (
+        asyncio.Lock() if app.state.db_engine.sync_engine.dialect.name == "sqlite" else None
+    )
 
     async with app.state.db_engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
@@ -346,6 +349,20 @@ async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
     """Dependency to get a database session."""
     async with AsyncSession(request.app.state.db_engine) as session:
         yield session
+
+
+@asynccontextmanager
+async def open_training_request_write_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
+    """Open a write session without contending SQLite writers for pooled connections."""
+    write_lock = request.app.state.training_request_write_lock
+    if write_lock is None:
+        async with AsyncSession(request.app.state.db_engine) as session:
+            yield session
+        return
+
+    async with write_lock:
+        async with AsyncSession(request.app.state.db_engine) as session:
+            yield session
 
 
 async def get_model(session: AsyncSession, model_id: str) -> ModelDB:
@@ -1108,56 +1125,59 @@ async def _read_forward_backward_request(request: Request) -> tuple[ForwardBackw
 
 
 @app.post("/api/v1/forward_backward", response_model=FutureResponse)
-async def forward_backward(request: Request, session: AsyncSession = Depends(get_session)):
+async def forward_backward(request: Request):
     """Compute and accumulate gradients (or run forward-only when the proto body asks for it)."""
     req, forward_only = await _read_forward_backward_request(request)
-    await get_model(session, req.model_id)
+    async with open_training_request_write_session(request) as session:
+        await get_model(session, req.model_id)
 
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.FORWARD if forward_only else types.RequestType.FORWARD_BACKWARD,
-        model_id=req.model_id,
-        request_data=req.forward_backward_input.to_types(),
-        seq_id=req.seq_id,
-    )
+        request_id = await create_future(
+            session=session,
+            request_type=types.RequestType.FORWARD if forward_only else types.RequestType.FORWARD_BACKWARD,
+            model_id=req.model_id,
+            request_data=req.forward_backward_input.to_types(),
+            seq_id=req.seq_id,
+        )
 
-    await session.commit()
+        await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
 @app.post("/api/v1/forward", response_model=FutureResponse)
-async def forward(request: ForwardRequest, session: AsyncSession = Depends(get_session)):
+async def forward(request: ForwardRequest, req: Request):
     """Forward pass to obtain logprobs without accumulating gradients"""
-    await get_model(session, request.model_id)
+    async with open_training_request_write_session(req) as session:
+        await get_model(session, request.model_id)
 
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.FORWARD,
-        model_id=request.model_id,
-        request_data=request.forward_input.to_types(),
-        seq_id=request.seq_id,
-    )
+        request_id = await create_future(
+            session=session,
+            request_type=types.RequestType.FORWARD,
+            model_id=request.model_id,
+            request_data=request.forward_input.to_types(),
+            seq_id=request.seq_id,
+        )
 
-    await session.commit()
+        await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
 @app.post("/api/v1/optim_step", response_model=FutureResponse)
-async def optim_step(request: OptimStepRequest, session: AsyncSession = Depends(get_session)):
+async def optim_step(request: OptimStepRequest, req: Request):
     """Update model using accumulated gradients."""
-    await get_model(session, request.model_id)
+    async with open_training_request_write_session(req) as session:
+        await get_model(session, request.model_id)
 
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.OPTIM_STEP,
-        model_id=request.model_id,
-        request_data=types.OptimStepInput(adam_params=request.adam_params.to_types()),
-        seq_id=request.seq_id,
-    )
+        request_id = await create_future(
+            session=session,
+            request_type=types.RequestType.OPTIM_STEP,
+            model_id=request.model_id,
+            request_data=types.OptimStepInput(adam_params=request.adam_params.to_types()),
+            seq_id=request.seq_id,
+        )
 
-    await session.commit()
+        await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 

--- a/tests/tinker/test_training_request_idempotency.py
+++ b/tests/tinker/test_training_request_idempotency.py
@@ -3,14 +3,19 @@
 import asyncio
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlmodel import SQLModel, select
+from sqlmodel import SQLModel, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from skyrl.tinker import types
-from skyrl.tinker.api import create_future
+from skyrl.tinker.api import create_future, open_training_request_write_session
 from skyrl.tinker.db_models import FutureDB, enable_sqlite_wal
+
+
+class LargeTrainingInput(BaseModel):
+    payload: str
 
 
 def optim_input(learning_rate: float = 1e-4) -> types.OptimStepInput:
@@ -128,4 +133,53 @@ async def test_training_requests_without_sequence_numbers_remain_distinct(tmp_pa
     assert second_id != first_id
     assert len(futures) == 2
     assert [future.seq_id for future in futures] == [None, None]
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_training_writes_wait_before_connection_checkout(tmp_path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'tinker.db'}",
+        pool_size=2,
+        max_overflow=0,
+        pool_timeout=0.05,
+    )
+    enable_sqlite_wal(engine.sync_engine)
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    app = FastAPI()
+    app.state.db_engine = engine
+    app.state.training_request_write_lock = asyncio.Lock()
+    request = Request({"type": "http", "app": app})
+    first_write_started = asyncio.Event()
+    release_first_write = asyncio.Event()
+
+    async def write_training_request(seq_id: int) -> None:
+        async with open_training_request_write_session(request) as session:
+            await create_future(
+                session,
+                types.RequestType.FORWARD_BACKWARD,
+                "model_1",
+                LargeTrainingInput(payload="x" * 100_000),
+                seq_id=seq_id,
+            )
+            if seq_id == 0:
+                first_write_started.set()
+                await release_first_write.wait()
+            await session.commit()
+
+    writes = [asyncio.create_task(write_training_request(seq_id)) for seq_id in range(32)]
+    await first_write_started.wait()
+
+    async with AsyncSession(engine) as heartbeat_session:
+        count = await asyncio.wait_for(heartbeat_session.exec(select(func.count()).select_from(FutureDB)), timeout=0.1)
+    assert count.one() == 1
+
+    release_first_write.set()
+    await asyncio.gather(*writes)
+
+    async with AsyncSession(engine) as session:
+        count = await session.exec(select(func.count()).select_from(FutureDB))
+    assert count.one() == 32
     await engine.dispose()


### PR DESCRIPTION
- Queue SQLite training writes before they check out a database connection. This prevents a burst of large training requests from filling the connection pool while SQLite waits for its single writer.
- Apply the queue only to training endpoints. The server parses large forward/backward bodies before admission, and PostgreSQL keeps concurrent writes.
- Preserve durable futures, request sequence IDs, and retry idempotency.

## Before and after

| Load | Before | After |
| --- | ---: | ---: |
| 64 concurrent 500 KB writes | 31 stored; 33 pool timeouts | 64 stored; 0 errors |
| 208 concurrent 3.3 MB writes | pool exhaustion reproduced | 208 stored; 0 missing sequence IDs |
| Heartbeats during the 208-request burst | blocked by pool exhaustion | 0 errors; 111 ms p95; 158 ms max |

The 208-request run completed in 26.77 seconds. It matches the request count and payload scale of the failed training update.

## Testing

```
uv run pytest tests/tinker -q
```

84 passed and 22 skipped. The suite verifies API behavior, future persistence, request idempotency, and concurrent SQLite admission.

```
uv run pre-commit run --files skyrl/tinker/api.py tests/tinker/test_training_request_idempotency.py
```

Ruff, Black, and secret detection passed.
