### PR TITLE
[train] FSDP2: wrap only input embeddings, not every nn.Embedding (fixes glm4v)

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/fsdp_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/fsdp_utils.py
@@ -223,16 +223,34 @@ def apply_fsdp2(model, fsdp_kwargs, config: Union[FSDPConfig, DictConfig]):
 
     assert len(fsdp_transformer_layer_cls_to_wrap) > 0 and fsdp_transformer_layer_cls_to_wrap[0] is not None
 
-    modules = []
-    for name, module in model.named_modules():
-        if module.__class__.__name__ in fsdp_transformer_layer_cls_to_wrap or (
-            isinstance(module, nn.Embedding) and not model.config.tie_word_embeddings
-        ):
-            modules.append(module)
+    modules = modules_to_wrap_fsdp2(model, fsdp_transformer_layer_cls_to_wrap)
 
     for idx, module in enumerate(modules):
         fully_shard(module, **fsdp_kwargs)
     fully_shard(model, **fsdp_kwargs)  # fsdp2 will not reshard_after_forward for root module
+
+
+def modules_to_wrap_fsdp2(model, transformer_layer_cls_to_wrap) -> list:
+    """Select the modules that get their own fully_shard group.
+
+    Only the INPUT (word) embeddings get a dedicated group, not every
+    nn.Embedding: a per-module group unshards its params in that module's
+    own forward pre-hook, so an embedding whose weight is read RAW from a
+    parent forward is still a sharded DTensor at access time. GLM4V's vision
+    position_embedding is exactly that (modeling_glm4v reads .weight and
+    feeds it to F.grid_sample, which has no DTensor rule -> "aten.
+    grid_sampler_2d.default got mixed torch.Tensor and DTensor"). Left
+    unwrapped, it lands in the root group, whose params are plain unsharded
+    tensors for the whole forward.
+    """
+    input_embeddings = model.get_input_embeddings() if hasattr(model, "get_input_embeddings") else None
+    modules = []
+    for name, module in model.named_modules():
+        if module.__class__.__name__ in transformer_layer_cls_to_wrap or (
+            module is input_embeddings and not model.config.tie_word_embeddings
+        ):
+            modules.append(module)
+    return modules
 
 
 def fsdp2_clip_grad_norm_(parameters, max_norm, norm_type=2.0, error_if_nonfinite=False, foreach=None):

--- a/tests/backends/skyrl_train/distributed/test_fsdp2_wrap_selection.py
+++ b/tests/backends/skyrl_train/distributed/test_fsdp2_wrap_selection.py
@@ -1,0 +1,69 @@
+"""FSDP2 wrap selection: only input embeddings get a dedicated shard group.
+
+Pins the fix for the GLM-4.6V-Flash crash `aten.grid_sampler_2d.default got
+mixed torch.Tensor and DTensor`: wrapping EVERY nn.Embedding gave GLM4V's
+vision position_embedding its own group, and its weight (read raw from the
+parent forward, never via its own forward) stayed a sharded DTensor when it
+reached F.grid_sample.
+"""
+
+import torch.nn as nn
+
+from skyrl.backends.skyrl_train.distributed.fsdp_utils import modules_to_wrap_fsdp2
+
+
+class _Cfg:
+    tie_word_embeddings = False
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(4, 4)
+
+
+class VisionEmbeddings(nn.Module):
+    """Like Glm4vVisionEmbeddings: holds an nn.Embedding whose weight is read raw."""
+
+    def __init__(self):
+        super().__init__()
+        self.position_embedding = nn.Embedding(16, 4)
+
+
+class TinyVLM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = _Cfg()
+        self.embed_tokens = nn.Embedding(32, 4)
+        self.layer0 = DecoderLayer()
+        self.layer1 = DecoderLayer()
+        self.vision_embed = VisionEmbeddings()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+
+def test_only_input_embeddings_and_layers_get_groups():
+    m = TinyVLM()
+    wrapped = modules_to_wrap_fsdp2(m, ["DecoderLayer"])
+    assert m.embed_tokens in wrapped  # word embeddings keep their group
+    assert m.layer0 in wrapped and m.layer1 in wrapped
+    assert m.vision_embed.position_embedding not in wrapped  # the GLM crash case
+    assert len(wrapped) == 3
+
+
+def test_tied_embeddings_not_wrapped():
+    m = TinyVLM()
+    m.config.tie_word_embeddings = True
+    wrapped = modules_to_wrap_fsdp2(m, ["DecoderLayer"])
+    assert m.embed_tokens not in wrapped
+
+
+def test_model_without_get_input_embeddings():
+    m = TinyVLM()
+    del TinyVLM.get_input_embeddings
+    try:
+        wrapped = modules_to_wrap_fsdp2(m, ["DecoderLayer"])
+        assert len(wrapped) == 2  # just the layers; no embedding claimed
+    finally:
+        TinyVLM.get_input_embeddings = lambda self: self.embed_tokens


### PR DESCRIPTION
Fixes #2087.

## What

`apply_fsdp2` wrapped every untied `nn.Embedding` in its own `fully_shard` group. This PR narrows that to `model.get_input_embeddings()` only, via a new `modules_to_wrap_fsdp2()` selection function, plus unit tests.

## Why

A per-module group unshards its params only in that module's own forward pre-hook. GLM4V's vision `position_embedding` weight is read raw from the parent forward and fed to `F.grid_sample` (no DTensor rule), so any `glm4v` model crashes at the first training forward:

```
RuntimeError: aten.grid_sampler_2d.default got mixed torch.Tensor and DTensor
```

Measured on GLM-4.6V-Flash (4x H200, transformers 5.8.0, GRPO multi-turn); details and mechanism in #2087.

## Behavior change

None for existing models: for any model whose only `nn.Embedding` is the input embedding (all text models; Qwen-VL vision towers use conv patch embeds), the selected module set is byte-identical. Auxiliary embeddings (the GLM4V vision table) now land in the root group — plain unsharded tensors during forward, which is the fix; the cost is that table staying unsharded through the forward (~1M params for glm4v).

Note this logic was adapted from verl, and verl main carries the same latent bug in `_select_fsdp2_wrap_targets`; verl avoids it only because its default strategy is still FSDP1 (`dp_actor.yaml` has `TODO(haibin.lin): switch to fsdp2`). Same fix applies there.

## Tests

`tests/backends/skyrl_train/distributed/test_fsdp2_wrap_selection.py`:
- input embeddings + configured layer classes selected
- auxiliary `nn.Embedding` inside a vision-embeddings-style module NOT selected (the crash case)
- tied embeddings not selected
- model without `get_input_embeddings` handled

With the fix, a GLM-4.6V-Flash GRPO run proceeds past the training forward that crashes on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FSDP2 wrap selection, which affects how parameters are sharded during training. Scope is small and behavior is intended to be identical for models whose only embedding is the input table.
> 
> **Overview**
> Fixes GLM-4V FSDP2 training crashing with mixed Tensor/DTensor on `F.grid_sample` by no longer giving every `nn.Embedding` its own `fully_shard` group.
> 
> `apply_fsdp2` now selects wrap targets via `modules_to_wrap_fsdp2`: transformer layers plus `get_input_embeddings()` when embeddings are untied. Auxiliary embeddings (e.g. GLM4V vision `position_embedding`, whose weight is read from a parent forward) stay in the root group so they are unsharded during forward. Typical text / Qwen-VL wrap sets are unchanged.
> 
> Adds unit tests covering input vs vision embeddings, tied embeddings, and models without `get_input_embeddings`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e4e874f7da4220d278ffbc04e13b286d1788769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->