### PR TITLE
[tinker] 16/n towards Kimi K2.6: accept zstd-compressed Tinker API forward_backward bodies (SDK >= 0.25)

### DIFF
--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 import fastapi
 import psutil
+import zstandard
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.exceptions import RequestValidationError as FastAPIRequestValidationError
 from fastapi.responses import RedirectResponse, StreamingResponse
@@ -1083,14 +1084,28 @@ async def get_training_run(model_id: str, session: AsyncSession = Depends(get_se
     )
 
 
+# Upper bound for a decompressed forward_backward body. Far above any
+# legitimate payload (requests are chunked client-side well below this), but
+# it keeps a small crafted body from ballooning into an arbitrarily large
+# allocation.
+_MAX_FWDBWD_BODY_BYTES = 1 << 30  # 1 GiB
+
+
 async def _read_forward_backward_request(request: Request) -> tuple[ForwardBackwardRequest, bool]:
     """Read a forward_backward body in either wire format.
 
     tinker SDK >= 0.25.0 submits the body as protobuf and routes forward-only
     passes here via the proto's ``forward_only`` flag instead of calling
     ``/api/v1/forward``; older SDKs keep sending JSON with forward_only False.
+    Large proto bodies may arrive zstd-compressed (``Content-Encoding: zstd``);
+    ASGI servers do not decode request bodies, so decompress here.
     """
     body = await request.body()
+    if request.headers.get("content-encoding", "").strip().lower() == "zstd":
+        try:
+            body = zstandard.ZstdDecompressor().decompress(body, max_output_size=_MAX_FWDBWD_BODY_BYTES)
+        except Exception as exc:
+            raise HTTPException(status_code=422, detail=f"failed to zstd-decompress request body: {exc}") from exc
     if PROTO_CONTENT_TYPE in request.headers.get("content-type", "").lower():
         try:
             request_dict, forward_only = parse_forward_backward_request(body)

--- a/tests/tinker/test_proto_serialization.py
+++ b/tests/tinker/test_proto_serialization.py
@@ -11,12 +11,15 @@ import math
 import numpy as np
 import pytest
 import tinker.types as sdk_types
+import zstandard
+from fastapi import HTTPException
 from tinker import ForwardBackwardOutput, SampleResponse
 from tinker.proto.request_conv import forward_backward_request_to_proto
 from tinker.proto.response_conv import deserialize_proto_response
 
 from skyrl.tinker import api, types
 from skyrl.tinker.proto_serialization import (
+    PROTO_CONTENT_TYPE,
     parse_forward_backward_request,
     serialize_result,
 )
@@ -212,3 +215,65 @@ def test_parse_forward_backward_request_forward_only_and_config():
 def test_parse_forward_backward_request_garbage_raises():
     with pytest.raises(Exception):
         parse_forward_backward_request(b"\xff\xfe not a proto")
+
+
+class _StubRequest:
+    """Just enough of fastapi.Request for _read_forward_backward_request:
+    the function only touches ``await request.body()`` and ``request.headers``."""
+
+    def __init__(self, body: bytes, headers: dict[str, str]):
+        self._body = body
+        self.headers = headers
+
+    async def body(self) -> bytes:
+        return self._body
+
+
+@pytest.mark.asyncio
+async def test_read_forward_backward_request_zstd_proto_body():
+    """SDK >= 0.25 may send the proto body zstd-compressed (Content-Encoding: zstd)."""
+    raw = encode_sdk_fwd_bwd_request(forward_only=True)
+    compressed = zstandard.ZstdCompressor().compress(raw)
+    request = _StubRequest(
+        compressed,
+        {"content-type": PROTO_CONTENT_TYPE, "content-encoding": "zstd"},
+    )
+    parsed, forward_only = await api._read_forward_backward_request(request)
+    assert forward_only
+    assert parsed.model_id == "model_abc"
+    (datum,) = parsed.forward_backward_input.data
+    assert datum.model_input.chunks[0].tokens == [1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_read_forward_backward_request_zstd_json_body():
+    """Content-Encoding applies to the raw body regardless of wire format."""
+    req = api.ForwardBackwardRequest(
+        model_id="model_json",
+        forward_backward_input=api.ForwardBackwardInput(
+            data=[
+                api.Datum(
+                    model_input=api.ModelInput(chunks=[api.EncodedTextChunk(tokens=[1, 2, 3])]),
+                    loss_fn_inputs={
+                        "target_tokens": api.TensorData(data=[2, 3, 4]),
+                        "weights": api.TensorData(data=[1.0, 1.0, 1.0]),
+                    },
+                )
+            ],
+            loss_fn="cross_entropy",
+        ),
+    )
+    compressed = zstandard.ZstdCompressor().compress(req.model_dump_json().encode())
+    parsed, forward_only = await api._read_forward_backward_request(
+        _StubRequest(compressed, {"content-encoding": "zstd"})
+    )
+    assert not forward_only
+    assert parsed.model_id == "model_json"
+
+
+@pytest.mark.asyncio
+async def test_read_forward_backward_request_bad_zstd_raises_422():
+    request = _StubRequest(b"\x00\x01 not zstd", {"content-encoding": "zstd"})
+    with pytest.raises(HTTPException) as exc_info:
+        await api._read_forward_backward_request(request)
+    assert exc_info.value.status_code == 422


### PR DESCRIPTION
Part of the Kimi K2.6/K2.7 series. Standalone, builds directly on the proto wire format from #2021. This is one of the two pieces salvaged from #2030 (closed as superseded by #2021), as flagged there.

## What

`_read_forward_backward_request` now handles `Content-Encoding: zstd`: the body is decompressed before wire-format dispatch (it applies to both proto and JSON bodies, since `Content-Encoding` is independent of `Content-Type`). Decompression is bounded at 1 GiB — far above any legitimate payload, but a small crafted body can no longer balloon into an arbitrarily large allocation. A malformed stream returns a clean 422.

Unit tests cover the SDK-encoded proto body compressed with zstd, a compressed JSON body, and the malformed-stream 422.

## Why

The tinker SDK >= 0.25 can submit the proto `forward_backward` body zstd-compressed. ASGI servers pass request bodies through undecoded, so on our Kimi K2.7 training service those requests failed proto parsing with a 422 until the server learned to decompress. The compression is worth supporting rather than disabling client-side: our RL forward_backward batches (long agentic transcripts) shrink several-fold on the wire, which matters when the training client is remote from the cluster.

Made with [Cursor](https://cursor.com)