### PR TITLE
[Tinker API] Keep training request bodies out of SQLite

### DIFF
--- a/docs/content/docs/tinker/architecture.mdx
+++ b/docs/content/docs/tinker/architecture.mdx
@@ -8,7 +8,7 @@ This page describes how SkyRL implements the Tinker API, including the system ar
 
 The integration is organized in three high-level layers:
 
-1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests, stores them in a database, and returns future IDs for async polling
+1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests and returns future IDs for async polling. Engine-owned operations use the database; API-forwarded samples use in-memory futures.
 2. **Engine Layer** (`skyrl.tinker.engine`) - Background subprocess that polls the database, batches pending requests, and dispatches them to the backend
 3. **Backend Layer** (`skyrl.backends`) - Translates Tinker operations into training and inference calls, managing Ray workers, FSDP/Megatron training, and vLLM inference
 
@@ -71,6 +71,9 @@ Sampling requests (`sample`) go through the following lifecycle:
 Client calls sample()
     │
     ▼
+API Server (FastAPI)
+    │  Creates an in-memory future
+    ▼
 SkyRL-Train Backend
     │  Converts Tinker SamplingParams → vLLM params
     ▼
@@ -83,10 +86,10 @@ RemoteInferenceClient
 Inference Workers (vLLM)
     │  Generate tokens with logprobs
     ▼
-Results aggregated → GeneratedSequence objects returned
+Results resolve the in-memory future → GeneratedSequence objects returned
 ```
 
-The `sample()` call is a fairly lightweight wrapper around SkyRL-Train's vLLM inference engines. The backend translates Tinker `SamplingParams` to vLLM format (e.g., `stop_strings` → `stop`, `stop_tokens` → `stop_token_ids`) and delegates prompts to the `RemoteInferenceClient`. `RemoteInferenceClient` forwards the requests to an instance of [vLLM Router](https://github.com/vllm-project/router), which handles load balancing and sticky routing across vLLM workers.
+The `sample()` call is a fairly lightweight wrapper around SkyRL-Train's vLLM inference engines. Non-colocated and external inference requests bypass the engine database: the API owns their futures and signals completion with `asyncio.Event`. The backend translates Tinker `SamplingParams` to vLLM format (e.g., `stop_strings` → `stop`, `stop_tokens` → `stop_token_ids`) and delegates prompts to the `RemoteInferenceClient`. `RemoteInferenceClient` forwards the requests to an instance of [vLLM Router](https://github.com/vllm-project/router), which handles load balancing and sticky routing across vLLM workers.
 
 
 ## Weight Sync

--- a/docs/content/docs/tinker/architecture.mdx
+++ b/docs/content/docs/tinker/architecture.mdx
@@ -8,8 +8,8 @@ This page describes how SkyRL implements the Tinker API, including the system ar
 
 The integration is organized in three high-level layers:
 
-1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests and returns future IDs for async polling. Engine-owned operations use the database; API-forwarded samples use in-memory futures.
-2. **Engine Layer** (`skyrl.tinker.engine`) - Background subprocess that polls the database, batches pending requests, and dispatches them to the backend
+1. **API Layer** (`skyrl.tinker.api`) - FastAPI HTTP server that accepts Tinker API requests and returns future IDs for async polling. It keeps ordered training requests and forwarded sample futures in memory. SQLite stores durable model, session, and checkpoint records.
+2. **Engine Layer** (`skyrl.tinker.engine`) - Background subprocess that receives training requests through a private Unix socket, batches compatible requests, and dispatches them to the backend. Database-backed model creation and sampling requests keep their existing path.
 3. **Backend Layer** (`skyrl.backends`) - Translates Tinker operations into training and inference calls, managing Ray workers, FSDP/Megatron training, and vLLM inference
 
 <div style={{width: "80%", margin: "0 auto"}}>
@@ -29,10 +29,10 @@ Client (tinker SDK)
     │
     ▼
 API Server (FastAPI)
-    │  Writes request to SQLite DB
+    │  Validates, orders, and bounds requests in memory
     ▼
 Background Engine (subprocess)
-    │  Polls DB, batches requests
+    │  Claims ready requests through a private Unix socket
     ▼
 SkyRL-Train Backend
     │  Converts Tinker batch → SkyRL TrainingInputBatch
@@ -43,8 +43,12 @@ RayPPOTrainer.dispatch
 GPU Workers (FSDP or Megatron)
     │  Execute forward/backward/optim
     ▼
-Results aggregated → DB updated → Client polls future
+Results returned through the socket → Client polls in-memory future
 ```
+
+The API retains each request body until the engine confirms receipt. It then releases the API copy. Oversized requests return HTTP 413. Per-model count and total-byte limits return HTTP 429 before memory grows without a bound. The queue reserves capacity for a missing sequence ID so later requests cannot block their own gap filler.
+
+Training operations and their futures are not durable. If the API controller or engine process restarts, pending and completed in-memory results are lost and `retrieve_future` returns 404. The API and engine stop together, so no request can continue against an empty controller. On startup, the API marks training work and checkpoints left pending by an older process as failed. Completed checkpoints remain available, but the client must resume from one and resubmit work after a restart.
 
 ### `forward_backward()`
 
@@ -159,9 +163,10 @@ SkyRL-Train's `PolicyLossRegistry` also contains additional loss functions (`reg
 The Tinker API is inherently asynchronous:
 
 1. Clients submit requests and receive a `request_id` (future)
-2. The background engine batches compatible requests (e.g., multiple `forward_backward` calls for the same model)
-3. Barrier operations (`optim_step`, `load_checkpoint`) block until prior operations complete
-4. Clients poll `retrieve_future` to get results
+2. The API holds out-of-order requests until each model has a continuous sequence
+3. The background engine batches compatible requests (e.g., multiple `forward_backward` calls for the same model)
+4. `optim_step` and checkpoint operations wait until prior operations complete
+5. Clients poll `retrieve_future` to get results
 
 This design allows the engine to batch small requests for better GPU utilization and to pipeline operations when possible.
 

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1,19 +1,23 @@
 import asyncio
+import hashlib
+import io
 import json
 import os
 import random
 import re
 import shutil
 import signal
+import tempfile
 import threading
 from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, AsyncGenerator, ClassVar, Literal
 from uuid import uuid4
 
 import fastapi
 import psutil
-import zstandard
+import zstandard as zstd
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.exceptions import RequestValidationError as FastAPIRequestValidationError
 from fastapi.responses import RedirectResponse, StreamingResponse
@@ -29,7 +33,7 @@ from pydantic import (
 )
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlmodel import SQLModel, func, select
+from sqlmodel import SQLModel, func, select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from skyrl.tinker import types
@@ -50,10 +54,18 @@ from skyrl.tinker.extra import (
     InMemoryFutureStore,
     SkyRLTrainInferenceForwardingClient,
 )
+from skyrl.tinker.operation_transport import (
+    TRANSPORTED_REQUEST_TYPES,
+    OperationBackpressure,
+    OperationExpired,
+    OperationPayloadFormat,
+    OperationTransportServer,
+    TrainingOperationQueue,
+)
 from skyrl.tinker.proto_serialization import (
     PROTO_CONTENT_TYPE,
     PROTO_SERIALIZABLE_REQUEST_TYPES,
-    parse_forward_backward_request,
+    parse_forward_backward_metadata,
     serialize_result,
 )
 from skyrl.utils.log import get_uvicorn_log_config, logger
@@ -79,6 +91,21 @@ FUTURE_POLL_INTERVAL_SECONDS = 0.05
 # Statuses a request never moves out of, i.e. the ones a waiter resolves on.
 TERMINAL_STATUSES = (RequestStatus.COMPLETED, RequestStatus.FAILED)
 
+# Parsing is CPU-heavy and produces a temporary expanded Pydantic tree.  Keep
+# only a small, fixed number of those trees alive while allowing all HTTP
+# callers to remain connected.  Production requests are ~3.3 MiB; the per-body
+# ceiling catches malformed uploads without constraining normal updates.
+TRAINING_PARSE_CONCURRENCY = 1
+MAX_TRAINING_REQUEST_BYTES = 64 * 1024**2
+TRAINING_BODY_CHUNK_BYTES = 1024**2
+
+
+@dataclass(frozen=True)
+class SamplingTarget:
+    base_model: str | None
+    model_id: str
+    checkpoint_id: str
+
 
 def raw_json_response(payload: str | None) -> Response:
     """Return already-serialized JSON without routing it through FastAPI's encoder.
@@ -91,7 +118,10 @@ def raw_json_response(payload: str | None) -> Response:
     """
     # `null` keeps the response valid JSON when a completed future stored no
     # result body, matching what encoding `None` would have produced.
-    return Response(content=payload if payload is not None else "null", media_type="application/json")
+    return Response(
+        content=payload if payload is not None else "null",
+        media_type="application/json",
+    )
 
 
 async def wait_for_future(
@@ -128,7 +158,9 @@ async def wait_for_future(
 
 
 async def poll_futures(
-    db_engine, waiters: dict[int, set[asyncio.Future]], poll_interval_sec: float = FUTURE_POLL_INTERVAL_SECONDS
+    db_engine,
+    waiters: dict[int, set[asyncio.Future]],
+    poll_interval_sec: float = FUTURE_POLL_INTERVAL_SECONDS,
 ) -> None:
     """Resolve the requests awaited in ``waiters`` as they finish, until cancelled.
 
@@ -154,7 +186,10 @@ async def poll_futures(
                     # by SQLite (since 3.32) and 65535 by Postgres -- far above
                     # any plausible number of in-flight requests.
                     statement = select(
-                        FutureDB.request_id, FutureDB.status, FutureDB.request_type, FutureDB.result_data
+                        FutureDB.request_id,
+                        FutureDB.status,
+                        FutureDB.request_type,
+                        FutureDB.result_data,
                     ).where(FutureDB.request_id.in_(awaited))
                     rows = (await session.exec(statement)).all()
 
@@ -209,7 +244,11 @@ def _get_parent_uv_run_args(parent_cmd: list[str]) -> list[str]:
     return parent_cmd
 
 
-def _build_uv_run_cmd_engine(parent_cmd: list[str], engine_config: BaseModel) -> list[str]:
+def _build_uv_run_cmd_engine(
+    parent_cmd: list[str],
+    engine_config: BaseModel,
+    operation_transport_socket: str | None = None,
+) -> list[str]:
     """Builds uv run command for the engine
 
     Args:
@@ -226,6 +265,8 @@ def _build_uv_run_cmd_engine(parent_cmd: list[str], engine_config: BaseModel) ->
     cmd.extend(["--extra", "tinker", "--extra", engine_config.backend])
     cmd.extend(["-m", "skyrl.tinker.engine"])
     cmd.extend(config_to_argv(engine_config))
+    if operation_transport_socket is not None:
+        cmd.extend(["--operation-transport-socket", operation_transport_socket])
     return cmd
 
 
@@ -240,8 +281,30 @@ async def lifespan(app: FastAPI):
     async with app.state.db_engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
 
+    await fail_stale_training_operations(app.state.db_engine)
+
     app.state.future_waiters = {}
     app.state.future_poller = asyncio.create_task(poll_futures(app.state.db_engine, app.state.future_waiters))
+
+    # The API process owns all new training operations.  The engine subprocess
+    # pulls them through a private UDS; no request tensor is persisted to SQL.
+    app.state.external_future_store = InMemoryFutureStore(
+        max_terminal_bytes=app.state.engine_config.training_operation_max_payload_bytes
+    )
+    app.state.training_operation_queue = TrainingOperationQueue(
+        app.state.external_future_store,
+        max_pending_per_model=app.state.engine_config.training_operation_max_pending_per_model,
+        max_payload_bytes=app.state.engine_config.training_operation_max_payload_bytes,
+    )
+    app.state.training_model_locks = {}
+    app.state.training_control_locks = {}
+    app.state.training_parse_semaphore = asyncio.Semaphore(TRAINING_PARSE_CONCURRENCY)
+    operation_transport_dir = tempfile.TemporaryDirectory(prefix="skyrl-tinker-operations-")
+    operation_transport_socket = os.path.join(operation_transport_dir.name, "engine.sock")
+    app.state.operation_transport_server = OperationTransportServer(
+        app.state.training_operation_queue, operation_transport_socket
+    )
+    await app.state.operation_transport_server.start()
 
     # Setup external inference client if configured.
     #
@@ -262,7 +325,8 @@ async def lifespan(app: FastAPI):
     # SkyRL-Train default is colocate_all=True; only opt into forwarding
     # when the operator explicitly sets it to False.
     is_colocated = bool(backend_cfg.get("trainer.placement.colocate_all", True))
-    app.state.external_future_store = InMemoryFutureStore()
+    app.state.external_sampling_targets = {}
+    app.state.external_sampling_target_locks = {}
     if app.state.engine_config.external_inference_url:
         app.state.external_inference_client = ExternalInferenceClient(
             app.state.engine_config, app.state.external_future_store
@@ -284,7 +348,7 @@ async def lifespan(app: FastAPI):
 
     # Build subprocess command with engine config parameters.
     parent_cmd = psutil.Process(os.getppid()).cmdline()
-    cmd = _build_uv_run_cmd_engine(parent_cmd, app.state.engine_config)
+    cmd = _build_uv_run_cmd_engine(parent_cmd, app.state.engine_config, operation_transport_socket)
 
     background_engine = await asyncio.create_subprocess_exec(*cmd)
     app.state.background_engine = background_engine
@@ -344,9 +408,41 @@ async def lifespan(app: FastAPI):
             background_engine.kill()
             await background_engine.wait()
     logger.info("Background engine stopped")
+    await app.state.operation_transport_server.close()
+    operation_transport_dir.cleanup()
 
 
 app = FastAPI(title="Tinker API Mock", version="0.0.1", lifespan=lifespan)
+
+
+async def fail_stale_training_operations(db_engine) -> None:
+    """Resolve database-backed training work left by an older server process."""
+    completed_at = datetime.now(timezone.utc)
+    error = types.ErrorResponse(
+        error="Training operation was lost when the API and engine restarted; resume from a checkpoint",
+        status="failed",
+    ).model_dump_json()
+    async with AsyncSession(db_engine) as session:
+        await session.exec(
+            update(FutureDB)
+            .where(FutureDB.status == RequestStatus.PENDING)
+            .where(FutureDB.request_type.in_(TRANSPORTED_REQUEST_TYPES))
+            .values(
+                status=RequestStatus.FAILED,
+                result_data=error,
+                completed_at=completed_at,
+            )
+        )
+        await session.exec(
+            update(CheckpointDB)
+            .where(CheckpointDB.status == CheckpointStatus.PENDING)
+            .values(
+                status=CheckpointStatus.FAILED,
+                error_message="Checkpoint operation was lost when the API and engine restarted",
+                completed_at=completed_at,
+            )
+        )
+        await session.commit()
 
 
 async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
@@ -363,6 +459,82 @@ async def get_model(session: AsyncSession, model_id: str) -> ModelDB:
     if not model:
         raise HTTPException(status_code=404, detail="Model not found")
     return model
+
+
+async def ensure_training_model(request: Request, session: AsyncSession, model_id: str) -> None:
+    """Validate and seed one model in the API-owned training queue.
+
+    Only the first operation for a model consults SQLite.  Concurrent upload
+    bursts share that lookup, so the steady-state training boundary checks out
+    no SQLAlchemy connection at all.
+    """
+    queue: TrainingOperationQueue = request.app.state.training_operation_queue
+    if queue.has_model(model_id):
+        return
+
+    locks: dict[str, asyncio.Lock] = request.app.state.training_model_locks
+    lock = locks.setdefault(model_id, asyncio.Lock())
+    async with lock:
+        if queue.has_model(model_id):
+            return
+        await get_model(session, model_id)
+        last_seq_id = (
+            await session.exec(
+                select(func.max(FutureDB.seq_id))
+                .where(FutureDB.model_id == model_id)
+                .where(FutureDB.seq_id.is_not(None))
+                .where(FutureDB.status != RequestStatus.PENDING)
+            )
+        ).one()
+        # The SDK numbers model operations from 1. A prior completed database
+        # request raises this starting point when the API resumes an older model.
+        queue.register_model(model_id, 1 if last_seq_id is None else last_seq_id + 1)
+
+
+def enqueue_training_operation(
+    request: Request,
+    request_type: types.RequestType,
+    model_id: str,
+    seq_id: int | None,
+    payload: bytes,
+    payload_format: OperationPayloadFormat = OperationPayloadFormat.JSON,
+) -> int:
+    """Map bounded-queue outcomes to the SDK-facing HTTP contract."""
+    try:
+        return request.app.state.training_operation_queue.enqueue(
+            request_type=request_type,
+            model_id=model_id,
+            seq_id=seq_id,
+            payload=payload,
+            payload_format=payload_format,
+        )
+    except OperationBackpressure as error:
+        raise HTTPException(status_code=429, detail=str(error), headers={"Retry-After": "1"}) from error
+    except OperationExpired as error:
+        raise HTTPException(status_code=410, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+
+
+def existing_training_operation(
+    request: Request,
+    request_type: types.RequestType,
+    model_id: str,
+    seq_id: int | None,
+    payload: bytes,
+) -> int | None:
+    """Return an exact prior request before repeating control-plane side effects."""
+    try:
+        return request.app.state.training_operation_queue.existing_request_id(
+            request_type=request_type,
+            model_id=model_id,
+            seq_id=seq_id,
+            payload=payload,
+        )
+    except OperationExpired as error:
+        raise HTTPException(status_code=410, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
 
 
 async def create_future(
@@ -441,14 +613,16 @@ async def create_checkpoint(
             raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")
         else:
             raise HTTPException(
-                status_code=409, detail=f"Checkpoint '{checkpoint_id}' already exists for model '{model_id}'"
+                status_code=409,
+                detail=f"Checkpoint '{checkpoint_id}' already exists for model '{model_id}'",
             )
 
 
 class LoRAConfig(BaseModel):
     rank: int
     seed: int | None = Field(
-        default=None, description="Seed for LoRA weight initialization. If None, a random seed is used."
+        default=None,
+        description="Seed for LoRA weight initialization. If None, a random seed is used.",
     )
 
 
@@ -625,13 +799,23 @@ class ForwardBackwardInput(BaseModel):
     }
 
     data: list[Datum]
-    loss_fn: Literal["cross_entropy", "importance_sampling", "ppo", "gspo", "cispo", "ppo_critic", "dppo"]
+    loss_fn: Literal[
+        "cross_entropy",
+        "importance_sampling",
+        "ppo",
+        "gspo",
+        "cispo",
+        "ppo_critic",
+        "dppo",
+    ]
     loss_fn_config: dict[str, float] | None = None
 
     @model_validator(mode="after")
     def validate_loss_fn_config_keys(self):
         """Validate loss_fn_config keys based on the selected loss function."""
         if self.loss_fn_config is None:
+            if self.loss_fn == "gspo":
+                raise ValueError("loss_fn='gspo' requires clip_low_threshold and clip_high_threshold.")
             return self
 
         allowed_keys = self._ALLOWED_KEYS_BY_LOSS_FN[self.loss_fn]
@@ -645,6 +829,18 @@ class ForwardBackwardInput(BaseModel):
             raise ValueError(
                 f"loss_fn='{self.loss_fn}' does not accept loss_fn_config keys. " f"Received: {invalid_keys}."
             )
+        if self.loss_fn == "gspo":
+            required_keys = {"clip_low_threshold", "clip_high_threshold"}
+            missing_keys = sorted(required_keys - self.loss_fn_config.keys())
+            if missing_keys:
+                raise ValueError(f"loss_fn='gspo' is missing required loss_fn_config keys: {missing_keys}.")
+            clip_low = self.loss_fn_config["clip_low_threshold"]
+            clip_high = self.loss_fn_config["clip_high_threshold"]
+            if not 0.0 <= clip_low <= 1.0 <= clip_high:
+                raise ValueError(
+                    "loss_fn='gspo' requires 0 <= clip_low_threshold <= 1 <= clip_high_threshold; "
+                    f"got {clip_low=} and {clip_high=}."
+                )
         return self
 
     def to_types(self) -> types.ForwardBackwardInput:
@@ -778,13 +974,13 @@ class SampleRequest(BaseModel):
 class SaveWeightsRequest(BaseModel):
     model_id: str
     path: str = Field(..., pattern=ID_PATTERN, max_length=ID_MAX_LENGTH)
+    seq_id: int | None = None
     type: Literal["save_weights"] | None = None
 
 
 class LoadWeightsRequest(BaseModel):
     model_id: str
     path: str
-    optimizer: bool = True
     seq_id: int | None = None
     type: Literal["load_weights"] | None = None
 
@@ -868,6 +1064,7 @@ class SupportedModel(BaseModel):
 
 class GetServerCapabilitiesResponse(BaseModel):
     supported_models: list[SupportedModel]
+    supported_loss_fns: list[str]
 
 
 class ListCheckpointsResponse(BaseModel):
@@ -900,6 +1097,10 @@ class WeightsInfoResponse(BaseModel):
 
 class ClientConfigResponse(BaseModel):
     pjwt_auth_enabled: bool = False
+    parallel_fwdbwd_chunks: bool = True
+    proto_write_fwdbwd: bool = True
+    proto_compress_fwdbwd: bool = True
+    fwd_via_fwdbwd: bool = True
 
 
 @app.post("/api/v1/client/config", response_model=ClientConfigResponse)
@@ -950,7 +1151,10 @@ async def create_sampling_session(request: CreateSamplingSessionRequest, session
         raise HTTPException(status_code=404, detail="Session not found")
     # Exactly one of base_model or model_path must be provided
     if (request.base_model is None) == (request.model_path is None):
-        raise HTTPException(status_code=400, detail="Exactly one of base_model or model_path must be provided")
+        raise HTTPException(
+            status_code=400,
+            detail="Exactly one of base_model or model_path must be provided",
+        )
     sampling_session_id = f"sampling_{uuid4().hex[:8]}"
     sampling_db = SamplingSessionDB(
         sampling_session_id=sampling_session_id,
@@ -1064,7 +1268,9 @@ async def get_model_info(request: GetInfoRequest, session: AsyncSession = Depend
 
     lora_config = types.LoraConfig.model_validate(model.lora_config)
     model_data = ModelData(
-        base_model=model.base_model, lora_config=LoRAConfig(rank=lora_config.rank), model_name=model.base_model
+        base_model=model.base_model,
+        lora_config=LoRAConfig(rank=lora_config.rank),
+        model_name=model.base_model,
     )
 
     return ModelInfoResponse(model_id=model.model_id, status=model.status, model_data=model_data)
@@ -1092,120 +1298,168 @@ async def get_training_run(model_id: str, session: AsyncSession = Depends(get_se
     )
 
 
-# Upper bound for a decompressed forward_backward body. Far above any
-# legitimate payload (requests are chunked client-side well below this), but
-# it keeps a small crafted body from ballooning into an arbitrarily large
-# allocation.
-_MAX_FWDBWD_BODY_BYTES = 1 << 30  # 1 GiB
+def _parse_forward_backward_body(
+    body: bytes, is_proto: bool, content_encoding: str
+) -> tuple[str, int | None, bool, bytes, OperationPayloadFormat]:
+    """Validate one body off-loop and return compact transport metadata."""
+    wire_body = body
+    if content_encoding == "zstd":
+        decompressed = bytearray()
+        with zstd.ZstdDecompressor().stream_reader(io.BytesIO(body)) as reader:
+            while chunk := reader.read(
+                min(TRAINING_BODY_CHUNK_BYTES, MAX_TRAINING_REQUEST_BYTES + 1 - len(decompressed))
+            ):
+                decompressed.extend(chunk)
+                if len(decompressed) > MAX_TRAINING_REQUEST_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"Decompressed training request exceeds {MAX_TRAINING_REQUEST_BYTES} bytes",
+                    )
+        body = bytes(decompressed)
+    if is_proto:
+        model_id, seq_id, forward_only = parse_forward_backward_metadata(body)
+    else:
+        forward_only = False
+        req = ForwardBackwardRequest.model_validate_json(body)
+    if is_proto:
+        payload = wire_body
+        payload_format = (
+            OperationPayloadFormat.PROTO_ZSTD if content_encoding == "zstd" else OperationPayloadFormat.PROTO
+        )
+    else:
+        payload = req.forward_backward_input.to_types().model_dump_json().encode()
+        payload_format = OperationPayloadFormat.JSON
+        model_id = req.model_id
+        seq_id = req.seq_id
+    return model_id, seq_id, forward_only, payload, payload_format
 
 
-async def _read_forward_backward_request(request: Request) -> tuple[ForwardBackwardRequest, bool]:
-    """Read a forward_backward body in either wire format.
+def _parse_forward_body(body: bytes) -> tuple[str, int | None, bytes]:
+    """Validate a legacy JSON forward body off the API event loop."""
+    req = ForwardRequest.model_validate_json(body)
+    payload = req.forward_input.to_types().model_dump_json().encode()
+    return req.model_id, req.seq_id, payload
+
+
+async def _read_training_body(request: Request) -> bytes:
+    """Read one request incrementally and stop at the fixed body limit."""
+    chunks = []
+    size = 0
+    async for chunk in request.stream():
+        size += len(chunk)
+        if size > MAX_TRAINING_REQUEST_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Training request exceeds {MAX_TRAINING_REQUEST_BYTES} bytes",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _read_forward_backward_request(
+    request: Request,
+) -> tuple[str, int | None, bool, bytes, OperationPayloadFormat]:
+    """Read and validate a forward_backward body in either wire format.
 
     tinker SDK >= 0.25.0 submits the body as protobuf and routes forward-only
     passes here via the proto's ``forward_only`` flag instead of calling
     ``/api/v1/forward``; older SDKs keep sending JSON with forward_only False.
-    Large proto bodies may arrive zstd-compressed (``Content-Encoding: zstd``);
-    ASGI servers do not decode request bodies, so decompress here.
     """
-    body = await request.body()
-    if request.headers.get("content-encoding", "").strip().lower() == "zstd":
+    async with request.app.state.training_parse_semaphore:
+        body = await _read_training_body(request)
+        is_proto = PROTO_CONTENT_TYPE in request.headers.get("content-type", "").lower()
+        content_encoding = request.headers.get("content-encoding", "").lower().strip()
+        if content_encoding not in ("", "identity", "zstd"):
+            raise HTTPException(
+                status_code=415,
+                detail=f"Unsupported content encoding: {content_encoding}",
+            )
         try:
-            body = zstandard.ZstdDecompressor().decompress(body, max_output_size=_MAX_FWDBWD_BODY_BYTES)
-        except Exception as exc:
-            raise HTTPException(status_code=422, detail=f"failed to zstd-decompress request body: {exc}") from exc
-    if PROTO_CONTENT_TYPE in request.headers.get("content-type", "").lower():
-        try:
-            request_dict, forward_only = parse_forward_backward_request(body)
-        except (DecodeError, ValueError) as e:
-            raise HTTPException(status_code=422, detail=f"Invalid proto forward_backward body: {e}")
-    else:
-        request_dict, forward_only = None, False
-    try:
-        if request_dict is not None:
-            return ForwardBackwardRequest.model_validate(request_dict), forward_only
-        return ForwardBackwardRequest.model_validate_json(body), forward_only
-    except ValidationError as e:
-        # Match FastAPI's native body validation error shape (422).
-        raise FastAPIRequestValidationError(e.errors())
+            return await asyncio.to_thread(
+                _parse_forward_backward_body,
+                body,
+                is_proto,
+                "" if content_encoding == "identity" else content_encoding,
+            )
+        except (DecodeError, ValueError, zstd.ZstdError) as error:
+            if isinstance(error, zstd.ZstdError):
+                raise HTTPException(status_code=422, detail=f"Invalid zstd training body: {error}")
+            if is_proto and not isinstance(error, ValidationError):
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Invalid proto forward_backward body: {error}",
+                )
+            if isinstance(error, ValidationError):
+                raise FastAPIRequestValidationError(error.errors())
+            raise
 
 
 @app.post("/api/v1/forward_backward", response_model=FutureResponse)
 async def forward_backward(request: Request, session: AsyncSession = Depends(get_session)):
     """Compute and accumulate gradients (or run forward-only when the proto body asks for it)."""
-    req, forward_only = await _read_forward_backward_request(request)
-    await get_model(session, req.model_id)
-
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.FORWARD if forward_only else types.RequestType.FORWARD_BACKWARD,
-        model_id=req.model_id,
-        request_data=req.forward_backward_input.to_types(),
-        seq_id=req.seq_id,
+    model_id, seq_id, forward_only, payload, payload_format = await _read_forward_backward_request(request)
+    await ensure_training_model(request, session, model_id)
+    request_id = enqueue_training_operation(
+        request,
+        types.RequestType.FORWARD if forward_only else types.RequestType.FORWARD_BACKWARD,
+        model_id,
+        seq_id,
+        payload,
+        payload_format,
     )
-
-    await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
 @app.post("/api/v1/forward", response_model=FutureResponse)
-async def forward(request: ForwardRequest, session: AsyncSession = Depends(get_session)):
+async def forward(request: Request, session: AsyncSession = Depends(get_session)):
     """Forward pass to obtain logprobs without accumulating gradients"""
-    await get_model(session, request.model_id)
-
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.FORWARD,
-        model_id=request.model_id,
-        request_data=request.forward_input.to_types(),
-        seq_id=request.seq_id,
+    async with request.app.state.training_parse_semaphore:
+        body = await _read_training_body(request)
+        try:
+            model_id, seq_id, payload = await asyncio.to_thread(_parse_forward_body, body)
+        except ValidationError as error:
+            raise FastAPIRequestValidationError(error.errors())
+    await ensure_training_model(request, session, model_id)
+    request_id = enqueue_training_operation(
+        request,
+        types.RequestType.FORWARD,
+        model_id,
+        seq_id,
+        payload,
     )
-
-    await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
 @app.post("/api/v1/optim_step", response_model=FutureResponse)
-async def optim_step(request: OptimStepRequest, session: AsyncSession = Depends(get_session)):
+async def optim_step(
+    request: OptimStepRequest,
+    req: Request,
+    session: AsyncSession = Depends(get_session),
+):
     """Update model using accumulated gradients."""
-    await get_model(session, request.model_id)
-
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.OPTIM_STEP,
-        model_id=request.model_id,
-        request_data=types.OptimStepInput(adam_params=request.adam_params.to_types()),
-        seq_id=request.seq_id,
+    await ensure_training_model(req, session, request.model_id)
+    payload = types.OptimStepInput(adam_params=request.adam_params.to_types()).model_dump_json().encode()
+    request_id = enqueue_training_operation(
+        req,
+        types.RequestType.OPTIM_STEP,
+        request.model_id,
+        request.seq_id,
+        payload,
     )
-
-    await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
 @app.post("/api/v1/load_weights", response_model=FutureResponse)
-async def load_weights(request: LoadWeightsRequest, req: Request, session: AsyncSession = Depends(get_session)):
-    """Loads weights and training state.
-
-    Matching the Tinker service, LoadWeights is only permitted as a model's first
-    request: any prior request for the model (forward_backward, save_weights, a
-    previous load_weights, ...) makes further loads a 400. Load into a freshly
-    created model instead (create_training_client_from_state[_with_optimizer]).
-    """
-    await get_model(session, request.model_id)
-
-    prior_requests = await session.exec(
-        select(func.count())
-        .select_from(FutureDB)
-        .where(FutureDB.model_id == request.model_id)
-        .where(FutureDB.request_type != types.RequestType.CREATE_MODEL)
-    )
-    prior_count = prior_requests.one()
-    if prior_count > 0:
-        seq_id = request.seq_id if request.seq_id is not None else prior_count + 1
-        raise HTTPException(status_code=400, detail=f"LoadWeights is not permitted with seq_id {seq_id}")
+async def load_weights(
+    request: LoadWeightsRequest,
+    req: Request,
+    session: AsyncSession = Depends(get_session),
+):
+    """Loads weights and training state."""
+    await ensure_training_model(req, session, request.model_id)
 
     path = types.TinkerPath.parse(request.path)
     if (
@@ -1215,96 +1469,158 @@ async def load_weights(request: LoadWeightsRequest, req: Request, session: Async
         or not (checkpoint_id := path.secondary_id)
     ):
         raise HTTPException(
-            status_code=400, detail="request.path must be in format tinker://source_model_id/weights/checkpoint_id"
+            status_code=400,
+            detail="request.path must be in format tinker://source_model_id/weights/checkpoint_id",
         )
 
-    await validate_checkpoint(req, source_model_id, checkpoint_id, types.CheckpointType.TRAINING, session)
-
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.LOAD_WEIGHTS,
-        model_id=request.model_id,
-        request_data=types.LoadWeightsInput(
-            source_model_id=source_model_id,
-            checkpoint_id=checkpoint_id,
-            load_optimizer=request.optimizer,
-        ),
+    payload = (
+        types.LoadWeightsInput(source_model_id=source_model_id, checkpoint_id=checkpoint_id).model_dump_json().encode()
     )
-
-    await session.commit()
+    if (
+        request_id := existing_training_operation(
+            req,
+            types.RequestType.LOAD_WEIGHTS,
+            request.model_id,
+            request.seq_id,
+            payload,
+        )
+    ) is None:
+        await validate_checkpoint(req, source_model_id, checkpoint_id, types.CheckpointType.TRAINING, session)
+        request_id = enqueue_training_operation(
+            req,
+            types.RequestType.LOAD_WEIGHTS,
+            request.model_id,
+            request.seq_id,
+            payload,
+        )
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
 @app.post("/api/v1/save_weights", response_model=FutureResponse)
-async def save_weights(request: SaveWeightsRequest, session: AsyncSession = Depends(get_session)):
+async def save_weights(
+    request: SaveWeightsRequest,
+    req: Request,
+    session: AsyncSession = Depends(get_session),
+):
     """Saves weights and training state."""
-    # Create pending checkpoint entry (validates model exists)
-    await create_checkpoint(
-        session=session,
-        model_id=request.model_id,
-        checkpoint_id=request.path,
-        checkpoint_type=types.CheckpointType.TRAINING,
-    )
-
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.SAVE_WEIGHTS,
-        model_id=request.model_id,
-        request_data=types.SaveWeightsInput(path=request.path),
-    )
-
-    await session.commit()
+    await ensure_training_model(req, session, request.model_id)
+    payload = types.SaveWeightsInput(path=request.path).model_dump_json().encode()
+    lock = req.app.state.training_control_locks.setdefault(request.model_id, asyncio.Lock())
+    async with lock:
+        request_id = existing_training_operation(
+            req,
+            types.RequestType.SAVE_WEIGHTS,
+            request.model_id,
+            request.seq_id,
+            payload,
+        )
+        if request_id is None:
+            await create_checkpoint(
+                session=session,
+                model_id=request.model_id,
+                checkpoint_id=request.path,
+                checkpoint_type=types.CheckpointType.TRAINING,
+            )
+            await session.commit()
+            try:
+                request_id = enqueue_training_operation(
+                    req,
+                    types.RequestType.SAVE_WEIGHTS,
+                    request.model_id,
+                    request.seq_id,
+                    payload,
+                )
+            except Exception:
+                checkpoint = await session.get(
+                    CheckpointDB,
+                    (request.model_id, request.path, types.CheckpointType.TRAINING),
+                )
+                if checkpoint is not None:
+                    await session.delete(checkpoint)
+                    await session.commit()
+                raise
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
 @app.post("/api/v1/save_weights_for_sampler", response_model=FutureResponse)
-async def save_weights_for_sampler(request: SaveWeightsForSamplerRequest, session: AsyncSession = Depends(get_session)):
+async def save_weights_for_sampler(
+    request: SaveWeightsForSamplerRequest,
+    req: Request,
+    session: AsyncSession = Depends(get_session),
+):
     """Saves weights in a format compatible with sampling/inference servers."""
     # Get the model (validates it exists and gives us the session_id)
     model = await get_model(session, request.model_id)
+    await ensure_training_model(req, session, request.model_id)
 
     checkpoint_id = request.path or f"ss{request.sampling_session_seq_id}_seq{request.seq_id}"
     sampling_session_id = None
     if request.sampling_session_seq_id is not None and request.seq_id is not None:
-        # Create the sampling session using the model's session
-        sampling_session_id = f"sampling_{uuid4().hex[:8]}"
-        sampling_db = SamplingSessionDB(
-            sampling_session_id=sampling_session_id,
-            session_id=model.session_id,
-            sampling_session_seq_id=request.sampling_session_seq_id,
-            base_model=None,
-            model_path=f"tinker://{request.model_id}/sampler_weights/{checkpoint_id}",
-        )
-        session.add(sampling_db)
-
-    # Create pending checkpoint entry
-    await create_checkpoint(
-        session=session,
-        model_id=request.model_id,
-        checkpoint_id=checkpoint_id,
-        checkpoint_type=types.CheckpointType.SAMPLER,
-    )
-
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER,
-        model_id=request.model_id,
-        request_data=types.SaveWeightsForSamplerInput(
+        identity = f"{request.model_id}:{request.seq_id}".encode()
+        sampling_session_id = f"sampling_{hashlib.sha256(identity).hexdigest()[:8]}"
+    payload = (
+        types.SaveWeightsForSamplerInput(
             path=checkpoint_id,
             sampling_session_seq_id=request.sampling_session_seq_id,
             seq_id=request.seq_id,
             sampling_session_id=sampling_session_id,
-        ),
+        )
+        .model_dump_json()
+        .encode()
     )
-
-    await session.commit()
+    lock = req.app.state.training_control_locks.setdefault(request.model_id, asyncio.Lock())
+    async with lock:
+        request_id = existing_training_operation(
+            req,
+            types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER,
+            request.model_id,
+            request.seq_id,
+            payload,
+        )
+        if request_id is None:
+            sampling_db = None
+            if sampling_session_id is not None:
+                sampling_db = SamplingSessionDB(
+                    sampling_session_id=sampling_session_id,
+                    session_id=model.session_id,
+                    sampling_session_seq_id=request.sampling_session_seq_id,
+                    base_model=None,
+                    model_path=f"tinker://{request.model_id}/sampler_weights/{checkpoint_id}",
+                )
+                session.add(sampling_db)
+            await create_checkpoint(
+                session=session,
+                model_id=request.model_id,
+                checkpoint_id=checkpoint_id,
+                checkpoint_type=types.CheckpointType.SAMPLER,
+            )
+            await session.commit()
+            try:
+                request_id = enqueue_training_operation(
+                    req,
+                    types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER,
+                    request.model_id,
+                    request.seq_id,
+                    payload,
+                )
+            except Exception:
+                checkpoint = await session.get(
+                    CheckpointDB,
+                    (request.model_id, checkpoint_id, types.CheckpointType.SAMPLER),
+                )
+                if checkpoint is not None:
+                    await session.delete(checkpoint)
+                if sampling_db is not None:
+                    await session.delete(sampling_db)
+                await session.commit()
+                raise
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
-async def get_sampling_model(request: SampleRequest, session: AsyncSession) -> (str | None, str | None):
+async def get_sampling_model(request: SampleRequest, session: AsyncSession) -> tuple[str | None, str | None]:
     """Return (base_model, model_path) for a sampling request."""
     # Resolve model/base from sampling_session_id if provided
     if request.sampling_session_id is not None:
@@ -1313,6 +1629,49 @@ async def get_sampling_model(request: SampleRequest, session: AsyncSession) -> (
             raise HTTPException(status_code=404, detail="Sampling session not found")
         return (sampling_session.base_model, sampling_session.model_path)
     return (request.base_model, request.model_path)
+
+
+async def get_sampling_target(request: SampleRequest, req: Request, session: AsyncSession) -> SamplingTarget:
+    """Resolve and validate the model used by a sample request."""
+
+    async def resolve() -> SamplingTarget:
+        base_model, model_path = await get_sampling_model(request, session)
+        if base_model:
+            return SamplingTarget(base_model=base_model, model_id="", checkpoint_id="")
+
+        assert model_path is not None
+        path = types.TinkerPath.parse(model_path)
+        if (
+            not path
+            or path.kind not in ("", "sampler_weights")
+            or not (model_id := path.primary_id)
+            or not (checkpoint_id := path.secondary_id)
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="model_path must be tinker://model_id/checkpoint_id or tinker://model_id/sampler_weights/checkpoint_id",
+            )
+        await get_model(session, model_id)
+        await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
+        return SamplingTarget(base_model=None, model_id=model_id, checkpoint_id=checkpoint_id)
+
+    sampling_session_id = request.sampling_session_id
+    if sampling_session_id is None or not req.app.state.external_inference_client:
+        return await resolve()
+
+    targets: dict[str, SamplingTarget] = req.app.state.external_sampling_targets
+    target = targets.get(sampling_session_id)
+    if target is not None:
+        return target
+
+    locks: dict[str, asyncio.Lock] = req.app.state.external_sampling_target_locks
+    lock = locks.setdefault(sampling_session_id, asyncio.Lock())
+    async with lock:
+        target = targets.get(sampling_session_id)
+        if target is None:
+            target = await resolve()
+            targets[sampling_session_id] = target
+        return target
 
 
 @app.post("/api/v1/asample", response_model=FutureResponse)
@@ -1324,46 +1683,30 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
             detail="sampling_session_id must not contain ':' (the routing-key delimiter)",
         )
 
-    base_model, model_path = await get_sampling_model(request, session)
-
-    if base_model:
-        model_id = checkpoint_id = ""
-    else:
-        assert model_path is not None
-        path = types.TinkerPath.parse(model_path)
-        if (
-            not path
-            # Accept either tinker://model_id/checkpoint_id or tinker://model_id/sampler_weights/checkpoint_id
-            or path.kind not in ("", "sampler_weights")
-            or not (model_id := path.primary_id)
-            or not (checkpoint_id := path.secondary_id)
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail="model_path must be tinker://model_id/checkpoint_id or tinker://model_id/sampler_weights/checkpoint_id",
-            )
-        await get_model(session, model_id)
-        # Validate that the checkpoint exists and is ready
-        await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
+    target = await get_sampling_target(request, req, session)
 
     if req.app.state.external_inference_client:
         request_id = req.app.state.external_future_store.create_future()
         asyncio.create_task(
             req.app.state.external_inference_client.call_and_store_result(
-                request_id, request, model_id, checkpoint_id, base_model=base_model
+                request_id,
+                request,
+                target.model_id,
+                target.checkpoint_id,
+                base_model=target.base_model,
             )
         )
     else:
         request_id = await create_future(
             session=session,
             request_type=types.RequestType.SAMPLE,
-            model_id=model_id,
+            model_id=target.model_id,
             request_data=types.SampleInput(
-                base_model=base_model,
+                base_model=target.base_model,
                 prompt=request.prompt.to_types(),
                 sampling_params=request.sampling_params.to_types(),
                 num_samples=request.num_samples,
-                checkpoint_id=checkpoint_id,
+                checkpoint_id=target.checkpoint_id,
                 # A positive topk implies prompt logprobs: both are read off the same
                 # prompt forward pass, so asking for one asks for the other.
                 prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
@@ -1383,7 +1726,10 @@ async def get_server_capabilities(request: Request):
     supported_models = [
         SupportedModel(model_name=request.app.state.engine_config.base_model),
     ]
-    return GetServerCapabilitiesResponse(supported_models=supported_models)
+    return GetServerCapabilitiesResponse(
+        supported_models=supported_models,
+        supported_loss_fns=sorted(types.SUPPORTED_LOSS_FNS),
+    )
 
 
 class RetrieveFutureRequest(BaseModel):
@@ -1400,7 +1746,11 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
         if is_external_future:
             row = await req.app.state.external_future_store.wait_for_future(request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
         else:
-            row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+            row = await wait_for_future(
+                req.app.state.future_waiters,
+                request_id,
+                RETRIEVE_FUTURE_TIMEOUT_SECONDS,
+            )
     except KeyError:
         raise HTTPException(status_code=404, detail="Future not found")
 
@@ -1409,7 +1759,7 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
 
     if is_external_future:
         status, result_data = row
-        request_type = None
+        request_type = req.app.state.external_future_store.request_type(request_id)
     else:
         status, request_type, result_data = row
     if status == RequestStatus.COMPLETED:
@@ -1445,7 +1795,11 @@ async def send_telemetry(request: TelemetryRequest):
 
 
 async def validate_checkpoint(
-    request: Request, unique_id: str, checkpoint_id: str, checkpoint_type: types.CheckpointType, session: AsyncSession
+    request: Request,
+    unique_id: str,
+    checkpoint_id: str,
+    checkpoint_type: types.CheckpointType,
+    session: AsyncSession,
 ):
     """Validate that a model and checkpoint exist in the database, returning the checkpoint path."""
     checkpoint_db = await session.get(CheckpointDB, (unique_id, checkpoint_id, checkpoint_type))
@@ -1457,13 +1811,19 @@ async def validate_checkpoint(
         raise HTTPException(status_code=425, detail="Checkpoint is still being created")
 
     if checkpoint_db.status == CheckpointStatus.FAILED:
-        raise HTTPException(status_code=500, detail=f"Checkpoint creation failed: {checkpoint_db.error_message}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Checkpoint creation failed: {checkpoint_db.error_message}",
+        )
 
     return checkpoint_file_path(request, unique_id, checkpoint_id, checkpoint_type)
 
 
 def checkpoint_file_path(
-    request: Request, unique_id: str, checkpoint_id: str, checkpoint_type: types.CheckpointType
+    request: Request,
+    unique_id: str,
+    checkpoint_id: str,
+    checkpoint_type: types.CheckpointType,
 ) -> Any:
     checkpoint_dir = request.app.state.engine_config.checkpoints_base / unique_id
     if checkpoint_type == types.CheckpointType.SAMPLER:
@@ -1546,7 +1906,8 @@ async def list_training_runs(
         )
 
     return TrainingRunsResponse(
-        training_runs=training_runs, cursor=Cursor(offset=offset, limit=limit, total_count=total_count)
+        training_runs=training_runs,
+        cursor=Cursor(offset=offset, limit=limit, total_count=total_count),
     )
 
 
@@ -1561,7 +1922,13 @@ async def get_checkpoint_archive_url(
     await validate_checkpoint(request, unique_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
 
     # Generate URL to the download endpoint and return 302 redirect
-    download_url = str(request.url_for("download_checkpoint_archive", unique_id=unique_id, checkpoint_id=checkpoint_id))
+    download_url = str(
+        request.url_for(
+            "download_checkpoint_archive",
+            unique_id=unique_id,
+            checkpoint_id=checkpoint_id,
+        )
+    )
     expires = datetime.utcnow() + timedelta(minutes=120)
 
     response = RedirectResponse(url=download_url, status_code=302)
@@ -1592,7 +1959,10 @@ async def download_checkpoint_archive(
     return StreamingResponse(file_buffer, media_type="application/octet-stream", headers=headers)
 
 
-@app.delete("/api/v1/training_runs/{unique_id}/checkpoints/{checkpoint_path:path}", status_code=204)
+@app.delete(
+    "/api/v1/training_runs/{unique_id}/checkpoints/{checkpoint_path:path}",
+    status_code=204,
+)
 async def delete_checkpoint(
     request: Request,
     unique_id: str = fastapi.Path(..., pattern=ID_PATTERN, max_length=ID_MAX_LENGTH),
@@ -1674,13 +2044,18 @@ async def list_checkpoints_models(
 
 
 @app.post("/api/v1/weights_info", response_model=WeightsInfoResponse)
-async def get_weights_info(request: WeightsInfoRequest, req: Request, session: AsyncSession = Depends(get_session)):
+async def get_weights_info(
+    request: WeightsInfoRequest,
+    req: Request,
+    session: AsyncSession = Depends(get_session),
+):
     """Get information about weights/checkpoint from a tinker path."""
     path = types.TinkerPath.parse(request.tinker_path)
 
     if not path or path.kind != "weights":
         raise HTTPException(
-            status_code=400, detail="Invalid tinker path format. Expected: tinker://model_id/weights/checkpoint_id"
+            status_code=400,
+            detail="Invalid tinker path format. Expected: tinker://model_id/weights/checkpoint_id",
         )
 
     model_id = path.primary_id

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1394,9 +1394,10 @@ class RetrieveFutureRequest(BaseModel):
 async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     """Retrieve the result of an async operation, waiting until it's available."""
     request_id = int(request.request_id)
+    is_external_future = request_id < 0
 
     try:
-        if request_id < 0:
+        if is_external_future:
             row = await req.app.state.external_future_store.wait_for_future(request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
         else:
             row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
@@ -1406,13 +1407,18 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     if row is None:
         raise HTTPException(status_code=408, detail="Timeout waiting for result")
 
-    status, request_type, result_data = row
+    if is_external_future:
+        status, result_data = row
+        request_type = None
+    else:
+        status, request_type, result_data = row
     if status == RequestStatus.COMPLETED:
         # The SDK retrieves sample/forward/forward_backward results in proto
         # wire format when it advertises support; SDK >= 0.25.0 rejects JSON
         # for these types. Errors and other result types stay JSON.
         if (
-            types.RequestType(request_type) in PROTO_SERIALIZABLE_REQUEST_TYPES
+            request_type is not None
+            and types.RequestType(request_type) in PROTO_SERIALIZABLE_REQUEST_TYPES
             and PROTO_CONTENT_TYPE in req.headers.get("accept", "").lower()
         ):
             return Response(

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -47,6 +47,7 @@ from skyrl.tinker.db_models import (
 )
 from skyrl.tinker.extra import (
     ExternalInferenceClient,
+    InMemoryFutureStore,
     SkyRLTrainInferenceForwardingClient,
 )
 from skyrl.tinker.proto_serialization import (
@@ -261,12 +262,17 @@ async def lifespan(app: FastAPI):
     # SkyRL-Train default is colocate_all=True; only opt into forwarding
     # when the operator explicitly sets it to False.
     is_colocated = bool(backend_cfg.get("trainer.placement.colocate_all", True))
+    app.state.external_future_store = InMemoryFutureStore()
     if app.state.engine_config.external_inference_url:
-        app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
+        app.state.external_inference_client = ExternalInferenceClient(
+            app.state.engine_config, app.state.external_future_store
+        )
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
         app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
-            app.state.engine_config, app.state.db_engine
+            app.state.engine_config,
+            app.state.db_engine,
+            app.state.external_future_store,
         )
         logger.info(
             "SkyRL-Train inference forwarding client enabled for non-colocated backend=%s",
@@ -1340,35 +1346,33 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
         # Validate that the checkpoint exists and is ready
         await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
 
-    request_id = await create_future(
-        session=session,
-        request_type=(
-            types.RequestType.EXTERNAL if req.app.state.external_inference_client else types.RequestType.SAMPLE
-        ),
-        model_id=model_id,
-        request_data=types.SampleInput(
-            base_model=base_model,
-            prompt=request.prompt.to_types(),
-            sampling_params=request.sampling_params.to_types(),
-            num_samples=request.num_samples,
-            checkpoint_id=checkpoint_id,
-            # A positive topk implies prompt logprobs: both are read off the same
-            # prompt forward pass, so asking for one asks for the other.
-            prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
-            topk_prompt_logprobs=request.topk_prompt_logprobs,
-            seq_id=request.seq_id,
-            sampling_session_id=request.sampling_session_id,
-        ),
-    )
-
-    await session.commit()
-
     if req.app.state.external_inference_client:
+        request_id = req.app.state.external_future_store.create_future()
         asyncio.create_task(
             req.app.state.external_inference_client.call_and_store_result(
                 request_id, request, model_id, checkpoint_id, base_model=base_model
             )
         )
+    else:
+        request_id = await create_future(
+            session=session,
+            request_type=types.RequestType.SAMPLE,
+            model_id=model_id,
+            request_data=types.SampleInput(
+                base_model=base_model,
+                prompt=request.prompt.to_types(),
+                sampling_params=request.sampling_params.to_types(),
+                num_samples=request.num_samples,
+                checkpoint_id=checkpoint_id,
+                # A positive topk implies prompt logprobs: both are read off the same
+                # prompt forward pass, so asking for one asks for the other.
+                prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
+                topk_prompt_logprobs=request.topk_prompt_logprobs,
+                seq_id=request.seq_id,
+                sampling_session_id=request.sampling_session_id,
+            ),
+        )
+        await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
@@ -1392,7 +1396,10 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     request_id = int(request.request_id)
 
     try:
-        row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        if request_id < 0:
+            row = await req.app.state.external_future_store.wait_for_future(request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        else:
+            row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
     except KeyError:
         raise HTTPException(status_code=404, detail="Future not found")
 

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -981,6 +981,7 @@ class SaveWeightsRequest(BaseModel):
 class LoadWeightsRequest(BaseModel):
     model_id: str
     path: str
+    optimizer: bool = True
     seq_id: int | None = None
     type: Literal["load_weights"] | None = None
 
@@ -1458,7 +1459,7 @@ async def load_weights(
     req: Request,
     session: AsyncSession = Depends(get_session),
 ):
-    """Loads weights and training state."""
+    """Load weights and training state as the model's first request."""
     await ensure_training_model(req, session, request.model_id)
 
     path = types.TinkerPath.parse(request.path)
@@ -1474,7 +1475,13 @@ async def load_weights(
         )
 
     payload = (
-        types.LoadWeightsInput(source_model_id=source_model_id, checkpoint_id=checkpoint_id).model_dump_json().encode()
+        types.LoadWeightsInput(
+            source_model_id=source_model_id,
+            checkpoint_id=checkpoint_id,
+            load_optimizer=request.optimizer,
+        )
+        .model_dump_json()
+        .encode()
     )
     if (
         request_id := existing_training_operation(
@@ -1485,6 +1492,15 @@ async def load_weights(
             payload,
         )
     ) is None:
+        prior_requests = await session.exec(
+            select(func.count())
+            .select_from(FutureDB)
+            .where(FutureDB.model_id == request.model_id)
+            .where(FutureDB.request_type != types.RequestType.CREATE_MODEL)
+        )
+        if prior_requests.one() > 0 or req.app.state.training_operation_queue.has_operations(request.model_id):
+            seq_id = request.seq_id if request.seq_id is not None else 1
+            raise HTTPException(status_code=400, detail=f"LoadWeights is not permitted with seq_id {seq_id}")
         await validate_checkpoint(req, source_model_id, checkpoint_id, types.CheckpointType.TRAINING, session)
         request_id = enqueue_training_operation(
             req,

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1365,8 +1365,8 @@ async def _read_forward_backward_request(
     passes here via the proto's ``forward_only`` flag instead of calling
     ``/api/v1/forward``; older SDKs keep sending JSON with forward_only False.
     """
+    body = await _read_training_body(request)
     async with request.app.state.training_parse_semaphore:
-        body = await _read_training_body(request)
         is_proto = PROTO_CONTENT_TYPE in request.headers.get("content-type", "").lower()
         content_encoding = request.headers.get("content-encoding", "").lower().strip()
         if content_encoding not in ("", "identity", "zstd"):
@@ -1414,8 +1414,8 @@ async def forward_backward(request: Request, session: AsyncSession = Depends(get
 @app.post("/api/v1/forward", response_model=FutureResponse)
 async def forward(request: Request, session: AsyncSession = Depends(get_session)):
     """Forward pass to obtain logprobs without accumulating gradients"""
+    body = await _read_training_body(request)
     async with request.app.state.training_parse_semaphore:
-        body = await _read_training_body(request)
         try:
             model_id, seq_id, payload = await asyncio.to_thread(_parse_forward_body, body)
         except ValidationError as error:

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1686,7 +1686,7 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
     target = await get_sampling_target(request, req, session)
 
     if req.app.state.external_inference_client:
-        request_id = req.app.state.external_future_store.create_future()
+        request_id = req.app.state.external_future_store.create_future(types.RequestType.SAMPLE)
         asyncio.create_task(
             req.app.state.external_inference_client.call_and_store_result(
                 request_id,

--- a/skyrl/tinker/config.py
+++ b/skyrl/tinker/config.py
@@ -58,6 +58,16 @@ class EngineConfig(BaseModel):
         ),
         json_schema_extra={"argparse_type": lambda v: None if v == "None" else int(v)},
     )
+    training_operation_max_pending_per_model: int = Field(
+        default=512,
+        gt=0,
+        description="Maximum number of incomplete training operations held for one model.",
+    )
+    training_operation_max_payload_bytes: int = Field(
+        default=2 * 1024**3,
+        gt=0,
+        description="Maximum total bytes of training request payloads held by the API process.",
+    )
     session_cleanup_interval_sec: int = Field(
         default=60,
         description="How often to check for stale sessions (seconds). Set to -1 to disable cleanup.",

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -5,12 +5,14 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+from itertools import groupby
 from pathlib import Path
 from typing import Any, Callable
 
 from cloudpathlib import AnyPath
 from pydantic import BaseModel
 from sqlmodel import Session, create_engine, func, select, update
+from zstandard import decompress as zstd_decompress
 
 from skyrl.backends.utils import log_timing
 from skyrl.tinker import types
@@ -25,6 +27,12 @@ from skyrl.tinker.db_models import (
     SessionDB,
     enable_sqlite_wal,
 )
+from skyrl.tinker.operation_transport import (
+    ClaimedOperation,
+    OperationPayloadFormat,
+    OperationTransportClient,
+)
+from skyrl.tinker.proto_serialization import parse_forward_backward_input
 from skyrl.utils.log import logger
 
 _MAX_IDS_PER_QUERY = 500
@@ -256,6 +264,7 @@ class TinkerEngine:
     def __init__(
         self,
         config: EngineConfig,
+        operation_transport_socket: str | None = None,
     ):
         """Initialize the engine with a database connection and base model."""
         self.config = config
@@ -267,6 +276,9 @@ class TinkerEngine:
         backend_class, backend_config_class = get_backend_classes(config.backend, use_ray=use_ray)
         backend_config = backend_config_class(**config.backend_config)
         self.backend = backend_class(config.base_model, backend_config)
+        self.operation_transport = (
+            OperationTransportClient(operation_transport_socket) if operation_transport_socket is not None else None
+        )
 
         # Backends that support async sample routing notify us when their
         # inference endpoint changes; we persist it to EngineStateDB so the
@@ -377,6 +389,58 @@ class TinkerEngine:
         )
         return dict(session.exec(query).all())
 
+    def _find_next_sequence_ids(self, session: Session) -> dict[str, int]:
+        """Derive each model's next SDK sequence from its persisted futures."""
+        query = (
+            select(FutureDB.model_id, func.max(FutureDB.seq_id))
+            .where(FutureDB.seq_id.is_not(None))
+            .where(FutureDB.status != RequestStatus.PENDING)
+            .group_by(FutureDB.model_id)
+        )
+        return {model_id: last_seq_id + 1 for model_id, last_seq_id in session.exec(query).all()}
+
+    def _find_sequenced_requests(
+        self, session: Session, request_types: set[types.RequestType]
+    ) -> list[tuple[int, str, types.RequestType]]:
+        """Find each model's leading contiguous SDK requests while their types are allowed."""
+        next_sequence_ids = self._find_next_sequence_ids(session)
+        pending = session.exec(
+            select(
+                FutureDB.request_id,
+                FutureDB.model_id,
+                FutureDB.seq_id,
+                FutureDB.request_type,
+            )
+            .where(FutureDB.seq_id.is_not(None))
+            .where(FutureDB.status == RequestStatus.PENDING)
+            .order_by(FutureDB.model_id, FutureDB.seq_id)
+        ).all()
+
+        batchable = []
+        for model_id, requests in groupby(pending, key=lambda row: row.model_id):
+            requests = list(requests)
+            expected_seq_id = next_sequence_ids.get(model_id)
+            if expected_seq_id is None:
+                expected_seq_id = requests[0].seq_id
+            for request_id, _, seq_id, pending_type in requests:
+                if seq_id != expected_seq_id or pending_type not in request_types:
+                    break
+                batchable.append((request_id, model_id, pending_type))
+                expected_seq_id += 1
+        return batchable
+
+    def _find_sequenced_single_requests(self, session: Session) -> list[tuple[int, str, types.RequestType]]:
+        """Find leading contiguous SDK requests that do not run as model-pass batches."""
+        return self._find_sequenced_requests(
+            session,
+            {
+                types.RequestType.OPTIM_STEP,
+                types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER,
+                types.RequestType.SAVE_WEIGHTS,
+                types.RequestType.LOAD_WEIGHTS,
+            },
+        )
+
     def find_batchable_model_passes(
         self, session: Session, request_type: types.RequestType
     ) -> dict[str, tuple[str, types.ForwardBackwardInput]]:
@@ -399,19 +463,26 @@ class TinkerEngine:
             select(FutureDB.request_id, FutureDB.model_id)
             .where(FutureDB.request_type == request_type)
             .where(FutureDB.status == RequestStatus.PENDING)
+            .where(FutureDB.seq_id.is_(None))
             .order_by(FutureDB.request_id)
         )
         ops = session.exec(query).all()
 
         # Filter: only include ops that come before their model's barrier
         batchable = [
+            (request_id, model_id) for request_id, model_id, _ in self._find_sequenced_requests(session, {request_type})
+        ]
+        batchable.extend(
             (request_id, model_id)
             for request_id, model_id in ops
             if model_id not in barriers or request_id < barriers[model_id]
-        ]
+        )
 
         return {
-            str(request_id): (model_id, types.ForwardBackwardInput.model_validate(request_data))
+            str(request_id): (
+                model_id,
+                types.ForwardBackwardInput.model_validate(request_data),
+            )
             for request_id, model_id, request_data in self._load_requests(session, batchable)
         }
 
@@ -433,7 +504,11 @@ class TinkerEngine:
         """
         # checkpoint_id is extracted in the database so prompts stay out of this query
         sample_query = (
-            select(FutureDB.request_id, FutureDB.model_id, FutureDB.request_data["checkpoint_id"].as_string())
+            select(
+                FutureDB.request_id,
+                FutureDB.model_id,
+                FutureDB.request_data["checkpoint_id"].as_string(),
+            )
             .where(FutureDB.request_type == types.RequestType.SAMPLE)
             .where(FutureDB.status == RequestStatus.PENDING)
             .order_by(FutureDB.request_id)
@@ -490,6 +565,7 @@ class TinkerEngine:
         statement = (
             select(FutureDB.request_id, FutureDB.model_id, FutureDB.request_type)
             .where(FutureDB.status == RequestStatus.PENDING)
+            .where(FutureDB.seq_id.is_(None))
             .where(FutureDB.request_type != types.RequestType.FORWARD_BACKWARD)
             .where(FutureDB.request_type != types.RequestType.FORWARD)
             .where(FutureDB.request_type != types.RequestType.SAMPLE)
@@ -499,15 +575,18 @@ class TinkerEngine:
         other_futures = session.exec(statement).all()
 
         # Filter: only include ops that come before the first blocked pass for their model
-        other_futures = [
+        legacy_futures = [
             (request_id, model_id, request_type)
             for request_id, model_id, request_type in other_futures
             if model_id not in blocked_pass_barriers or request_id < blocked_pass_barriers[model_id]
         ]
+        sequenced_futures = self._find_sequenced_single_requests(session)
 
         return {
             str(request_id): (model_id, request_type, request_data)
-            for request_id, model_id, request_type, request_data in self._load_requests(session, other_futures)
+            for request_id, model_id, request_type, request_data in self._load_requests(
+                session, sequenced_futures + legacy_futures
+            )
         }
 
     def process_create_model(self, model_id: str, request_data: types.CreateModelInput) -> types.CreateModelOutput:
@@ -641,7 +720,7 @@ class TinkerEngine:
             self.config.checkpoints_base / request_data.source_model_id / f"{request_data.checkpoint_id}.tar.gz"
         )
 
-        self.backend.load_checkpoint(checkpoint_path, model_id, load_optimizer=request_data.load_optimizer)
+        self.backend.load_checkpoint(checkpoint_path, model_id)
 
         return types.LoadWeightsOutput(type="load_weights")
 
@@ -733,7 +812,8 @@ class TinkerEngine:
                 return self.process_optim_step(model_id, types.OptimStepInput.model_validate(request_data))
             case types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER:
                 return self.process_save_weights_for_sampler(
-                    model_id, types.SaveWeightsForSamplerInput.model_validate(request_data)
+                    model_id,
+                    types.SaveWeightsForSamplerInput.model_validate(request_data),
                 )
             case types.RequestType.SAVE_WEIGHTS:
                 return self.process_save_weights(model_id, types.SaveWeightsInput.model_validate(request_data))
@@ -802,16 +882,122 @@ class TinkerEngine:
                     results = {request_id: types.ErrorResponse(error=str(e), status="failed") for request_id in group}
             self._complete_futures(results)
 
+    def process_transport_operations(self, operations: list[ClaimedOperation]) -> None:
+        """Execute one API-owned batch and return results over the local IPC channel."""
+        if not operations:
+            return
+        assert self.operation_transport is not None
+        request_type = operations[0].request_type
+        if any(operation.request_type != request_type for operation in operations):
+            raise ValueError("operation transport returned a mixed-kind batch")
+
+        if request_type in (
+            types.RequestType.FORWARD,
+            types.RequestType.FORWARD_BACKWARD,
+        ):
+            requests: dict[str, tuple[str, types.ForwardBackwardInput]] = {}
+            results: dict[str, BaseModel] = {}
+            for operation in operations:
+                try:
+                    if operation.payload_format is OperationPayloadFormat.JSON:
+                        request_data = types.ForwardBackwardInput.model_validate_json(operation.payload)
+                    else:
+                        body = (
+                            zstd_decompress(operation.payload)
+                            if operation.payload_format is OperationPayloadFormat.PROTO_ZSTD
+                            else operation.payload
+                        )
+                        request_data = parse_forward_backward_input(body)
+                    operation.payload = b""
+                    requests[str(operation.request_id)] = (
+                        operation.model_id,
+                        request_data,
+                    )
+                except Exception as error:
+                    logger.exception(
+                        "Error parsing transported %s operation %s",
+                        request_type.value,
+                        operation.request_id,
+                    )
+                    results[str(operation.request_id)] = types.ErrorResponse(
+                        error=str(error),
+                        status="failed",
+                    )
+            try:
+                invalid, valid = self._filter_valid_requests(requests)
+                results.update(invalid)
+                if valid:
+                    processor = (
+                        self.process_forward
+                        if request_type == types.RequestType.FORWARD
+                        else self.process_forward_backward
+                    )
+                    results.update(processor(valid))
+            except Exception as error:
+                logger.exception("Error processing transported %s batch", request_type.value)
+                results.update(
+                    {
+                        str(operation.request_id): types.ErrorResponse(error=str(error), status="failed")
+                        for operation in operations
+                        if str(operation.request_id) not in results
+                    }
+                )
+            for operation in operations:
+                result = results.get(str(operation.request_id))
+                if result is None:
+                    result = types.ErrorResponse(error="Backend returned no result", status="failed")
+                self.operation_transport.complete(operation.request_id, result)
+            return
+
+        control_input_types = {
+            types.RequestType.OPTIM_STEP: types.OptimStepInput,
+            types.RequestType.SAVE_WEIGHTS: types.SaveWeightsInput,
+            types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER: types.SaveWeightsForSamplerInput,
+            types.RequestType.LOAD_WEIGHTS: types.LoadWeightsInput,
+        }
+        if request_type in control_input_types and len(operations) == 1:
+            operation = operations[0]
+            try:
+                request_data = control_input_types[request_type].model_validate_json(operation.payload)
+                operation.payload = b""
+                result = self.process_single_request(
+                    request_type,
+                    operation.model_id,
+                    request_data.model_dump(mode="json"),
+                )
+            except Exception as error:
+                logger.exception("Error processing transported %s", request_type.value)
+                result = types.ErrorResponse(error=str(error), status="failed")
+            self.operation_transport.complete(operation.request_id, result)
+            return
+
+        error = types.ErrorResponse(
+            error=f"Unsupported transported request type: {request_type.value}",
+            status="failed",
+        )
+        for operation in operations:
+            self.operation_transport.complete(operation.request_id, error)
+
     def process_pending_requests(self):
         """Main loop to process pending requests."""
         while True:
+            if self.operation_transport is not None:
+                transported = self.operation_transport.claim()
+                if transported:
+                    self.process_transport_operations(transported)
+                    continue
+
             # Query for pending requests and extract data within session context
             with Session(self.db_engine) as session:
-                # Use look-ahead scheduling to find batchable forward_backward and forward model passes
-                forward_backward_requests = self.find_batchable_model_passes(
-                    session, types.RequestType.FORWARD_BACKWARD
-                )
-                forward_requests = self.find_batchable_model_passes(session, types.RequestType.FORWARD)
+                if self.operation_transport is None:
+                    # Direct engine construction keeps the database path for tests and benchmarks.
+                    forward_backward_requests = self.find_batchable_model_passes(
+                        session, types.RequestType.FORWARD_BACKWARD
+                    )
+                    forward_requests = self.find_batchable_model_passes(session, types.RequestType.FORWARD)
+                else:
+                    forward_backward_requests = {}
+                    forward_requests = {}
                 # Find pending sample requests that can be batched
                 sample_requests = self.find_batchable_sample(session)
                 # Get other pending requests (non forward_backward and non sampling)
@@ -819,7 +1005,10 @@ class TinkerEngine:
 
             # Process batches outside of session context
             self.process_batch_requests(
-                forward_backward_requests, self.process_forward_backward, "forward_backward", per_model=True
+                forward_backward_requests,
+                self.process_forward_backward,
+                "forward_backward",
+                per_model=True,
             )
             self.process_batch_requests(forward_requests, self.process_forward, "forward", per_model=True)
             self.process_batch_requests(sample_requests, self.process_sample, "sample")
@@ -847,15 +1036,18 @@ def main():
     # Create argument parser and add Pydantic model fields
     parser = argparse.ArgumentParser(description="SkyRL tinker engine for processing requests")
     add_model(parser, EngineConfig)
+    parser.add_argument("--operation-transport-socket", default=None, help=argparse.SUPPRESS)
 
     # Parse command-line arguments
     args = parser.parse_args()
 
     # Create EngineConfig from parsed arguments
-    config = EngineConfig.model_validate(vars(args))
+    parsed = vars(args)
+    operation_transport_socket = parsed.pop("operation_transport_socket")
+    config = EngineConfig.model_validate(parsed)
 
     # Initialize and run the engine
-    TinkerEngine(config).run()
+    TinkerEngine(config, operation_transport_socket=operation_transport_socket).run()
 
 
 if __name__ == "__main__":

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -720,7 +720,7 @@ class TinkerEngine:
             self.config.checkpoints_base / request_data.source_model_id / f"{request_data.checkpoint_id}.tar.gz"
         )
 
-        self.backend.load_checkpoint(checkpoint_path, model_id)
+        self.backend.load_checkpoint(checkpoint_path, model_id, load_optimizer=request_data.load_optimizer)
 
         return types.LoadWeightsOutput(type="load_weights")
 

--- a/skyrl/tinker/extra/__init__.py
+++ b/skyrl/tinker/extra/__init__.py
@@ -1,6 +1,11 @@
 from skyrl.tinker.extra.external_inference import ExternalInferenceClient
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
     SkyRLTrainInferenceForwardingClient,
 )
 
-__all__ = ["ExternalInferenceClient", "SkyRLTrainInferenceForwardingClient"]
+__all__ = [
+    "ExternalInferenceClient",
+    "InMemoryFutureStore",
+    "SkyRLTrainInferenceForwardingClient",
+]

--- a/skyrl/tinker/extra/external_inference.py
+++ b/skyrl/tinker/extra/external_inference.py
@@ -1,17 +1,16 @@
 import asyncio
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
 from cloudpathlib import AnyPath
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from skyrl.backends.renderer import render_model_input
 from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
-from skyrl.tinker.db_models import FutureDB, RequestStatus
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.utils.log import logger
 from skyrl.utils.storage import download_and_unpack
 
@@ -41,12 +40,12 @@ def _extract_checkpoint_sync(checkpoint_path: AnyPath, target_dir: Path) -> None
 class ExternalInferenceClient:
     """Client for calling external inference engines (e.g., vLLM)."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(self, engine_config: EngineConfig, future_store: InMemoryFutureStore):
         self.base_url = f"{engine_config.external_inference_url}/v1"
         self.api_key = engine_config.external_inference_api_key
         self.checkpoints_base = engine_config.checkpoints_base
         self.lora_base_dir = engine_config.external_inference_lora_base
-        self.db_engine = db_engine
+        self.future_store = future_store
 
     async def call_and_store_result(
         self,
@@ -57,7 +56,7 @@ class ExternalInferenceClient:
         *,
         base_model: str | None = None,
     ):
-        """Background task to call external engine and store result in database."""
+        """Call the external engine and resolve its API-process-owned future."""
         try:
             async with httpx.AsyncClient(
                 base_url=self.base_url,
@@ -73,13 +72,7 @@ class ExternalInferenceClient:
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
 
-        async with AsyncSession(self.db_engine) as session:
-            future = await session.get(FutureDB, request_id)
-            # `result_data` is a text column holding pre-serialized JSON.
-            future.result_data = result.model_dump_json()
-            future.status = status
-            future.completed_at = datetime.now(timezone.utc)
-            await session.commit()
+        self.future_store.complete_future(request_id, status, result.model_dump_json())
 
     async def _forward_to_engine(
         self,

--- a/skyrl/tinker/extra/in_memory_future_store.py
+++ b/skyrl/tinker/extra/in_memory_future_store.py
@@ -4,11 +4,13 @@ import time
 from collections import deque
 from dataclasses import dataclass, field
 
+from skyrl.tinker import types
 from skyrl.tinker.db_models import RequestStatus
 
 
 @dataclass
 class _StoredFuture:
+    request_type: types.RequestType | None = None
     event: asyncio.Event = field(default_factory=asyncio.Event)
     status: RequestStatus = RequestStatus.PENDING
     result_data: str | None = None
@@ -18,25 +20,45 @@ class _StoredFuture:
 class InMemoryFutureStore:
     """Store API-process-owned futures without routing them through the engine database."""
 
-    def __init__(self, *, terminal_retention_sec: float = 600, max_terminal_futures: int = 10_000):
+    def __init__(
+        self,
+        *,
+        terminal_retention_sec: float = 600,
+        max_terminal_futures: int = 10_000,
+        max_terminal_bytes: int = 2 * 1024**3,
+    ):
         self._terminal_retention_sec = terminal_retention_sec
         self._max_terminal_futures = max_terminal_futures
+        self._max_terminal_bytes = max_terminal_bytes
         self._next_id = itertools.count(start=-1, step=-1)
         self._futures: dict[int, _StoredFuture] = {}
-        self._terminal_futures: deque[tuple[float, int]] = deque()
+        self._terminal_futures: deque[tuple[float, int, int]] = deque()
+        self._terminal_bytes = 0
 
-    def create_future(self) -> int:
+    def create_future(self, request_type: types.RequestType | None = None) -> int:
         self._cleanup_terminal_futures()
         request_id = next(self._next_id)
-        self._futures[request_id] = _StoredFuture()
+        self._futures[request_id] = _StoredFuture(request_type=request_type)
         return request_id
+
+    def request_type(self, request_id: int) -> types.RequestType | None:
+        future = self._futures.get(request_id)
+        if future is None:
+            raise KeyError(request_id)
+        return future.request_type
+
+    def has_future(self, request_id: int) -> bool:
+        self._cleanup_terminal_futures()
+        return request_id in self._futures
 
     def complete_future(self, request_id: int, status: RequestStatus, result_data: str) -> None:
         future = self._futures[request_id]
         future.status = status
         future.result_data = result_data
         future.completed_at = time.monotonic()
-        self._terminal_futures.append((future.completed_at, request_id))
+        result_bytes = len(result_data.encode())
+        self._terminal_bytes += result_bytes
+        self._terminal_futures.append((future.completed_at, request_id, result_bytes))
         future.event.set()
         self._cleanup_terminal_futures()
 
@@ -56,6 +78,8 @@ class InMemoryFutureStore:
         while self._terminal_futures and (
             now - self._terminal_futures[0][0] > self._terminal_retention_sec
             or len(self._terminal_futures) > self._max_terminal_futures
+            or self._terminal_bytes > self._max_terminal_bytes
         ):
-            _, request_id = self._terminal_futures.popleft()
+            _, request_id, result_bytes = self._terminal_futures.popleft()
+            self._terminal_bytes -= result_bytes
             del self._futures[request_id]

--- a/skyrl/tinker/extra/in_memory_future_store.py
+++ b/skyrl/tinker/extra/in_memory_future_store.py
@@ -1,6 +1,7 @@
 import asyncio
 import itertools
 import time
+from collections import deque
 from dataclasses import dataclass, field
 
 from skyrl.tinker.db_models import RequestStatus
@@ -22,6 +23,7 @@ class InMemoryFutureStore:
         self._max_terminal_futures = max_terminal_futures
         self._next_id = itertools.count(start=-1, step=-1)
         self._futures: dict[int, _StoredFuture] = {}
+        self._terminal_futures: deque[tuple[float, int]] = deque()
 
     def create_future(self) -> int:
         self._cleanup_terminal_futures()
@@ -34,7 +36,9 @@ class InMemoryFutureStore:
         future.status = status
         future.result_data = result_data
         future.completed_at = time.monotonic()
+        self._terminal_futures.append((future.completed_at, request_id))
         future.event.set()
+        self._cleanup_terminal_futures()
 
     async def wait_for_future(self, request_id: int, timeout: float) -> tuple[RequestStatus, str | None] | None:
         future = self._futures.get(request_id)
@@ -49,19 +53,9 @@ class InMemoryFutureStore:
 
     def _cleanup_terminal_futures(self) -> None:
         now = time.monotonic()
-        expired = [
-            request_id
-            for request_id, future in self._futures.items()
-            if future.completed_at is not None and now - future.completed_at > self._terminal_retention_sec
-        ]
-        for request_id in expired:
-            del self._futures[request_id]
-
-        terminal = sorted(
-            (future.completed_at, request_id)
-            for request_id, future in self._futures.items()
-            if future.completed_at is not None
-        )
-        overflow = len(terminal) - self._max_terminal_futures
-        for _, request_id in terminal[: max(overflow, 0)]:
+        while self._terminal_futures and (
+            now - self._terminal_futures[0][0] > self._terminal_retention_sec
+            or len(self._terminal_futures) > self._max_terminal_futures
+        ):
+            _, request_id = self._terminal_futures.popleft()
             del self._futures[request_id]

--- a/skyrl/tinker/extra/in_memory_future_store.py
+++ b/skyrl/tinker/extra/in_memory_future_store.py
@@ -1,0 +1,67 @@
+import asyncio
+import itertools
+import time
+from dataclasses import dataclass, field
+
+from skyrl.tinker.db_models import RequestStatus
+
+
+@dataclass
+class _StoredFuture:
+    event: asyncio.Event = field(default_factory=asyncio.Event)
+    status: RequestStatus = RequestStatus.PENDING
+    result_data: str | None = None
+    completed_at: float | None = None
+
+
+class InMemoryFutureStore:
+    """Store API-process-owned futures without routing them through the engine database."""
+
+    def __init__(self, *, terminal_retention_sec: float = 600, max_terminal_futures: int = 10_000):
+        self._terminal_retention_sec = terminal_retention_sec
+        self._max_terminal_futures = max_terminal_futures
+        self._next_id = itertools.count(start=-1, step=-1)
+        self._futures: dict[int, _StoredFuture] = {}
+
+    def create_future(self) -> int:
+        self._cleanup_terminal_futures()
+        request_id = next(self._next_id)
+        self._futures[request_id] = _StoredFuture()
+        return request_id
+
+    def complete_future(self, request_id: int, status: RequestStatus, result_data: str) -> None:
+        future = self._futures[request_id]
+        future.status = status
+        future.result_data = result_data
+        future.completed_at = time.monotonic()
+        future.event.set()
+
+    async def wait_for_future(self, request_id: int, timeout: float) -> tuple[RequestStatus, str | None] | None:
+        future = self._futures.get(request_id)
+        if future is None:
+            raise KeyError(request_id)
+        if future.status == RequestStatus.PENDING:
+            try:
+                await asyncio.wait_for(future.event.wait(), timeout)
+            except asyncio.TimeoutError:
+                return None
+        return future.status, future.result_data
+
+    def _cleanup_terminal_futures(self) -> None:
+        now = time.monotonic()
+        expired = [
+            request_id
+            for request_id, future in self._futures.items()
+            if future.completed_at is not None and now - future.completed_at > self._terminal_retention_sec
+        ]
+        for request_id in expired:
+            del self._futures[request_id]
+
+        terminal = sorted(
+            (future.completed_at, request_id)
+            for request_id, future in self._futures.items()
+            if future.completed_at is not None
+        )
+        overflow = len(terminal) - self._max_terminal_futures
+        for _, request_id in terminal[: max(overflow, 0)]:
+            del self._futures[request_id]

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -5,7 +5,6 @@ Pair to :class:`ExternalInferenceClient`; resolves the target URL from
 """
 
 import asyncio
-from datetime import datetime, timezone
 
 import httpx
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -14,16 +13,18 @@ from skyrl.backends.renderer import render_model_input
 from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
-from skyrl.tinker.db_models import EngineStateDB, FutureDB, RequestStatus
+from skyrl.tinker.db_models import EngineStateDB, RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
 from skyrl.utils.log import logger
 
 
 class SkyRLTrainInferenceForwardingClient:
     """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(self, engine_config: EngineConfig, db_engine, future_store: InMemoryFutureStore):
         self.engine_config = engine_config
         self.db_engine = db_engine
+        self.future_store = future_store
         self._cached_proxy_url: str | None = None
         self._cache_lock = asyncio.Lock()
         # Backpressure layered: httpx pool -> vllm-router -> vLLM max_num_seqs.
@@ -71,7 +72,7 @@ class SkyRLTrainInferenceForwardingClient:
         *,
         base_model: str | None = None,
     ):
-        """Forward a sample request to vLLM and write the result to FutureDB."""
+        """Forward a sample request to vLLM and resolve its API-process-owned future."""
         try:
             result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
             status = RequestStatus.COMPLETED
@@ -80,18 +81,7 @@ class SkyRLTrainInferenceForwardingClient:
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
 
-        async with AsyncSession(self.db_engine) as session:
-            future = await session.get(FutureDB, request_id)
-            if future is None:
-                # Row was deleted between scheduling and completion (cancelled
-                # request, stale-session GC). Nothing to write back.
-                logger.warning("FutureDB row %s missing on completion write — skipping", request_id)
-                return
-            # `result_data` is a text column holding pre-serialized JSON.
-            future.result_data = result.model_dump_json()
-            future.status = status
-            future.completed_at = datetime.now(timezone.utc)
-            await session.commit()
+        self.future_store.complete_future(request_id, status, result.model_dump_json())
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
         # httpx.RequestError covers ConnectError, ReadError, TimeoutException, etc.

--- a/skyrl/tinker/operation_transport.py
+++ b/skyrl/tinker/operation_transport.py
@@ -132,6 +132,14 @@ class TrainingOperationQueue:
     def has_model(self, model_id: str) -> bool:
         return model_id in self._models
 
+    def has_operations(self, model_id: str) -> bool:
+        queue = self._models.get(model_id)
+        if queue is None:
+            return False
+        if queue.retired_through_seq_id > 0:
+            return True
+        return any(operation.model_id == model_id for operation in self._by_request_id.values())
+
     def register_model(self, model_id: str, next_seq_id: int | None) -> None:
         retired_through_seq_id = 0 if next_seq_id is None else max(0, next_seq_id - 1)
         self._models.setdefault(

--- a/skyrl/tinker/operation_transport.py
+++ b/skyrl/tinker/operation_transport.py
@@ -1,0 +1,516 @@
+"""In-memory training-operation queue and local API-to-engine transport.
+
+The API process is the single owner of operation identity, ordering, payload
+retention, and future completion.  The background engine claims ready work over
+one Unix-domain socket.  Large model-pass payloads therefore never enter the
+database while the existing process boundary remains explicit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import socket
+import struct
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from skyrl.tinker import types
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
+
+_FRAME_LENGTH = struct.Struct("!Q")
+_STREAM_CHUNK_BYTES = 1024 * 1024
+_DEFAULT_GAP_RESERVE_BYTES = 64 * 1024**2
+
+TRANSPORTED_REQUEST_TYPES = frozenset(
+    {
+        types.RequestType.FORWARD,
+        types.RequestType.FORWARD_BACKWARD,
+        types.RequestType.OPTIM_STEP,
+        types.RequestType.SAVE_WEIGHTS,
+        types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER,
+        types.RequestType.LOAD_WEIGHTS,
+    }
+)
+
+
+class OperationBackpressure(RuntimeError):
+    """The bounded queue cannot accept another non-gap-filling operation."""
+
+
+class OperationExpired(RuntimeError):
+    """A retry arrived after its compact operation record was released."""
+
+
+class OperationState(str, Enum):
+    QUEUED = "queued"
+    CLAIMED = "claimed"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class OperationPayloadFormat(str, Enum):
+    JSON = "json"
+    PROTO = "proto"
+    PROTO_ZSTD = "proto_zstd"
+
+
+@dataclass
+class Operation:
+    request_id: int
+    request_type: types.RequestType
+    model_id: str
+    seq_id: int | None
+    payload: bytes
+    payload_format: OperationPayloadFormat
+    fingerprint: str
+    arrival: int
+    state: OperationState = OperationState.QUEUED
+
+    @property
+    def terminal(self) -> bool:
+        return self.state in (OperationState.COMPLETED, OperationState.FAILED)
+
+
+@dataclass
+class _ModelQueue:
+    next_seq_id: int | None
+    by_seq_id: dict[int, Operation] = field(default_factory=dict)
+    unsequenced: deque[Operation] = field(default_factory=deque)
+    retired_through_seq_id: int = 0
+    pending_count: int = 0
+
+    def fills_blocking_gap(self, seq_id: int | None) -> bool:
+        if seq_id is None or not self.by_seq_id:
+            return False
+        if self.next_seq_id is not None:
+            return seq_id == self.next_seq_id and any(value > seq_id for value in self.by_seq_id)
+        lowest = min(self.by_seq_id)
+        return seq_id < lowest
+
+
+class TrainingOperationQueue:
+    """Single-owner, gap-buffered queue for model-pass and optimizer work.
+
+    Queue methods do not await. FastAPI therefore updates the queue from one
+    event-loop thread at a time.
+    """
+
+    def __init__(
+        self,
+        future_store: InMemoryFutureStore,
+        *,
+        max_pending_per_model: int = 512,
+        max_payload_bytes: int = 2 * 1024**3,
+        gap_reserve_bytes: int = _DEFAULT_GAP_RESERVE_BYTES,
+        max_terminal_records: int = 10_000,
+    ) -> None:
+        self.future_store = future_store
+        self.max_pending_per_model = max_pending_per_model
+        self.max_payload_bytes = max_payload_bytes
+        self.gap_reserve_bytes = min(gap_reserve_bytes, max_payload_bytes)
+        self.max_terminal_records = max_terminal_records
+        self._models: dict[str, _ModelQueue] = {}
+        self._by_request_id: dict[int, Operation] = {}
+        self._terminal_order: deque[int] = deque()
+        self._payload_bytes = 0
+        self._pending_count = 0
+        self._arrival = 0
+
+    @property
+    def payload_bytes(self) -> int:
+        return self._payload_bytes
+
+    @property
+    def pending_count(self) -> int:
+        return self._pending_count
+
+    def has_model(self, model_id: str) -> bool:
+        return model_id in self._models
+
+    def register_model(self, model_id: str, next_seq_id: int | None) -> None:
+        retired_through_seq_id = 0 if next_seq_id is None else max(0, next_seq_id - 1)
+        self._models.setdefault(
+            model_id,
+            _ModelQueue(
+                next_seq_id=next_seq_id,
+                retired_through_seq_id=retired_through_seq_id,
+            ),
+        )
+
+    @staticmethod
+    def _fingerprint(
+        request_type: types.RequestType,
+        payload: bytes,
+        payload_format: OperationPayloadFormat,
+    ) -> str:
+        return hashlib.sha256(
+            request_type.value.encode() + b"\0" + payload_format.value.encode() + b"\0" + payload
+        ).hexdigest()
+
+    def existing_request_id(
+        self,
+        request_type: types.RequestType,
+        model_id: str,
+        seq_id: int | None,
+        payload: bytes,
+        payload_format: OperationPayloadFormat = OperationPayloadFormat.JSON,
+    ) -> int | None:
+        """Return the original request ID for an exact sequenced retry."""
+        if seq_id is None:
+            return None
+        queue = self._models.get(model_id)
+        if queue is None:
+            return None
+        if seq_id <= queue.retired_through_seq_id:
+            raise OperationExpired(f"Training request sequence {seq_id} is older than the retained retry history")
+        if (existing := queue.by_seq_id.get(seq_id)) is None:
+            return None
+        if existing.terminal and not self.future_store.has_future(existing.request_id):
+            raise OperationExpired(f"Training request sequence {seq_id} is older than the retained retry history")
+        if existing.request_type != request_type or existing.fingerprint != self._fingerprint(
+            request_type, payload, payload_format
+        ):
+            raise ValueError("Training request sequence number was reused")
+        return existing.request_id
+
+    def enqueue(
+        self,
+        request_type: types.RequestType,
+        model_id: str,
+        seq_id: int | None,
+        payload: bytes,
+        payload_format: OperationPayloadFormat = OperationPayloadFormat.JSON,
+    ) -> int:
+        """Admit an operation or return the original future for an exact retry."""
+        queue = self._models.get(model_id)
+        if queue is None:
+            raise KeyError(f"model '{model_id}' is not registered in the operation queue")
+
+        fingerprint = self._fingerprint(request_type, payload, payload_format)
+        if (
+            request_id := self.existing_request_id(
+                request_type,
+                model_id,
+                seq_id,
+                payload,
+                payload_format,
+            )
+        ) is not None:
+            return request_id
+
+        gap_filler = queue.fills_blocking_gap(seq_id)
+        ready_sequence = seq_id is None or queue.next_seq_id is None or seq_id == queue.next_seq_id
+        if queue.pending_count >= self.max_pending_per_model:
+            raise OperationBackpressure(
+                f"model '{model_id}' has {self.max_pending_per_model} training operations pending"
+            )
+        if not ready_sequence and not gap_filler and queue.pending_count >= self.max_pending_per_model - 1:
+            raise OperationBackpressure(f"model '{model_id}' is reserving one pending slot for its next sequence")
+
+        new_payload_bytes = self._payload_bytes + len(payload)
+        if new_payload_bytes > self.max_payload_bytes:
+            raise OperationBackpressure(
+                f"training operation queue holds {self._payload_bytes} payload bytes "
+                f"(limit {self.max_payload_bytes})"
+            )
+        if (
+            not ready_sequence
+            and not gap_filler
+            and new_payload_bytes > self.max_payload_bytes - self.gap_reserve_bytes
+        ):
+            raise OperationBackpressure("training operation queue is reserving payload space for its next sequence")
+
+        request_id = self.future_store.create_future(request_type=request_type)
+        self._arrival += 1
+        operation = Operation(
+            request_id=request_id,
+            request_type=request_type,
+            model_id=model_id,
+            seq_id=seq_id,
+            payload=payload,
+            payload_format=payload_format,
+            fingerprint=fingerprint,
+            arrival=self._arrival,
+        )
+        self._by_request_id[request_id] = operation
+        if seq_id is None:
+            queue.unsequenced.append(operation)
+        else:
+            queue.by_seq_id[seq_id] = operation
+        queue.pending_count += 1
+        self._pending_count += 1
+        self._payload_bytes += len(payload)
+        return request_id
+
+    def claim_ready(self) -> list[Operation]:
+        """Claim one same-type batch for one model in sequence order."""
+        candidates: list[Operation] = []
+        for queue in self._models.values():
+            candidate = self._next_open(queue)
+            if candidate is not None:
+                candidates.append(candidate)
+        if not candidates:
+            return []
+
+        first = min(candidates, key=lambda operation: operation.arrival)
+        queue = self._models[first.model_id]
+        claimed = [first]
+        if first.seq_id is not None and first.request_type in (
+            types.RequestType.FORWARD,
+            types.RequestType.FORWARD_BACKWARD,
+        ):
+            seq_id = first.seq_id + 1
+            while (operation := queue.by_seq_id.get(seq_id)) is not None:
+                if operation.state is not OperationState.QUEUED or operation.request_type != first.request_type:
+                    break
+                claimed.append(operation)
+                seq_id += 1
+        elif first.seq_id is None and first.request_type in (
+            types.RequestType.FORWARD,
+            types.RequestType.FORWARD_BACKWARD,
+        ):
+            for operation in list(queue.unsequenced)[1:]:
+                if operation.state is not OperationState.QUEUED or operation.request_type != first.request_type:
+                    break
+                claimed.append(operation)
+
+        for operation in claimed:
+            operation.state = OperationState.CLAIMED
+        return claimed
+
+    def acknowledge_claim(self, request_ids: list[int]) -> None:
+        """Release API-side request bodies after the engine owns a complete copy."""
+        for request_id in request_ids:
+            operation = self._by_request_id[request_id]
+            if operation.state is not OperationState.CLAIMED:
+                raise ValueError(f"operation {request_id} is not claimed")
+            self._payload_bytes -= len(operation.payload)
+            operation.payload = b""
+
+    def complete(self, request_id: int, status: RequestStatus, result_data: str) -> None:
+        operation = self._by_request_id[request_id]
+        if operation.terminal:
+            return
+        if operation.state is not OperationState.CLAIMED:
+            raise ValueError(f"operation {request_id} completed without a claim")
+        operation.state = OperationState.COMPLETED if status == RequestStatus.COMPLETED else OperationState.FAILED
+        self._models[operation.model_id].pending_count -= 1
+        self._pending_count -= 1
+        self.future_store.complete_future(request_id, status, result_data)
+        self._advance(self._models[operation.model_id])
+        self._terminal_order.append(request_id)
+        self._trim_terminal_records()
+
+    def _next_open(self, queue: _ModelQueue) -> Operation | None:
+        if queue.next_seq_id is not None:
+            operation = queue.by_seq_id.get(queue.next_seq_id)
+            if operation is not None:
+                return operation if operation.state is OperationState.QUEUED else None
+            if any(not operation.terminal for operation in queue.by_seq_id.values()):
+                return None
+            if queue.unsequenced and queue.unsequenced[0].state is OperationState.QUEUED:
+                return queue.unsequenced[0]
+            return None
+
+        sequenced = [operation for operation in queue.by_seq_id.values() if not operation.terminal]
+        if sequenced:
+            operation = min(sequenced, key=lambda item: item.seq_id)
+            if operation.state is not OperationState.QUEUED:
+                return None
+            queue.next_seq_id = operation.seq_id
+            return operation
+        if queue.unsequenced and queue.unsequenced[0].state is OperationState.QUEUED:
+            return queue.unsequenced[0]
+        return None
+
+    def _advance(self, queue: _ModelQueue) -> None:
+        if queue.next_seq_id is not None:
+            while (operation := queue.by_seq_id.get(queue.next_seq_id)) is not None and operation.terminal:
+                queue.next_seq_id += 1
+        while queue.unsequenced and queue.unsequenced[0].terminal:
+            queue.unsequenced.popleft()
+
+    def _trim_terminal_records(self) -> None:
+        while len(self._terminal_order) > self.max_terminal_records:
+            request_id = self._terminal_order.popleft()
+            operation = self._by_request_id.pop(request_id, None)
+            if operation is None:
+                continue
+            if operation.seq_id is not None:
+                queue = self._models[operation.model_id]
+                if queue.by_seq_id.get(operation.seq_id) is operation:
+                    queue.by_seq_id.pop(operation.seq_id)
+                    queue.retired_through_seq_id = max(queue.retired_through_seq_id, operation.seq_id)
+
+
+async def _send_async(writer: asyncio.StreamWriter, header: dict[str, Any], payload: bytes = b"") -> None:
+    encoded_header = json.dumps({**header, "payload_size": len(payload)}, separators=(",", ":")).encode()
+    writer.write(_FRAME_LENGTH.pack(len(encoded_header)))
+    writer.write(encoded_header)
+    await writer.drain()
+    view = memoryview(payload)
+    for start in range(0, len(view), _STREAM_CHUNK_BYTES):
+        writer.write(view[start : start + _STREAM_CHUNK_BYTES])
+        await writer.drain()
+
+
+async def _receive_async(reader: asyncio.StreamReader) -> tuple[dict[str, Any], bytes]:
+    (header_size,) = _FRAME_LENGTH.unpack(await reader.readexactly(_FRAME_LENGTH.size))
+    header = json.loads(await reader.readexactly(header_size))
+    payload = await reader.readexactly(header.pop("payload_size"))
+    return header, payload
+
+
+def _recv_exact(sock: socket.socket, size: int) -> bytes:
+    chunks = bytearray(size)
+    view = memoryview(chunks)
+    received = 0
+    while received < size:
+        count = sock.recv_into(view[received:])
+        if count == 0:
+            raise EOFError("operation transport closed")
+        received += count
+    return bytes(chunks)
+
+
+def _send_sync(sock: socket.socket, header: dict[str, Any], payload: bytes = b"") -> None:
+    encoded_header = json.dumps({**header, "payload_size": len(payload)}, separators=(",", ":")).encode()
+    sock.sendall(_FRAME_LENGTH.pack(len(encoded_header)))
+    sock.sendall(encoded_header)
+    if payload:
+        sock.sendall(payload)
+
+
+def _receive_sync(sock: socket.socket) -> tuple[dict[str, Any], bytes]:
+    (header_size,) = _FRAME_LENGTH.unpack(_recv_exact(sock, _FRAME_LENGTH.size))
+    header = json.loads(_recv_exact(sock, header_size))
+    payload = _recv_exact(sock, header.pop("payload_size"))
+    return header, payload
+
+
+class OperationTransportServer:
+    """Expose the API-owned queue to exactly one local engine process."""
+
+    def __init__(self, queue: TrainingOperationQueue, socket_path: str) -> None:
+        self.queue = queue
+        self.socket_path = socket_path
+        self._server: asyncio.AbstractServer | None = None
+        self._connected = False
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_unix_server(self._handle, path=self.socket_path)
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        if self._connected:
+            writer.close()
+            await writer.wait_closed()
+            return
+        self._connected = True
+        try:
+            while True:
+                header, payload = await _receive_async(reader)
+                kind = header["kind"]
+                if kind == "claim":
+                    operations = self.queue.claim_ready()
+                    await _send_async(writer, {"kind": "batch", "count": len(operations)})
+                    for operation in operations:
+                        await _send_async(
+                            writer,
+                            {
+                                "kind": "operation",
+                                "request_id": operation.request_id,
+                                "request_type": operation.request_type.value,
+                                "model_id": operation.model_id,
+                                "seq_id": operation.seq_id,
+                                "payload_format": operation.payload_format.value,
+                            },
+                            operation.payload,
+                        )
+                        ack, _ = await _receive_async(reader)
+                        if ack.get("kind") != "claim_ack" or ack.get("request_id") != operation.request_id:
+                            raise ValueError(f"invalid claim acknowledgement: {ack}")
+                        self.queue.acknowledge_claim([operation.request_id])
+                        await _send_async(writer, {"kind": "ack"})
+                elif kind == "complete":
+                    self.queue.complete(
+                        int(header["request_id"]),
+                        RequestStatus(header["status"]),
+                        payload.decode(),
+                    )
+                    await _send_async(writer, {"kind": "ack"})
+                else:
+                    raise ValueError(f"unknown operation transport message: {kind}")
+        except (asyncio.IncompleteReadError, ConnectionError):
+            pass
+        finally:
+            self._connected = False
+            writer.close()
+            await writer.wait_closed()
+
+
+@dataclass
+class ClaimedOperation:
+    request_id: int
+    request_type: types.RequestType
+    model_id: str
+    seq_id: int | None
+    payload: bytes
+    payload_format: OperationPayloadFormat = OperationPayloadFormat.JSON
+
+
+class OperationTransportClient:
+    """Synchronous engine-side client for the API queue."""
+
+    def __init__(self, socket_path: str) -> None:
+        self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.socket.connect(socket_path)
+
+    def claim(self) -> list[ClaimedOperation]:
+        _send_sync(self.socket, {"kind": "claim"})
+        header, _ = _receive_sync(self.socket)
+        if header["kind"] != "batch":
+            raise ValueError(f"expected batch, received {header['kind']}")
+        operations = []
+        for _ in range(header["count"]):
+            item, payload = _receive_sync(self.socket)
+            operation = ClaimedOperation(
+                request_id=int(item["request_id"]),
+                request_type=types.RequestType(item["request_type"]),
+                model_id=item["model_id"],
+                seq_id=item["seq_id"],
+                payload=payload,
+                payload_format=OperationPayloadFormat(item["payload_format"]),
+            )
+            operations.append(operation)
+            _send_sync(
+                self.socket,
+                {"kind": "claim_ack", "request_id": operation.request_id},
+            )
+            ack, _ = _receive_sync(self.socket)
+            if ack["kind"] != "ack":
+                raise ValueError(f"expected claim ack, received {ack['kind']}")
+        return operations
+
+    def complete(self, request_id: int, result: Any) -> None:
+        status = RequestStatus.FAILED if isinstance(result, types.ErrorResponse) else RequestStatus.COMPLETED
+        _send_sync(
+            self.socket,
+            {"kind": "complete", "request_id": request_id, "status": status.value},
+            result.model_dump_json().encode(),
+        )
+        ack, _ = _receive_sync(self.socket)
+        if ack["kind"] != "ack":
+            raise ValueError(f"expected completion ack, received {ack['kind']}")
+
+    def close(self) -> None:
+        self.socket.close()

--- a/skyrl/tinker/proto_serialization.py
+++ b/skyrl/tinker/proto_serialization.py
@@ -104,6 +104,28 @@ def parse_forward_backward_request(body: bytes) -> tuple[dict, bool]:
     return request_dict, msg.forward_only
 
 
+def parse_forward_backward_metadata(body: bytes) -> tuple[str, int | None, bool]:
+    """Read ordering fields without expanding tensor bytes into Python lists."""
+    msg = pb.ForwardBackwardRequest()
+    msg.ParseFromString(body)
+    return msg.model_id, msg.seq_id or None, msg.forward_only
+
+
+def parse_forward_backward_input(body: bytes) -> types.ForwardBackwardInput:
+    """Parse a protobuf request into the type consumed by training backends."""
+    request_dict, _ = parse_forward_backward_request(body)
+    forward_backward_input = request_dict["forward_backward_input"]
+    for datum in forward_backward_input["data"]:
+        loss_fn_inputs = datum["loss_fn_inputs"]
+        target_tokens = loss_fn_inputs["target_tokens"]["data"]
+        loss_fn_inputs.setdefault("weights", {"data": [1.0] * len(target_tokens)})
+        loss_fn_inputs.setdefault("advantages", {"data": []})
+        loss_fn_inputs.setdefault("logprobs", {"data": []})
+        loss_fn_inputs.setdefault("values", {"data": []})
+        loss_fn_inputs.setdefault("returns", {"data": []})
+    return types.ForwardBackwardInput.model_validate(forward_backward_input)
+
+
 def _tensor_from_proto(tensor: pb.Tensor) -> dict:
     np_dtype = _PROTO_DTYPE_TO_NUMPY.get(tensor.dtype)
     if np_dtype is None:

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -9,8 +9,8 @@ bypassing the engine subprocess's serial scheduling loop.
 Coverage:
   - test_engine_state_published: after ``save_weights_for_sampler``, the
     engine's vLLM proxy URL is written to ``EngineStateDB``.
-  - test_sample_uses_external_path: an issued sample creates a future of
-    type ``EXTERNAL`` (not ``SAMPLE``) and resolves successfully.
+  - test_sample_bypasses_future_db: an issued sample resolves without creating
+    a database future.
   - test_sample_concurrent_with_training_is_fast: the central
     parallelism test. While a long-running stream of ``forward_backward``
     + ``optim_step`` calls is in flight, a sample request resolves in
@@ -210,15 +210,14 @@ def test_engine_state_published(server_db_path):
     ), f"expected an http(s) proxy URL, got {row.inference_proxy_url!r}"
 
 
-def test_sample_uses_external_path(server_db_path):
-    """A sample issued through the SDK creates a FutureDB row of type EXTERNAL.
+def test_sample_bypasses_future_db(server_db_path):
+    """A sample issued through the SDK does not use the engine's FutureDB.
 
     This is the "test" half of the design: the API hoists the sample off
-    the engine's serial loop and into the API process's asyncio loop.
+    the engine's serial loop and keeps its future in the API process.
     """
     from sqlmodel import Session, create_engine, func, select
 
-    from skyrl.tinker import types as skyrl_types
     from skyrl.tinker.db_models import FutureDB
 
     proc, db_path, _ = server_db_path
@@ -229,12 +228,11 @@ def test_sample_uses_external_path(server_db_path):
     _train_one_step(tc, tok)
     sampler = tc.save_weights_and_get_sampling_client(name="external_path_a")
 
-    # Snapshot the max future_id before submitting our sample so we can
-    # filter out any EXTERNAL futures from earlier tests.
+    # Snapshot the number of database futures before submitting our sample.
     eng = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(eng) as s:
-            max_before = s.exec(select(func.max(FutureDB.request_id))).one() or 0
+            count_before = s.exec(select(func.count()).select_from(FutureDB)).one()
     finally:
         eng.dispose()
 
@@ -245,24 +243,16 @@ def test_sample_uses_external_path(server_db_path):
     ).result()
     assert len(out.sequences) == 1
 
-    # Look for an EXTERNAL future with id > max_before. If async routing
-    # is on, every sample creates exactly one such row.
+    # API-forwarded samples use negative, in-memory future ids and must not
+    # add database work to the engine's scheduling hot path.
     eng = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(eng) as s:
-            stmt = (
-                select(FutureDB.request_id, FutureDB.request_type)
-                .where(FutureDB.request_id > max_before)
-                .where(FutureDB.request_type == skyrl_types.RequestType.EXTERNAL)
-            )
-            rows = s.exec(stmt).all()
+            count_after = s.exec(select(func.count()).select_from(FutureDB)).one()
     finally:
         eng.dispose()
 
-    assert len(rows) >= 1, (
-        f"expected at least one EXTERNAL future to be created by the sample call, "
-        f"found {len(rows)}; async sample routing may not be active"
-    )
+    assert count_after == count_before
 
 
 def test_sample_concurrent_with_training_is_fast(server_db_path):

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -187,11 +187,17 @@ async def test_query_count_does_not_scale_with_waiters(waiters, sync_engine, asy
     assert 0 < len(statements) < 50
 
 
-def _stub_request(async_engine, waiters, headers: dict | None = None):
+def _stub_request(async_engine, waiters, external_future_store=None, headers: dict | None = None):
     from types import SimpleNamespace
 
     return SimpleNamespace(
-        app=SimpleNamespace(state=SimpleNamespace(db_engine=async_engine, future_waiters=waiters)),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                db_engine=async_engine,
+                external_future_store=external_future_store,
+                future_waiters=waiters,
+            )
+        ),
         headers=headers or {},
     )
 
@@ -215,6 +221,24 @@ async def test_retrieve_future_returns_completed_result(waiters, async_engine, s
     )
 
     # The stored JSON text is returned as-is rather than re-encoded by FastAPI.
+    assert response.media_type == "application/json"
+    assert response.body == SAMPLE_RESULT.model_dump_json().encode()
+
+
+@pytest.mark.asyncio
+async def test_retrieve_future_returns_in_memory_external_result(waiters, async_engine):
+    from skyrl.tinker import api
+    from skyrl.tinker.extra import InMemoryFutureStore
+
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+    store.complete_future(request_id, RequestStatus.COMPLETED, SAMPLE_RESULT.model_dump_json())
+
+    response = await api.retrieve_future(
+        api.RetrieveFutureRequest(request_id=str(request_id)),
+        _stub_request(async_engine, waiters, store),
+    )
+
     assert response.media_type == "application/json"
     assert response.body == SAMPLE_RESULT.model_dump_json().encode()
 

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -236,9 +236,10 @@ async def test_retrieve_future_returns_in_memory_external_result(waiters, async_
 
     response = await api.retrieve_future(
         api.RetrieveFutureRequest(request_id=str(request_id)),
-        _stub_request(async_engine, waiters, store),
+        _stub_request(async_engine, waiters, store, headers={"accept": api.PROTO_CONTENT_TYPE}),
     )
 
+    # Forwarded samples use the Tinker JSON response even when the client also accepts proto.
     assert response.media_type == "application/json"
     assert response.body == SAMPLE_RESULT.model_dump_json().encode()
 

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -2,6 +2,8 @@
 
 import asyncio
 from contextlib import suppress
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -226,22 +228,43 @@ async def test_retrieve_future_returns_completed_result(waiters, async_engine, s
 
 
 @pytest.mark.asyncio
-async def test_retrieve_future_returns_in_memory_external_result(waiters, async_engine):
+async def test_external_sample_future_is_served_as_proto(waiters, async_engine, monkeypatch):
+    from tinker import SampleResponse
+    from tinker.proto.response_conv import deserialize_proto_response
+
     from skyrl.tinker import api
     from skyrl.tinker.extra import InMemoryFutureStore
 
     store = InMemoryFutureStore()
-    request_id = store.create_future()
+    inference_client = AsyncMock()
+    request = _stub_request(async_engine, waiters, store, headers={"accept": api.PROTO_CONTENT_TYPE})
+    request.app.state.external_inference_client = inference_client
+    monkeypatch.setattr(
+        api,
+        "get_sampling_target",
+        AsyncMock(return_value=api.SamplingTarget(base_model=None, model_id="model_a", checkpoint_id="checkpoint_a")),
+    )
+
+    pending = await api.asample(
+        request=SimpleNamespace(sampling_session_id="sampling_a"),
+        req=request,
+        session=None,
+    )
+    request_id = int(pending.request_id)
+    await asyncio.sleep(0)
+
+    assert store.request_type(request_id) == types.RequestType.SAMPLE
+    inference_client.call_and_store_result.assert_awaited_once()
     store.complete_future(request_id, RequestStatus.COMPLETED, SAMPLE_RESULT.model_dump_json())
 
     response = await api.retrieve_future(
         api.RetrieveFutureRequest(request_id=str(request_id)),
-        _stub_request(async_engine, waiters, store, headers={"accept": api.PROTO_CONTENT_TYPE}),
+        request,
     )
 
-    # Forwarded samples use the Tinker JSON response even when the client also accepts proto.
-    assert response.media_type == "application/json"
-    assert response.body == SAMPLE_RESULT.model_dump_json().encode()
+    assert response.media_type == api.PROTO_CONTENT_TYPE
+    result = deserialize_proto_response(response.body, SampleResponse)
+    assert result.sequences[0].tokens == [1]
 
 
 @pytest.mark.asyncio

--- a/tests/tinker/test_in_memory_future_store.py
+++ b/tests/tinker/test_in_memory_future_store.py
@@ -1,0 +1,61 @@
+import asyncio
+
+import pytest
+
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
+
+
+@pytest.mark.asyncio
+async def test_concurrent_waiters_receive_completed_result():
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+    waiters = [asyncio.create_task(store.wait_for_future(request_id, 1)) for _ in range(3)]
+
+    store.complete_future(request_id, RequestStatus.COMPLETED, '{"value":1}')
+
+    assert await asyncio.gather(*waiters) == [
+        (RequestStatus.COMPLETED, '{"value":1}'),
+        (RequestStatus.COMPLETED, '{"value":1}'),
+        (RequestStatus.COMPLETED, '{"value":1}'),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_timed_out_waiter_does_not_cancel_future():
+    store = InMemoryFutureStore()
+    request_id = store.create_future()
+
+    assert await store.wait_for_future(request_id, 0) is None
+    store.complete_future(request_id, RequestStatus.FAILED, '{"error":"boom"}')
+
+    assert await store.wait_for_future(request_id, 1) == (
+        RequestStatus.FAILED,
+        '{"error":"boom"}',
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_future_raises_key_error():
+    store = InMemoryFutureStore()
+
+    with pytest.raises(KeyError):
+        await store.wait_for_future(-1, 1)
+
+
+@pytest.mark.asyncio
+async def test_terminal_future_retention_is_bounded():
+    store = InMemoryFutureStore(max_terminal_futures=1)
+    first_id = store.create_future()
+    store.complete_future(first_id, RequestStatus.COMPLETED, "{}")
+    second_id = store.create_future()
+    store.complete_future(second_id, RequestStatus.COMPLETED, "{}")
+
+    store.create_future()
+
+    with pytest.raises(KeyError):
+        await store.wait_for_future(first_id, 1)
+    assert await store.wait_for_future(second_id, 1) == (
+        RequestStatus.COMPLETED,
+        "{}",
+    )

--- a/tests/tinker/test_in_memory_future_store.py
+++ b/tests/tinker/test_in_memory_future_store.py
@@ -59,3 +59,16 @@ async def test_terminal_future_retention_is_bounded():
         RequestStatus.COMPLETED,
         "{}",
     )
+
+
+@pytest.mark.asyncio
+async def test_terminal_result_bytes_are_bounded():
+    store = InMemoryFutureStore(max_terminal_bytes=4)
+    first_id = store.create_future()
+    store.complete_future(first_id, RequestStatus.COMPLETED, "1234")
+    second_id = store.create_future()
+    store.complete_future(second_id, RequestStatus.COMPLETED, "56")
+
+    with pytest.raises(KeyError):
+        await store.wait_for_future(first_id, 1)
+    assert await store.wait_for_future(second_id, 1) == (RequestStatus.COMPLETED, "56")

--- a/tests/tinker/test_operation_transport.py
+++ b/tests/tinker/test_operation_transport.py
@@ -1,0 +1,237 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from skyrl.tinker import types
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.engine import TinkerEngine
+from skyrl.tinker.extra.in_memory_future_store import InMemoryFutureStore
+from skyrl.tinker.operation_transport import (
+    ClaimedOperation,
+    OperationBackpressure,
+    OperationExpired,
+    OperationTransportClient,
+    OperationTransportServer,
+    TrainingOperationQueue,
+)
+
+
+def _payload(value: str = "cross_entropy") -> bytes:
+    return types.ForwardBackwardInput(data=[], loss_fn=value).model_dump_json().encode()
+
+
+def test_gap_buffering_idempotency_and_optimizer_barrier():
+    futures = InMemoryFutureStore()
+    queue = TrainingOperationQueue(futures)
+    queue.register_model("model_a", next_seq_id=1)
+
+    second = queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 2, _payload())
+    third = queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 3, _payload())
+    assert queue.claim_ready() == []
+
+    first = queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 1, _payload())
+    assert queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 1, _payload()) == first
+    with pytest.raises(ValueError, match="sequence number was reused"):
+        queue.enqueue(types.RequestType.FORWARD, "model_a", 1, _payload())
+
+    save = queue.enqueue(
+        types.RequestType.SAVE_WEIGHTS,
+        "model_a",
+        4,
+        types.SaveWeightsInput(path="checkpoint").model_dump_json().encode(),
+    )
+    optim = queue.enqueue(
+        types.RequestType.OPTIM_STEP,
+        "model_a",
+        5,
+        types.OptimStepInput(
+            adam_params=types.AdamParams(
+                learning_rate=1e-4,
+                beta1=0.9,
+                beta2=0.95,
+                eps=1e-12,
+                weight_decay=0.0,
+            )
+        )
+        .model_dump_json()
+        .encode(),
+    )
+    assert [operation.request_id for operation in queue.claim_ready()] == [
+        first,
+        second,
+        third,
+    ]
+    assert queue.claim_ready() == []
+
+    queue.acknowledge_claim([first, second, third])
+    for request_id in (first, second, third):
+        queue.complete(request_id, RequestStatus.COMPLETED, "{}")
+    assert [operation.request_id for operation in queue.claim_ready()] == [save]
+    queue.acknowledge_claim([save])
+    queue.complete(save, RequestStatus.COMPLETED, "{}")
+    assert [operation.request_id for operation in queue.claim_ready()] == [optim]
+
+
+def test_forward_forward_backward_and_optimizer_keep_sequence_order():
+    futures = InMemoryFutureStore()
+    queue = TrainingOperationQueue(futures)
+    queue.register_model("model_a", next_seq_id=1)
+    forward_backward = queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 2, _payload())
+    optimizer = queue.enqueue(
+        types.RequestType.OPTIM_STEP,
+        "model_a",
+        3,
+        types.OptimStepInput(
+            adam_params=types.AdamParams(
+                learning_rate=1e-4,
+                beta1=0.9,
+                beta2=0.95,
+                eps=1e-12,
+                weight_decay=0.0,
+            )
+        )
+        .model_dump_json()
+        .encode(),
+    )
+    forward = queue.enqueue(types.RequestType.FORWARD, "model_a", 1, _payload())
+
+    for expected_request_id in (forward, forward_backward, optimizer):
+        (operation,) = queue.claim_ready()
+        assert operation.request_id == expected_request_id
+        queue.acknowledge_claim([expected_request_id])
+        queue.complete(expected_request_id, RequestStatus.COMPLETED, "{}")
+
+
+def test_gap_filler_bypasses_backpressure_but_tail_does_not():
+    futures = InMemoryFutureStore()
+    queue = TrainingOperationQueue(
+        futures,
+        max_pending_per_model=2,
+        max_payload_bytes=8,
+        gap_reserve_bytes=4,
+    )
+    queue.register_model("model_a", next_seq_id=1)
+
+    queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 2, b"tail")
+    with pytest.raises(OperationBackpressure):
+        queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 3, b"later")
+
+    # Refusing the missing ordinal could never free capacity: seq=2 cannot run
+    # until seq=1 arrives, so the exact hole filler is admitted over the cap.
+    queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 1, b"gap")
+
+
+def test_unsequenced_operation_runs_when_no_sequenced_request_is_pending():
+    futures = InMemoryFutureStore()
+    queue = TrainingOperationQueue(futures)
+    queue.register_model("model_a", next_seq_id=1)
+
+    request_id = queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", None, _payload())
+
+    assert [operation.request_id for operation in queue.claim_ready()] == [request_id]
+
+
+def test_registered_sequence_rejects_retry_from_older_database_history():
+    futures = InMemoryFutureStore()
+    queue = TrainingOperationQueue(futures)
+    queue.register_model("model_a", next_seq_id=10)
+
+    with pytest.raises(OperationExpired):
+        queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 9, _payload())
+
+
+def test_terminal_retry_history_is_bounded_and_old_sequence_is_not_reused():
+    futures = InMemoryFutureStore()
+    queue = TrainingOperationQueue(futures, max_terminal_records=1)
+    queue.register_model("model_a", next_seq_id=1)
+    for seq_id in (1, 2):
+        request_id = queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", seq_id, _payload())
+        queue.claim_ready()
+        queue.acknowledge_claim([request_id])
+        queue.complete(request_id, RequestStatus.COMPLETED, "{}")
+
+    with pytest.raises(OperationExpired):
+        queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 1, _payload())
+
+
+def test_retry_expires_when_its_completed_result_is_released():
+    futures = InMemoryFutureStore(max_terminal_futures=1)
+    queue = TrainingOperationQueue(futures)
+    queue.register_model("model_a", next_seq_id=1)
+    for seq_id in (1, 2):
+        request_id = queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", seq_id, _payload())
+        queue.claim_ready()
+        queue.acknowledge_claim([request_id])
+        queue.complete(request_id, RequestStatus.COMPLETED, "{}")
+
+    with pytest.raises(OperationExpired):
+        queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 1, _payload())
+
+
+@pytest.mark.asyncio
+async def test_unix_transport_releases_payload_after_claim_and_completes_future(
+    tmp_path,
+):
+    futures = InMemoryFutureStore()
+    queue = TrainingOperationQueue(futures)
+    queue.register_model("model_a", next_seq_id=1)
+    payload = _payload()
+    request_id = queue.enqueue(types.RequestType.FORWARD_BACKWARD, "model_a", 1, payload)
+
+    socket_path = str(tmp_path / "operations.sock")
+    server = OperationTransportServer(queue, socket_path)
+    await server.start()
+    client = await asyncio.to_thread(OperationTransportClient, socket_path)
+    try:
+        operations = await asyncio.to_thread(client.claim)
+        assert len(operations) == 1
+        assert operations[0].request_id == request_id
+        assert operations[0].payload == payload
+        assert queue.payload_bytes == 0
+
+        result = types.ForwardBackwardOutput(loss_fn_outputs=[], loss_fn_output_type="", metrics={})
+        await asyncio.to_thread(client.complete, request_id, result)
+        assert await futures.wait_for_future(request_id, 1) == (
+            RequestStatus.COMPLETED,
+            result.model_dump_json(),
+        )
+    finally:
+        client.close()
+        await server.close()
+
+
+def test_engine_executes_transport_batch_without_database_futures():
+    completed = {}
+
+    class FakeTransport:
+        def complete(self, request_id, result):
+            completed[request_id] = result
+
+    def forward_backward(batch):
+        return {
+            request_id: types.ForwardBackwardOutput(loss_fn_outputs=[], loss_fn_output_type="", metrics={})
+            for request_id, *_ in batch.request_batch_slices
+        }
+
+    engine = object.__new__(TinkerEngine)
+    engine.backend = SimpleNamespace(
+        has_model=lambda model_id: model_id == "model_a",
+        forward_backward=forward_backward,
+    )
+    engine.operation_transport = FakeTransport()
+    operations = [
+        ClaimedOperation(
+            request_id=-index,
+            request_type=types.RequestType.FORWARD_BACKWARD,
+            model_id="model_a",
+            seq_id=index,
+            payload=_payload(),
+        )
+        for index in (1, 2, 3)
+    ]
+
+    engine.process_transport_operations(operations)
+
+    assert set(completed) == {-1, -2, -3}
+    assert all(isinstance(result, types.ForwardBackwardOutput) for result in completed.values())

--- a/tests/tinker/test_proto_serialization.py
+++ b/tests/tinker/test_proto_serialization.py
@@ -11,15 +11,14 @@ import math
 import numpy as np
 import pytest
 import tinker.types as sdk_types
-import zstandard
-from fastapi import HTTPException
 from tinker import ForwardBackwardOutput, SampleResponse
 from tinker.proto.request_conv import forward_backward_request_to_proto
 from tinker.proto.response_conv import deserialize_proto_response
 
 from skyrl.tinker import api, types
 from skyrl.tinker.proto_serialization import (
-    PROTO_CONTENT_TYPE,
+    parse_forward_backward_input,
+    parse_forward_backward_metadata,
     parse_forward_backward_request,
     serialize_result,
 )
@@ -204,6 +203,15 @@ def test_parse_forward_backward_request():
     assert datum.loss_fn_inputs["target_tokens"].data == [2, 3, 4, 5]
     assert datum.loss_fn_inputs["weights"].data == [1.0, 0.5, 1.0, 0.0]
 
+    assert parse_forward_backward_metadata(encode_sdk_fwd_bwd_request()) == (
+        "model_abc",
+        1,
+        False,
+    )
+    internal = parse_forward_backward_input(encode_sdk_fwd_bwd_request())
+    assert internal.data[0].loss_fn_inputs.target_tokens.data == [2, 3, 4, 5]
+    assert internal.data[0].loss_fn_inputs.advantages.data == []
+
 
 def test_parse_forward_backward_request_forward_only_and_config():
     body = encode_sdk_fwd_bwd_request(loss_fn_config={"clip_low_threshold": 0.2}, forward_only=True)
@@ -215,65 +223,3 @@ def test_parse_forward_backward_request_forward_only_and_config():
 def test_parse_forward_backward_request_garbage_raises():
     with pytest.raises(Exception):
         parse_forward_backward_request(b"\xff\xfe not a proto")
-
-
-class _StubRequest:
-    """Just enough of fastapi.Request for _read_forward_backward_request:
-    the function only touches ``await request.body()`` and ``request.headers``."""
-
-    def __init__(self, body: bytes, headers: dict[str, str]):
-        self._body = body
-        self.headers = headers
-
-    async def body(self) -> bytes:
-        return self._body
-
-
-@pytest.mark.asyncio
-async def test_read_forward_backward_request_zstd_proto_body():
-    """SDK >= 0.25 may send the proto body zstd-compressed (Content-Encoding: zstd)."""
-    raw = encode_sdk_fwd_bwd_request(forward_only=True)
-    compressed = zstandard.ZstdCompressor().compress(raw)
-    request = _StubRequest(
-        compressed,
-        {"content-type": PROTO_CONTENT_TYPE, "content-encoding": "zstd"},
-    )
-    parsed, forward_only = await api._read_forward_backward_request(request)
-    assert forward_only
-    assert parsed.model_id == "model_abc"
-    (datum,) = parsed.forward_backward_input.data
-    assert datum.model_input.chunks[0].tokens == [1, 2, 3, 4]
-
-
-@pytest.mark.asyncio
-async def test_read_forward_backward_request_zstd_json_body():
-    """Content-Encoding applies to the raw body regardless of wire format."""
-    req = api.ForwardBackwardRequest(
-        model_id="model_json",
-        forward_backward_input=api.ForwardBackwardInput(
-            data=[
-                api.Datum(
-                    model_input=api.ModelInput(chunks=[api.EncodedTextChunk(tokens=[1, 2, 3])]),
-                    loss_fn_inputs={
-                        "target_tokens": api.TensorData(data=[2, 3, 4]),
-                        "weights": api.TensorData(data=[1.0, 1.0, 1.0]),
-                    },
-                )
-            ],
-            loss_fn="cross_entropy",
-        ),
-    )
-    compressed = zstandard.ZstdCompressor().compress(req.model_dump_json().encode())
-    parsed, forward_only = await api._read_forward_backward_request(
-        _StubRequest(compressed, {"content-encoding": "zstd"})
-    )
-    assert not forward_only
-    assert parsed.model_id == "model_json"
-
-
-@pytest.mark.asyncio
-async def test_read_forward_backward_request_bad_zstd_raises_422():
-    request = _StubRequest(b"\x00\x01 not zstd", {"content-encoding": "zstd"})
-    with pytest.raises(HTTPException) as exc_info:
-        await api._read_forward_backward_request(request)
-    assert exc_info.value.status_code == 422

--- a/tests/tinker/test_sampling_target_cache.py
+++ b/tests/tinker/test_sampling_target_cache.py
@@ -1,0 +1,107 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from skyrl.tinker import api
+from skyrl.tinker.db_models import SamplingSessionDB
+
+
+class _SamplingSession:
+    base_model = None
+    model_path = "tinker://model_a/sampler_weights/checkpoint_a"
+
+
+class _Session:
+    def __init__(self, reads: list[str]):
+        self._reads = reads
+
+    async def get(self, model, sampling_session_id):
+        assert model is SamplingSessionDB
+        self._reads.append(sampling_session_id)
+        await asyncio.sleep(0.01)
+        return _SamplingSession()
+
+
+def _request():
+    return SimpleNamespace(
+        sampling_session_id="sampling_a",
+        base_model=None,
+        model_path=None,
+    )
+
+
+def _server_request(external_inference_client=object()):
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                external_inference_client=external_inference_client,
+                external_sampling_targets={},
+                external_sampling_target_locks={},
+            )
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_external_sampling_target_resolves_once_under_concurrency(monkeypatch):
+    reads = []
+    get_model = AsyncMock()
+    validate_checkpoint = AsyncMock()
+    monkeypatch.setattr(api, "get_model", get_model)
+    monkeypatch.setattr(api, "validate_checkpoint", validate_checkpoint)
+    request = _request()
+    server_request = _server_request()
+
+    targets = await asyncio.gather(
+        *(api.get_sampling_target(request, server_request, _Session(reads)) for _ in range(512))
+    )
+
+    assert targets == [api.SamplingTarget(None, "model_a", "checkpoint_a")] * 512
+    assert reads == ["sampling_a"]
+    get_model.assert_awaited_once()
+    validate_checkpoint.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_external_sampling_target_caches_only_successful_validation(monkeypatch):
+    reads = []
+    monkeypatch.setattr(api, "get_model", AsyncMock())
+    validate_checkpoint = AsyncMock(
+        side_effect=[
+            HTTPException(status_code=425, detail="Checkpoint is still being created"),
+            None,
+        ]
+    )
+    monkeypatch.setattr(api, "validate_checkpoint", validate_checkpoint)
+    request = _request()
+    server_request = _server_request()
+
+    with pytest.raises(HTTPException, match="Checkpoint is still being created"):
+        await api.get_sampling_target(request, server_request, _Session(reads))
+    target = await api.get_sampling_target(request, server_request, _Session(reads))
+    cached_target = await api.get_sampling_target(request, server_request, _Session(reads))
+
+    assert target == cached_target == api.SamplingTarget(None, "model_a", "checkpoint_a")
+    assert reads == ["sampling_a", "sampling_a"]
+    assert validate_checkpoint.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_internal_sampling_target_preserves_database_validation(monkeypatch):
+    reads = []
+    get_model = AsyncMock()
+    validate_checkpoint = AsyncMock()
+    monkeypatch.setattr(api, "get_model", get_model)
+    monkeypatch.setattr(api, "validate_checkpoint", validate_checkpoint)
+    request = _request()
+    server_request = _server_request(external_inference_client=None)
+
+    await api.get_sampling_target(request, server_request, _Session(reads))
+    await api.get_sampling_target(request, server_request, _Session(reads))
+
+    assert reads == ["sampling_a", "sampling_a"]
+    assert get_model.await_count == 2
+    assert validate_checkpoint.await_count == 2

--- a/tests/tinker/test_training_operation_api.py
+++ b/tests/tinker/test_training_operation_api.py
@@ -1,0 +1,713 @@
+import asyncio
+import json
+import os
+import random
+import time
+
+import httpx
+import psutil
+import pytest
+import pytest_asyncio
+import tinker.types as sdk_types
+import zstandard as zstd
+from fastapi import Depends, FastAPI, Request
+from google.protobuf.message import Message
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel, func, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+from tinker.proto.request_conv import forward_backward_request_to_proto
+
+from skyrl.tinker import api, types
+from skyrl.tinker.db_models import (
+    CheckpointDB,
+    CheckpointStatus,
+    FutureDB,
+    ModelDB,
+    RequestStatus,
+    SessionDB,
+    enable_sqlite_wal,
+)
+from skyrl.tinker.extra import InMemoryFutureStore
+from skyrl.tinker.operation_transport import (
+    OperationPayloadFormat,
+    OperationTransportClient,
+    OperationTransportServer,
+    TrainingOperationQueue,
+)
+
+
+@pytest_asyncio.fixture()
+async def operation_api(tmp_path):
+    db_engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'tinker.db'}")
+    async with db_engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    async with AsyncSession(db_engine) as session:
+        session.add(SessionDB(session_id="session_a", sdk_version="test"))
+        session.add(
+            ModelDB(
+                model_id="model_a",
+                base_model="test/model",
+                lora_config=types.LoraConfig(rank=8, alpha=16, seed=0).model_dump(),
+                status="created",
+                request_id=1,
+                session_id="session_a",
+            )
+        )
+        await session.commit()
+
+    future_store = InMemoryFutureStore()
+    api.app.state.db_engine = db_engine
+    api.app.state.external_future_store = future_store
+    api.app.state.training_operation_queue = TrainingOperationQueue(future_store)
+    api.app.state.training_model_locks = {}
+    api.app.state.training_control_locks = {}
+    parse_concurrency = int(os.getenv("SKYRL_TRANSPORT_PARSE_CONCURRENCY", str(api.TRAINING_PARSE_CONCURRENCY)))
+    api.app.state.training_parse_semaphore = asyncio.Semaphore(parse_concurrency)
+    transport = httpx.ASGITransport(app=api.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, db_engine, api.app.state.training_operation_queue
+    await db_engine.dispose()
+
+
+def _forward_backward(seq_id: int) -> dict:
+    return {
+        "model_id": "model_a",
+        "seq_id": seq_id,
+        "forward_backward_input": {"data": [], "loss_fn": "cross_entropy"},
+    }
+
+
+def _proto_forward_backward(seq_id: int, *, forward_only: bool = False) -> bytes:
+    request = sdk_types.ForwardBackwardRequest(
+        model_id="model_a",
+        seq_id=seq_id,
+        forward_backward_input=sdk_types.ForwardBackwardInput(
+            data=[
+                sdk_types.Datum(
+                    model_input=sdk_types.ModelInput.from_ints([1, 2, 3, 4]),
+                    loss_fn_inputs={
+                        "target_tokens": sdk_types.TensorData(data=[2, 3, 4, 5], dtype="int64", shape=[4]),
+                        "weights": sdk_types.TensorData(data=[1.0, 0.5, 1.0, 0.0], dtype="float32", shape=[4]),
+                    },
+                )
+            ],
+            loss_fn="cross_entropy",
+        ),
+    )
+    message = forward_backward_request_to_proto(request)
+    message.forward_only = forward_only
+    return message.SerializeToString()
+
+
+def _realistic_forward_backward_body() -> bytes:
+    """Build one valid native-GSPO request body near the production size."""
+    token_count = 216_250
+    tokens = [1] * token_count
+    ones = [1.0] * token_count
+    zeros = [0.0] * token_count
+    request = {
+        "model_id": "model_a",
+        "seq_id": 0,
+        "forward_backward_input": {
+            "data": [
+                {
+                    "model_input": {"chunks": [{"tokens": tokens}]},
+                    "loss_fn_inputs": {
+                        "target_tokens": {"data": tokens},
+                        "weights": {"data": ones},
+                        "advantages": {"data": ones},
+                        "logprobs": {"data": zeros},
+                    },
+                }
+            ],
+            "loss_fn": "gspo",
+            "loss_fn_config": {
+                "clip_low_threshold": 0.2,
+                "clip_high_threshold": 1.2,
+            },
+        },
+    }
+    return json.dumps(request, separators=(",", ":")).encode()
+
+
+def _realistic_proto_message() -> Message:
+    """Build one valid native-GSPO protobuf request at production scale."""
+    token_count = 276_000
+    generator = random.Random(0)
+    tokens = [generator.randrange(32_000) for _ in range(token_count)]
+    weights = [0.0 if index % 7 == 0 else 1.0 for index in range(token_count)]
+    advantages = [generator.uniform(-10, 10) for _ in range(token_count)]
+    logprobs = [generator.uniform(-10, 0) for _ in range(token_count)]
+    request = sdk_types.ForwardBackwardRequest(
+        model_id="model_a",
+        seq_id=0,
+        forward_backward_input=sdk_types.ForwardBackwardInput(
+            data=[
+                sdk_types.Datum(
+                    model_input=sdk_types.ModelInput.from_ints(tokens),
+                    loss_fn_inputs={
+                        "target_tokens": sdk_types.TensorData(
+                            data=tokens,
+                            dtype="int64",
+                            shape=[token_count],
+                        ),
+                        "weights": sdk_types.TensorData(
+                            data=weights,
+                            dtype="float32",
+                            shape=[token_count],
+                        ),
+                        "advantages": sdk_types.TensorData(
+                            data=advantages,
+                            dtype="float32",
+                            shape=[token_count],
+                        ),
+                        "logprobs": sdk_types.TensorData(
+                            data=logprobs,
+                            dtype="float32",
+                            shape=[token_count],
+                        ),
+                    },
+                )
+            ],
+            loss_fn="gspo",
+            loss_fn_config={
+                "clip_low_threshold": 0.2,
+                "clip_high_threshold": 1.2,
+            },
+        ),
+    )
+    return forward_backward_request_to_proto(request)
+
+
+@pytest.mark.asyncio
+async def test_http_training_burst_stays_out_of_sqlite_and_orders_optimizer(
+    operation_api,
+):
+    client, db_engine, queue = operation_api
+    requests = [client.post("/api/v1/forward_backward", json=_forward_backward(seq_id)) for seq_id in range(2, 209)]
+    # The SDK deliberately submits the first chunk after the parallel tail.
+    requests.append(client.post("/api/v1/forward_backward", json=_forward_backward(1)))
+    requests.append(
+        client.post(
+            "/api/v1/optim_step",
+            json={
+                "model_id": "model_a",
+                "seq_id": 209,
+                "adam_params": {"learning_rate": 1e-4},
+            },
+        )
+    )
+    responses = await asyncio.gather(*requests)
+
+    assert {response.status_code for response in responses} == {200}
+    assert len({response.json()["request_id"] for response in responses}) == 209
+    async with AsyncSession(db_engine) as session:
+        assert (await session.exec(select(func.count()).select_from(FutureDB))).one() == 0
+
+    model_passes = queue.claim_ready()
+    assert [operation.seq_id for operation in model_passes] == list(range(1, 209))
+    queue.acknowledge_claim([operation.request_id for operation in model_passes])
+    for operation in model_passes:
+        queue.complete(operation.request_id, api.RequestStatus.COMPLETED, "{}")
+    (optimizer,) = queue.claim_ready()
+    assert optimizer.request_type == types.RequestType.OPTIM_STEP
+    assert optimizer.seq_id == 209
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("compressed", [False, True])
+async def test_forward_backward_accepts_sdk_proto(operation_api, compressed):
+    client, _, queue = operation_api
+    body = _proto_forward_backward(1, forward_only=True)
+    headers = {"content-type": api.PROTO_CONTENT_TYPE}
+    if compressed:
+        body = zstd.compress(body)
+        headers["content-encoding"] = "zstd"
+
+    response = await client.post("/api/v1/forward_backward", content=body, headers=headers)
+
+    assert response.status_code == 200
+    (operation,) = queue.claim_ready()
+    assert operation.request_type == types.RequestType.FORWARD
+    assert operation.seq_id == 1
+    assert operation.payload == body
+    assert operation.payload_format is (
+        OperationPayloadFormat.PROTO_ZSTD if compressed else OperationPayloadFormat.PROTO
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_config_advertises_parallel_compressed_proto(operation_api):
+    client, _, _ = operation_api
+
+    response = await client.post("/api/v1/client/config")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "pjwt_auth_enabled": False,
+        "parallel_fwdbwd_chunks": True,
+        "proto_write_fwdbwd": True,
+        "proto_compress_fwdbwd": True,
+        "fwd_via_fwdbwd": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_forward_backward_rejects_invalid_or_oversized_zstd(operation_api, monkeypatch):
+    client, _, _ = operation_api
+    headers = {
+        "content-type": api.PROTO_CONTENT_TYPE,
+        "content-encoding": "zstd",
+    }
+
+    invalid = await client.post("/api/v1/forward_backward", content=b"not-zstd", headers=headers)
+    monkeypatch.setattr(api, "MAX_TRAINING_REQUEST_BYTES", 1024)
+    oversized = await client.post(
+        "/api/v1/forward_backward",
+        content=zstd.compress(b"x" * 1025),
+        headers=headers,
+    )
+
+    assert invalid.status_code == 422
+    assert oversized.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_training_retry_is_idempotent_and_conflicting_reuse_is_409(operation_api):
+    client, _, _ = operation_api
+    original = await client.post("/api/v1/forward_backward", json=_forward_backward(1))
+    retry = await client.post("/api/v1/forward_backward", json=_forward_backward(1))
+    conflict = await client.post(
+        "/api/v1/forward",
+        json={
+            "model_id": "model_a",
+            "seq_id": 1,
+            "forward_input": {"data": [], "loss_fn": "cross_entropy"},
+        },
+    )
+
+    assert original.status_code == retry.status_code == 200
+    assert original.json()["request_id"] == retry.json()["request_id"]
+    assert conflict.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_request_shares_model_sequence_without_storing_payload(
+    operation_api,
+):
+    client, db_engine, queue = operation_api
+    first = await client.post("/api/v1/forward_backward", json=_forward_backward(1))
+    save = await client.post(
+        "/api/v1/save_weights",
+        json={"model_id": "model_a", "seq_id": 2, "path": "checkpoint_a"},
+    )
+    later = await client.post("/api/v1/forward_backward", json=_forward_backward(3))
+
+    assert first.status_code == save.status_code == later.status_code == 200
+    async with AsyncSession(db_engine) as session:
+        assert (await session.exec(select(func.count()).select_from(FutureDB))).one() == 0
+        assert (await session.exec(select(func.count()).select_from(CheckpointDB))).one() == 1
+
+    (first_operation,) = queue.claim_ready()
+    queue.acknowledge_claim([first_operation.request_id])
+    queue.complete(first_operation.request_id, api.RequestStatus.COMPLETED, "{}")
+    (save_operation,) = queue.claim_ready()
+    assert save_operation.request_type == types.RequestType.SAVE_WEIGHTS
+    assert save_operation.seq_id == 2
+
+
+@pytest.mark.asyncio
+async def test_restart_marks_old_database_training_work_failed(operation_api):
+    _, db_engine, _ = operation_api
+    async with AsyncSession(db_engine) as session:
+        session.add(
+            FutureDB(
+                request_type=types.RequestType.FORWARD_BACKWARD,
+                model_id="model_a",
+                seq_id=1,
+                request_data={"old": "payload"},
+            )
+        )
+        session.add(
+            CheckpointDB(
+                model_id="model_a",
+                checkpoint_id="stale",
+                checkpoint_type=types.CheckpointType.TRAINING,
+                status=CheckpointStatus.PENDING,
+            )
+        )
+        await session.commit()
+
+    await api.fail_stale_training_operations(db_engine)
+
+    async with AsyncSession(db_engine) as session:
+        future = (await session.exec(select(FutureDB))).one()
+        checkpoint = (await session.exec(select(CheckpointDB))).one()
+    assert future.status == RequestStatus.FAILED
+    assert "resume from a checkpoint" in future.result_data
+    assert checkpoint.status == CheckpointStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_restart_loses_in_memory_future_with_explicit_404(operation_api):
+    client, _, _ = operation_api
+    response = await client.post("/api/v1/forward_backward", json=_forward_backward(1))
+    api.app.state.external_future_store = InMemoryFutureStore()
+
+    retrieved = await client.post(
+        "/api/v1/retrieve_future",
+        json={"request_id": response.json()["request_id"]},
+    )
+
+    assert retrieved.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_queue_backpressure_is_retryable_http_429(operation_api):
+    client, _, queue = operation_api
+    queue.max_pending_per_model = 1
+    first = await client.post("/api/v1/forward_backward", json=_forward_backward(1))
+    rejected = await client.post("/api/v1/forward_backward", json=_forward_backward(2))
+
+    assert first.status_code == 200
+    assert rejected.status_code == 429
+    assert rejected.headers["retry-after"] == "1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    os.getenv("SKYRL_RUN_TRANSPORT_LOAD_TEST") != "1",
+    reason="set SKYRL_RUN_TRANSPORT_LOAD_TEST=1 for the 208-request production-size check",
+)
+async def test_production_size_training_update(operation_api, tmp_path, caplog):
+    client, db_engine, operation_queue = operation_api
+    request_count = int(os.getenv("SKYRL_TRANSPORT_LOAD_REQUESTS", "208"))
+    operation_queue.register_model("model_a", 1)
+    server = OperationTransportServer(operation_queue, str(tmp_path / "operations.sock"))
+    await server.start()
+
+    wire_format = os.getenv("SKYRL_TRANSPORT_LOAD_FORMAT", "json")
+    proto_message = _realistic_proto_message() if wire_format == "proto-zstd" else None
+    base_body = (
+        zstd.compress(proto_message.SerializeToString())
+        if proto_message is not None
+        else _realistic_forward_backward_body()
+    )
+    assert 3.2 * 1024**2 <= len(base_body) <= 3.4 * 1024**2
+    request_bodies = {}
+    for seq_id in range(1, request_count + 1):
+        if proto_message is not None:
+            message = proto_message.__class__()
+            message.CopyFrom(proto_message)
+            message.seq_id = seq_id
+            request_bodies[seq_id] = zstd.compress(message.SerializeToString())
+        else:
+            request_bodies[seq_id] = base_body.replace(
+                b'"seq_id":0',
+                f'"seq_id":{seq_id}'.encode(),
+                1,
+            )
+
+    process = psutil.Process()
+    start_rss = process.memory_info().rss
+    peak_rss = start_rss
+    stop_memory_sample = asyncio.Event()
+    submissions_done = asyncio.Event()
+    request_latencies = []
+    heartbeat_latencies = []
+    heartbeat_statuses = []
+
+    async def sample_memory():
+        nonlocal peak_rss
+        while not stop_memory_sample.is_set():
+            peak_rss = max(peak_rss, process.memory_info().rss)
+            await asyncio.sleep(0.02)
+
+    async def send_heartbeats():
+        while not submissions_done.is_set():
+            started = time.perf_counter()
+            response = await client.post("/api/v1/session_heartbeat", json={"session_id": "session_a"})
+            heartbeat_latencies.append(time.perf_counter() - started)
+            heartbeat_statuses.append(response.status_code)
+            await asyncio.sleep(0.05)
+
+    async def submit(seq_id: int):
+        if proto_message is not None:
+            headers = {
+                "content-type": api.PROTO_CONTENT_TYPE,
+                "content-encoding": "zstd",
+            }
+        else:
+            headers = {"content-type": "application/json"}
+        # ASGITransport is in-process. Copy the client-owned bytes once to
+        # model the allocation that a real HTTP server makes while reading.
+        body = bytes(bytearray(request_bodies[seq_id]))
+        started = time.perf_counter()
+        response = await client.post(
+            "/api/v1/forward_backward",
+            content=body,
+            headers=headers,
+        )
+        request_latencies.append(time.perf_counter() - started)
+        return response
+
+    memory_task = asyncio.create_task(sample_memory())
+    heartbeat_task = asyncio.create_task(send_heartbeats())
+    submission_started = time.perf_counter()
+    try:
+        responses = await asyncio.gather(*(submit(seq_id) for seq_id in range(2, request_count + 1)), submit(1))
+    finally:
+        submissions_done.set()
+        await heartbeat_task
+    optimizer_response = await client.post(
+        "/api/v1/optim_step",
+        json={
+            "model_id": "model_a",
+            "seq_id": request_count + 1,
+            "adam_params": {"learning_rate": 1e-4},
+        },
+    )
+    submission_seconds = time.perf_counter() - submission_started
+    status_codes = [response.status_code for response in responses]
+    assert status_codes == [200] * request_count
+    assert optimizer_response.status_code == 200, optimizer_response.text
+
+    transport_client = await asyncio.to_thread(OperationTransportClient, str(tmp_path / "operations.sock"))
+    transfer_started = time.perf_counter()
+    operations = await asyncio.to_thread(transport_client.claim)
+    claimed_seq_ids = [operation.seq_id for operation in operations]
+
+    def complete_model_passes():
+        result = types.ForwardBackwardOutput(loss_fn_output_type="per_token_loss", loss_fn_outputs=[], metrics={})
+        for operation in operations:
+            transport_client.complete(operation.request_id, result)
+
+    await asyncio.to_thread(complete_model_passes)
+    (optimizer,) = await asyncio.to_thread(transport_client.claim)
+    await asyncio.to_thread(
+        transport_client.complete,
+        optimizer.request_id,
+        types.OptimStepOutput(metrics={}),
+    )
+    transfer_seconds = time.perf_counter() - transfer_started
+
+    first_future = responses[-1].json()["request_id"]
+    first_result = await client.post("/api/v1/retrieve_future", json={"request_id": first_future})
+    optimizer_result = await client.post(
+        "/api/v1/retrieve_future",
+        json={"request_id": optimizer_response.json()["request_id"]},
+    )
+
+    stop_memory_sample.set()
+    await memory_task
+    peak_rss = max(peak_rss, process.memory_info().rss)
+    transport_client.close()
+    await server.close()
+
+    queue_pool_failures = sum("QueuePool" in record.getMessage() for record in caplog.records)
+    async with AsyncSession(db_engine) as session:
+        sqlite_future_rows = (await session.exec(select(func.count()).select_from(FutureDB))).one()
+
+    metrics = {
+        "accepted_forward_backward": status_codes.count(200),
+        "http_4xx": sum(400 <= status < 500 for status in status_codes),
+        "http_5xx": sum(status >= 500 for status in status_codes),
+        "queue_pool_failures": queue_pool_failures,
+        "sequence_gaps": len(set(range(1, request_count + 1)) - set(claimed_seq_ids)),
+        "request_bytes": len(base_body),
+        "wire_format": wire_format,
+        "submission_seconds": round(submission_seconds, 3),
+        "max_request_seconds": round(max(request_latencies), 3),
+        "max_heartbeat_seconds": round(max(heartbeat_latencies), 3),
+        "transport_and_completion_seconds": round(transfer_seconds, 3),
+        "peak_rss_delta_mib": round((peak_rss - start_rss) / 1024**2, 1),
+        "sqlite_future_rows": sqlite_future_rows,
+    }
+    print("\nTRAINING_TRANSPORT_METRICS=" + json.dumps(metrics, sort_keys=True))
+
+    assert len({response.json()["request_id"] for response in responses}) == request_count
+    assert claimed_seq_ids == list(range(1, request_count + 1))
+    assert optimizer.seq_id == request_count + 1
+    assert optimizer.request_type == types.RequestType.OPTIM_STEP
+    assert heartbeat_statuses and heartbeat_statuses == [200] * len(heartbeat_statuses)
+    assert max(request_latencies) < 60
+    assert first_result.status_code == optimizer_result.status_code == 200
+    assert queue_pool_failures == 0
+    assert sqlite_future_rows == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    os.getenv("SKYRL_RUN_LEGACY_SQLITE_LOAD_TEST") != "1",
+    reason="set SKYRL_RUN_LEGACY_SQLITE_LOAD_TEST=1 for the previous SQLite path",
+)
+async def test_legacy_sqlite_production_size_training_update(tmp_path, caplog):
+    """Measure the previous API path with the production pool and payload shape."""
+    request_count = int(os.getenv("SKYRL_TRANSPORT_LOAD_REQUESTS", "208"))
+    db_engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'legacy-tinker.db'}",
+        pool_size=5,
+        max_overflow=10,
+    )
+    enable_sqlite_wal(db_engine.sync_engine)
+    async with db_engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    async with AsyncSession(db_engine) as session:
+        session.add(SessionDB(session_id="session_a", sdk_version="test"))
+        session.add(
+            ModelDB(
+                model_id="model_a",
+                base_model="test/model",
+                lora_config=types.LoraConfig(rank=8, alpha=16, seed=0).model_dump(),
+                status="created",
+                request_id=1,
+                session_id="session_a",
+            )
+        )
+        await session.commit()
+
+    legacy_app = FastAPI()
+
+    async def get_legacy_session() -> AsyncSession:
+        async with AsyncSession(db_engine) as session:
+            yield session
+
+    @legacy_app.post("/api/v1/forward_backward")
+    async def legacy_forward_backward(
+        request: Request,
+        session: AsyncSession = Depends(get_legacy_session),
+    ):
+        parsed = api.ForwardBackwardRequest.model_validate_json(await request.body())
+        await api.get_model(session, parsed.model_id)
+        request_id = await api.create_future(
+            session=session,
+            request_type=types.RequestType.FORWARD_BACKWARD,
+            model_id=parsed.model_id,
+            request_data=parsed.forward_backward_input.to_types(),
+            seq_id=parsed.seq_id,
+        )
+        await session.commit()
+        return {"request_id": str(request_id), "status": "pending"}
+
+    @legacy_app.post("/api/v1/optim_step")
+    async def legacy_optim_step(
+        request: api.OptimStepRequest,
+        session: AsyncSession = Depends(get_legacy_session),
+    ):
+        await api.get_model(session, request.model_id)
+        request_id = await api.create_future(
+            session=session,
+            request_type=types.RequestType.OPTIM_STEP,
+            model_id=request.model_id,
+            request_data=types.OptimStepInput(adam_params=request.adam_params.to_types()),
+            seq_id=request.seq_id,
+        )
+        await session.commit()
+        return {"request_id": str(request_id), "status": "pending"}
+
+    @legacy_app.post("/api/v1/session_heartbeat")
+    async def legacy_heartbeat(
+        request: api.SessionHeartbeatRequest,
+        session: AsyncSession = Depends(get_legacy_session),
+    ):
+        session_db = await session.get(SessionDB, request.session_id)
+        session_db.heartbeat_count += 1
+        await session.commit()
+        return {"type": "session_heartbeat"}
+
+    base_body = _realistic_forward_backward_body()
+    request_bodies = {
+        seq_id: base_body.replace(b'"seq_id":0', f'"seq_id":{seq_id}'.encode(), 1)
+        for seq_id in range(1, request_count + 1)
+    }
+    process = psutil.Process()
+    start_rss = process.memory_info().rss
+    peak_rss = start_rss
+    stop_memory_sample = asyncio.Event()
+    submissions_done = asyncio.Event()
+    heartbeat_latencies = []
+    heartbeat_statuses = []
+
+    async def sample_memory():
+        nonlocal peak_rss
+        while not stop_memory_sample.is_set():
+            peak_rss = max(peak_rss, process.memory_info().rss)
+            await asyncio.sleep(0.02)
+
+    transport = httpx.ASGITransport(app=legacy_app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+
+        async def send_heartbeats():
+            while not submissions_done.is_set():
+                started = time.perf_counter()
+                response = await client.post(
+                    "/api/v1/session_heartbeat",
+                    json={"session_id": "session_a"},
+                )
+                heartbeat_latencies.append(time.perf_counter() - started)
+                heartbeat_statuses.append(response.status_code)
+                await asyncio.sleep(0.05)
+
+        async def submit(seq_id: int):
+            body = bytes(bytearray(request_bodies[seq_id]))
+            return await client.post(
+                "/api/v1/forward_backward",
+                content=body,
+                headers={"content-type": "application/json"},
+            )
+
+        memory_task = asyncio.create_task(sample_memory())
+        heartbeat_task = asyncio.create_task(send_heartbeats())
+        submission_started = time.perf_counter()
+        try:
+            responses = await asyncio.gather(
+                *(submit(seq_id) for seq_id in range(2, request_count + 1)),
+                submit(1),
+            )
+        finally:
+            submissions_done.set()
+            await heartbeat_task
+        optimizer_response = await client.post(
+            "/api/v1/optim_step",
+            json={
+                "model_id": "model_a",
+                "seq_id": request_count + 1,
+                "adam_params": {"learning_rate": 1e-4},
+            },
+        )
+        submission_seconds = time.perf_counter() - submission_started
+
+    stop_memory_sample.set()
+    await memory_task
+    peak_rss = max(peak_rss, process.memory_info().rss)
+    status_codes = [response.status_code for response in responses]
+    async with AsyncSession(db_engine) as session:
+        stored_seq_ids = set(
+            (
+                await session.exec(
+                    select(FutureDB.seq_id)
+                    .where(FutureDB.model_id == "model_a")
+                    .where(FutureDB.request_type == types.RequestType.FORWARD_BACKWARD)
+                )
+            ).all()
+        )
+    queue_pool_failures = sum("QueuePool" in record.getMessage() for record in caplog.records)
+    metrics = {
+        "accepted_forward_backward": status_codes.count(200),
+        "http_4xx": sum(400 <= status < 500 for status in status_codes),
+        "http_5xx": sum(status >= 500 for status in status_codes),
+        "heartbeat_4xx": sum(400 <= status < 500 for status in heartbeat_statuses),
+        "heartbeat_5xx": sum(status >= 500 for status in heartbeat_statuses),
+        "max_heartbeat_seconds": round(max(heartbeat_latencies), 3),
+        "optimizer_status": optimizer_response.status_code,
+        "peak_rss_delta_mib": round((peak_rss - start_rss) / 1024**2, 1),
+        "queue_pool_failures": queue_pool_failures,
+        "request_bytes": len(base_body),
+        "sequence_gaps": len(set(range(1, request_count + 1)) - stored_seq_ids),
+        "submission_seconds": round(submission_seconds, 3),
+        "wire_format": "json",
+    }
+    print("\nLEGACY_SQLITE_METRICS=" + json.dumps(metrics, sort_keys=True))
+    await db_engine.dispose()
+
+    assert len(status_codes) == request_count

--- a/tests/tinker/test_training_operation_api.py
+++ b/tests/tinker/test_training_operation_api.py
@@ -215,6 +215,40 @@ async def test_http_training_burst_stays_out_of_sqlite_and_orders_optimizer(
 
 
 @pytest.mark.asyncio
+async def test_parallel_training_uploads_do_not_wait_for_the_parse_slot(operation_api):
+    client, _, _ = operation_api
+    uploads_started = [asyncio.Event(), asyncio.Event()]
+    release_uploads = asyncio.Event()
+
+    async def body(index: int):
+        uploads_started[index].set()
+        await release_uploads.wait()
+        yield json.dumps(_forward_backward(index + 1)).encode()
+
+    requests = [
+        asyncio.create_task(
+            client.post(
+                "/api/v1/forward_backward",
+                content=body(index),
+                headers={"content-type": "application/json"},
+            )
+        )
+        for index in range(2)
+    ]
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*(started.wait() for started in uploads_started)),
+            timeout=1,
+        )
+    finally:
+        release_uploads.set()
+
+    responses = await asyncio.gather(*requests)
+
+    assert [response.status_code for response in responses] == [200, 200]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("compressed", [False, True])
 async def test_forward_backward_accepts_sdk_proto(operation_api, compressed):
     client, _, queue = operation_api


### PR DESCRIPTION
## Summary

- Keep `forward`, `forward_backward`, optimizer, and checkpoint request bodies in a bounded
  in-memory queue.
- Send ready operations to the training engine over a local Unix socket in SDK sequence order.
- Validate the external sampling target once per sampling session and reuse it for later requests.
- Preserve current checkpoint-load and compressed-request behavior.

This PR depends on #2059.

## Context

SkyRL's Tinker-compatible client submits one training update as an ordered sequence of operations.
The API accepts each body, validates and parses it, and sends consecutive sequence IDs to the local
training engine. Concurrent sample calls in one sampling session also refer to the same external
sampling target.

SQLite remains the durable store for operation metadata. Large request bodies and repeated reads of
unchanged sampling metadata do not need that durability, and they can exhaust the database
connection pool before GPU training begins.

## Before

One Qwen 27B update submitted about 208 training operations of about 3.3 MB each. The API wrote
those bodies to SQLite. Concurrent writes exhausted the SQLAlchemy pool, which had 5 regular
connections and 10 overflow connections, and left gaps in the operation sequence.

Each of 512 concurrent sample requests also read the same sampling session, model, and checkpoint
from SQLite. External integration XID `1045664` exhausted the same pool on these repeated reads.

The following runs used SkyRL through its Tinker-compatible API and recorded the missing sequence
IDs:

| XID | Hardware and SkyRL parallelism | Operations accepted | Missing sequence IDs |
| ---: | --- | ---: | ---: |
| `1045743` | H200 TP4×DP4 | 91 | 117 |
| `1045744` | B300 TP2×DP4 | 197 | 11 |
| `1045745` | B300 TP4×DP2 | 166 | 27 at observation time |

The first in-memory implementation read each request body while holding the one-operation parsing
limit. XID `1045913` then recorded 344 `ClientDisconnect` errors during its first update.

## After

The API reads request bodies concurrently, parses one operation at a time, and keeps accepted bodies
in a bounded in-memory queue. The local training engine receives only consecutive sequence IDs over
a Unix socket. The first sample request validates its sampling target; the other 511 requests reuse
that result.

The queue returns explicit HTTP errors for conflicting retries, expired operations, invalid input,
oversized bodies, and full capacity. Checkpoint loading and compressed requests retain their current
behavior.

Historical B300 XIDs `1046610` (TP4×DP2) and `1046707` (TP2×DP4) completed 20 updates with the
earlier image that first used this design. The current source still needs a fresh B300 run.

## Testing

```bash
uv run --isolated --extra dev --extra tinker --extra jax pytest \
  tests/tinker/test_operation_transport.py \
  tests/tinker/test_training_operation_api.py \
  tests/tinker/test_future_waiting.py \
  tests/tinker/test_in_memory_future_store.py \
  tests/tinker/test_proto_serialization.py \
  tests/tinker/test_api_validation.py \
  tests/tinker/test_engine.py \
  tests/tinker/test_sampling_target_cache.py -q

uv run --isolated --extra dev --extra tinker --extra skyrl-train pytest \
  tests/backends/skyrl_train/test_token_based_batching_utils.py -q
```

107 passed, 2 skipped across both commands.
