### PR TITLE
[fix][generators] VLM generator: honor generator.chat_template in renders + image-token/feature integrity guard

### DIFF
--- a/skyrl/train/generators/skyrl_vlm_generator.py
+++ b/skyrl/train/generators/skyrl_vlm_generator.py
@@ -59,9 +59,20 @@ class SkyRLVLMGymGenerator(SkyRLGymGenerator):
             )
 
     async def _render_conversation(self, conversation: ConversationType) -> RenderedConversation:
-        rendered = await self.inference_engine_client.render_chat_completion(
-            {"json": {"model": self.inference_engine_client.model_name, "messages": conversation}}
-        )
+        body: Dict[str, Any] = {"model": self.inference_engine_client.model_name, "messages": conversation}
+        # Honor generator.chat_template / chat_template_kwargs (already supported
+        # by the base generator) on the render path. The deferred obs-token
+        # extraction below requires each re-render to be a token-prefix
+        # extension of the previous one (see NOTE in agent_loop); thinking-model
+        # vendor templates strip reasoning from history and violate that, so a
+        # thinking-preserving custom template is the supported way to train
+        # them (issue #2075). Servers need trust_request_chat_template for
+        # per-request templates.
+        if self.custom_chat_template:
+            body["chat_template"] = self.custom_chat_template
+        if self.generator_cfg.chat_template_kwargs:
+            body["chat_template_kwargs"] = dict(self.generator_cfg.chat_template_kwargs)
+        rendered = await self.inference_engine_client.render_chat_completion({"json": body})
         return RenderedConversation(prompt_ids=rendered["token_ids"], features=rendered.get("features", None))
 
     async def agent_loop(
@@ -129,12 +140,14 @@ class SkyRLVLMGymGenerator(SkyRLGymGenerator):
             # sequences which are a prefix of subsequent turns. In general, this
             # will not hold for thinking models, e.g., Qwen3-Thinking.
             pending_obs_offset: Optional[int] = None
+            last_render_ids: Optional[List[int]] = None
 
             while not done:
                 # 1. Render full conversation for this turn's generation input
                 rendered_conversation = await self._render_conversation(conversation)
                 input_ids = rendered_conversation["prompt_ids"]
                 latest_features = rendered_conversation["features"]
+                last_render_ids = input_ids
 
                 # 1b. Flush pending obs tokens from the previous turn
                 if pending_obs_offset is not None:
@@ -208,6 +221,28 @@ class SkyRLVLMGymGenerator(SkyRLGymGenerator):
             mm_kwargs = decode_mm_kwargs((latest_features or {}).get("kwargs_data"))
             pixel_values = mm_kwargs["pixel_values"]
             image_grid_thw = mm_kwargs["image_grid_thw"]
+
+            # ── Integrity guard: image tokens vs features ─────────────────
+            # The model forward pairs each image token with exactly one
+            # feature row; a mismatch fails there as an opaque torch._check
+            # deep into training. Detect it here, per trajectory, with an
+            # actionable message. Uses the render response's mm_placeholders,
+            # so no model constants are needed.
+            placeholders = (latest_features or {}).get("mm_placeholders", {}).get("image", [])
+            if placeholders:
+                render_ids = last_render_ids if last_render_ids is not None else prompt_ids
+                ph0 = placeholders[0]
+                image_token = render_ids[ph0["offset"] + ph0["length"] // 2]
+                expected = sum(ph["length"] for ph in placeholders)
+                actual = (list(prompt_ids) + list(response_ids)).count(image_token)
+                if actual != expected:
+                    raise RuntimeError(
+                        f"trajectory image-token mismatch: sequence has {actual} image tokens, "
+                        f"render declares {expected} across {len(placeholders)} images "
+                        f"(stop_reason={stop_reason}). The trajectory token stream diverged from "
+                        f"the render -- typically a history-editing chat template breaking the "
+                        f"prefix-extension assumption (issue #2075)."
+                    )
 
             # ── Cleanup ───────────────────────────────────────────────────
             env_metrics = env.get_metrics()

--- a/tests/train/generators/test_vlm_render_template.py
+++ b/tests/train/generators/test_vlm_render_template.py
@@ -1,0 +1,41 @@
+"""The VLM render path honors generator.chat_template (issue #2075).
+
+Unit seam: _render_conversation built without __init__ so the test needs no
+engines. Asserts the request body carries the custom template exactly when
+configured, and stays untouched otherwise.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from skyrl.train.generators.skyrl_vlm_generator import SkyRLVLMGymGenerator
+
+
+def _bare_generator(custom_template, kwargs=None):
+    gen = SkyRLVLMGymGenerator.__new__(SkyRLVLMGymGenerator)
+    gen.custom_chat_template = custom_template
+    gen.generator_cfg = SimpleNamespace(chat_template_kwargs=kwargs or {})
+    gen.inference_engine_client = SimpleNamespace(
+        model_name="test-model",
+        render_chat_completion=AsyncMock(return_value={"token_ids": [1, 2], "features": None}),
+    )
+    return gen
+
+
+@pytest.mark.asyncio
+async def test_custom_template_reaches_render_body():
+    gen = _bare_generator("{{ messages }}", {"enable_thinking": True})
+    await gen._render_conversation([{"role": "user", "content": "hi"}])
+    body = gen.inference_engine_client.render_chat_completion.call_args.args[0]["json"]
+    assert body["chat_template"] == "{{ messages }}"
+    assert body["chat_template_kwargs"] == {"enable_thinking": True}
+
+
+@pytest.mark.asyncio
+async def test_no_template_leaves_body_untouched():
+    gen = _bare_generator(None)
+    await gen._render_conversation([{"role": "user", "content": "hi"}])
+    body = gen.inference_engine_client.render_chat_completion.call_args.args[0]["json"]
+    assert "chat_template" not in body and "chat_template_kwargs" not in body


### PR DESCRIPTION
Fixes #2075.

`SkyRLVLMGymGenerator` extracts observation tokens by slicing each turn's re-render at a predicted offset (`pending_obs_offset = len(prev_render) + len(gen_ids)`), which requires renders to be token-prefix extensions of one another — the assumption named in the file's own NOTE. Thinking-model vendor templates (Qwen3/3.5, DeepSeek-R1, Kimi-K2-Thinking, GLM-4.6 — templates quoted in the issue) strip reasoning from historical assistant turns, violating it: the stale offset then swallows the head of the next observation. With images in observations this crashes the first policy update (`Image features and image tokens do not match`); with text observations it corrupts training sequences silently.

Two minimal changes; no behavior change for existing users:

1. **`_render_conversation` forwards `chat_template` / `chat_template_kwargs`** — both already exist on the base generator via `generator.chat_template` (including `source=file`, so users supply their own template file); the VLM path just never sent them. A thinking-preserving template (vendor template rendering assistant history verbatim inside the `<think>` scaffold) restores the prefix property and makes training on-policy for thinking models. Note: vLLM requires `trust_request_chat_template` server-side for per-request templates (reachable via `engine_init_kwargs`).
2. **Trajectory-end integrity guard** using the render response's own `mm_placeholders`: image tokens present in the assembled sequence vs declared placeholder lengths, failing with an actionable per-trajectory message instead of the opaque `torch._check` deep inside training. No model constants needed.

Tests: a unit test asserting the render body carries the configured template (and is untouched without one).

Validated end to end: Qwen3.5-9B multi-turn computer-use GRPO — 64-turn episodes with screenshots in observations, 6 GRPO steps, one full epoch, completed cleanly with a thinking-preserving template supplied via `source=file`; the identical setup crashed at the first policy update twice without these changes (traces in #2075). Property tests for such a template (token-prefix extension against the real tokenizer; offset arithmetic landing exactly on observation boundaries) are available if maintainers want a registered template shipped — kept out of this PR to stay minimal.

Follow-up offered: a template-agnostic default fix — measuring the observation boundary (one extra render before appending the observation) or independent observation tokenization as the text generator does — so arbitrary templates are safe by default. Happy to send as a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)