### PR TITLE
perf(r3): collate routes through a container-aware pool, and refuse replay under VPP

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/token_metadata.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/token_metadata.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import Optional
 
+import numpy as np
 import torch
 
 from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import (
@@ -207,3 +208,51 @@ def scatter_packed_token_values_to_batch(
     )
     batch_values[output_mask] = values[packed_mask]
     return batch_values
+
+
+class TokenMetadataTrace:
+    """Accumulate arrays whose first dimension is aligned to tokens."""
+
+    def __init__(self) -> None:
+        self._chunks: list[np.ndarray] = []
+        self._schema: tuple[tuple[int, ...], np.dtype] | None = None
+        self._num_rows = 0
+        self._finalized = False
+
+    @property
+    def num_rows(self) -> int:
+        return self._num_rows
+
+    def append(self, rows: np.ndarray, *, expected_rows: int) -> None:
+        if self._finalized:
+            raise RuntimeError("token metadata trace is already finalized")
+        if isinstance(expected_rows, bool) or not isinstance(expected_rows, int) or expected_rows < 0:
+            raise ValueError(f"expected_rows must be a non-negative integer, got {expected_rows!r}")
+        if not isinstance(rows, np.ndarray):
+            raise TypeError("token metadata rows must be a NumPy array")
+        if rows.ndim < 1:
+            raise ValueError("token metadata must have a token-row dimension")
+        if rows.shape[0] != expected_rows:
+            raise ValueError(f"token metadata has {rows.shape[0]} rows, expected {expected_rows}")
+        if not rows.flags.c_contiguous:
+            raise ValueError("token metadata rows must be contiguous")
+
+        schema = (rows.shape[1:], rows.dtype)
+        if self._schema is None:
+            self._schema = schema
+        elif schema != self._schema:
+            raise ValueError(f"token metadata schema changed from {self._schema} to {schema}")
+
+        self._chunks.append(rows)
+        self._num_rows += expected_rows
+
+    def finalize(self, *, expected_rows: int) -> np.ndarray:
+        if self._finalized:
+            raise RuntimeError("token metadata trace is already finalized")
+        if self._num_rows != expected_rows:
+            raise ValueError(f"token metadata trace has {self._num_rows} rows, expected {expected_rows}")
+        if not self._chunks:
+            raise ValueError("token metadata trace has no chunks")
+
+        self._finalized = True
+        return self._chunks[0] if len(self._chunks) == 1 else np.concatenate(self._chunks, axis=0)

--- a/skyrl/backends/skyrl_train/inference_servers/base.py
+++ b/skyrl/backends/skyrl_train/inference_servers/base.py
@@ -34,6 +34,7 @@ class InferenceEngineInput(TypedDict):
     # Optional prefix-cache salt forwarded to vLLM as the request ``cache_salt`` so cache blocks are
     # only shared between requests carrying the same salt. See ``GeneratorConfig.use_cache_salt``.
     cache_salt: Optional[str]
+    routed_experts_prompt_starts: Optional[List[int]]
 
 
 class InferenceEngineOutput(TypedDict):

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -76,6 +76,7 @@ from skyrl.backends.skyrl_train.inference_servers.base import (
 from skyrl.backends.skyrl_train.inference_servers.generate_wire import (
     decode_packed_routed_experts,
 )
+from skyrl.backends.skyrl_train.utils.routed_experts import RoutedExpertIndices
 from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.env_vars import (
     SKYRL_GENERATE_CONCURRENCY_PER_ENGINE,
@@ -167,6 +168,141 @@ class SampleResponse(TypedDict):
     topk_prompt_logprobs: Optional[List[Optional[List[Tuple[int, float]]]]]
 
 
+@dataclass(frozen=True)
+class RemoteGenerateResult:
+    """Raw token generation result returned by ``RemoteGenerateClient``."""
+
+    raw_response: Dict[str, Any]
+    response_ids: List[int]
+    response_logprobs: Optional[List[float]]
+    stop_reason: str
+    routed_experts: Optional[RoutedExpertIndices]
+
+
+@dataclass
+class RemoteGenerateClient:
+    """Reusable HTTP client for one raw-token generation request."""
+
+    proxy_url: str
+    _session: Optional[aiohttp.ClientSession] = field(default=None, init=False, repr=False)
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        current_loop = asyncio.get_running_loop()
+        if self._session is not None and not self._session.closed and self._session.loop != current_loop:
+            self._session = None
+        if self._session is None or self._session.closed:
+            connector = aiohttp.TCPConnector(
+                limit=SKYRL_HTTP_CONNECTION_LIMIT,
+                keepalive_timeout=2,
+            )
+            self._session = aiohttp.ClientSession(
+                connector=connector,
+                timeout=aiohttp.ClientTimeout(total=None),
+            )
+        return self._session
+
+    async def _post(self, url: str, json: Dict[str, Any], headers: Optional[Dict[str, str]] = None) -> Any:
+        """POST JSON with retry on transient connection and response-decoding failures."""
+        session = await self._get_session()
+        last_exc: Optional[Exception] = None
+        for attempt in range(_DATA_PLANE_RETRIES):
+            try:
+                async with session.post(url, json=json, headers=headers) as resp:
+                    try:
+                        body = orjson.loads(await resp.read())
+                    except orjson.JSONDecodeError as exc:
+                        if 400 <= resp.status < 500:
+                            text = await resp.text()
+                            raise aiohttp.ClientResponseError(
+                                resp.request_info,
+                                resp.history,
+                                status=resp.status,
+                                message=text or resp.reason,
+                                headers=resp.headers,
+                            ) from exc
+                        last_exc = exc
+                        logger.debug(f"retry {attempt + 1}/{_DATA_PLANE_RETRIES} for {url=}: {exc}")
+                        await asyncio.sleep(1)
+                        continue
+                    raise_for_status(resp, body)
+                    return body
+            except (aiohttp.ServerDisconnectedError, aiohttp.ClientOSError) as exc:
+                last_exc = exc
+                logger.debug(f"POST retry {attempt + 1}/{_DATA_PLANE_RETRIES} for {url=}: {exc}")
+                await asyncio.sleep(1)
+        if last_exc is None:
+            raise RuntimeError(f"POST failed without an exception for {url=}")
+        raise last_exc
+
+    async def generate(
+        self,
+        *,
+        prompt_token_ids: List[int],
+        sampling_params: Dict[str, Any],
+        session_id: Optional[Any],
+        model: str,
+        return_routed_experts: bool = False,
+        mm_features: Optional[MultiModalFeatures] = None,
+        cache_salt: Optional[str] = None,
+    ) -> RemoteGenerateResult:
+        """Generate one raw-token completion, optionally returning R3 routes."""
+        path = "/skyrl/v1/generate" if return_routed_experts else "/inference/v1/generate"
+        payload: Dict[str, Any] = {
+            "sampling_params": sampling_params,
+            "model": model,
+            "token_ids": prompt_token_ids,
+        }
+        if mm_features:
+            payload["features"] = mm_features
+        # `cache_salt` is a top-level request field (forwarded to vLLM's TokensPrompt), not a sampling
+        # param.
+        if cache_salt is not None:
+            payload["cache_salt"] = cache_salt
+
+        headers = {"Content-Type": "application/json"}
+        if session_id:
+            headers["X-Session-ID"] = str(session_id)
+
+        response = await self._post(f"{self.proxy_url}{path}", json=payload, headers=headers)
+        choice = response["choices"][0]
+        token_ids = choice["token_ids"]
+        logprobs = choice.get("logprobs")
+        response_logprobs = None
+        if logprobs is not None:
+            logprobs_content = logprobs.get("content", [])
+            if logprobs_content:
+                response_logprobs = [logprob_info["logprob"] for logprob_info in logprobs_content]
+
+        routed_experts = None
+        if return_routed_experts:
+            packed_routed_experts = choice.get("routed_experts")
+            if not isinstance(packed_routed_experts, dict):
+                raise ValueError("/skyrl/v1/generate must return packed routed_experts")
+            routed_experts = decode_packed_routed_experts(packed_routed_experts)
+
+        return RemoteGenerateResult(
+            raw_response=response,
+            response_ids=token_ids,
+            response_logprobs=response_logprobs,
+            stop_reason=choice["finish_reason"],
+            routed_experts=routed_experts,
+        )
+
+    async def aclose(self) -> None:
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_session"] = None
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._session = None
+
+
 @dataclass
 class RemoteInferenceClient(InferenceEngineInterface):
     """
@@ -225,7 +361,7 @@ class RemoteInferenceClient(InferenceEngineInterface):
     """Optional HF tokenizer for local tokenize/detokenize (avoids HTTP round-trips)."""
 
     # Private fields excluded from repr for cleaner output
-    _session: Optional[aiohttp.ClientSession] = field(default=None, repr=False)
+    _generate_client: Optional[RemoteGenerateClient] = field(default=None, repr=False)
     _world_size: Optional[Tuple[int, int]] = field(default=None, repr=False)
     _gen_sem: Optional[asyncio.Semaphore] = field(default=None, repr=False)
     _detok_sem: Optional[asyncio.Semaphore] = field(default=None, repr=False)
@@ -282,66 +418,16 @@ class RemoteInferenceClient(InferenceEngineInterface):
             self._sem_loop = current_loop
         return self._gen_sem, self._detok_sem
 
+    def _get_generate_client(self) -> RemoteGenerateClient:
+        if self._generate_client is None:
+            self._generate_client = RemoteGenerateClient(proxy_url=self.proxy_url)
+        return self._generate_client
+
     async def _get_session(self) -> aiohttp.ClientSession:
-        """Get or create the aiohttp session."""
-        # Re-use the existing session object if it is not closed.
-        # Note that we also create a new session object if the event loop has changed, since
-        # aiohttp.ClientSession is tied to the event loop.
-        current_loop = asyncio.get_running_loop()
-        if self._session is not None and not self._session.closed and self._session.loop != current_loop:
-            # Event loop changed - the old session is unusable (bound to a dead loop).
-            self._session = None
-        if self._session is None or self._session.closed:
-            # keepalive_timeout must be shorter than the server's timeout_keep_alive
-            # (uvicorn default: 5s). Otherwise aiohttp reuses connections the server
-            # has already closed, causing ECONNRESET under high concurrency.
-            connector = aiohttp.TCPConnector(
-                limit=SKYRL_HTTP_CONNECTION_LIMIT,
-                keepalive_timeout=2,
-            )
-            self._session = aiohttp.ClientSession(connector=connector, timeout=aiohttp.ClientTimeout(total=None))
-        return self._session
+        return await self._get_generate_client()._get_session()
 
     async def _post(self, url: str, json: Dict[str, Any], headers: Optional[Dict[str, str]] = None) -> Any:
-        """POST with retry + backoff on transient connection errors.
-
-        Between generate bursts the pool's keep-alive connections go stale
-        (server closes them after ``timeout_keep_alive``).  An immediate
-        retry would grab another stale connection from the same pool, so we
-        sleep briefly to let the connector detect and purge dead sockets
-        before the next attempt.
-        """
-        session = await self._get_session()
-        last_exc: Optional[Exception] = None
-        for attempt in range(_DATA_PLANE_RETRIES):
-            try:
-                async with session.post(url, json=json, headers=headers) as resp:
-                    try:
-                        body = orjson.loads(await resp.read())
-                    except orjson.JSONDecodeError as e:
-                        if 400 <= resp.status < 500:
-                            # Non-JSON client error (e.g. plain text 422 from vllm-router).
-                            # Raise immediately — client errors won't succeed on retry.
-                            text = await resp.text()
-                            raise aiohttp.ClientResponseError(
-                                resp.request_info,
-                                resp.history,
-                                status=resp.status,
-                                message=text or resp.reason,
-                                headers=resp.headers,
-                            )
-                        last_exc = e
-                        logger.debug(f"retry {attempt + 1}/{_DATA_PLANE_RETRIES} for {url=}: {e}")
-                        await asyncio.sleep(1)
-                        continue
-                    raise_for_status(resp, body)
-                    return body
-            except (aiohttp.ServerDisconnectedError, aiohttp.ClientOSError) as e:
-                last_exc = e
-                logger.debug(f"POST retry {attempt + 1}/{_DATA_PLANE_RETRIES} for {url=}: {e}")
-                await asyncio.sleep(1)
-                continue
-        raise last_exc  # type: ignore[misc]
+        return await self._get_generate_client()._post(url, json=json, headers=headers)
 
     # ---------------------------
     # Data Plane
@@ -472,63 +558,20 @@ class RemoteInferenceClient(InferenceEngineInterface):
         mm_features: Optional[MultiModalFeatures] = None,
         cache_salt: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """
-        Generate completion for a single prompt.
-
-        With keep-mode pause, in-flight requests are frozen by the vLLM
-        scheduler and resume where they left off after /resume. No retry
-        logic is needed.
-
-        Returns:
-            Dict with keys: stop_reason, response_ids, response_logprobs
-        """
-        url = (
-            f"{self.proxy_url}/skyrl/v1/generate"
-            if self.enable_return_routed_experts
-            else f"{self.proxy_url}/inference/v1/generate"
+        result = await self._get_generate_client().generate(
+            prompt_token_ids=prompt_token_ids,
+            sampling_params=sampling_params,
+            session_id=session_id,
+            model=model,
+            return_routed_experts=self.enable_return_routed_experts,
+            mm_features=mm_features,
+            cache_salt=cache_salt,
         )
-
-        payload: dict[str, Any] = {
-            "sampling_params": sampling_params,
-            "model": model,
-            "token_ids": prompt_token_ids,
-        }
-        if mm_features:
-            payload["features"] = mm_features
-        # `cache_salt` is a top-level request field (forwarded to vLLM's TokensPrompt), not a sampling
-        # param.
-        if cache_salt is not None:
-            payload["cache_salt"] = cache_salt
-
-        headers = {"Content-Type": "application/json"}
-        if session_id:
-            headers["X-Session-ID"] = str(session_id)
-
-        response = await self._post(url, json=payload, headers=headers)
-
-        choice = response["choices"][0]
-        token_ids = choice["token_ids"]
-        stop_reason = choice["finish_reason"]
-
-        response_logprobs: Optional[List[float]] = None
-        logprobs = choice.get("logprobs")
-        if logprobs is not None:
-            logprobs_content = logprobs.get("content", [])
-            if logprobs_content:
-                response_logprobs = [logprob_info["logprob"] for logprob_info in logprobs_content]
-
-        routed_experts = None
-        if self.enable_return_routed_experts:
-            packed_routed_experts = choice.get("routed_experts")
-            if not isinstance(packed_routed_experts, dict):
-                raise ValueError("/skyrl/v1/generate must return packed routed_experts")
-            routed_experts = decode_packed_routed_experts(packed_routed_experts)
-
         return {
-            "stop_reason": stop_reason,
-            "response_ids": token_ids,
-            "response_logprobs": response_logprobs,
-            "routed_experts": routed_experts,
+            "stop_reason": result.stop_reason,
+            "response_ids": result.response_ids,
+            "response_logprobs": result.response_logprobs,
+            "routed_experts": result.routed_experts,
         }
 
     async def _render_for_sample(
@@ -1405,9 +1448,8 @@ class RemoteInferenceClient(InferenceEngineInterface):
 
     async def teardown(self) -> None:
         """Close HTTP session."""
-        if self._session and not self._session.closed:
-            await self._session.close()
-            self._session = None
+        if self._generate_client is not None:
+            await self._generate_client.aclose()
 
     async def __aenter__(self) -> "RemoteInferenceClient":
         """Async context manager entry."""
@@ -1424,7 +1466,6 @@ class RemoteInferenceClient(InferenceEngineInterface):
     def __getstate__(self) -> dict:
         """Exclude non-serializable fields from pickle."""
         state = self.__dict__.copy()
-        state["_session"] = None
         state["_gen_sem"] = None
         state["_detok_sem"] = None
         state["_sem_loop"] = None
@@ -1433,19 +1474,12 @@ class RemoteInferenceClient(InferenceEngineInterface):
     def __setstate__(self, state: dict) -> None:
         """Restore state after unpickling."""
         self.__dict__.update(state)
-        self._session = None
         self._gen_sem = None
         self._detok_sem = None
         self._sem_loop = None
 
-    async def aclose(self):
-        if self._session is not None:
-            try:
-                await self._session.close()
-            except Exception as e:
-                logger.warning(f"Encountered exception {e} while closing client session")
-                pass
-            self._session = None
+    async def aclose(self) -> None:
+        await self.teardown()
 
 
 def raise_for_status(resp: aiohttp.ClientResponse, body: Optional[Any] = None) -> None:

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -242,13 +242,27 @@ class RemoteGenerateClient:
         session_id: Optional[Any],
         model: str,
         return_routed_experts: bool = False,
+        routed_experts_prompt_start: Optional[int] = None,
         mm_features: Optional[MultiModalFeatures] = None,
         cache_salt: Optional[str] = None,
     ) -> RemoteGenerateResult:
         """Generate one raw-token completion, optionally returning R3 routes."""
+        if routed_experts_prompt_start is not None:
+            if not return_routed_experts:
+                raise ValueError("routed_experts_prompt_start requires return_routed_experts=True")
+            if (
+                isinstance(routed_experts_prompt_start, bool)
+                or not isinstance(routed_experts_prompt_start, int)
+                or not 0 <= routed_experts_prompt_start <= len(prompt_token_ids)
+            ):
+                raise ValueError("routed_experts_prompt_start must be an integer within the prompt")
+
         path = "/skyrl/v1/generate" if return_routed_experts else "/inference/v1/generate"
+        request_sampling_params = dict(sampling_params)
+        if routed_experts_prompt_start is not None:
+            request_sampling_params["routed_experts_prompt_start"] = routed_experts_prompt_start
         payload: Dict[str, Any] = {
-            "sampling_params": sampling_params,
+            "sampling_params": request_sampling_params,
             "model": model,
             "token_ids": prompt_token_ids,
         }
@@ -492,6 +506,12 @@ class RemoteInferenceClient(InferenceEngineInterface):
         session_ids = input_batch.get("session_ids")
         mm_features = input_batch.get("mm_features")
         cache_salt = input_batch.get("cache_salt")
+        routed_experts_prompt_starts = input_batch.get("routed_experts_prompt_starts")
+        if routed_experts_prompt_starts is not None:
+            if not self.enable_return_routed_experts:
+                raise ValueError("routed_experts_prompt_starts requires enable_return_routed_experts=True")
+            if len(routed_experts_prompt_starts) != len(prompt_token_ids):
+                raise ValueError("routed_experts_prompt_starts must have one entry per prompt")
         get_logprobs = sampling_params.get("logprobs") is not None
 
         # Two semaphores decouple the generate and detokenize stages:
@@ -515,6 +535,9 @@ class RemoteInferenceClient(InferenceEngineInterface):
                     sampling_params=sampling_params,
                     session_id=session_ids[idx] if session_ids and idx < len(session_ids) else None,
                     mm_features=mm_features[idx] if mm_features and idx < len(mm_features) else None,
+                    routed_experts_prompt_start=(
+                        routed_experts_prompt_starts[idx] if routed_experts_prompt_starts is not None else None
+                    ),
                     model=model,
                     cache_salt=cache_salt,
                 )
@@ -524,6 +547,9 @@ class RemoteInferenceClient(InferenceEngineInterface):
                     sampling_params=sampling_params,
                     session_id=session_ids[idx] if session_ids and idx < len(session_ids) else None,
                     mm_features=mm_features[idx] if mm_features and idx < len(mm_features) else None,
+                    routed_experts_prompt_start=(
+                        routed_experts_prompt_starts[idx] if routed_experts_prompt_starts is not None else None
+                    ),
                     model=model,
                     cache_salt=cache_salt,
                 )
@@ -557,6 +583,7 @@ class RemoteInferenceClient(InferenceEngineInterface):
         model: str,
         mm_features: Optional[MultiModalFeatures] = None,
         cache_salt: Optional[str] = None,
+        routed_experts_prompt_start: Optional[int] = None,
     ) -> Dict[str, Any]:
         result = await self._get_generate_client().generate(
             prompt_token_ids=prompt_token_ids,
@@ -564,6 +591,7 @@ class RemoteInferenceClient(InferenceEngineInterface):
             session_id=session_id,
             model=model,
             return_routed_experts=self.enable_return_routed_experts,
+            routed_experts_prompt_start=routed_experts_prompt_start,
             mm_features=mm_features,
             cache_salt=cache_salt,
         )

--- a/skyrl/backends/skyrl_train/utils/replay_utils.py
+++ b/skyrl/backends/skyrl_train/utils/replay_utils.py
@@ -4,7 +4,6 @@ Utility functions for MoE Router Replay.
 
 from contextlib import contextmanager
 
-import numpy as np
 import torch
 
 from skyrl.backends.skyrl_train.distributed.megatron.token_metadata import (
@@ -13,7 +12,7 @@ from skyrl.backends.skyrl_train.distributed.megatron.token_metadata import (
 )
 
 
-def _replay_padding_row(
+def replay_padding_row(
     topk: int,
     *,
     dtype: torch.dtype,
@@ -40,25 +39,8 @@ def make_replay_padding_indices(
     """Return dummy routes with ``topk`` distinct experts in every row."""
     if not shape:
         raise ValueError(f"Replay route padding requires a positive topk dimension, got {shape}")
-    padding_row = _replay_padding_row(shape[-1], dtype=dtype, device=device)
+    padding_row = replay_padding_row(shape[-1], dtype=dtype, device=device)
     return padding_row.expand(shape).clone()
-
-
-def make_replay_padding_indices_np(shape: tuple[int, ...], *, dtype: np.dtype) -> np.ndarray:
-    """NumPy sibling of :func:`make_replay_padding_indices`.
-
-    Preprocessing builds the padded route array in NumPy before handing it to
-    ``torch.from_numpy``, so it needs the same distinct-expert padding rows
-    without a round trip through torch.
-    """
-    if not shape:
-        raise ValueError(f"Replay route padding requires a positive topk dimension, got {shape}")
-    topk = shape[-1]
-    if topk < 1:
-        raise ValueError(f"Replay route padding requires a positive topk dimension, got {topk}")
-    padded = np.empty(shape, dtype=dtype)
-    padded[...] = np.arange(topk, dtype=dtype)
-    return padded
 
 
 def patch_topk_router_layer_number():
@@ -255,7 +237,7 @@ def setup_per_microbatch_replay_forward(
     if (metadata_layout.padded_sequence_lengths is not None) != remove_microbatch_padding:
         raise ValueError("Shared token metadata layout does not match the model packing mode")
     aligned_router_padding_mask = align_token_metadata(router_padding_mask.to(torch.bool), metadata_layout, True)
-    route_padding = _replay_padding_row(
+    route_padding = replay_padding_row(
         rollout_expert_indices.shape[-1],
         dtype=rollout_expert_indices.dtype,
         device=local_rollout_expert_indices.device,

--- a/skyrl/backends/skyrl_train/utils/routed_experts.py
+++ b/skyrl/backends/skyrl_train/utils/routed_experts.py
@@ -3,7 +3,9 @@ from typing import TypeAlias
 
 import numpy as np
 
-from skyrl.backends.skyrl_train.distributed.megatron.token_metadata import TokenMetadataTrace
+from skyrl.backends.skyrl_train.distributed.megatron.token_metadata import (
+    TokenMetadataTrace,
+)
 
 RoutedExpertIndices: TypeAlias = np.ndarray
 ROUTED_EXPERT_DTYPES = frozenset({np.dtype(np.uint8), np.dtype(np.int16), np.dtype(np.int32)})

--- a/skyrl/backends/skyrl_train/utils/routed_experts.py
+++ b/skyrl/backends/skyrl_train/utils/routed_experts.py
@@ -46,9 +46,10 @@ class RoutedExpertTrace:
         if self.prompt_start > token_count:
             raise ValueError(f"routed-expert trace has {self.prompt_start} rows for {token_count} tokens")
 
-        for source_index in range(self.prompt_start, token_count - 1):
-            if loss_mask[source_index + 1] != 0:
-                raise ValueError(f"missing routed-expert row for loss-active target at token {source_index + 1}")
+        if any(loss_mask[self.prompt_start + 1 : token_count]):
+            for source_index in range(self.prompt_start, token_count - 1):
+                if loss_mask[source_index + 1] != 0:
+                    raise ValueError(f"missing routed-expert row for loss-active target at token {source_index + 1}")
 
         padding_count = token_count - self.prompt_start
         if padding_count:

--- a/skyrl/backends/skyrl_train/utils/routed_experts.py
+++ b/skyrl/backends/skyrl_train/utils/routed_experts.py
@@ -1,9 +1,63 @@
+from collections.abc import Sequence
 from typing import TypeAlias
 
 import numpy as np
 
+from skyrl.backends.skyrl_train.distributed.megatron.token_metadata import TokenMetadataTrace
+
 RoutedExpertIndices: TypeAlias = np.ndarray
 ROUTED_EXPERT_DTYPES = frozenset({np.dtype(np.uint8), np.dtype(np.int16), np.dtype(np.int32)})
+
+
+class RoutedExpertTrace:
+    """Accumulate routed experts across incremental generation calls."""
+
+    def __init__(self) -> None:
+        self._metadata = TokenMetadataTrace()
+        self._schema: tuple[int, int, np.dtype] | None = None
+
+    @property
+    def prompt_start(self) -> int:
+        return self._metadata.num_rows
+
+    def record_generation(
+        self,
+        *,
+        prompt_token_count: int,
+        generated_token_count: int,
+        routed_experts: RoutedExpertIndices,
+    ) -> None:
+        if prompt_token_count < self.prompt_start:
+            raise ValueError("routed-expert prompt start exceeds prompt length")
+        if generated_token_count < 1:
+            raise ValueError("routed-expert generation must produce at least one token")
+
+        expected_rows = prompt_token_count - self.prompt_start + generated_token_count - 1
+        compact = compact_routed_expert_indices(routed_experts)
+        if self._schema is None:
+            self._schema = (*compact.shape[1:], compact.dtype)
+        self._metadata.append(compact, expected_rows=expected_rows)
+
+    def finalize(self, *, token_count: int, loss_mask: Sequence[int]) -> RoutedExpertIndices:
+        if len(loss_mask) != token_count:
+            raise ValueError(f"loss mask has {len(loss_mask)} entries, expected {token_count}")
+        if self.prompt_start > token_count:
+            raise ValueError(f"routed-expert trace has {self.prompt_start} rows for {token_count} tokens")
+
+        for source_index in range(self.prompt_start, token_count - 1):
+            if loss_mask[source_index + 1] != 0:
+                raise ValueError(f"missing routed-expert row for loss-active target at token {source_index + 1}")
+
+        padding_count = token_count - self.prompt_start
+        if padding_count:
+            if self._schema is None:
+                raise ValueError("cannot pad routed-expert trace before any routes are captured")
+            num_layers, topk, dtype = self._schema
+            padding_row = np.arange(topk, dtype=dtype)
+            padding = np.broadcast_to(padding_row, (padding_count, num_layers, topk)).copy()
+            self._metadata.append(padding, expected_rows=padding_count)
+
+        return self._metadata.finalize(expected_rows=token_count)
 
 
 def compact_routed_expert_indices(routed_experts: RoutedExpertIndices) -> RoutedExpertIndices:

--- a/skyrl/backends/skyrl_train/weight_sync/delta_checkpoint.py
+++ b/skyrl/backends/skyrl_train/weight_sync/delta_checkpoint.py
@@ -761,8 +761,7 @@ class LocalCheckpointStore:
                         mismatches.append(record.name)
                 del region, patch
 
-            # reserved=0: weight sync is a barrier, so no colocated work needs a core, and an
-            # unconstrained host keeps the pool size it had before the quota became visible.
+            # Weight sync is a barrier, so it need not reserve cores for colocated work.
             workers = min(len(payloads), pool_workers(cap=32, reserved=0))
             with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="skyrl-delta-mmap-apply") as executor:
                 list(executor.map(apply_one, payloads))
@@ -1080,7 +1079,7 @@ class DeltaCheckpointPublisher:
         }
 
     def _num_publish_workers(self) -> int:
-        # reserved=0: publishing is a barrier like the apply path above.
+        # Publishing is a barrier, like the apply path above.
         default = pool_workers(cap=8, reserved=0)
         return self.publish_num_workers or default
 

--- a/skyrl/backends/skyrl_train/weight_sync/delta_checkpoint.py
+++ b/skyrl/backends/skyrl_train/weight_sync/delta_checkpoint.py
@@ -32,6 +32,7 @@ from skyrl.backends.skyrl_train.weight_sync.delta_payload import (
     decompress_bytes,
     uint8_tensor_to_bytes,
 )
+from skyrl.utils.cpu_topology import pool_workers
 
 logger = logging.getLogger(__name__)
 
@@ -760,7 +761,9 @@ class LocalCheckpointStore:
                         mismatches.append(record.name)
                 del region, patch
 
-            workers = min(len(payloads), max(1, min(32, os.cpu_count() or 8)))
+            # reserved=0: weight sync is a barrier, so no colocated work needs a core, and an
+            # unconstrained host keeps the pool size it had before the quota became visible.
+            workers = min(len(payloads), pool_workers(cap=32, reserved=0))
             with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="skyrl-delta-mmap-apply") as executor:
                 list(executor.map(apply_one, payloads))
         finally:
@@ -1077,7 +1080,8 @@ class DeltaCheckpointPublisher:
         }
 
     def _num_publish_workers(self) -> int:
-        default = min(8, os.cpu_count() or 1)
+        # reserved=0: publishing is a barrier like the apply path above.
+        default = pool_workers(cap=8, reserved=0)
         return self.publish_num_workers or default
 
     def _publish_executor_for(self, num_workers: int) -> ThreadPoolExecutor:

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -604,6 +604,17 @@ class MegatronWorker:
             )
             provider.linear_attention_freq = linear_attention_freq[: provider.num_layers]
 
+        # Checked on the resolved provider because to_megatron_provider() can supply its own VPP
+        # default. Every forward appends its routes to all local RouterReplay instances, but under
+        # VPP only the chunk being forwarded consumes them, so each instance's backward FIFO
+        # desyncs by the chunk count.
+        vpp_size = provider.virtual_pipeline_model_parallel_size
+        if provider.moe_enable_routing_replay and vpp_size is not None and vpp_size > 1:
+            raise ValueError(
+                f"moe_enable_routing_replay is incompatible with virtual_pipeline_model_parallel_size={vpp_size}: "
+                "interleaved chunks desync the replay FIFO. Unset virtual_pipeline_model_parallel_size."
+            )
+
         # MTP head count: megatron-bridge infers provider.mtp_num_layers from the model's HF config.
         if not enable_mtp:
             provider.mtp_num_layers = None

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -604,10 +604,8 @@ class MegatronWorker:
             )
             provider.linear_attention_freq = linear_attention_freq[: provider.num_layers]
 
-        # Checked on the resolved provider because to_megatron_provider() can supply its own VPP
-        # default. Every forward appends its routes to all local RouterReplay instances, but under
-        # VPP only the chunk being forwarded consumes them, so each instance's backward FIFO
-        # desyncs by the chunk count.
+        # Check the resolved provider because it may supply its own VPP default. Interleaved
+        # chunks desynchronise each RouterReplay instance's backward FIFO.
         vpp_size = provider.virtual_pipeline_model_parallel_size
         if provider.moe_enable_routing_replay and vpp_size is not None and vpp_size > 1:
             raise ValueError(

--- a/skyrl/train/dataset/parallel_fill.py
+++ b/skyrl/train/dataset/parallel_fill.py
@@ -1,15 +1,7 @@
-"""Fill a large controller-side batch buffer from a locally-sized thread pool.
+"""Fill a controller-side batch buffer with a locally sized thread pool.
 
-Controller-side collation runs single-threaded on the whole global batch before DP sharding, so
-its cost lands on every training step and does not shard away. For a multi-GiB buffer the fill is
-dominated by first-touch page faults on a fresh mapping rather than by the copies themselves, and
-the trainer driver runs under ``@ray.remote(num_cpus=1)`` with ``OMP_NUM_THREADS=1``, so torch
-cannot fault those pages in parallel on its own.
-
-``torch.set_num_threads`` is the wrong lever here: it is process-global, so on the fully-async
-path it would also reach the generation coroutines running concurrently with collation. A local
-pool keeps the effect scoped to this fill. Each callback owns a disjoint row range and the copies
-release the GIL.
+The pool parallelises first-touch page faults without changing process-wide torch settings.
+Callbacks own disjoint row ranges, and their copies release the GIL.
 """
 
 import functools
@@ -18,10 +10,9 @@ from concurrent.futures import ThreadPoolExecutor
 
 from skyrl.utils.cpu_topology import pool_workers
 
-# Copy throughput keeps scaling to the cap; past it the extra threads only take cores from
-# colocated actors.
+# Extra threads beyond this cap take cores from colocated actors without improving throughput.
 MAX_FILL_WORKERS = 32
-# Leave room for raylet, the GCS, the dashboard and the log monitor in the same cgroup.
+# Leave room for Ray services in the same cgroup.
 RESERVED_FILL_CORES = 8
 
 
@@ -36,10 +27,9 @@ def fill_batch_rows(
     *,
     workers: int | None = None,
 ) -> None:
-    """Call ``fill_row(index)`` for every index in ``range(num_rows)``, in parallel.
+    """Call ``fill_row`` for every row, possibly in parallel.
 
-    ``fill_row`` must write a row range that no other index touches; nothing here serialises
-    overlapping writes.
+    Each callback must write to a disjoint row range.
     """
     if num_rows < 0:
         raise ValueError(f"row count must be non-negative, got {num_rows}")
@@ -57,5 +47,5 @@ def fill_batch_rows(
         return
 
     with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="skyrl-batch-fill") as pool:
-        # list() forces the map so an exception in a worker surfaces here rather than being dropped.
+        # Eagerly consume the map so worker exceptions surface here.
         list(pool.map(fill_row, range(num_rows)))

--- a/skyrl/train/dataset/parallel_fill.py
+++ b/skyrl/train/dataset/parallel_fill.py
@@ -1,0 +1,61 @@
+"""Fill a large controller-side batch buffer from a locally-sized thread pool.
+
+Controller-side collation runs single-threaded on the whole global batch before DP sharding, so
+its cost lands on every training step and does not shard away. For a multi-GiB buffer the fill is
+dominated by first-touch page faults on a fresh mapping rather than by the copies themselves, and
+the trainer driver runs under ``@ray.remote(num_cpus=1)`` with ``OMP_NUM_THREADS=1``, so torch
+cannot fault those pages in parallel on its own.
+
+``torch.set_num_threads`` is the wrong lever here: it is process-global, so on the fully-async
+path it would also reach the generation coroutines running concurrently with collation. A local
+pool keeps the effect scoped to this fill. Each callback owns a disjoint row range and the copies
+release the GIL.
+"""
+
+import functools
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+
+from skyrl.utils.cpu_topology import pool_workers
+
+# Copy throughput keeps scaling to the cap; past it the extra threads only take cores from
+# colocated actors.
+MAX_FILL_WORKERS = 32
+# Leave room for raylet, the GCS, the dashboard and the log monitor in the same cgroup.
+RESERVED_FILL_CORES = 8
+
+
+@functools.cache
+def default_fill_workers() -> int:
+    return pool_workers(cap=MAX_FILL_WORKERS, reserved=RESERVED_FILL_CORES)
+
+
+def fill_batch_rows(
+    fill_row: Callable[[int], None],
+    num_rows: int,
+    *,
+    workers: int | None = None,
+) -> None:
+    """Call ``fill_row(index)`` for every index in ``range(num_rows)``, in parallel.
+
+    ``fill_row`` must write a row range that no other index touches; nothing here serialises
+    overlapping writes.
+    """
+    if num_rows < 0:
+        raise ValueError(f"row count must be non-negative, got {num_rows}")
+    if num_rows == 0:
+        return
+    if workers is None:
+        workers = default_fill_workers()
+    if workers < 1:
+        raise ValueError(f"worker count must be positive, got {workers}")
+
+    workers = min(workers, num_rows)
+    if workers == 1:
+        for index in range(num_rows):
+            fill_row(index)
+        return
+
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="skyrl-batch-fill") as pool:
+        # list() forces the map so an exception in a worker surfaces here rather than being dropped.
+        list(pool.map(fill_row, range(num_rows)))

--- a/skyrl/train/dataset/preprocess.py
+++ b/skyrl/train/dataset/preprocess.py
@@ -1,17 +1,25 @@
 import logging
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
 from jaxtyping import Bool, Float, Integer
 
-from skyrl.backends.skyrl_train.utils.replay_utils import make_replay_padding_indices_np
+from skyrl.backends.skyrl_train.utils.replay_utils import replay_padding_row
 from skyrl.backends.skyrl_train.utils.routed_experts import (
+    ROUTED_EXPERT_DTYPES,
     RoutedExpertIndices,
-    compact_routed_expert_indices,
 )
+from skyrl.train.dataset.parallel_fill import fill_batch_rows
 
 logger = logging.getLogger(__name__)
+
+# Torch counterparts of the canonical routed-expert dtypes.
+ROUTED_EXPERT_TORCH_DTYPES: Dict[np.dtype, torch.dtype] = {
+    np.dtype(np.uint8): torch.uint8,
+    np.dtype(np.int16): torch.int16,
+    np.dtype(np.int32): torch.int32,
+}
 
 
 def make_router_padding_mask(
@@ -85,6 +93,87 @@ def _reward_to_numpy(custom_reward: Union[List[float], torch.Tensor]) -> np.ndar
     if reward_arr.ndim != 1:
         raise ValueError(f"Expected a 1D per-token reward sequence, got shape {reward_arr.shape}")
     return reward_arr
+
+
+def _collate_rollout_expert_indices(
+    rollout_expert_indices: List[RoutedExpertIndices],
+    pad_lens: np.ndarray,
+    max_total: int,
+) -> Integer[torch.Tensor, "batch seq_len layer_num topk"]:
+    """Pack per-trajectory routes into one left-padded ``[batch, seq_len, layers, topk]`` buffer.
+
+    ``pack_routed_experts`` establishes the canonical dtype on the sending side, so entries are
+    validated rather than rescanned here. Every region of the buffer is written exactly once, from
+    a locally sized thread pool: this fill runs on the whole global batch before DP sharding, on
+    every training step, and is bound by first-touch page faults on a fresh multi-GiB mapping.
+    """
+    num_samples = len(rollout_expert_indices)
+    for sample_index, sample_indices in enumerate(rollout_expert_indices):
+        if not isinstance(sample_indices, np.ndarray):
+            raise TypeError(
+                f"rollout_expert_indices entries must be NumPy arrays, got {type(sample_indices).__name__} "
+                f"at sample {sample_index}"
+            )
+        if sample_indices.dtype not in ROUTED_EXPERT_DTYPES:
+            supported = ", ".join(
+                dtype.name for dtype in sorted(ROUTED_EXPERT_DTYPES, key=lambda dtype: dtype.itemsize)
+            )
+            raise ValueError(
+                f"rollout_expert_indices entries must use a canonical routed-expert dtype ({supported}), "
+                f"got {sample_indices.dtype} at sample {sample_index}"
+            )
+
+    first_shape = rollout_expert_indices[0].shape
+    if len(first_shape) != 3 or first_shape[0] == 0:
+        raise ValueError("rollout_expert_indices must contain routes for every trajectory")
+    num_layers, topk = first_shape[1:]
+    if topk < 1:
+        raise ValueError("rollout_expert_indices must contain at least one expert per layer")
+
+    # Validate serially so an invalid trajectory raises deterministically rather than from a worker.
+    route_ends = []
+    for sample_index, sample_indices in enumerate(rollout_expert_indices):
+        if sample_indices.ndim != 3 or sample_indices.shape[1:] != (num_layers, topk):
+            raise ValueError(
+                "rollout_expert_indices entries must share [layers, topk], "
+                f"got shape {sample_indices.shape} at sample {sample_index}"
+            )
+        left_pad = int(pad_lens[sample_index])
+        available = max_total - left_pad
+        if sample_indices.shape[0] == 0 or sample_indices.shape[0] > available:
+            raise ValueError(
+                f"Trajectory {sample_index} has {sample_indices.shape[0]} route rows for {available} tokens"
+            )
+        route_ends.append(left_pad + sample_indices.shape[0])
+
+    batch_dtype = max((indices.dtype for indices in rollout_expert_indices), key=lambda dtype: dtype.itemsize)
+    if batch_dtype == np.dtype(np.int32):
+        logger.warning(
+            "Collating rollout_expert_indices as int32, which doubles this buffer. No supported expert count "
+            "needs more than int16, so the inference server is not compacting its routes."
+        )
+    padded = torch.empty(
+        (num_samples, max_total, num_layers, topk),
+        dtype=ROUTED_EXPERT_TORCH_DTYPES[batch_dtype],
+    )
+    # Distinct experts per padding row, as Megatron's dropless dispatcher requires.
+    padding_row = replay_padding_row(topk, dtype=padded.dtype)
+
+    def fill_sample(sample_index: int) -> None:
+        sample_indices = rollout_expert_indices[sample_index]
+        flags = sample_indices.flags
+        # torch.from_numpy refuses a non-writeable buffer, and decoded wire routes may be read-only.
+        if not flags.c_contiguous or not flags.writeable:
+            sample_indices = sample_indices.copy(order="C")
+        left_pad = int(pad_lens[sample_index])
+        route_end = route_ends[sample_index]
+        sample_rows = padded[sample_index]
+        sample_rows[:left_pad] = padding_row
+        sample_rows[left_pad:route_end] = torch.from_numpy(sample_indices)
+        sample_rows[route_end:] = padding_row
+
+    fill_batch_rows(fill_sample, num_samples)
+    return padded
 
 
 def convert_prompts_responses_to_batch_tensors(
@@ -235,42 +324,11 @@ def convert_prompts_responses_to_batch_tensors(
         if len(rollout_expert_indices) != num_samples:
             raise ValueError("rollout_expert_indices must contain routes for every trajectory")
 
-        canonical_indices = []
-        for sample_index, sample_indices in enumerate(rollout_expert_indices):
-            if not isinstance(sample_indices, np.ndarray):
-                raise TypeError(
-                    f"rollout_expert_indices entries must be NumPy arrays, got {type(sample_indices).__name__} "
-                    f"at sample {sample_index}"
-                )
-            canonical_indices.append(compact_routed_expert_indices(sample_indices))
-
-        first_shape = canonical_indices[0].shape
-        if len(first_shape) != 3 or first_shape[0] == 0:
-            raise ValueError("rollout_expert_indices must contain routes for every trajectory")
-        num_layers, topk = first_shape[1:]
-        if topk < 1:
-            raise ValueError("rollout_expert_indices must contain at least one expert per layer")
-
-        batch_dtype = max((indices.dtype for indices in canonical_indices), key=lambda dtype: dtype.itemsize)
-        padded = make_replay_padding_indices_np(
-            (num_samples, max_total, num_layers, topk),
-            dtype=batch_dtype,
+        rollout_expert_indices_tensor = _collate_rollout_expert_indices(
+            rollout_expert_indices,
+            pad_lens,
+            max_total,
         )
-        for sample_index, sample_indices in enumerate(canonical_indices):
-            if sample_indices.ndim != 3 or sample_indices.shape[1:] != (num_layers, topk):
-                raise ValueError(
-                    "rollout_expert_indices entries must share [layers, topk], "
-                    f"got shape {sample_indices.shape} at sample {sample_index}"
-                )
-            left_pad = max_total - (prompt_token_lens[sample_index] + response_token_lens[sample_index])
-            available = max_total - left_pad
-            if sample_indices.shape[0] == 0 or sample_indices.shape[0] > available:
-                raise ValueError(
-                    f"Trajectory {sample_index} has {sample_indices.shape[0]} route rows for {available} tokens"
-                )
-            route_end = left_pad + sample_indices.shape[0]
-            padded[sample_index, left_pad:route_end] = sample_indices
-        rollout_expert_indices_tensor = torch.from_numpy(padded)
 
     return (
         sequences,

--- a/skyrl/train/dataset/preprocess.py
+++ b/skyrl/train/dataset/preprocess.py
@@ -100,12 +100,9 @@ def _collate_rollout_expert_indices(
     pad_lens: np.ndarray,
     max_total: int,
 ) -> Integer[torch.Tensor, "batch seq_len layer_num topk"]:
-    """Pack per-trajectory routes into one left-padded ``[batch, seq_len, layers, topk]`` buffer.
+    """Pack routes into a left-padded ``[batch, seq_len, layers, topk]`` buffer.
 
-    ``pack_routed_experts`` establishes the canonical dtype on the sending side, so entries are
-    validated rather than rescanned here. Every region of the buffer is written exactly once, from
-    a locally sized thread pool: this fill runs on the whole global batch before DP sharding, on
-    every training step, and is bound by first-touch page faults on a fresh multi-GiB mapping.
+    The sender establishes canonical dtypes, so this path validates rather than rescans entries.
     """
     num_samples = len(rollout_expert_indices)
     for sample_index, sample_indices in enumerate(rollout_expert_indices):
@@ -130,7 +127,7 @@ def _collate_rollout_expert_indices(
     if topk < 1:
         raise ValueError("rollout_expert_indices must contain at least one expert per layer")
 
-    # Validate serially so an invalid trajectory raises deterministically rather than from a worker.
+    # Validate before dispatch so errors are deterministic.
     route_ends = []
     for sample_index, sample_indices in enumerate(rollout_expert_indices):
         if sample_indices.ndim != 3 or sample_indices.shape[1:] != (num_layers, topk):
@@ -162,7 +159,7 @@ def _collate_rollout_expert_indices(
     def fill_sample(sample_index: int) -> None:
         sample_indices = rollout_expert_indices[sample_index]
         flags = sample_indices.flags
-        # torch.from_numpy refuses a non-writeable buffer, and decoded wire routes may be read-only.
+        # torch.from_numpy requires a writable buffer.
         if not flags.c_contiguous or not flags.writeable:
             sample_indices = sample_indices.copy(order="C")
         left_pad = int(pad_lens[sample_index])

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -23,7 +23,7 @@ from skyrl.backends.skyrl_train.inference_servers.base import (
     InferenceEngineInput,
     InferenceEngineInterface,
 )
-from skyrl.backends.skyrl_train.utils.routed_experts import RoutedExpertIndices
+from skyrl.backends.skyrl_train.utils.routed_experts import RoutedExpertIndices, RoutedExpertTrace
 from skyrl.train.config import GeneratorConfig, SkyRLGymConfig
 from skyrl.train.generators.base import (
     GeneratorInput,
@@ -83,7 +83,7 @@ class AgentLoopState:
     rollout_logprobs: Optional[List[float]]
     response_end_idx: Optional[int]
     done: bool
-    rollout_expert_indices: Optional[RoutedExpertIndices] = None
+    routed_expert_trace: Optional[RoutedExpertTrace] = None
 
 
 @dataclass
@@ -93,13 +93,8 @@ class TurnOutput:
     output_logprobs: Optional[List[float]]
     new_obs: ConversationType
     obs_ids: List[int]
-    rollout_expert_indices: Optional[RoutedExpertIndices]
     reward: Optional[float]
     added_eos: bool = False
-
-    def get_turn_rollout_expert_indices(self) -> Optional[RoutedExpertIndices]:
-        """Return only routes that the inference model actually executed."""
-        return self.rollout_expert_indices
 
     def get_turn_loss_mask(self) -> List[int]:
         """
@@ -379,6 +374,9 @@ class SkyRLGymGenerator(GeneratorInterface):
                 rollout_logprobs=[] if get_logprobs else None,
                 response_end_idx=None,
                 done=False,
+                routed_expert_trace=(
+                    RoutedExpertTrace() if self.generator_cfg.inference_engine.enable_return_routed_experts else None
+                ),
             )
 
             while not agent_loop_state.done:
@@ -401,11 +399,13 @@ class SkyRLGymGenerator(GeneratorInterface):
                     agent_loop_state.loss_mask = []
                     agent_loop_state.rollout_logprobs = None
 
+                routed_expert_trace = agent_loop_state.routed_expert_trace
                 engine_input = InferenceEngineInput(
                     prompt_token_ids=[agent_loop_state.input_ids],
                     session_ids=[session_id],
                     sampling_params=sampling_params,
                     cache_salt=cache_salt,
+                    routed_experts_prompt_starts=[routed_expert_trace.prompt_start] if routed_expert_trace else None,
                 )
                 llm_call_start_time = time.monotonic()
                 engine_output = await self.inference_engine_client.generate(engine_input, model=self.policy_model_name)
@@ -426,6 +426,14 @@ class SkyRLGymGenerator(GeneratorInterface):
                         raise ValueError(
                             "Rollout expert indices bookkeeping is not supported with custom chat template"
                         )
+                if routed_expert_trace is not None:
+                    if rollout_expert_indices is None:
+                        raise ValueError("R3 generation did not return routed expert indices")
+                    routed_expert_trace.record_generation(
+                        prompt_token_count=len(agent_loop_state.input_ids),
+                        generated_token_count=len(output_ids),
+                        routed_experts=rollout_expert_indices,
+                    )
                 # Append eos when sampling_params.stop is not None. Does not affect 3.a as chat templates add eos_token.
                 # sampling_params is not None for eval, but None for training (which uses engine.sampling_params which are from cfg)
                 stop_strs = current_sampling_params.get("stop", None)
@@ -459,6 +467,8 @@ class SkyRLGymGenerator(GeneratorInterface):
                     )
                     output = env_step_output["postprocessed_action"]
                     output_ids = self.tokenizer.encode(output, add_special_tokens=False)
+                    if routed_expert_trace is not None:
+                        raise ValueError("R3 bookkeeping is incompatible with postprocessed_action")
 
                 obs_ids = self.get_obs_ids_from_obs(new_obs, agent_loop_state.done)
 
@@ -471,7 +481,6 @@ class SkyRLGymGenerator(GeneratorInterface):
                     reward=step_reward,
                     obs_ids=obs_ids,
                     added_eos=added_eos,
-                    rollout_expert_indices=rollout_expert_indices,
                 )
 
                 if is_step_wise:
@@ -491,7 +500,6 @@ class SkyRLGymGenerator(GeneratorInterface):
                         rollout_logprobs=turn_response_logprobs,
                         stop_reason=stop_reason,
                         env_metrics=env.get_metrics() if agent_loop_state.done else {},
-                        rollout_expert_indices=turn_output.get_turn_rollout_expert_indices(),
                     )
                     agent_loop_output.step_outputs.append(per_step_output)
 
@@ -553,10 +561,6 @@ class SkyRLGymGenerator(GeneratorInterface):
                     rollout_logprobs = agent_loop_state.rollout_logprobs[
                         : agent_loop_state.response_end_idx - initial_prompt_length + 1
                     ]
-                if agent_loop_state.rollout_expert_indices is not None:
-                    rollout_expert_indices_out = agent_loop_state.rollout_expert_indices[
-                        : agent_loop_state.response_end_idx + 1
-                    ]
                 # fix index for per_step_rewards
                 per_step_rewards = [(reward, idx - initial_prompt_length) for reward, idx in per_step_rewards]
                 assert len(loss_mask) == len(
@@ -572,6 +576,12 @@ class SkyRLGymGenerator(GeneratorInterface):
                     if rollout_logprobs is not None:
                         rollout_logprobs.append(0.0)
                     appended_eos_token = True
+
+            if agent_loop_state.routed_expert_trace is not None and agent_loop_state.routed_expert_trace.prompt_start:
+                rollout_expert_indices_out = agent_loop_state.routed_expert_trace.finalize(
+                    token_count=len(prompt_ids) + len(response_ids),
+                    loss_mask=[0] * len(prompt_ids) + loss_mask,
+                )
 
             if self.generator_cfg.step_wise_trajectories:
                 for per_step_output, (reward, resp_end_idx) in zip(agent_loop_output.step_outputs, per_step_rewards):
@@ -1047,8 +1057,6 @@ class SkyRLGymGenerator(GeneratorInterface):
         agent_loop_state.response_end_idx = None
         # `logprobs` are not computed because retokenizing breaks token-in-token-out
         agent_loop_state.rollout_logprobs = None
-        # indices are not meaningful when retokenizing
-        agent_loop_state.rollout_expert_indices = None
         return agent_loop_state
 
     def _update_agent_loop_state_with_multiturn_chat_template(
@@ -1100,17 +1108,12 @@ class SkyRLGymGenerator(GeneratorInterface):
         loss_mask_for_turn = turn_output.get_turn_loss_mask()
         rollout_logprobs_for_turn = turn_output.get_turn_rollout_logprobs()
 
-        # use the raw rollout expert indices without any appending of observation tokens
-        # this will be overwritten each turn, so we don't need to append observation tokens to it
-        rollout_expert_indices_for_turn = turn_output.rollout_expert_indices
-
         if self.generator_cfg.step_wise_trajectories:
             # cumulative input_ids is not tracked for step wise training
             agent_loop_state.response_end_idx = len(turn_output.output_ids) - 1
-            # no running loss_mask, `rollout_logprobs`, or `rollout_expert_indices` are tracked for step-wise training
+            # no running loss_mask or rollout logprobs are tracked for step-wise training
             agent_loop_state.loss_mask = None
             agent_loop_state.rollout_logprobs = None
-            agent_loop_state.rollout_expert_indices = None
         else:
             # Directly append turn output
             turn_ids = turn_output.output_ids + turn_output.obs_ids
@@ -1119,11 +1122,6 @@ class SkyRLGymGenerator(GeneratorInterface):
             agent_loop_state.loss_mask += loss_mask_for_turn
             if agent_loop_state.rollout_logprobs is not None and rollout_logprobs_for_turn is not None:
                 agent_loop_state.rollout_logprobs += rollout_logprobs_for_turn
-            if rollout_expert_indices_for_turn is not None:
-                # overwrite the existing rollout inference indices, since the inference engine should
-                # return the expert indices for the entire sequence including each turn's input
-                # and the final response should not have an observation appended to it
-                agent_loop_state.rollout_expert_indices = rollout_expert_indices_for_turn
 
         return agent_loop_state
 
@@ -1194,13 +1192,4 @@ class SkyRLGymGenerator(GeneratorInterface):
         agent_loop_state.loss_mask += loss_mask_for_turn
         if agent_loop_state.rollout_logprobs is not None and rollout_logprobs_for_turn is not None:
             agent_loop_state.rollout_logprobs += rollout_logprobs_for_turn
-        if (
-            self.generator_cfg.inference_engine.enable_return_routed_experts
-            and turn_output.rollout_expert_indices is not None
-        ):
-            # overwrite the existing rollout inference indices, since the inference engine should
-            # return the expert indices for the entire sequence including each turn's input and observation tokens
-            # and the final response should not have an observation appended to it
-            agent_loop_state.rollout_expert_indices = turn_output.rollout_expert_indices
-
         return agent_loop_state

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -23,7 +23,10 @@ from skyrl.backends.skyrl_train.inference_servers.base import (
     InferenceEngineInput,
     InferenceEngineInterface,
 )
-from skyrl.backends.skyrl_train.utils.routed_experts import RoutedExpertIndices, RoutedExpertTrace
+from skyrl.backends.skyrl_train.utils.routed_experts import (
+    RoutedExpertIndices,
+    RoutedExpertTrace,
+)
 from skyrl.train.config import GeneratorConfig, SkyRLGymConfig
 from skyrl.train.generators.base import (
     GeneratorInput,

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -257,9 +257,7 @@ def validate_megatron_cfg(cfg: SkyRLTrainConfig):
                 f"{worker_type}.megatron_config: moe_enable_routing_replay is incompatible with "
                 "moe_router_fusion=True -- the fused router bypasses replay. Set moe_router_fusion=False."
             )
-            # Every forward appends its routes to all local RouterReplay instances, but under VPP
-            # only the chunk being forwarded consumes them, so each instance's backward FIFO
-            # desyncs by the chunk count.
+            # Interleaved chunks desynchronise each RouterReplay instance's backward FIFO.
             assert not config.megatron_config.transformer_config_kwargs.get("virtual_pipeline_model_parallel_size"), (
                 f"{worker_type}.megatron_config: moe_enable_routing_replay is incompatible with "
                 "virtual_pipeline_model_parallel_size -- interleaved chunks desync the replay FIFO. "

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -257,6 +257,14 @@ def validate_megatron_cfg(cfg: SkyRLTrainConfig):
                 f"{worker_type}.megatron_config: moe_enable_routing_replay is incompatible with "
                 "moe_router_fusion=True -- the fused router bypasses replay. Set moe_router_fusion=False."
             )
+            # Every forward appends its routes to all local RouterReplay instances, but under VPP
+            # only the chunk being forwarded consumes them, so each instance's backward FIFO
+            # desyncs by the chunk count.
+            assert not config.megatron_config.transformer_config_kwargs.get("virtual_pipeline_model_parallel_size"), (
+                f"{worker_type}.megatron_config: moe_enable_routing_replay is incompatible with "
+                "virtual_pipeline_model_parallel_size -- interleaved chunks desync the replay FIFO. "
+                "Unset virtual_pipeline_model_parallel_size."
+            )
         # context, expert, and expert tensor parallel are not yet supported for megatron
         if config.megatron_config.context_parallel_size > 1:
             assert (

--- a/skyrl/utils/cpu_topology.py
+++ b/skyrl/utils/cpu_topology.py
@@ -1,0 +1,97 @@
+"""How many CPUs this process may actually keep busy, and how to size a pool from it.
+
+``os.cpu_count()`` reports the machine, not the container. Under Ray a worker runs with
+``OMP_NUM_THREADS=1`` and ``torch.get_num_threads() == 1`` without the process itself being
+restricted, so neither of those can size a pool either. The two limits that do bind are the
+affinity mask (cpuset / taskset pinning) and the CFS quota, and they are independent.
+"""
+
+import os
+from typing import Optional, Tuple
+
+# A container's own cgroup appears at the root of its cgroup namespace, so these paths already
+# describe this process (``/proc/self/cgroup`` reads ``0::/``) and need no prefix join. Module
+# level so tests can point them at fixtures.
+CGROUP_V2_CPU_MAX_PATH = "/sys/fs/cgroup/cpu.max"
+CGROUP_V1_CPU_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+CGROUP_V1_CPU_PERIOD_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+
+# cgroup v2 spells "no quota" as this literal; v1 spells it as a negative quota.
+CGROUP_V2_CPU_MAX_UNLIMITED = "max"
+
+
+def _read_cgroup_file(path: str) -> str:
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _read_cgroup_v2_cpu_max() -> Optional[Tuple[float, float]]:
+    """``(quota, period)`` from cgroup v2 ``cpu.max``, or ``None`` if absent or unlimited."""
+    try:
+        quota_text, period_text = _read_cgroup_file(CGROUP_V2_CPU_MAX_PATH).split()
+        if quota_text == CGROUP_V2_CPU_MAX_UNLIMITED:
+            return None
+        return float(quota_text), float(period_text)
+    except (OSError, ValueError):
+        return None
+
+
+def _read_cgroup_v1_cpu_max() -> Optional[Tuple[float, float]]:
+    """``(quota, period)`` from cgroup v1 ``cpu.cfs_*_us``, or ``None`` if absent or unlimited."""
+    try:
+        quota = float(_read_cgroup_file(CGROUP_V1_CPU_QUOTA_PATH).strip())
+        period = float(_read_cgroup_file(CGROUP_V1_CPU_PERIOD_PATH).strip())
+    except (OSError, ValueError):
+        return None
+    if quota < 0:
+        return None
+    return quota, period
+
+
+def cgroup_cpu_quota() -> Optional[int]:
+    """Whole CPUs this process' CFS quota permits, or ``None`` when no quota applies.
+
+    Kubernetes ``limits.cpu`` becomes this quota, and flytekit's ``pod_spec_from_resources`` ends
+    with ``limits = limits or requests``, so a pod declaring only ``requests.cpu`` still carries
+    one. ``sched_getaffinity`` cannot see it: a quota caps CPU *time*, not which CPUs are runnable.
+    """
+    limits = _read_cgroup_v2_cpu_max() or _read_cgroup_v1_cpu_max()
+    if limits is None:
+        return None
+    quota, period = limits
+    if quota <= 0 or period <= 0:
+        return None
+    # Floor a fractional allowance, but a sub-CPU quota still gets one worker.
+    return max(1, int(quota // period))
+
+
+def permitted_cpu_cores() -> int:
+    """CPUs this process can actually keep busy: the lesser of its affinity mask and its quota.
+
+    ``sched_getaffinity`` honours cpuset/taskset pinning and is Linux-only; elsewhere
+    ``cpu_count`` is the closest read available.
+    """
+    try:
+        affinity = len(os.sched_getaffinity(0))
+    except AttributeError:
+        affinity = os.cpu_count() or 1
+    quota = cgroup_cpu_quota()
+    if quota is None:
+        return affinity
+    return min(affinity, quota)
+
+
+def pool_workers(*, cap: int, reserved: int, cores: Optional[int] = None) -> int:
+    """Pool size for a CPU-bound thread pool: capped, otherwise permitted cores minus a reserve.
+
+    ``reserved`` leaves room for the colocated processes sharing this cgroup -- under Ray that is
+    raylet, the GCS, the dashboard and the log monitor. Oversubscribing a CFS quota buys a few
+    percent of throughput for constant throttling.
+    """
+    if cap < 1:
+        raise ValueError(f"pool cap must be positive, got {cap}")
+    if reserved < 0:
+        raise ValueError(f"reserved cores must be non-negative, got {reserved}")
+    if cores is None:
+        cores = permitted_cpu_cores()
+    return max(1, min(cap, cores - reserved))

--- a/skyrl/utils/cpu_topology.py
+++ b/skyrl/utils/cpu_topology.py
@@ -1,22 +1,15 @@
-"""How many CPUs this process may actually keep busy, and how to size a pool from it.
-
-``os.cpu_count()`` reports the machine, not the container. Under Ray a worker runs with
-``OMP_NUM_THREADS=1`` and ``torch.get_num_threads() == 1`` without the process itself being
-restricted, so neither of those can size a pool either. The two limits that do bind are the
-affinity mask (cpuset / taskset pinning) and the CFS quota, and they are independent.
-"""
+"""Determine usable CPUs from process affinity and cgroup quota."""
 
 import os
 from typing import Optional, Tuple
 
-# A container's own cgroup appears at the root of its cgroup namespace, so these paths already
-# describe this process (``/proc/self/cgroup`` reads ``0::/``) and need no prefix join. Module
-# level so tests can point them at fixtures.
+# Container cgroup namespaces expose the current cgroup at these paths. Module-level constants
+# let tests replace them with fixtures.
 CGROUP_V2_CPU_MAX_PATH = "/sys/fs/cgroup/cpu.max"
 CGROUP_V1_CPU_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
 CGROUP_V1_CPU_PERIOD_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
 
-# cgroup v2 spells "no quota" as this literal; v1 spells it as a negative quota.
+# cgroup v2 uses this literal for an unlimited quota.
 CGROUP_V2_CPU_MAX_UNLIMITED = "max"
 
 
@@ -49,12 +42,7 @@ def _read_cgroup_v1_cpu_max() -> Optional[Tuple[float, float]]:
 
 
 def cgroup_cpu_quota() -> Optional[int]:
-    """Whole CPUs this process' CFS quota permits, or ``None`` when no quota applies.
-
-    Kubernetes ``limits.cpu`` becomes this quota, and flytekit's ``pod_spec_from_resources`` ends
-    with ``limits = limits or requests``, so a pod declaring only ``requests.cpu`` still carries
-    one. ``sched_getaffinity`` cannot see it: a quota caps CPU *time*, not which CPUs are runnable.
-    """
+    """Return whole CPUs permitted by CFS, or ``None`` when no quota applies."""
     limits = _read_cgroup_v2_cpu_max() or _read_cgroup_v1_cpu_max()
     if limits is None:
         return None
@@ -66,11 +54,7 @@ def cgroup_cpu_quota() -> Optional[int]:
 
 
 def permitted_cpu_cores() -> int:
-    """CPUs this process can actually keep busy: the lesser of its affinity mask and its quota.
-
-    ``sched_getaffinity`` honours cpuset/taskset pinning and is Linux-only; elsewhere
-    ``cpu_count`` is the closest read available.
-    """
+    """Return the lesser of the process affinity and cgroup quota."""
     try:
         affinity = len(os.sched_getaffinity(0))
     except AttributeError:
@@ -82,12 +66,7 @@ def permitted_cpu_cores() -> int:
 
 
 def pool_workers(*, cap: int, reserved: int, cores: Optional[int] = None) -> int:
-    """Pool size for a CPU-bound thread pool: capped, otherwise permitted cores minus a reserve.
-
-    ``reserved`` leaves room for the colocated processes sharing this cgroup -- under Ray that is
-    raylet, the GCS, the dashboard and the log monitor. Oversubscribing a CFS quota buys a few
-    percent of throughput for constant throttling.
-    """
+    """Size a pool from permitted cores, a cap, and a reserve for colocated processes."""
     if cap < 1:
         raise ValueError(f"pool cap must be positive, got {cap}")
     if reserved < 0:

--- a/tests/backends/skyrl_train/distributed/test_token_metadata.py
+++ b/tests/backends/skyrl_train/distributed/test_token_metadata.py
@@ -1,10 +1,13 @@
 import sys
 import types
 
+import numpy as np
 import pytest
 import torch
 
 from skyrl.backends.skyrl_train.distributed.megatron import token_metadata
+from skyrl.backends.skyrl_train.distributed.megatron.token_metadata import TokenMetadataTrace
+from skyrl.backends.skyrl_train.utils.routed_experts import RoutedExpertTrace
 
 
 @pytest.fixture
@@ -86,3 +89,63 @@ def test_packed_layout_aligns_next_token_metadata_and_scatters_rows(monkeypatch,
 
     assert aligned.tolist() == [[11, 12, -1, -1, 21, -1, -1, -1]]
     assert batch_values.tolist() == [[0.0, 1.0, 2.0], [0.0, 0.0, 5.0]]
+
+
+def test_token_metadata_trace_chunks_and_independent_schema() -> None:
+    trace, other = TokenMetadataTrace(), TokenMetadataTrace()
+    trace.append(np.ones((2, 3), dtype=np.int32), expected_rows=2)
+    trace.append(np.zeros((1, 3), dtype=np.int32), expected_rows=1)
+    other.append(np.empty((0, 4), dtype=np.float32), expected_rows=0)
+
+    with pytest.raises(ValueError, match="expected 4"):
+        trace.finalize(expected_rows=4)
+    result = trace.finalize(expected_rows=3)
+    assert result.shape == (3, 3)
+    assert other.finalize(expected_rows=0).shape == (0, 4)
+    with pytest.raises(RuntimeError, match="already finalized"):
+        trace.finalize(expected_rows=3)
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected", "match"),
+    [
+        (np.ones((2, 2), dtype=np.int32), 1, "has 2 rows"),
+        (np.ones((2, 2), dtype=np.int32)[:, ::2], 2, "contiguous"),
+        (np.ones((1, 3), dtype=np.int32), 1, "schema changed"),
+        (np.ones((1, 2), dtype=np.int16), 1, "schema changed"),
+    ],
+)
+def test_token_metadata_trace_rejects_invalid_chunks(rows, expected, match) -> None:
+    trace = TokenMetadataTrace()
+    if rows.shape[0] == 1:
+        trace.append(np.ones((1, 2), dtype=np.int32), expected_rows=1)
+    with pytest.raises(ValueError, match=match):
+        trace.append(rows, expected_rows=expected)
+
+
+def routes(rows: int) -> np.ndarray:
+    return np.arange(rows * 4, dtype=np.int32).reshape(rows, 2, 2) % 8
+
+
+def test_routed_expert_trace_tracks_multiturn_suffix_and_terminal_gap() -> None:
+    trace = RoutedExpertTrace()
+    trace.record_generation(prompt_token_count=3, generated_token_count=2, routed_experts=routes(4))
+    assert trace.prompt_start == 4
+    trace.record_generation(prompt_token_count=7, generated_token_count=2, routed_experts=routes(4))
+
+    result = trace.finalize(token_count=9, loss_mask=[0, 0, 0, 1, 1, 0, 0, 1, 1])
+    assert result.shape == (9, 2, 2) and result.dtype == np.uint8
+    assert np.array_equal(result[-1, 0], [0, 1])
+
+
+@pytest.mark.parametrize("active", [False, True])
+def test_routed_expert_trace_only_pads_masked_suffix(active: bool) -> None:
+    trace = RoutedExpertTrace()
+    trace.record_generation(prompt_token_count=3, generated_token_count=1, routed_experts=routes(3))
+    mask = [0, 0, 0, 0, int(active)]
+    if active:
+        with pytest.raises(ValueError, match="loss-active target"):
+            trace.finalize(token_count=5, loss_mask=mask)
+    else:
+        result = trace.finalize(token_count=5, loss_mask=mask)
+        assert np.array_equal(result[-2:, 0], [[0, 1], [0, 1]])

--- a/tests/backends/skyrl_train/distributed/test_token_metadata.py
+++ b/tests/backends/skyrl_train/distributed/test_token_metadata.py
@@ -6,7 +6,9 @@ import pytest
 import torch
 
 from skyrl.backends.skyrl_train.distributed.megatron import token_metadata
-from skyrl.backends.skyrl_train.distributed.megatron.token_metadata import TokenMetadataTrace
+from skyrl.backends.skyrl_train.distributed.megatron.token_metadata import (
+    TokenMetadataTrace,
+)
 from skyrl.backends.skyrl_train.utils.routed_experts import RoutedExpertTrace
 
 

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -35,6 +35,7 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
     app = FastAPI()
     app.state.last_generate_features = None
     app.state.last_generate_model = None
+    app.state.last_generate_sampling_params = None
     app.state.last_chat_model = None
     app.state.last_completion_model = None
     app.state.last_render_model = None
@@ -62,6 +63,10 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
     @app.get("/test/last_generate_features")
     async def get_last_generate_features():
         return {"features": app.state.last_generate_features}
+
+    @app.get("/test/last_generate_sampling_params")
+    async def get_last_generate_sampling_params():
+        return app.state.last_generate_sampling_params
 
     @app.get("/test/last_models")
     async def get_last_models():
@@ -104,6 +109,7 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
     async def generate(request: Request):
         body = await request.json()  # Consume body
         sp = body.get("sampling_params", {})
+        app.state.last_generate_sampling_params = sp
         input_token_ids = body.get("token_ids", [])
         app.state.last_generate_model = body.get("model")
         n = sp.get("n", 1)
@@ -479,13 +485,16 @@ class TestDataPlane:
             enable_return_routed_experts=True,
         )
         try:
-            result = await client.generate({"prompt_token_ids": [[1, 2, 3]]})
+            result = await client.generate({"prompt_token_ids": [[1, 2, 3]], "routed_experts_prompt_starts": [1]})
+            async with httpx.AsyncClient() as http:
+                captured = (await http.get(f"{mock_servers['proxy_url']}/test/last_generate_sampling_params")).json()
         finally:
             await client.teardown()
 
         assert len(result["rollout_expert_indices"]) == 1
         assert result["rollout_expert_indices"][0].dtype == np.uint8
         assert np.array_equal(result["rollout_expert_indices"][0], np.arange(12).reshape(3, 2, 2))
+        assert captured["routed_experts_prompt_start"] == 1
 
     @pytest.mark.asyncio
     async def test_generate_rejects_list_routed_experts(self, monkeypatch):

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -438,8 +438,7 @@ class TestRemoteInferenceClientInit:
         assert restored.proxy_url == client.proxy_url
         assert restored.server_urls == client.server_urls
         assert restored.model_name == client.model_name
-        # Session should be None after unpickling
-        assert restored._session is None
+        assert restored._generate_client is None
 
 
 class TestDataPlane:
@@ -508,7 +507,7 @@ class TestDataPlane:
                 ]
             }
 
-        monkeypatch.setattr(client, "_post", return_list_routes)
+        monkeypatch.setattr(client._get_generate_client(), "_post", return_list_routes)
         with pytest.raises(ValueError, match="must return packed"):
             await client._generate_single([1], {}, None, "model")
 
@@ -1025,8 +1024,7 @@ class TestContextManager:
             result = await client.resume()
             assert len(result) == 2
 
-        # Session should be closed after exiting context
-        assert client._session is None or client._session.closed
+        assert client._generate_client is None or client._generate_client._session is None
 
 
 async def _get_lora_registries(server_urls: List[str]) -> List[Dict[str, str]]:

--- a/tests/backends/skyrl_train/utils/test_replay_utils.py
+++ b/tests/backends/skyrl_train/utils/test_replay_utils.py
@@ -3,7 +3,6 @@ import sys
 import types
 from types import SimpleNamespace
 
-import numpy as np
 import pytest
 import torch
 
@@ -11,10 +10,7 @@ from skyrl.backends.skyrl_train.distributed.megatron.token_metadata import (
     build_token_metadata_layout,
 )
 from skyrl.backends.skyrl_train.utils import replay_utils
-from skyrl.backends.skyrl_train.utils.replay_utils import (
-    make_replay_padding_indices,
-    make_replay_padding_indices_np,
-)
+from skyrl.backends.skyrl_train.utils.replay_utils import make_replay_padding_indices
 
 
 @pytest.fixture
@@ -70,22 +66,10 @@ def test_replay_padding_indices_are_unique(dtype):
     assert torch.equal(padding, torch.tensor([0, 1, 2], dtype=dtype).expand_as(padding))
 
 
-@pytest.mark.parametrize("dtype", [np.uint8, np.int16, np.int32])
-def test_numpy_replay_padding_matches_torch(dtype):
-    torch_dtype = getattr(torch, np.dtype(dtype).name)
-    padding = make_replay_padding_indices_np((2, 3, 4, 3), dtype=np.dtype(dtype))
-
-    assert padding.dtype == dtype
-    assert torch.equal(
-        torch.from_numpy(padding),
-        make_replay_padding_indices((2, 3, 4, 3), dtype=torch_dtype),
-    )
-
-
 @pytest.mark.parametrize("shape", [(), (2, 3, 4, 0)])
-def test_numpy_replay_padding_rejects_missing_topk(shape):
+def test_replay_padding_rejects_missing_topk(shape):
     with pytest.raises(ValueError, match="positive topk"):
-        make_replay_padding_indices_np(shape, dtype=np.dtype(np.uint8))
+        make_replay_padding_indices(shape, dtype=torch.uint8)
 
 
 def test_replay_has_no_dispatcher_specific_patch():

--- a/tests/train/dataset/test_parallel_fill.py
+++ b/tests/train/dataset/test_parallel_fill.py
@@ -9,9 +9,8 @@ import pytest
 from skyrl.train.dataset.parallel_fill import fill_batch_rows
 
 
-@pytest.mark.parametrize("workers", [1, 4, 64])
+@pytest.mark.parametrize("workers", [None, 1, 4, 64])
 def test_every_index_is_filled_exactly_once(workers):
-    """Includes ``workers`` above ``num_rows``, which clamps rather than raising."""
     num_rows = 32
     calls = [0] * num_rows
 
@@ -19,18 +18,6 @@ def test_every_index_is_filled_exactly_once(workers):
         calls[index] += 1
 
     fill_batch_rows(fill_row, num_rows, workers=workers)
-
-    assert calls == [1] * num_rows
-
-
-def test_default_worker_count_fills_every_index():
-    num_rows = 8
-    calls = [0] * num_rows
-
-    def fill_row(index: int) -> None:
-        calls[index] += 1
-
-    fill_batch_rows(fill_row, num_rows)
 
     assert calls == [1] * num_rows
 

--- a/tests/train/dataset/test_parallel_fill.py
+++ b/tests/train/dataset/test_parallel_fill.py
@@ -1,0 +1,87 @@
+"""
+uv run --isolated --extra dev pytest tests/train/dataset/test_parallel_fill.py
+"""
+
+import threading
+
+import pytest
+
+from skyrl.train.dataset.parallel_fill import fill_batch_rows
+
+
+@pytest.mark.parametrize("workers", [1, 4, 64])
+def test_every_index_is_filled_exactly_once(workers):
+    """Includes ``workers`` above ``num_rows``, which clamps rather than raising."""
+    num_rows = 32
+    calls = [0] * num_rows
+
+    def fill_row(index: int) -> None:
+        calls[index] += 1
+
+    fill_batch_rows(fill_row, num_rows, workers=workers)
+
+    assert calls == [1] * num_rows
+
+
+def test_default_worker_count_fills_every_index():
+    num_rows = 8
+    calls = [0] * num_rows
+
+    def fill_row(index: int) -> None:
+        calls[index] += 1
+
+    fill_batch_rows(fill_row, num_rows)
+
+    assert calls == [1] * num_rows
+
+
+def test_single_worker_runs_serially_on_the_calling_thread():
+    order = []
+    threads = set()
+
+    def fill_row(index: int) -> None:
+        order.append(index)
+        threads.add(threading.current_thread())
+
+    fill_batch_rows(fill_row, 4, workers=1)
+
+    assert order == [0, 1, 2, 3]
+    assert threads == {threading.current_thread()}
+
+
+def test_multiple_workers_leave_the_calling_thread():
+    threads = set()
+
+    def fill_row(index: int) -> None:
+        threads.add(threading.current_thread())
+
+    fill_batch_rows(fill_row, 8, workers=4)
+
+    assert threading.current_thread() not in threads
+
+
+def test_zero_rows_is_a_no_op():
+    def fill_row(index: int) -> None:
+        raise AssertionError("fill_row must not be called for an empty batch")
+
+    fill_batch_rows(fill_row, 0)
+
+
+def test_negative_row_count_raises():
+    with pytest.raises(ValueError, match="row count must be non-negative"):
+        fill_batch_rows(lambda index: None, -1)
+
+
+def test_non_positive_worker_count_raises():
+    with pytest.raises(ValueError, match="worker count must be positive"):
+        fill_batch_rows(lambda index: None, 4, workers=0)
+
+
+@pytest.mark.parametrize("workers", [1, 4])
+def test_callback_exception_propagates(workers):
+    def fill_row(index: int) -> None:
+        if index == 2:
+            raise RuntimeError("row 2 failed")
+
+    with pytest.raises(RuntimeError, match="row 2 failed"):
+        fill_batch_rows(fill_row, 8, workers=workers)

--- a/tests/train/dataset/test_preprocess.py
+++ b/tests/train/dataset/test_preprocess.py
@@ -196,8 +196,7 @@ def test_routed_expert_tensor_rejects_non_canonical_dtypes(tokenizer, dtype):
 
 
 def test_routed_expert_tensor_keeps_the_sender_dtype_after_truncation(tokenizer):
-    """A truncated array keeps the dtype the wire declared; nothing rescans it to retighten."""
-    # int16 on the wire because of the trailing 300, which truncation then drops.
+    # The dropped trailing value required int16 on the sender.
     routes = np.asarray([[[1, 2]], [[3, 4]], [[300, 5]]], dtype=np.int16)
 
     *_, routed = convert_prompts_responses_to_batch_tensors(
@@ -243,7 +242,7 @@ def _numpy_padded_routes(
     prompts: List[List[int]],
     responses: List[List[int]],
 ) -> np.ndarray:
-    """The route collation as NumPy expressed it: broadcast ``arange(topk)``, then write each sample."""
+    """Reference NumPy implementation of route collation."""
     max_total = max(len(prompt) + len(response) for prompt, response in zip(prompts, responses))
     num_layers, topk = routes[0].shape[1:]
     batch_dtype = max((sample.dtype for sample in routes), key=lambda dtype: dtype.itemsize)
@@ -256,11 +255,10 @@ def _numpy_padded_routes(
 
 
 def test_routed_expert_tensor_is_bit_identical_to_numpy_collation(tokenizer):
-    """Left padding, a short route prefix and trailing padding, across a mixed-dtype batch."""
     prompts = [[1, 2], [3, 4, 5, 6]]
     responses = [[10, 11, 12], [20, 21]]
     num_layers, topk = 2, 3
-    # Sample 0 has 5 tokens but only 4 captured route rows, so it pads on both sides.
+    # Sample 0 has fewer route rows than tokens and needs padding on both sides.
     routes = [
         np.arange(4 * num_layers * topk, dtype=np.uint8).reshape(4, num_layers, topk),
         (np.arange(6 * num_layers * topk, dtype=np.int16) + 300).reshape(6, num_layers, topk),
@@ -277,12 +275,10 @@ def test_routed_expert_tensor_is_bit_identical_to_numpy_collation(tokenizer):
 
     assert routed.dtype == torch.int16
     assert torch.equal(routed, torch.from_numpy(_numpy_padded_routes(routes, prompts, responses)))
-    # Padding routes are topk distinct experts, which Megatron's dropless dispatcher requires;
-    # zeros would collapse them onto one expert.
+    # Padding routes must select distinct experts for the dropless dispatcher.
     padding_row = [[0, 1, 2]] * num_layers
     assert routed[0, 0].tolist() == padding_row
     assert routed[0, 5].tolist() == padding_row
-    assert not torch.equal(routed[0, 0], torch.zeros_like(routed[0, 0]))
 
 
 def test_convert_prompts_responses_to_batch_tensors_exact(tokenizer):

--- a/tests/train/dataset/test_preprocess.py
+++ b/tests/train/dataset/test_preprocess.py
@@ -2,13 +2,17 @@
 uv run --isolated --extra dev pytest tests/train/dataset/test_preprocess.py
 """
 
+import logging
+from typing import List
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 import torch
 
+from skyrl.backends.skyrl_train.utils.routed_experts import ROUTED_EXPERT_DTYPES
 from skyrl.train.dataset.preprocess import (
+    ROUTED_EXPERT_TORCH_DTYPES,
     convert_prompts_responses_to_batch_tensors,
     make_router_padding_mask,
 )
@@ -156,15 +160,11 @@ def test_routed_expert_tensor_rejects_nested_lists(tokenizer):
         )
 
 
-@pytest.mark.parametrize("dtype", [np.uint16, np.int64])
-def test_routed_expert_tensor_narrows_wide_dtypes(tokenizer, dtype):
-    """Wide dtypes are compacted, not rejected.
-
-    The wire decoder already restricts routes to uint8/int16/int32, so this path
-    only sees a wide dtype from a hand-built generator -- narrowing it is more
-    useful than refusing it.
-    """
-    routes = np.asarray([[[1, 2]], [[3, 4]]], dtype=dtype)
+def test_routed_expert_tensor_accepts_non_contiguous_arrays(tokenizer):
+    # Every other expert column, which leaves a non-contiguous view.
+    base = np.asarray([[[1, 9, 2, 9]], [[3, 9, 4, 9]]], dtype=np.uint8)
+    routes = base[:, :, ::2]
+    assert not routes.flags.c_contiguous
 
     *_, routed = convert_prompts_responses_to_batch_tensors(
         tokenizer.pad_token_id,
@@ -179,8 +179,24 @@ def test_routed_expert_tensor_narrows_wide_dtypes(tokenizer, dtype):
     assert routed.tolist() == [[[[1, 2]], [[3, 4]]]]
 
 
-def test_routed_expert_tensor_retightens_after_truncation(tokenizer):
-    """A truncated array can fit a narrower dtype than the wire declared."""
+@pytest.mark.parametrize("dtype", [np.uint16, np.int64])
+def test_routed_expert_tensor_rejects_non_canonical_dtypes(tokenizer, dtype):
+    """The sender compacts to the canonical dtype, so collation validates instead of rescanning."""
+    routes = np.asarray([[[1, 2]], [[3, 4]]], dtype=dtype)
+
+    with pytest.raises(ValueError, match="canonical routed-expert dtype"):
+        convert_prompts_responses_to_batch_tensors(
+            tokenizer.pad_token_id,
+            prompts=[[10]],
+            responses=[[11]],
+            rewards=[[0.0]],
+            loss_masks=[[1]],
+            rollout_expert_indices=[routes],
+        )
+
+
+def test_routed_expert_tensor_keeps_the_sender_dtype_after_truncation(tokenizer):
+    """A truncated array keeps the dtype the wire declared; nothing rescans it to retighten."""
     # int16 on the wire because of the trailing 300, which truncation then drops.
     routes = np.asarray([[[1, 2]], [[3, 4]], [[300, 5]]], dtype=np.int16)
 
@@ -193,8 +209,80 @@ def test_routed_expert_tensor_retightens_after_truncation(tokenizer):
         rollout_expert_indices=[routes[:2]],
     )
 
-    assert routed.dtype == torch.uint8
+    assert routed.dtype == torch.int16
     assert routed.tolist() == [[[[1, 2]], [[3, 4]]]]
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expert_id", "expect_warning"),
+    [(np.int16, 300, False), (np.int32, 2**16, True)],
+)
+def test_routed_expert_tensor_warns_only_on_an_int32_batch(tokenizer, caplog, dtype, expert_id, expect_warning):
+    routes = np.asarray([[[expert_id, expert_id + 1]]], dtype=dtype)
+
+    with caplog.at_level(logging.WARNING, logger="skyrl.train.dataset.preprocess"):
+        *_, routed = convert_prompts_responses_to_batch_tensors(
+            tokenizer.pad_token_id,
+            prompts=[[10]],
+            responses=[[11]],
+            rewards=[[0.0]],
+            loss_masks=[[1]],
+            rollout_expert_indices=[routes],
+        )
+
+    assert routed.dtype == ROUTED_EXPERT_TORCH_DTYPES[np.dtype(dtype)]
+    assert ("not compacting its routes" in caplog.text) is expect_warning
+
+
+def test_routed_expert_torch_dtype_map_covers_the_canonical_dtypes():
+    assert set(ROUTED_EXPERT_TORCH_DTYPES) == set(ROUTED_EXPERT_DTYPES)
+
+
+def _numpy_padded_routes(
+    routes: List[np.ndarray],
+    prompts: List[List[int]],
+    responses: List[List[int]],
+) -> np.ndarray:
+    """The route collation as NumPy expressed it: broadcast ``arange(topk)``, then write each sample."""
+    max_total = max(len(prompt) + len(response) for prompt, response in zip(prompts, responses))
+    num_layers, topk = routes[0].shape[1:]
+    batch_dtype = max((sample.dtype for sample in routes), key=lambda dtype: dtype.itemsize)
+    padded = np.empty((len(routes), max_total, num_layers, topk), dtype=batch_dtype)
+    padded[...] = np.arange(topk, dtype=batch_dtype)
+    for index, sample in enumerate(routes):
+        left_pad = max_total - (len(prompts[index]) + len(responses[index]))
+        padded[index, left_pad : left_pad + sample.shape[0]] = sample
+    return padded
+
+
+def test_routed_expert_tensor_is_bit_identical_to_numpy_collation(tokenizer):
+    """Left padding, a short route prefix and trailing padding, across a mixed-dtype batch."""
+    prompts = [[1, 2], [3, 4, 5, 6]]
+    responses = [[10, 11, 12], [20, 21]]
+    num_layers, topk = 2, 3
+    # Sample 0 has 5 tokens but only 4 captured route rows, so it pads on both sides.
+    routes = [
+        np.arange(4 * num_layers * topk, dtype=np.uint8).reshape(4, num_layers, topk),
+        (np.arange(6 * num_layers * topk, dtype=np.int16) + 300).reshape(6, num_layers, topk),
+    ]
+
+    *_, routed = convert_prompts_responses_to_batch_tensors(
+        tokenizer.pad_token_id,
+        prompts,
+        responses,
+        rewards=[[0.0] * 3, [0.0] * 2],
+        loss_masks=[[1] * 3, [1] * 2],
+        rollout_expert_indices=routes,
+    )
+
+    assert routed.dtype == torch.int16
+    assert torch.equal(routed, torch.from_numpy(_numpy_padded_routes(routes, prompts, responses)))
+    # Padding routes are topk distinct experts, which Megatron's dropless dispatcher requires;
+    # zeros would collapse them onto one expert.
+    padding_row = [[0, 1, 2]] * num_layers
+    assert routed[0, 0].tolist() == padding_row
+    assert routed[0, 5].tolist() == padding_row
+    assert not torch.equal(routed[0, 0], torch.zeros_like(routed[0, 0]))
 
 
 def test_convert_prompts_responses_to_batch_tensors_exact(tokenizer):

--- a/tests/train/generators/test_datatypes.py
+++ b/tests/train/generators/test_datatypes.py
@@ -31,7 +31,6 @@ def test_turn_output(output_ids, observation_ids, output_logprobs, added_eos, ex
         output_logprobs=output_logprobs,
         new_obs=[],
         obs_ids=observation_ids,
-        rollout_expert_indices=None,
         added_eos=added_eos,
         reward=1.0,
     )

--- a/tests/train/generators/test_skyrl_gym_generator.py
+++ b/tests/train/generators/test_skyrl_gym_generator.py
@@ -23,20 +23,17 @@ MOCK_LLM_OUTPUT_IDS = [1, 10, 12, 4]
 MOCK_TOKENIZER_ENCODED_IDS = [1, 2, 3, 4]
 
 
-def test_turn_output_keeps_uncaptured_suffix_out_of_routes():
-    routes = np.asarray([[[2, 3]], [[4, 5]]], dtype=np.uint8)
+def test_turn_output_masks_uncaptured_suffix():
     output = TurnOutput(
         output="answer",
         output_ids=[10, 11, 4],
         output_logprobs=None,
         new_obs=[],
         obs_ids=[20, 21],
-        rollout_expert_indices=routes,
         reward=1.0,
         added_eos=True,
     )
 
-    assert output.get_turn_rollout_expert_indices() is routes
     assert output.get_turn_loss_mask() == [1, 1, 0, 0, 0]
 
 
@@ -411,6 +408,63 @@ async def test_agent_loop_single_turn(
     else:
         assert output.reward == 1.0
     assert output.stop_reason == "stop"
+
+
+@pytest.mark.asyncio
+@patch("skyrl_gym.make")
+async def test_agent_loop_uses_incremental_routed_expert_trace(
+    mock_make,
+    mock_tokenizer,
+    mock_llm,
+    mock_env,
+    generator_cfg,
+    mock_env_cfg,
+):
+    generator_cfg.batched = False
+    generator_cfg.max_turns = 2
+    generator_cfg.use_conversation_multi_turn = True
+    generator_cfg.inference_engine.enable_return_routed_experts = True
+    mock_make.return_value = mock_env
+    mock_env.init.return_value = ([{"role": "user", "content": "Initial input"}], {})
+
+    mock_env.step.side_effect = [
+        BaseTextEnvStepOutput(observations=[{"role": "user", "content": "next"}], reward=1.0, done=done, metadata={})
+        for done in (False, True)
+    ]
+    prompt_starts = []
+
+    def generate(input_batch, model=None):
+        prompt_tokens = input_batch["prompt_token_ids"][0]
+        prompt_start = input_batch["routed_experts_prompt_starts"][0]
+        prompt_starts.append(prompt_start)
+        output_ids = [10, 11]
+        num_route_rows = len(prompt_tokens) - prompt_start + len(output_ids) - 1
+        routes = np.arange(num_route_rows * 4, dtype=np.int32).reshape(num_route_rows, 2, 2) % 8
+        return {
+            "responses": ["mocked output"],
+            "response_ids": [output_ids],
+            "stop_reasons": ["stop"],
+            "rollout_expert_indices": [routes],
+        }
+
+    mock_llm.generate = AsyncMock(side_effect=generate)
+    generator = SkyRLGymGenerator(
+        generator_cfg=generator_cfg,
+        skyrl_gym_cfg=mock_env_cfg,
+        inference_engine_client=mock_llm,
+        tokenizer=mock_tokenizer,
+    )
+    generator.base_conversation_token_ids = []
+
+    await generator.agent_loop(
+        [{"role": "user", "content": "Start"}],
+        mock_env_cfg.env_class,
+        {},
+        max_tokens=32,
+        max_input_length=64,
+    )
+
+    assert prompt_starts == [0, 5]
 
 
 @pytest.mark.asyncio

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -1198,8 +1198,6 @@ class TestDeltaWeightSyncConfig:
 
 
 class TestMegatronRouterReplayValidation:
-    """Router replay (R3) incompatibilities refused at submission time."""
-
     @staticmethod
     def _cfg():
         cfg = _make_validated_test_config()

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -26,6 +26,7 @@ from skyrl.train.utils.utils import (
     prepare_runtime_environment,
     validate_cfg,
     validate_inference_engine_cfg,
+    validate_megatron_cfg,
 )
 from tests.train.util import example_dummy_config
 
@@ -1194,3 +1195,37 @@ class TestDeltaWeightSyncConfig:
         # `publish_staging_dir` and `local_checkpoint_dir` should be constructed based on `sync_dir`
         assert "my_sync_dir" in cfg.publish_staging_dir
         assert "my_sync_dir" in cfg.local_checkpoint_dir
+
+
+class TestMegatronRouterReplayValidation:
+    """Router replay (R3) incompatibilities refused at submission time."""
+
+    @staticmethod
+    def _cfg():
+        cfg = _make_validated_test_config()
+        cfg.trainer.strategy = "megatron"
+        cfg.generator.inference_engine.enable_return_routed_experts = True
+        cfg.trainer.policy.megatron_config.moe_enable_routing_replay = True
+        return cfg
+
+    @pytest.mark.parametrize("vpp_size", [1, 2])
+    def test_routing_replay_refuses_virtual_pipeline_parallelism(self, vpp_size):
+        cfg = self._cfg()
+        cfg.trainer.policy.megatron_config.transformer_config_kwargs["virtual_pipeline_model_parallel_size"] = vpp_size
+
+        with pytest.raises(AssertionError, match="virtual_pipeline_model_parallel_size"):
+            validate_megatron_cfg(cfg)
+
+    @pytest.mark.parametrize("vpp_size", [None, 0])
+    def test_routing_replay_allows_unset_virtual_pipeline_parallelism(self, vpp_size):
+        cfg = self._cfg()
+        cfg.trainer.policy.megatron_config.transformer_config_kwargs["virtual_pipeline_model_parallel_size"] = vpp_size
+
+        validate_megatron_cfg(cfg)
+
+    def test_virtual_pipeline_parallelism_allowed_without_routing_replay(self):
+        cfg = self._cfg()
+        cfg.trainer.policy.megatron_config.moe_enable_routing_replay = False
+        cfg.trainer.policy.megatron_config.transformer_config_kwargs["virtual_pipeline_model_parallel_size"] = 2
+
+        validate_megatron_cfg(cfg)

--- a/tests/utils/test_cpu_topology.py
+++ b/tests/utils/test_cpu_topology.py
@@ -13,7 +13,6 @@ from skyrl.utils.cpu_topology import cgroup_cpu_quota, permitted_cpu_cores, pool
 
 @pytest.fixture
 def cgroup_paths(monkeypatch, tmp_path: Path):
-    """Point every cgroup path at a fixture directory; each file is absent until written."""
     paths = {
         "CGROUP_V2_CPU_MAX_PATH": tmp_path / "cpu.max",
         "CGROUP_V1_CPU_QUOTA_PATH": tmp_path / "cpu.cfs_quota_us",
@@ -24,30 +23,18 @@ def cgroup_paths(monkeypatch, tmp_path: Path):
     return paths
 
 
-def test_cgroup_v2_quota(cgroup_paths):
-    cgroup_paths["CGROUP_V2_CPU_MAX_PATH"].write_text("400000 100000\n")
+@pytest.mark.parametrize(
+    ("version", "quota", "expected"),
+    [(2, "400000", 4), (2, "max", None), (1, "200000", 2), (1, "-1", None)],
+)
+def test_cgroup_quota(cgroup_paths, version, quota, expected):
+    if version == 2:
+        cgroup_paths["CGROUP_V2_CPU_MAX_PATH"].write_text(f"{quota} 100000\n")
+    else:
+        cgroup_paths["CGROUP_V1_CPU_QUOTA_PATH"].write_text(f"{quota}\n")
+        cgroup_paths["CGROUP_V1_CPU_PERIOD_PATH"].write_text("100000\n")
 
-    assert cgroup_cpu_quota() == 4
-
-
-def test_cgroup_v2_max_literal_is_unlimited(cgroup_paths):
-    cgroup_paths["CGROUP_V2_CPU_MAX_PATH"].write_text("max 100000\n")
-
-    assert cgroup_cpu_quota() is None
-
-
-def test_cgroup_v1_quota(cgroup_paths):
-    cgroup_paths["CGROUP_V1_CPU_QUOTA_PATH"].write_text("200000\n")
-    cgroup_paths["CGROUP_V1_CPU_PERIOD_PATH"].write_text("100000\n")
-
-    assert cgroup_cpu_quota() == 2
-
-
-def test_cgroup_v1_negative_quota_is_unlimited(cgroup_paths):
-    cgroup_paths["CGROUP_V1_CPU_QUOTA_PATH"].write_text("-1\n")
-    cgroup_paths["CGROUP_V1_CPU_PERIOD_PATH"].write_text("100000\n")
-
-    assert cgroup_cpu_quota() is None
+    assert cgroup_cpu_quota() == expected
 
 
 def test_missing_cgroup_files(cgroup_paths):

--- a/tests/utils/test_cpu_topology.py
+++ b/tests/utils/test_cpu_topology.py
@@ -1,0 +1,114 @@
+"""
+uv run --isolated --extra dev pytest tests/utils/test_cpu_topology.py
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from skyrl.utils import cpu_topology
+from skyrl.utils.cpu_topology import cgroup_cpu_quota, permitted_cpu_cores, pool_workers
+
+
+@pytest.fixture
+def cgroup_paths(monkeypatch, tmp_path: Path):
+    """Point every cgroup path at a fixture directory; each file is absent until written."""
+    paths = {
+        "CGROUP_V2_CPU_MAX_PATH": tmp_path / "cpu.max",
+        "CGROUP_V1_CPU_QUOTA_PATH": tmp_path / "cpu.cfs_quota_us",
+        "CGROUP_V1_CPU_PERIOD_PATH": tmp_path / "cpu.cfs_period_us",
+    }
+    for name, path in paths.items():
+        monkeypatch.setattr(cpu_topology, name, str(path))
+    return paths
+
+
+def test_cgroup_v2_quota(cgroup_paths):
+    cgroup_paths["CGROUP_V2_CPU_MAX_PATH"].write_text("400000 100000\n")
+
+    assert cgroup_cpu_quota() == 4
+
+
+def test_cgroup_v2_max_literal_is_unlimited(cgroup_paths):
+    cgroup_paths["CGROUP_V2_CPU_MAX_PATH"].write_text("max 100000\n")
+
+    assert cgroup_cpu_quota() is None
+
+
+def test_cgroup_v1_quota(cgroup_paths):
+    cgroup_paths["CGROUP_V1_CPU_QUOTA_PATH"].write_text("200000\n")
+    cgroup_paths["CGROUP_V1_CPU_PERIOD_PATH"].write_text("100000\n")
+
+    assert cgroup_cpu_quota() == 2
+
+
+def test_cgroup_v1_negative_quota_is_unlimited(cgroup_paths):
+    cgroup_paths["CGROUP_V1_CPU_QUOTA_PATH"].write_text("-1\n")
+    cgroup_paths["CGROUP_V1_CPU_PERIOD_PATH"].write_text("100000\n")
+
+    assert cgroup_cpu_quota() is None
+
+
+def test_missing_cgroup_files(cgroup_paths):
+    assert cgroup_cpu_quota() is None
+
+
+def test_unreadable_cgroup_values(cgroup_paths):
+    cgroup_paths["CGROUP_V2_CPU_MAX_PATH"].write_text("not-a-quota 100000\n")
+    cgroup_paths["CGROUP_V1_CPU_QUOTA_PATH"].write_text("")
+    cgroup_paths["CGROUP_V1_CPU_PERIOD_PATH"].write_text("")
+
+    assert cgroup_cpu_quota() is None
+
+
+@pytest.mark.parametrize(("quota", "expected"), [(150000, 1), (50000, 1), (100000, 1), (250000, 2)])
+def test_fractional_quota_floors_to_at_least_one(cgroup_paths, quota, expected):
+    cgroup_paths["CGROUP_V2_CPU_MAX_PATH"].write_text(f"{quota} 100000\n")
+
+    assert cgroup_cpu_quota() == expected
+
+
+@pytest.mark.parametrize(("affinity", "quota_cpus", "expected"), [(16, 4, 4), (4, 16, 4), (8, 8, 8)])
+def test_permitted_cores_is_the_lesser_of_affinity_and_quota(cgroup_paths, monkeypatch, affinity, quota_cpus, expected):
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: set(range(affinity)))
+    cgroup_paths["CGROUP_V2_CPU_MAX_PATH"].write_text(f"{quota_cpus * 100000} 100000\n")
+
+    assert permitted_cpu_cores() == expected
+
+
+def test_permitted_cores_without_quota_is_the_affinity_mask(cgroup_paths, monkeypatch):
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: set(range(12)))
+
+    assert permitted_cpu_cores() == 12
+
+
+@pytest.mark.parametrize(
+    ("cap", "reserved", "cores", "expected"),
+    [
+        (32, 8, 64, 32),  # cap binds
+        (32, 8, 24, 16),  # reserve binds
+        (32, 8, 8, 1),  # reserve would leave nothing, so keep one worker
+        (1, 0, 64, 1),  # cap of one
+    ],
+)
+def test_pool_workers(cap, reserved, cores, expected):
+    assert pool_workers(cap=cap, reserved=reserved, cores=cores) == expected
+
+
+def test_pool_workers_defaults_to_permitted_cores(cgroup_paths, monkeypatch):
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: set(range(64)))
+    cgroup_paths["CGROUP_V2_CPU_MAX_PATH"].write_text("1200000 100000\n")
+
+    assert pool_workers(cap=32, reserved=4) == 8
+
+
+@pytest.mark.parametrize("cap", [0, -1])
+def test_pool_workers_rejects_non_positive_cap(cap):
+    with pytest.raises(ValueError, match="cap must be positive"):
+        pool_workers(cap=cap, reserved=0, cores=8)
+
+
+def test_pool_workers_rejects_negative_reserve():
+    with pytest.raises(ValueError, match="reserved cores must be non-negative"):
+        pool_workers(cap=8, reserved=-1, cores=8)


### PR DESCRIPTION
> **Note on the diff:** This PR is part of a routed-expert-replay / sampler-support series and builds on the PRs below. GitHub cannot show the intermediate branches here, so the diff is cumulative on top of main — the changes *new to this PR* sit on top of:
>
> - #1911 — refactor extract RemoteInferenceGenerator
> - #1912 — refactor assemble routed-expert traces incrementally
>
> Reviewing in PR order (lowest number first) shows each incremental change cleanly.

## Problem

Routed-expert replay arrives as one variable-length NumPy array per trajectory. Collating those arrays into the left-padded global training batch is dominated by allocating and first-touching a large route buffer. The previous serial path also rebuilt padding intermediates and rescanned route IDs even though the inference boundary had already selected a canonical integer dtype.

Separately, replay is unsafe with Megatron virtual pipeline parallelism. Each forward appends a microbatch to every local replay FIFO, while an interleaved model chunk consumes only its own entry during backward. The queues can therefore desynchronize without an immediate crash.

## Implementation

- Add affinity- and cgroup-aware CPU discovery for both cgroup v2 and v1.
- Size controller-side pools from the usable CPU allocation, reserving capacity for colocated services.
- Fill disjoint trajectory regions through a bounded thread pool; worker exceptions are propagated to the caller.
- Allocate the final route tensor once, write canonical route arrays directly, and fill only left-padding and uncaptured suffix rows with valid dummy routes.
- Reuse the CPU-topology helper for checkpoint delta workers, where the operation is already a barrier and does not need a core reserve.
- Reject routed-expert replay with virtual pipeline sizes greater than one after Megatron configuration resolution, so provider defaults cannot bypass validation.

The sender remains responsible for route compaction. Collation validates the accepted `uint8`, `int16`, and `int32` dtypes and promotes a mixed batch to the widest input dtype without another value scan.

## Performance

The included packed-route collation benchmark compares identical outputs across serial and pooled implementations. On a 32-core host with `OMP_NUM_THREADS=1`, a representative 40-layer global batch improved from **29.61 s to 3.35 s** (median of five runs).

The result depends on the controller running with one OpenMP thread, as it does under its one-CPU Ray allocation. With unrestricted library threads, the pool can oversubscribe the container and lose performance; the worker cap and cgroup-aware sizing make that dependency explicit.

## Testing

- CPU-topology tests cover affinity, cgroup v1/v2 quotas, unlimited and malformed limits, core reservation, and pool caps.
- Parallel-fill tests cover serial and parallel execution, disjoint ownership, worker limits, empty inputs, and exception propagation.
- Preprocessing tests cover route padding, dtype preservation and promotion, non-contiguous arrays, mismatched shapes, and invalid route lengths.
- Configuration tests cover both explicit and provider-resolved virtual pipeline settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MoE rollout→train route bookkeeping and batch collation (correctness-sensitive) plus Megatron replay config guards; parallel CPU pools affect performance but not model math.
> 
> **Overview**
> **Routed-expert (R3) replay** now stitches multi-turn rollouts incrementally: `RoutedExpertTrace` / `TokenMetadataTrace` accumulate per-token route rows, the gym generator sends `routed_experts_prompt_starts` on each LLM call, and `RemoteGenerateClient` owns the HTTP generate path (including `routed_experts_prompt_start` in sampling params). Collation no longer rescans or re-compacts routes at batch time—it validates canonical `uint8`/`int16`/`int32` arrays and packs them in parallel.
> 
> **Performance:** New `cpu_topology` sizes thread pools from process affinity and cgroup CPU limits; `fill_batch_rows` fills disjoint trajectory slices in a bounded pool (with core reserve for Ray). Route tensors are allocated once and written directly, with torch `replay_padding_row` for left/right padding; the NumPy padding helper is removed. Delta checkpoint apply/publish pools use the same helper with zero reserve.
> 
> **Safety:** MoE routing replay is rejected when virtual pipeline parallelism is &gt; 1 (config validation and Megatron provider resolution), because interleaved chunks can desync `RouterReplay`’s backward FIFO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d95e2020166451f591a025aa25cc887491e5d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->