### PR TITLE
fix(inference): stop importing vLLM at module scope in trainer processes

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -24,6 +24,8 @@ Usage:
         skyrl.backends.skyrl_train.inference_servers.new_inference_worker_wrap.NewInferenceWorkerWrap
 """
 
+import sys
+
 import torch
 
 from skyrl.backends.skyrl_train.inference_servers.layerwise_reload import (
@@ -34,7 +36,15 @@ from skyrl.backends.skyrl_train.patches.vllm.patch_hybrid_fp8_kv_wake import (
     patch_hybrid_fp8_kv_wake,
 )
 
-patch_hybrid_fp8_kv_wake()
+# Trainer processes import this module only to read
+# VLLM_NEW_INFERENCE_WORKER_EXTENSION_CLS, and importing vLLM there can crash
+# (e.g. flashinfer resolves tilelang's libcudart stub once mamba_ssm is
+# loaded). vLLM workers resolve this extension class only after
+# vllm.v1.worker.gpu_worker -- and therefore gpu_model_runner -- is imported,
+# so patching only when the target module is already loaded covers every
+# process that needs the patch without importing vLLM anywhere else.
+if "vllm.v1.worker.gpu_model_runner" in sys.modules:
+    patch_hybrid_fp8_kv_wake()
 
 try:
     from skyrl.backends.skyrl_train.weight_sync.delta_engine import (

--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -36,13 +36,6 @@ from skyrl.backends.skyrl_train.patches.vllm.patch_hybrid_fp8_kv_wake import (
     patch_hybrid_fp8_kv_wake,
 )
 
-# Trainer processes import this module only to read
-# VLLM_NEW_INFERENCE_WORKER_EXTENSION_CLS, and importing vLLM there can crash
-# (e.g. flashinfer resolves tilelang's libcudart stub once mamba_ssm is
-# loaded). vLLM workers resolve this extension class only after
-# vllm.v1.worker.gpu_worker -- and therefore gpu_model_runner -- is imported,
-# so patching only when the target module is already loaded covers every
-# process that needs the patch without importing vLLM anywhere else.
 if "vllm.v1.worker.gpu_model_runner" in sys.modules:
     patch_hybrid_fp8_kv_wake()
 

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
@@ -43,10 +43,6 @@ def patch_hybrid_fp8_kv_wake() -> bool:
     except ModuleNotFoundError:
         return False
     except Exception as e:
-        # vLLM's import graph can fail for reasons other than a missing
-        # package (e.g. flashinfer resolving tilelang's libcudart stub in a
-        # process that loaded mamba_ssm). The patch only matters in vLLM
-        # worker processes, where this import succeeds; elsewhere skip it.
         logger.warning("Importing vLLM failed; skipping hybrid KV wake patch: {}", e)
         return False
 

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_hybrid_fp8_kv_wake.py
@@ -42,6 +42,13 @@ def patch_hybrid_fp8_kv_wake() -> bool:
         from vllm.v1.worker import gpu_model_runner
     except ModuleNotFoundError:
         return False
+    except Exception as e:
+        # vLLM's import graph can fail for reasons other than a missing
+        # package (e.g. flashinfer resolving tilelang's libcudart stub in a
+        # process that loaded mamba_ssm). The patch only matters in vLLM
+        # worker processes, where this import succeeds; elsewhere skip it.
+        logger.warning("Importing vLLM failed; skipping hybrid KV wake patch: {}", e)
+        return False
 
     runner_cls = gpu_model_runner.GPUModelRunner
     target = runner_cls.init_fp8_kv_scales


### PR DESCRIPTION
## Summary

`new_inference_worker_wrap.py` called `patch_hybrid_fp8_kv_wake()` at module scope (added in #2053), which imports `vllm.v1.worker.gpu_model_runner` in **every** process that imports `inference_servers/utils.py` — including Megatron trainer actors that only need the `VLLM_NEW_INFERENCE_WORKER_EXTENSION_CLS` string.

In a trainer actor, vLLM's import graph eagerly imports `flashinfer.comm` (via `all2all.py`'s import-time `has_flashinfer_nvlink_two_sided()` call). flashinfer's `cuda_ipc.py` resolves libcudart by taking the **first** `/proc/self/maps` line containing `libcudart` — and once `megatron.core` has pulled in `mamba_ssm` → `tilelang`, that can be tilelang's `libcudart_stub.so` (its filename passes flashinfer's `startswith("libcudart")` check but exports only 39 symbols). Actor creation then dies with:

```
AttributeError: .../tilelang/lib/libcudart_stub.so: undefined symbol: cudaDeviceReset
```

This broke `test_megatron_extractor_consistency`, `test_mtp_grad_isolation`, and `test_sft_packing_parity` in megatron GPU CI — the three tests that define probe actor classes in the test module, forcing Ray to run the full import chain inside the actor. Which libcudart wins depends on library mapping order, so the failure is intermittent (one parametrization of the extractor test passed while its sibling failed).

## Fix

- Apply the patch only when `vllm.v1.worker.gpu_model_runner` is already in `sys.modules`. vLLM resolves `worker_extension_cls` **after** importing the worker module (`worker_base.py` resolves `worker_cls` first), so the patch still applies in every vLLM worker process, while trainer processes never import vLLM at all.
- Broaden the patch's import guard from `ModuleNotFoundError` to `Exception` (log and skip), so an unexpected vLLM import failure can never kill a non-vLLM process. The patch only matters where vLLM actually runs.

## Validation

- Reproduced the exact CI `AttributeError` on the unfixed tree by importing the three failing test modules inside fresh Ray workers; with the fix all three import cleanly and `vllm.v1.worker.gpu_model_runner` is never loaded in trainer workers — including a run where the tilelang stub demonstrably won the mapping race (modelopt's guarded vLLM-plugin import hit the stub error and warned, while the SkyRL chain stayed clean).
- Verified the vLLM-worker path still applies the patch: importing `gpu_model_runner` first and then this module sets the patched flag on `GPUModelRunner.init_fp8_kv_scales`.
- Full `skyrl-train-gpu-ci-megatron` suite currently running on an `l4_ci` Anyscale job with this fix; will report results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Import-order change around a vLLM monkeypatch: trainers should stay clean, but if the worker-extension loads before gpu_model_runner the patch would be skipped.
> 
> **Overview**
> Stops trainer/Megatron actor processes from pulling in vLLM (and flashinfer) just because they import the worker-extension class string.
> 
> `patch_hybrid_fp8_kv_wake()` now runs only if `vllm.v1.worker.gpu_model_runner` is already in `sys.modules`, so vLLM workers still get the hybrid FP8 KV wake patch while trainers never import vLLM. The patch also treats any import failure as skip-and-log instead of only `ModuleNotFoundError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472674b3dfef7bcbde1f4b8b8beaf059928c58f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->