### PR TITLE
[tinker] 17/n towards Kimi K2.6: run Tinker API forward requests through the training loss path

### DIFF
--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -948,7 +948,22 @@ class SkyRLTrainBackend(AbstractBackend):
         )
         batch, pad_size = self._pad_batch(batch, micro_batch_size=micro_bs)
         model_id = prepared_batch.all_model_ids[0] if prepared_batch.all_model_ids else None
-        data = self._dispatch.forward(role, batch, model_id=model_id)
+        # Forward must run the SAME pipeline as forward_backward (loss path,
+        # forward_only): the loss-less worker forward takes Megatron's
+        # inference route, which bypasses training-only transforms like
+        # fake-INT4 QAT and the fused LM-head logprob, so its logprobs
+        # diverge from what gradients are computed against. The tinker
+        # FORWARD request always carries a loss_fn; use it (policy roles).
+        loss_fn = prepared_batch.all_loss_fns[0] if prepared_batch.all_loss_fns else None
+        loss_fn_config = next((c for c in prepared_batch.all_loss_fn_configs if c is not None), None)
+        if role != "critic" and loss_fn is not None:
+            self._validate_batch_role_and_loss(role, loss_fn)
+            loss_fn, loss_fn_config = self._normalize_policy_loss_request(role, loss_fn, loss_fn_config)
+            data = self._dispatch.forward(
+                role, batch, loss_fn=loss_fn, loss_fn_config=loss_fn_config, model_id=model_id
+            )
+        else:
+            data = self._dispatch.forward(role, batch, model_id=model_id)
 
         # Workers emit per-sample loss_fn_outputs directly. Trim padding entries.
         per_sample_outputs = data.loss_fn_outputs


### PR DESCRIPTION
Part of the Kimi K2.6/K2.7 series. Standalone. This is the second piece salvaged from #2030 (closed as superseded by #2021), as flagged there.

## What

`_forward_single_model_batch` in the SkyRL-Train backend now routes FORWARD requests through the same loss pipeline as `forward_backward` (the dispatch's loss-path forward with `forward_only` semantics) whenever the request carries a `loss_fn` and the role is not critic — the tinker FORWARD request always carries one. Validation and loss normalization are shared with `forward_backward`. Critic and loss-less callers keep the plain worker forward.

## Why

The loss-less worker forward takes Megatron's inference route, which bypasses training-only transforms — fake-INT4 QAT weight quantization (#1862) and the fused LM-head logprob (#1841). Its logprobs therefore diverge from what gradients are computed against.

On our Kimi K2.7-Code INT4 QAT runs through the Tinker API this was not cosmetic: `forward()` silently scored the *unquantized* weights, so client-side importance-sampling corrections computed from FORWARD logprobs disagreed with the training-side logprobs (a persistent rollout/train logprob gap in the #1880 metrics), and eval losses measured through FORWARD were skewed relative to training loss. With FORWARD on the loss path, the same batch scored via `forward()` and via `forward_backward()` produces matching logprobs.

Made with [Cursor](https://cursor.com)