### PR TITLE
[tinker] Restrict load_weights to a model's first request, matching Tinker

### DIFF
--- a/.claude/docs/tinker.md
+++ b/.claude/docs/tinker.md
@@ -36,7 +36,7 @@ All endpoints are under `/api/v1/`. Requests are async -- submit via POST, get a
 | `/asample` | POST | Generate samples from current or base model |
 | `/save_weights` | POST | Save full training checkpoint (weights + optimizer) |
 | `/save_weights_for_sampler` | POST | Sync weights to inference engines |
-| `/load_weights` | POST | Load a previously saved checkpoint |
+| `/load_weights` | POST | Load a previously saved checkpoint. Only permitted as a model's first request (matching the Tinker service); later attempts get a 400 -- load into a freshly created model instead |
 | `/training_runs/{unique_id}/checkpoints/weights/{checkpoint_id}` | DELETE | Delete a saved training checkpoint archive from disk |
 | `/training_runs/{unique_id}/checkpoints/sampler_weights/{checkpoint_id}` | DELETE | Delete a saved sampler checkpoint archive from disk |
 | `/retrieve_future` | POST | Long-poll for async result (300s timeout) |

--- a/skyrl/backends/backend.py
+++ b/skyrl/backends/backend.py
@@ -125,12 +125,13 @@ class AbstractBackend(ABC):
         pass
 
     @abstractmethod
-    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str) -> None:
+    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, optimizer: bool) -> None:
         """Load training checkpoint from disk.
 
         Args:
             checkpoint_path: Path to the checkpoint file
             model_id: The model identifier
+            optimizer: Whether to restore optimizer and scheduler state
         """
         pass
 

--- a/skyrl/backends/backend.py
+++ b/skyrl/backends/backend.py
@@ -125,13 +125,13 @@ class AbstractBackend(ABC):
         pass
 
     @abstractmethod
-    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, optimizer: bool) -> None:
+    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, load_optimizer: bool) -> None:
         """Load training checkpoint from disk.
 
         Args:
             checkpoint_path: Path to the checkpoint file
             model_id: The model identifier
-            optimizer: Whether to restore optimizer and scheduler state
+            load_optimizer: Whether to restore optimizer and scheduler state
         """
         pass
 

--- a/skyrl/backends/jax.py
+++ b/skyrl/backends/jax.py
@@ -953,7 +953,7 @@ class JaxBackendImpl(AbstractBackend):
             "lora_config": self.models[model_id].lora_config.model_dump(),
         }
 
-    def _insert_checkpoint_data(self, model_id: str, checkpoint_data: dict) -> None:
+    def _insert_checkpoint_data(self, model_id: str, checkpoint_data: dict, optimizer: bool) -> None:
         """Insert checkpoint data into model state."""
         adapter_index = self.models[model_id].adapter_index
         rank = checkpoint_data["lora_config"]["rank"]
@@ -965,11 +965,12 @@ class JaxBackendImpl(AbstractBackend):
             )
 
         insert_adapter_state(adapter_index, self.lora_params, checkpoint_data["lora_weights"], rank)
-        insert_adapter_state(
-            adapter_index, nnx.state(self.optimizers[model_id]), checkpoint_data["optimizer_state"], rank
-        )
+        if optimizer:
+            insert_adapter_state(
+                adapter_index, nnx.state(self.optimizers[model_id]), checkpoint_data["optimizer_state"], rank
+            )
 
-    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str) -> None:
+    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, optimizer: bool) -> None:
         """Load training checkpoint using Flax checkpoints."""
         checkpoint = checkpoints.restore_checkpoint(
             ckpt_dir=checkpoint_path,
@@ -980,7 +981,7 @@ class JaxBackendImpl(AbstractBackend):
         if checkpoint is None:
             raise FileNotFoundError(f"Training checkpoint not found in {checkpoint_path}")
 
-        self._insert_checkpoint_data(model_id, checkpoint)
+        self._insert_checkpoint_data(model_id, checkpoint, optimizer)
         logger.info(f"Loaded training checkpoint from {checkpoint_path}")
 
     def save_sampler_checkpoint(self, output_path: AnyPath, model_id: str, persist: bool = True) -> None:
@@ -1152,8 +1153,10 @@ class JaxBackend(JaxBackendImpl):
     def save_checkpoint(self, output_path: AnyPath, model_id: str) -> None:
         self._broadcast_and_call("save_checkpoint", output_path=output_path, model_id=model_id)
 
-    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str) -> None:
-        self._broadcast_and_call("load_checkpoint", checkpoint_path=checkpoint_path, model_id=model_id)
+    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, optimizer: bool) -> None:
+        self._broadcast_and_call(
+            "load_checkpoint", checkpoint_path=checkpoint_path, model_id=model_id, optimizer=optimizer
+        )
 
     def save_sampler_checkpoint(self, output_path: AnyPath, model_id: str, persist: bool = True) -> None:
         # Write probe so workers can detect shared filesystem

--- a/skyrl/backends/jax.py
+++ b/skyrl/backends/jax.py
@@ -953,7 +953,7 @@ class JaxBackendImpl(AbstractBackend):
             "lora_config": self.models[model_id].lora_config.model_dump(),
         }
 
-    def _insert_checkpoint_data(self, model_id: str, checkpoint_data: dict, optimizer: bool) -> None:
+    def _insert_checkpoint_data(self, model_id: str, checkpoint_data: dict, load_optimizer: bool) -> None:
         """Insert checkpoint data into model state."""
         adapter_index = self.models[model_id].adapter_index
         rank = checkpoint_data["lora_config"]["rank"]
@@ -965,12 +965,12 @@ class JaxBackendImpl(AbstractBackend):
             )
 
         insert_adapter_state(adapter_index, self.lora_params, checkpoint_data["lora_weights"], rank)
-        if optimizer:
+        if load_optimizer:
             insert_adapter_state(
                 adapter_index, nnx.state(self.optimizers[model_id]), checkpoint_data["optimizer_state"], rank
             )
 
-    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, optimizer: bool) -> None:
+    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, load_optimizer: bool) -> None:
         """Load training checkpoint using Flax checkpoints."""
         checkpoint = checkpoints.restore_checkpoint(
             ckpt_dir=checkpoint_path,
@@ -981,7 +981,7 @@ class JaxBackendImpl(AbstractBackend):
         if checkpoint is None:
             raise FileNotFoundError(f"Training checkpoint not found in {checkpoint_path}")
 
-        self._insert_checkpoint_data(model_id, checkpoint, optimizer)
+        self._insert_checkpoint_data(model_id, checkpoint, load_optimizer)
         logger.info(f"Loaded training checkpoint from {checkpoint_path}")
 
     def save_sampler_checkpoint(self, output_path: AnyPath, model_id: str, persist: bool = True) -> None:
@@ -1153,9 +1153,9 @@ class JaxBackend(JaxBackendImpl):
     def save_checkpoint(self, output_path: AnyPath, model_id: str) -> None:
         self._broadcast_and_call("save_checkpoint", output_path=output_path, model_id=model_id)
 
-    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, optimizer: bool) -> None:
+    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, load_optimizer: bool) -> None:
         self._broadcast_and_call(
-            "load_checkpoint", checkpoint_path=checkpoint_path, model_id=model_id, optimizer=optimizer
+            "load_checkpoint", checkpoint_path=checkpoint_path, model_id=model_id, load_optimizer=load_optimizer
         )
 
     def save_sampler_checkpoint(self, output_path: AnyPath, model_id: str, persist: bool = True) -> None:

--- a/skyrl/backends/ray_jax.py
+++ b/skyrl/backends/ray_jax.py
@@ -71,8 +71,8 @@ class RayJaxBackendImpl:
     def save_checkpoint(self, output_path: AnyPath, model_id: str) -> None:
         self.backend.save_checkpoint(output_path, model_id)
 
-    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str) -> None:
-        self.backend.load_checkpoint(checkpoint_path, model_id)
+    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, optimizer: bool) -> None:
+        self.backend.load_checkpoint(checkpoint_path, model_id, optimizer)
 
     def save_sampler_checkpoint(self, output_path: AnyPath, model_id: str, persist: bool = True) -> None:
         self.backend.save_sampler_checkpoint(output_path, model_id, persist)
@@ -182,8 +182,8 @@ class RayJaxBackend(AbstractBackend):
         results = ray.get([w.sample.remote(prepared_batch) for w in self.workers])
         return results[0]
 
-    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str) -> None:
-        ray.get([w.load_checkpoint.remote(checkpoint_path, model_id) for w in self.workers])
+    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, optimizer: bool) -> None:
+        ray.get([w.load_checkpoint.remote(checkpoint_path, model_id, optimizer) for w in self.workers])
 
     def save_checkpoint(self, output_path: AnyPath, model_id: str) -> None:
         ray.get([w.save_checkpoint.remote(output_path, model_id) for w in self.workers])

--- a/skyrl/backends/ray_jax.py
+++ b/skyrl/backends/ray_jax.py
@@ -71,8 +71,8 @@ class RayJaxBackendImpl:
     def save_checkpoint(self, output_path: AnyPath, model_id: str) -> None:
         self.backend.save_checkpoint(output_path, model_id)
 
-    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, optimizer: bool) -> None:
-        self.backend.load_checkpoint(checkpoint_path, model_id, optimizer)
+    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, load_optimizer: bool) -> None:
+        self.backend.load_checkpoint(checkpoint_path, model_id, load_optimizer)
 
     def save_sampler_checkpoint(self, output_path: AnyPath, model_id: str, persist: bool = True) -> None:
         self.backend.save_sampler_checkpoint(output_path, model_id, persist)
@@ -182,8 +182,8 @@ class RayJaxBackend(AbstractBackend):
         results = ray.get([w.sample.remote(prepared_batch) for w in self.workers])
         return results[0]
 
-    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, optimizer: bool) -> None:
-        ray.get([w.load_checkpoint.remote(checkpoint_path, model_id, optimizer) for w in self.workers])
+    def load_checkpoint(self, checkpoint_path: AnyPath, model_id: str, load_optimizer: bool) -> None:
+        ray.get([w.load_checkpoint.remote(checkpoint_path, model_id, load_optimizer) for w in self.workers])
 
     def save_checkpoint(self, output_path: AnyPath, model_id: str) -> None:
         ray.get([w.save_checkpoint.remote(output_path, model_id) for w in self.workers])

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -1232,7 +1232,7 @@ class SkyRLTrainBackend(AbstractBackend):
 
         logger.info(f"Saved checkpoint for {model_id} to {output_path}")
 
-    def load_checkpoint(self, checkpoint_path, model_id: str, optimizer: bool) -> None:
+    def load_checkpoint(self, checkpoint_path, model_id: str, load_optimizer: bool) -> None:
         """Load model state and optionally optimizer state from a training checkpoint."""
         self._validate_model_state(model_id)
         role = self._get_role(model_id)
@@ -1247,8 +1247,8 @@ class SkyRLTrainBackend(AbstractBackend):
             self._dispatch.load_checkpoint(
                 model=role,
                 ckpt_dir=temp_dir,
-                load_optimizer_states=optimizer,
-                load_lr_scheduler_states=optimizer,
+                load_optimizer_states=load_optimizer,
+                load_lr_scheduler_states=load_optimizer,
                 model_id=model_id,
             )
 

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -1232,8 +1232,8 @@ class SkyRLTrainBackend(AbstractBackend):
 
         logger.info(f"Saved checkpoint for {model_id} to {output_path}")
 
-    def load_checkpoint(self, checkpoint_path, model_id: str) -> None:
-        """Load full training checkpoint (model + optimizer + scheduler) from tar."""
+    def load_checkpoint(self, checkpoint_path, model_id: str, optimizer: bool) -> None:
+        """Load model state and optionally optimizer state from a training checkpoint."""
         self._validate_model_state(model_id)
         role = self._get_role(model_id)
 
@@ -1244,12 +1244,11 @@ class SkyRLTrainBackend(AbstractBackend):
             with tarfile.open(checkpoint_path, "r") as tar:
                 tar.extractall(temp_dir, filter="data")
 
-            # Load checkpoint (includes optimizer and scheduler states)
             self._dispatch.load_checkpoint(
                 model=role,
                 ckpt_dir=temp_dir,
-                load_optimizer_states=True,
-                load_lr_scheduler_states=True,
+                load_optimizer_states=optimizer,
+                load_lr_scheduler_states=optimizer,
                 model_id=model_id,
             )
 

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -614,7 +614,7 @@ class SaveWeightsRequest(BaseModel):
 class LoadWeightsRequest(BaseModel):
     model_id: str
     path: str
-    optimizer: bool
+    optimizer: bool = True
     type: Literal["load_weights"] | None = None
 
 

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -615,6 +615,7 @@ class LoadWeightsRequest(BaseModel):
     model_id: str
     path: str
     optimizer: bool = True
+    seq_id: int | None = None
     type: Literal["load_weights"] | None = None
 
 
@@ -974,8 +975,25 @@ async def optim_step(request: OptimStepRequest, session: AsyncSession = Depends(
 
 @app.post("/api/v1/load_weights", response_model=FutureResponse)
 async def load_weights(request: LoadWeightsRequest, req: Request, session: AsyncSession = Depends(get_session)):
-    """Loads weights and training state."""
+    """Loads weights and training state.
+
+    Matching the Tinker service, LoadWeights is only permitted as a model's first
+    request: any prior request for the model (forward_backward, save_weights, a
+    previous load_weights, ...) makes further loads a 400. Load into a freshly
+    created model instead (create_training_client_from_state[_with_optimizer]).
+    """
     await get_model(session, request.model_id)
+
+    prior_requests = await session.exec(
+        select(func.count())
+        .select_from(FutureDB)
+        .where(FutureDB.model_id == request.model_id)
+        .where(FutureDB.request_type != types.RequestType.CREATE_MODEL)
+    )
+    prior_count = prior_requests.one()
+    if prior_count > 0:
+        seq_id = request.seq_id if request.seq_id is not None else prior_count + 1
+        raise HTTPException(status_code=400, detail=f"LoadWeights is not permitted with seq_id {seq_id}")
 
     path = types.TinkerPath.parse(request.path)
     if (

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -614,6 +614,7 @@ class SaveWeightsRequest(BaseModel):
 class LoadWeightsRequest(BaseModel):
     model_id: str
     path: str
+    optimizer: bool
     type: Literal["load_weights"] | None = None
 
 
@@ -993,7 +994,11 @@ async def load_weights(request: LoadWeightsRequest, req: Request, session: Async
         session=session,
         request_type=types.RequestType.LOAD_WEIGHTS,
         model_id=request.model_id,
-        request_data=types.LoadWeightsInput(source_model_id=source_model_id, checkpoint_id=checkpoint_id),
+        request_data=types.LoadWeightsInput(
+            source_model_id=source_model_id,
+            checkpoint_id=checkpoint_id,
+            optimizer=request.optimizer,
+        ),
     )
 
     await session.commit()

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -997,7 +997,7 @@ async def load_weights(request: LoadWeightsRequest, req: Request, session: Async
         request_data=types.LoadWeightsInput(
             source_model_id=source_model_id,
             checkpoint_id=checkpoint_id,
-            optimizer=request.optimizer,
+            load_optimizer=request.optimizer,
         ),
     )
 

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -641,7 +641,7 @@ class TinkerEngine:
             self.config.checkpoints_base / request_data.source_model_id / f"{request_data.checkpoint_id}.tar.gz"
         )
 
-        self.backend.load_checkpoint(checkpoint_path, model_id)
+        self.backend.load_checkpoint(checkpoint_path, model_id, optimizer=request_data.optimizer)
 
         return types.LoadWeightsOutput(type="load_weights")
 

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -641,7 +641,7 @@ class TinkerEngine:
             self.config.checkpoints_base / request_data.source_model_id / f"{request_data.checkpoint_id}.tar.gz"
         )
 
-        self.backend.load_checkpoint(checkpoint_path, model_id, optimizer=request_data.optimizer)
+        self.backend.load_checkpoint(checkpoint_path, model_id, load_optimizer=request_data.load_optimizer)
 
         return types.LoadWeightsOutput(type="load_weights")
 

--- a/skyrl/tinker/types.py
+++ b/skyrl/tinker/types.py
@@ -208,7 +208,7 @@ class SaveWeightsOutput(BaseModel):
 class LoadWeightsInput(BaseModel):
     source_model_id: str
     checkpoint_id: str
-    optimizer: bool
+    optimizer: bool = True
 
 
 class LoadWeightsOutput(BaseModel):

--- a/skyrl/tinker/types.py
+++ b/skyrl/tinker/types.py
@@ -208,6 +208,7 @@ class SaveWeightsOutput(BaseModel):
 class LoadWeightsInput(BaseModel):
     source_model_id: str
     checkpoint_id: str
+    optimizer: bool
 
 
 class LoadWeightsOutput(BaseModel):

--- a/skyrl/tinker/types.py
+++ b/skyrl/tinker/types.py
@@ -208,7 +208,7 @@ class SaveWeightsOutput(BaseModel):
 class LoadWeightsInput(BaseModel):
     source_model_id: str
     checkpoint_id: str
-    optimizer: bool = True
+    load_optimizer: bool = True
 
 
 class LoadWeightsOutput(BaseModel):

--- a/tests/backends/skyrl_train/test_checkpoint_loading.py
+++ b/tests/backends/skyrl_train/test_checkpoint_loading.py
@@ -7,8 +7,8 @@ from skyrl.backends.skyrl_train.workers.worker import Worker
 from skyrl.backends.skyrl_train_backend import SkyRLTrainBackend
 
 
-@pytest.mark.parametrize("optimizer", [False, True])
-def test_load_checkpoint_restores_requested_training_state(tmp_path, optimizer):
+@pytest.mark.parametrize("load_optimizer", [False, True])
+def test_load_checkpoint_restores_requested_training_state(tmp_path, load_optimizer):
     checkpoint_path = tmp_path / "checkpoint.tar.gz"
     with tarfile.open(checkpoint_path, "w"):
         pass
@@ -17,12 +17,12 @@ def test_load_checkpoint_restores_requested_training_state(tmp_path, optimizer):
     backend._model_ids_to_role = {"model_test": "policy"}
     backend._dispatch = MagicMock()
 
-    backend.load_checkpoint(str(checkpoint_path), "model_test", optimizer=optimizer)
+    backend.load_checkpoint(str(checkpoint_path), "model_test", load_optimizer=load_optimizer)
 
     backend._dispatch.load_checkpoint.assert_called_once()
     call = backend._dispatch.load_checkpoint.call_args
-    assert call.kwargs["load_optimizer_states"] is optimizer
-    assert call.kwargs["load_lr_scheduler_states"] is optimizer
+    assert call.kwargs["load_optimizer_states"] is load_optimizer
+    assert call.kwargs["load_lr_scheduler_states"] is load_optimizer
 
 
 def test_weights_only_load_does_not_reset_live_optimizer():

--- a/tests/tinker/skyrl_train/test_checkpoint_loading.py
+++ b/tests/tinker/skyrl_train/test_checkpoint_loading.py
@@ -1,0 +1,54 @@
+import tarfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from skyrl.backends.skyrl_train.workers.worker import Worker
+from skyrl.backends.skyrl_train_backend import SkyRLTrainBackend
+
+
+@pytest.mark.parametrize("optimizer", [False, True])
+def test_load_checkpoint_restores_requested_training_state(tmp_path, optimizer):
+    checkpoint_path = tmp_path / "checkpoint.tar.gz"
+    with tarfile.open(checkpoint_path, "w"):
+        pass
+
+    backend = object.__new__(SkyRLTrainBackend)
+    backend._model_ids_to_role = {"model_test": "policy"}
+    backend._dispatch = MagicMock()
+
+    backend.load_checkpoint(str(checkpoint_path), "model_test", optimizer=optimizer)
+
+    backend._dispatch.load_checkpoint.assert_called_once()
+    call = backend._dispatch.load_checkpoint.call_args
+    assert call.kwargs["load_optimizer_states"] is optimizer
+    assert call.kwargs["load_lr_scheduler_states"] is optimizer
+
+
+def test_weights_only_load_does_not_reset_live_optimizer():
+    worker = object.__new__(Worker)
+    worker.model = MagicMock()
+    worker.optimizer = MagicMock()
+    worker.scheduler = MagicMock()
+    worker.strategy = MagicMock()
+    worker.strategy.load_checkpoint.return_value = ("/checkpoint", {})
+    live_optimizer = worker.optimizer
+    live_scheduler = worker.scheduler
+
+    Worker.load_checkpoint(
+        worker,
+        "/checkpoint",
+        load_optimizer_states=False,
+        load_lr_scheduler_states=False,
+    )
+    assert worker.optimizer is live_optimizer
+    assert worker.scheduler is live_scheduler
+
+    worker.strategy.load_checkpoint.assert_called_once_with(
+        model=worker.model,
+        optimizer=None,
+        scheduler=None,
+        ckpt_dir="/checkpoint",
+        load_optimizer_states=False,
+        load_lr_scheduler_states=False,
+    )

--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -222,10 +222,11 @@ def test_training_workflow(service_client):
     # The third example omits weights (auto-filled with 1s), so all losses should be non-zero
     assert all(v != 0.0 for v in fwdbwd_result.loss_fn_outputs[2]["elementwise_loss"].data)
 
-    # Load the optimizer state and verify another forward_backward pass has the same loss
-    training_client.load_state(resume_path)
+    # Load weights without optimizer state and verify another forward_backward pass has the same loss
+    training_client.load_state(resume_path).result()
     fwdbwd_result2 = training_client.forward_backward(processed_examples, "cross_entropy").result()
     assert_loss_fn_outputs_equal(fwdbwd_result2.loss_fn_outputs, fwdbwd_result.loss_fn_outputs)
+    training_client.load_state_with_optimizer(resume_path).result()
     # Also check that custom loss function produces the same loss
     fwdbwd_result_custom = training_client.forward_backward_custom(
         processed_examples, loss_fn=custom_cross_entropy_loss

--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -222,21 +222,27 @@ def test_training_workflow(service_client):
     # The third example omits weights (auto-filled with 1s), so all losses should be non-zero
     assert all(v != 0.0 for v in fwdbwd_result.loss_fn_outputs[2]["elementwise_loss"].data)
 
-    # Load weights without optimizer state and verify another forward_backward pass has the same loss
-    training_client.load_state(resume_path).result()
+    # Matching the Tinker service, LoadWeights is only permitted as a model's first
+    # request; this client has already saved and trained, so both load flavors are rejected.
+    with pytest.raises(Exception, match="LoadWeights is not permitted"):
+        training_client.load_state(resume_path).result()
+    with pytest.raises(Exception, match="LoadWeights is not permitted"):
+        training_client.load_state_with_optimizer(resume_path).result()
+
+    # Restore the run on a fresh client instead (weights-only load as its first request)
+    # and verify a forward_backward pass reproduces the pre-optim-step losses.
+    training_client = service_client.create_training_client_from_state(resume_path)
     fwdbwd_result2 = training_client.forward_backward(processed_examples, "cross_entropy").result()
     assert_loss_fn_outputs_equal(fwdbwd_result2.loss_fn_outputs, fwdbwd_result.loss_fn_outputs)
-    training_client.load_state_with_optimizer(resume_path).result()
     # Also check that custom loss function produces the same loss
     fwdbwd_result_custom = training_client.forward_backward_custom(
         processed_examples, loss_fn=custom_cross_entropy_loss
     ).result()
     assert_loss_fn_outputs_equal(fwdbwd_result_custom.loss_fn_outputs, fwdbwd_result.loss_fn_outputs)
 
-    # Test that we can restore the training run
-    training_client = service_client.create_training_client_from_state(resume_path)
-    # Verify the restored client has the same state by running forward_backward again
-    fwdbwd_result3 = training_client.forward_backward(processed_examples, "cross_entropy").result()
+    # Restoring with optimizer state also loads as a fresh client's first request
+    training_client_opt = service_client.create_training_client_from_state_with_optimizer(resume_path)
+    fwdbwd_result3 = training_client_opt.forward_backward(processed_examples, "cross_entropy").result()
     assert_loss_fn_outputs_equal(fwdbwd_result3.loss_fn_outputs, fwdbwd_result.loss_fn_outputs)
 
     sampling_path = training_client.save_weights_for_sampler(name="final").result().path

--- a/tests/tinker/test_api_validation.py
+++ b/tests/tinker/test_api_validation.py
@@ -102,6 +102,17 @@ def test_datum_to_types_preserves_values_and_returns():
     assert datum.loss_fn_inputs.returns.data == [0.4, 0.5, 0.6]
 
 
+@pytest.mark.parametrize("optimizer", [False, True])
+def test_load_weights_request_preserves_optimizer_choice(optimizer):
+    request = api.LoadWeightsRequest(
+        model_id="model_test",
+        path="tinker://source_model/weights/checkpoint",
+        optimizer=optimizer,
+    )
+
+    assert request.optimizer is optimizer
+
+
 # --- ModelInputChunk discriminator tests (api) ---
 
 _api_adapter = TypeAdapter(api.ModelInputChunk)

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -366,6 +366,8 @@ def test_process_batch_requests_per_model_completes_incrementally(scheduling_eng
     assert processed_models == ["model_a", "model_b"]
     with Session(engine.db_engine) as session:
         assert all(f.status == RequestStatus.COMPLETED for f in session.exec(select(FutureDB)).all())
+
+
 def forward_backward_payload() -> dict:
     return types.ForwardBackwardInput(
         data=[

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from cloudpathlib import AnyPath
@@ -14,6 +16,30 @@ from skyrl.tinker.engine import (
 )
 
 BASE_MODEL = "trl-internal-testing/tiny-Qwen3ForCausalLM"
+
+
+@pytest.mark.parametrize("optimizer", [False, True])
+def test_process_load_weights_forwards_optimizer_choice(optimizer):
+    engine = object.__new__(TinkerEngine)
+    engine.config = SimpleNamespace(checkpoints_base=AnyPath("/checkpoints"))
+    engine.backend = MagicMock()
+    engine.backend.has_model.return_value = True
+
+    result = engine.process_load_weights(
+        "target_model",
+        types.LoadWeightsInput(
+            source_model_id="source_model",
+            checkpoint_id="checkpoint",
+            optimizer=optimizer,
+        ),
+    )
+
+    engine.backend.load_checkpoint.assert_called_once_with(
+        AnyPath("/checkpoints/source_model/checkpoint.tar.gz"),
+        "target_model",
+        optimizer=optimizer,
+    )
+    assert result.type == "load_weights"
 
 
 def test_process_unload_model():

--- a/tests/tinker/test_engine.py
+++ b/tests/tinker/test_engine.py
@@ -18,8 +18,8 @@ from skyrl.tinker.engine import (
 BASE_MODEL = "trl-internal-testing/tiny-Qwen3ForCausalLM"
 
 
-@pytest.mark.parametrize("optimizer", [False, True])
-def test_process_load_weights_forwards_optimizer_choice(optimizer):
+@pytest.mark.parametrize("load_optimizer", [False, True])
+def test_process_load_weights_forwards_optimizer_choice(load_optimizer):
     engine = object.__new__(TinkerEngine)
     engine.config = SimpleNamespace(checkpoints_base=AnyPath("/checkpoints"))
     engine.backend = MagicMock()
@@ -30,14 +30,14 @@ def test_process_load_weights_forwards_optimizer_choice(optimizer):
         types.LoadWeightsInput(
             source_model_id="source_model",
             checkpoint_id="checkpoint",
-            optimizer=optimizer,
+            load_optimizer=load_optimizer,
         ),
     )
 
     engine.backend.load_checkpoint.assert_called_once_with(
         AnyPath("/checkpoints/source_model/checkpoint.tar.gz"),
         "target_model",
-        optimizer=optimizer,
+        load_optimizer=load_optimizer,
     )
     assert result.type == "load_weights"
 


### PR DESCRIPTION
**Stacked on #1996 — merge that first; this diff will then shrink to one commit.**

The real Tinker service only permits `LoadWeights` (`load_state` and `load_state_with_optimizer`) as a training client's **first** request. Any later attempt fails synchronously with `400: LoadWeights is not permitted with seq_id N` — verified empirically against the production service, including after a lone `forward_backward` (no optim step), a lone `save_state`, and a prior successful load. The sanctioned pattern is loading into a freshly created client (`create_training_client_from_state[_with_optimizer]`), which is why a weights-only load always lands on a zeroed optimizer there.

This PR enforces the same rule in `api.py`: the `load_weights` endpoint rejects the request if the model has any prior non-`create_model` future, echoing the SDK's `seq_id` in the error. `test_training_workflow` now asserts the rejection for both load flavors and restores through fresh clients — which also adds e2e coverage for the `optimizer=True` restore path from #1996.

**Note for reviewers:** this removes SkyRL's mid-run load support, which #1996's discussion leaned toward keeping as a deliberate extension. Happy to convert the restriction to an opt-in config flag (default permissive) if the team prefers the superset behavior.

## Testing

- `uv run --isolated --extra dev --extra jax --extra tinker pytest tests/tinker/` — 37 unit tests + full `test_api.py` e2e suite (17 tests) pass, including the rewritten `test_training_workflow` against a real server + tinker SDK client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint restore API semantics and training state (optimizer) on load; mid-run load is removed, which can break callers that relied on SkyRL’s previous behavior.
> 
> **Overview**
> Aligns **`load_weights`** with the real Tinker service: it is only allowed as a model’s **first** request (after `create_model`). If the model already has any other future (`forward_backward`, `save_weights`, etc.), the API returns **400** with `LoadWeights is not permitted with seq_id N`. Restores must use a **new** training client via `create_training_client_from_state` / `create_training_client_from_state_with_optimizer`.
> 
> The **`LoadWeightsRequest`** adds **`optimizer`** (default `true`) and optional **`seq_id`** for the error message. That choice flows through **`LoadWeightsInput.load_optimizer`** into **`AbstractBackend.load_checkpoint(..., load_optimizer)`** on JAX, Ray-JAX, and SkyRL-Train so weights-only loads skip optimizer/scheduler restore. Docs note the first-request-only rule.
> 
> Tests cover optimizer forwarding, SkyRL-Train load flags, and the e2e workflow (reject mid-run load; restore on fresh clients).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0c5bdfbf789dc4cd013c2f76e6b0de1e32957f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->