### PR TITLE
[fsdp] Trim dense padding per final microbatch

### DIFF
--- a/skyrl/backends/skyrl_train/workers/worker.py
+++ b/skyrl/backends/skyrl_train/workers/worker.py
@@ -54,6 +54,7 @@ from skyrl.backends.skyrl_train.workers.worker_utils import (
     compute_minibatch_rollout_logprob_diff_metrics,
     get_microbatch_iterator,
     reduce_metrics,
+    restore_microbatch_response_padding,
 )
 from skyrl.env_vars import (
     SKYRL_RAY_PG_TIMEOUT_IN_S,
@@ -870,6 +871,7 @@ class PolicyWorkerBase(Worker):
             data,
             micro_batch_size=self.cfg.micro_train_batch_size_per_gpu,
             max_tokens_per_microbatch=self.cfg.max_tokens_per_microbatch,
+            trim_padding=self.cfg.strategy == "fsdp" and not self.cfg.remove_microbatch_padding,
         )
         all_metrics = defaultdict(list)
         all_loss_fn_outputs = []  # Handle separately from scalar metrics
@@ -1174,6 +1176,7 @@ class PolicyWorkerBase(Worker):
                 data,
                 micro_batch_size=self.cfg.micro_forward_batch_size_per_gpu,
                 max_tokens_per_microbatch=self.cfg.max_tokens_per_microbatch,
+                trim_padding=self.cfg.strategy == "fsdp" and not self.cfg.remove_microbatch_padding,
             )
             outputs = [self._forward_micro_batch(micro_batch) for micro_batch in microbatch_iterator]
             output = microbatch_iterator.reorder_and_combine_batches(outputs)
@@ -1187,7 +1190,12 @@ class PolicyWorkerBase(Worker):
         all_metrics = defaultdict(list)
         all_loss_fn_outputs: List[Dict[str, Any]] = []
 
-        for micro_batch in BatchIterator(data, micro_batch_size, drop_last=False):
+        for micro_batch in BatchIterator(
+            data,
+            micro_batch_size,
+            drop_last=False,
+            trim_padding=self.cfg.strategy == "fsdp" and not self.cfg.remove_microbatch_padding,
+        ):
             metrics = self._forward_micro_with_loss(
                 micro_batch,
                 loss_fn=loss_fn,
@@ -1331,6 +1339,7 @@ class PolicyWorkerBase(Worker):
                 image_grid_thw=image_grid_thw,
             )
         policy_logprob = policy_logprob.to("cpu")
+        policy_logprob = restore_microbatch_response_padding(policy_logprob, micro_batch.metadata)
         output = TrainingOutputBatch(
             {"output": policy_logprob},
         )
@@ -1426,6 +1435,7 @@ class CriticWorkerBase(Worker):
             data,
             micro_batch_size=self.cfg.micro_train_batch_size_per_gpu,
             max_tokens_per_microbatch=self.cfg.max_tokens_per_microbatch,
+            trim_padding=self.cfg.strategy == "fsdp" and not self.cfg.remove_microbatch_padding,
         )
         all_metrics = defaultdict(list)
 
@@ -1555,6 +1565,7 @@ class CriticWorkerBase(Worker):
             )
         self.model.train()  # reset model state
         value = value.to("cpu")
+        value = restore_microbatch_response_padding(value, micro_batch.metadata)
         output = TrainingOutputBatch(
             {"output": value},
         )
@@ -1574,6 +1585,7 @@ class CriticWorkerBase(Worker):
             data,
             micro_batch_size=self.cfg.micro_forward_batch_size_per_gpu,
             max_tokens_per_microbatch=self.cfg.max_tokens_per_microbatch,
+            trim_padding=self.cfg.strategy == "fsdp" and not self.cfg.remove_microbatch_padding,
         )
         outputs = [self._forward_micro_batch(micro_batch) for micro_batch in microbatch_iterator]
         output = microbatch_iterator.reorder_and_combine_batches(outputs)
@@ -1605,6 +1617,7 @@ class RefWorkerBase(Worker):
             data,
             micro_batch_size=self.cfg.micro_forward_batch_size_per_gpu,
             max_tokens_per_microbatch=self.cfg.max_tokens_per_microbatch,
+            trim_padding=self.cfg.strategy == "fsdp" and not self.cfg.remove_microbatch_padding,
         )
         outputs = [self._forward_micro_batch(micro_batch) for micro_batch in microbatch_iterator]
         output = microbatch_iterator.reorder_and_combine_batches(outputs)
@@ -1632,6 +1645,7 @@ class RefWorkerBase(Worker):
                 image_grid_thw=image_grid_thw,
             )
         log_probs = log_probs.to("cpu")
+        log_probs = restore_microbatch_response_padding(log_probs, micro_batch.metadata)
         output = TrainingOutputBatch(
             {"output": log_probs},
         )

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -11,6 +11,30 @@ from skyrl.backends.skyrl_train.utils.torch_utils import masked_mean
 from skyrl.train.dataset.bin_packing import make_seq_packer
 from skyrl.train.dataset.replay_buffer import Experience
 
+_SEQUENCE_FIELDS = frozenset(
+    {
+        "sequences",
+        "attention_mask",
+        "rollout_expert_indices",
+        "router_padding_mask",
+    }
+)
+_RESPONSE_FIELDS = frozenset(
+    {
+        "action_log_probs",
+        "base_action_log_probs",
+        "values",
+        "returns",
+        "advantages",
+        "kl",
+        "rewards",
+        "loss_mask",
+        "response_mask",
+        "rollout_logprobs",
+    }
+)
+_PADDED_RESPONSE_LENGTH = "response_length_before_microbatch_trim"
+
 # Metrics that end in `_loss` but are plain per-token MEANS, not pre-scaled minibatch sums.
 # The `sum_loss_metrics` convention sums every `_loss` key because the *policy* losses are
 # pre-scaled (by num_microbatches * dp_size) so that summing recovers the correct minibatch
@@ -130,11 +154,87 @@ def all_reduce_metrics(
     return status_mean
 
 
+def trim_microbatch_padding(batch: TrainingInputBatch) -> TrainingInputBatch:
+    """Project a left-padded batch to the final microbatch's local widths.
+
+    The controller keeps one rectangular representation for advantage calculation,
+    dispatch, and replay metadata. Dense FSDP forwards do not remove padding inside
+    the model, so they should receive a view padded only to the longest sequence and
+    response in the final microbatch.
+
+    Packed rows and batches without an explicit ``response_mask`` retain their
+    original representation because their response boundary cannot be recovered
+    from ``loss_mask`` (which may contain semantic zeros).
+    """
+    attention_mask = batch.get("attention_mask")
+    response_mask = batch.get("response_mask")
+    if (
+        attention_mask is None
+        or response_mask is None
+        or len(batch) == 0
+        or batch.get("sub_seq_lengths") is not None
+        or (batch.metadata or {}).get("is_padding_batch", False)
+    ):
+        return batch
+    if attention_mask.ndim != 2 or response_mask.ndim != 2:
+        raise ValueError(
+            "Expected 2D attention_mask and response_mask for microbatch trimming, "
+            f"got {attention_mask.shape} and {response_mask.shape}"
+        )
+
+    sequence_length = int(attention_mask.sum(dim=1).max().item())
+    response_length = int(response_mask.sum(dim=1).max().item())
+    if sequence_length <= 0 or response_length <= 0:
+        return batch
+    if sequence_length < response_length + 1:
+        raise ValueError(
+            f"Microbatch sequence length ({sequence_length}) must exceed response length ({response_length})"
+        )
+
+    sequence_width = attention_mask.shape[1]
+    response_width = response_mask.shape[1]
+    if sequence_length == sequence_width and response_length == response_width:
+        return batch
+
+    projected = {}
+    for key, value in batch.items():
+        if isinstance(value, torch.Tensor) and key in _SEQUENCE_FIELDS:
+            projected[key] = value[:, -sequence_length:]
+        elif isinstance(value, torch.Tensor) and key in _RESPONSE_FIELDS:
+            projected[key] = value[:, -response_length:]
+        else:
+            projected[key] = value
+
+    microbatch = TrainingInputBatch(projected)
+    microbatch.metadata = dict(batch.metadata or {})
+    microbatch.metadata[_PADDED_RESPONSE_LENGTH] = response_width
+    microbatch.metadata["response_length"] = response_length
+    return microbatch
+
+
+def restore_microbatch_response_padding(tensor: torch.Tensor, metadata: Optional[dict]) -> torch.Tensor:
+    """Restore a microbatch output to the controller batch's response width."""
+    if metadata is None or _PADDED_RESPONSE_LENGTH not in metadata:
+        return tensor
+    if tensor.ndim != 2:
+        raise ValueError(f"Expected a [batch, response] output, got shape {tuple(tensor.shape)}")
+    padded_length = metadata[_PADDED_RESPONSE_LENGTH]
+    if tensor.shape[-1] > padded_length:
+        raise ValueError(f"Cannot restore response width {tensor.shape[-1]} to smaller width {padded_length}")
+    if tensor.shape[-1] == padded_length:
+        return tensor
+    return torch.nn.functional.pad(tensor, (padded_length - tensor.shape[-1], 0))
+
+
 class BaseBatchIterator:
     """Base class for batch iterators that chunk a TrainingInputBatch into microbatches."""
 
-    def __init__(self, data: TrainingInputBatch):
+    def __init__(self, data: TrainingInputBatch, trim_padding: bool = False):
         self.data = data
+        self.trim_padding = trim_padding
+
+    def _project(self, batch: TrainingInputBatch) -> TrainingInputBatch:
+        return trim_microbatch_padding(batch) if self.trim_padding else batch
 
     def __len__(self):
         raise NotImplementedError
@@ -186,8 +286,14 @@ class BatchIterator(BaseBatchIterator):
     This is the original sample-based iterator. Kept as an alias for SampleBasedBatchIterator.
     """
 
-    def __init__(self, data: TrainingInputBatch, sample_batch_size: int, drop_last: bool = False):
-        super().__init__(data)
+    def __init__(
+        self,
+        data: TrainingInputBatch,
+        sample_batch_size: int,
+        drop_last: bool = False,
+        trim_padding: bool = False,
+    ):
+        super().__init__(data, trim_padding=trim_padding)
         self.sample_batch_size = sample_batch_size
         self.total_batch_size = data.batch_size
         self.drop_last = drop_last
@@ -206,7 +312,7 @@ class BatchIterator(BaseBatchIterator):
 
     def __next__(self) -> Experience:
         try:
-            batch = next(self._iter)
+            batch = self._project(next(self._iter))
             exp = self.batch_to_experience(batch)
             return exp
         except StopIteration:
@@ -224,8 +330,14 @@ class SampleBasedBatchIterator(BaseBatchIterator):
     Yields TrainingInputBatch objects (not Experience), unlike the legacy BatchIterator.
     """
 
-    def __init__(self, data: TrainingInputBatch, sample_batch_size: int, drop_last: bool = False):
-        super().__init__(data)
+    def __init__(
+        self,
+        data: TrainingInputBatch,
+        sample_batch_size: int,
+        drop_last: bool = False,
+        trim_padding: bool = False,
+    ):
+        super().__init__(data, trim_padding=trim_padding)
         self.sample_batch_size = sample_batch_size
         self.total_batch_size = data.batch_size
         self.drop_last = drop_last
@@ -238,7 +350,7 @@ class SampleBasedBatchIterator(BaseBatchIterator):
         return self.num_micro_batches
 
     def __iter__(self) -> Iterator[TrainingInputBatch]:
-        return iter(self._chunks)
+        return (self._project(chunk) for chunk in self._chunks)
 
     def reorder_and_combine_batches(self, batches: List[TensorBatch]) -> TensorBatch:
         """Concatenate output batches. No reordering needed for sample-based splitting."""
@@ -257,13 +369,14 @@ class TokenBasedBatchIterator(BaseBatchIterator):
         self,
         data: TrainingInputBatch,
         max_tokens_per_microbatch: int,
+        trim_padding: bool = False,
     ):
         """
         Args:
             data: The training input batch to chunk.
             max_tokens_per_microbatch: Maximum number of tokens per microbatch.
         """
-        super().__init__(data)
+        super().__init__(data, trim_padding=trim_padding)
         self._max_tokens_per_microbatch = max_tokens_per_microbatch
 
         # Compute token counts per sample using attention_mask
@@ -291,7 +404,7 @@ class TokenBasedBatchIterator(BaseBatchIterator):
                 selected_data[key] = value[indices_tensor]
         microbatch = TrainingInputBatch(selected_data)
         microbatch.metadata = self.data.metadata
-        return microbatch
+        return self._project(microbatch)
 
     def _create_padding_microbatch(self) -> TrainingInputBatch:
         """Create a padding microbatch with loss_mask=0 so it doesn't affect the loss."""
@@ -426,7 +539,10 @@ class TokenBasedBatchIterator(BaseBatchIterator):
 
 
 def get_microbatch_iterator(
-    data: TrainingInputBatch, micro_batch_size: int, max_tokens_per_microbatch: int
+    data: TrainingInputBatch,
+    micro_batch_size: int,
+    max_tokens_per_microbatch: int,
+    trim_padding: bool = False,
 ) -> BaseBatchIterator:
     """Factory function to get the appropriate microbatch iterator.
 
@@ -434,11 +550,21 @@ def get_microbatch_iterator(
         data: The training input batch.
         micro_batch_size: Number of samples per microbatch (used if max_tokens_per_microbatch <= 0).
         max_tokens_per_microbatch: Maximum tokens per microbatch. If > 0, uses token-based batching.
+        trim_padding: Whether to project each microbatch to its local sequence and response widths.
 
     Returns:
         A BaseBatchIterator instance.
     """
     if max_tokens_per_microbatch > 0:
-        return TokenBasedBatchIterator(data, max_tokens_per_microbatch=max_tokens_per_microbatch)
+        return TokenBasedBatchIterator(
+            data,
+            max_tokens_per_microbatch=max_tokens_per_microbatch,
+            trim_padding=trim_padding,
+        )
     else:
-        return SampleBasedBatchIterator(data, sample_batch_size=micro_batch_size, drop_last=False)
+        return SampleBasedBatchIterator(
+            data,
+            sample_batch_size=micro_batch_size,
+            drop_last=False,
+            trim_padding=trim_padding,
+        )

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -1323,7 +1323,7 @@ class RayPPOTrainer:
             - `["action_log_probs"]`: Float[torch.Tensor, "batch_size response_len"]
             - `["values"]`: Float[torch.Tensor, "batch_size response_len"]
         """
-        fwd_keys = ["sequences", "attention_mask"]
+        fwd_keys = ["sequences", "attention_mask", "response_mask"]
         if training_input.get("rollout_expert_indices") is not None:
             fwd_keys.append("rollout_expert_indices")
         if training_input.get("router_padding_mask") is not None:

--- a/tests/backends/skyrl_train/test_token_based_batching_utils.py
+++ b/tests/backends/skyrl_train/test_token_based_batching_utils.py
@@ -9,12 +9,16 @@ uv run --isolated --extra dev --extra skyrl-train pytest tests/backends/skyrl_tr
 
 from typing import List
 
+import pytest
 import torch
 
 from skyrl.backends.skyrl_train.training_batch import TensorList, TrainingInputBatch
 from skyrl.backends.skyrl_train.workers.worker_utils import (
+    SampleBasedBatchIterator,
     TokenBasedBatchIterator,
     get_microbatch_iterator,
+    restore_microbatch_response_padding,
+    trim_microbatch_padding,
 )
 from skyrl.train.dataset.bin_packing import make_seq_packer
 
@@ -168,10 +172,6 @@ class TestTokenBasedBatchIterator:
         assert isinstance(it, TokenBasedBatchIterator)
 
         # Sample-based (disabled)
-        from skyrl.backends.skyrl_train.workers.worker_utils import (
-            SampleBasedBatchIterator,
-        )
-
         it = get_microbatch_iterator(batch, micro_batch_size=2, max_tokens_per_microbatch=-1)
         assert isinstance(it, SampleBasedBatchIterator)
 
@@ -232,3 +232,96 @@ class TestTokenBasedBatchIterator:
             assert len(pv) == microbatch["sequences"].shape[0]
             total_pv += len(pv)
         assert total_pv == batch_size  # every sample's pixel_values is accounted for
+
+    def test_trim_padding_uses_final_token_microbatch_widths(self):
+        batch = self._make_left_padded_batch()
+        iterator = TokenBasedBatchIterator(batch, max_tokens_per_microbatch=6, trim_padding=True)
+
+        microbatches = list(iterator)
+        short = next(mb for mb in microbatches if mb["attention_mask"].sum() == 2)
+
+        assert short["sequences"].shape == (1, 2)
+        assert short["sequences"].tolist() == [[11, 12]]
+        assert short["response_mask"].shape == (1, 1)
+        assert short["action_log_probs"].shape == (1, 1)
+        assert short["rollout_expert_indices"].shape == (1, 2, 1, 1)
+        assert short["router_padding_mask"].shape == (1, 2)
+        assert short.metadata["response_length"] == 1
+        assert short.metadata["response_length_before_microbatch_trim"] == 3
+
+        # The controller batch remains the canonical, full-width representation.
+        assert batch["sequences"].shape == (2, 6)
+        assert batch["response_mask"].shape == (2, 3)
+        assert batch.metadata == {"response_length": 3}
+
+    def test_trim_padding_applies_to_sample_microbatches(self):
+        batch = self._make_left_padded_batch()
+        iterator = SampleBasedBatchIterator(batch, sample_batch_size=1, trim_padding=True)
+
+        short = next(iter(iterator))
+
+        assert short["sequences"].shape == (1, 2)
+        assert short["response_mask"].shape == (1, 1)
+        assert short.metadata["response_length"] == 1
+
+    def test_restore_response_padding_preserves_output_contract(self):
+        batch = self._make_left_padded_batch()
+        iterator = SampleBasedBatchIterator(batch, sample_batch_size=1, trim_padding=True)
+        short = next(iter(iterator))
+
+        local_output = torch.tensor([[0.25]])
+        restored = restore_microbatch_response_padding(local_output, short.metadata)
+
+        assert restored.tolist() == [[0.0, 0.0, 0.25]]
+
+    def test_trim_padding_empty_batch_is_noop(self):
+        batch = TrainingInputBatch(
+            {
+                "sequences": torch.empty((0, 6), dtype=torch.long),
+                "attention_mask": torch.empty((0, 6), dtype=torch.long),
+                "response_mask": torch.empty((0, 3), dtype=torch.long),
+            }
+        )
+
+        assert trim_microbatch_padding(batch) is batch
+
+    def test_restore_response_padding_rejects_non_matrix_output(self):
+        with pytest.raises(ValueError, match=r"Expected a \[batch, response\] output"):
+            restore_microbatch_response_padding(
+                torch.zeros((1, 2, 8)),
+                {"response_length_before_microbatch_trim": 3},
+            )
+
+    @staticmethod
+    def _make_left_padded_batch():
+        sequences = torch.tensor(
+            [
+                [0, 0, 0, 0, 11, 12],
+                [21, 22, 23, 24, 25, 26],
+            ]
+        )
+        attention_mask = torch.tensor(
+            [
+                [0, 0, 0, 0, 1, 1],
+                [1, 1, 1, 1, 1, 1],
+            ]
+        )
+        response_mask = torch.tensor(
+            [
+                [0, 0, 1],
+                [1, 1, 1],
+            ]
+        )
+        batch = TrainingInputBatch(
+            {
+                "sequences": sequences,
+                "attention_mask": attention_mask,
+                "response_mask": response_mask,
+                "loss_mask": response_mask.clone(),
+                "action_log_probs": torch.tensor([[0.0, 0.0, 0.1], [0.2, 0.3, 0.4]]),
+                "rollout_expert_indices": torch.arange(12).reshape(2, 6, 1, 1),
+                "router_padding_mask": ~attention_mask.bool(),
+            }
+        )
+        batch.metadata = {"response_length": 3}
+        return batch

--- a/tests/backends/skyrl_train/workers/test_policy_worker_loss_scaling.py
+++ b/tests/backends/skyrl_train/workers/test_policy_worker_loss_scaling.py
@@ -103,6 +103,42 @@ def _all_reduce_payload(strategy, op, key):
     raise AssertionError(f"No all_reduce call found for op={op!r}, key={key!r}")
 
 
+def test_policy_forward_trims_dense_fsdp_microbatches_and_restores_output_width():
+    cfg = _make_loss_scaling_cfg("dual_clip", micro_batch_size=1)
+    cfg.trainer.micro_forward_batch_size_per_gpu = 1
+    cfg.trainer.max_tokens_per_microbatch = -1
+
+    batch = TrainingInputBatch(
+        {
+            "sequences": torch.tensor([[0, 0, 0, 0, 11, 12], [21, 22, 23, 24, 25, 26]]),
+            "attention_mask": torch.tensor([[0, 0, 0, 0, 1, 1], [1, 1, 1, 1, 1, 1]]),
+            "response_mask": torch.tensor([[0, 0, 1], [1, 1, 1]]),
+        }
+    )
+    batch.metadata = {"response_length": 3}
+
+    model_calls = []
+
+    def model_forward(sequences, num_actions, attention_mask, **kwargs):
+        model_calls.append((sequences.clone(), num_actions, attention_mask.clone()))
+        return torch.ones((sequences.shape[0], num_actions))
+
+    model = MagicMock(side_effect=model_forward)
+    worker = _make_policy_worker(cfg, model=model)
+
+    with _patch_worker_cuda_for_cpu():
+        result = worker.forward(batch)
+
+    assert [(call[0].shape, call[1]) for call in model_calls] == [
+        (torch.Size([1, 2]), 1),
+        (torch.Size([1, 6]), 3),
+    ]
+    assert result.loss_fn_outputs == [
+        {"logprobs": [0.0, 0.0, 1.0]},
+        {"logprobs": [1.0, 1.0, 1.0]},
+    ]
+
+
 @pytest.mark.parametrize("loss_fn", ["cross_entropy", "dual_clip"])
 def test_policy_forward_backward_loss_scaling_with_mocked_ranks(loss_fn):
     """FSDP forward_backward scales local microbatch losses before DP reduction."""


### PR DESCRIPTION
## Summary

Dense FSDP forwards currently inherit the sequence width chosen when the controller rectangularizes the whole rollout batch. Final sample- or token-based microbatch membership is decided later in the worker, so a short microbatch can still execute at the longest sequence and response widths of an unrelated sample elsewhere in the global batch.

This PR projects each finalized dense-FSDP microbatch to its own local maxima immediately before model execution:

- sequence-aligned tensors are sliced to the longest real sequence in that microbatch;
- response-aligned tensors are sliced to its longest real response;
- policy, reference, and critic outputs are left-restored to the controller's canonical response width before microbatch outputs are recombined.

The controller batch remains the single full-width representation used by advantage calculation, dispatch, and replay. Packed inputs, intentional DP-equalization padding microbatches, SFT batches without an explicit response boundary, `remove_microbatch_padding=True`, and all Megatron paths remain unchanged.

## Why this boundary

The worker iterator is the first place that knows the final sample/token bin membership. Re-collating earlier in the controller cannot choose the correct per-rank token bins, while trimming inside the model would mix scheduling metadata with model semantics. The existing left-padding contract makes the projection and output restoration unambiguous: real sequence and response values are right-aligned, and semantic zeros in `loss_mask` are not used to infer response length.


## Performance trade-off

Local trimming reduces dense token work and memory but increases sequence- and response-shape variability across final microbatches, which may reduce kernel or compilation-cache reuse. This PR has no SkyRL GPU evidence of repeated execution-plan builds, so it does not assume the net throughput direction or add a user-facing mode for a theoretical cost. A fixed-width opt-out should be earned by an observed SkyRL workload; the current PR claims only the verified layout reduction.

## Verification

- Focused sample/token microbatch and output-restoration regressions: 25 passed
- Related batch, VLM-plumbing, worker-utils, and preprocessing CPU suite: 68 passed, 1 skipped
- Megatron packing/THD regression suite: 14 passed
- Broad CPU train/backend suite: 1,467 passed, 9 skipped
- Changed-file Ruff, Black, gitleaks, and `git diff --check`: passed

Two optional-test failures require unavailable `vllm`, and two collection errors require unavailable `torchvision`; they are environment setup gaps rather than failures in the changed paths. I did not run distributed FSDP/VLM GPU parity or claim measured peak-memory/throughput improvements. The CPU tests establish the tensor-layout and output-contract invariants.

An independent exact-head review found no merge-blocking issues and additionally exercised all schema fields, VLM `TensorList` selection, token/sample batching, restoration/reordering, and packed/dummy no-op behavior in a CPU adversarial probe.

## Scope

This addresses premature dense-FSDP padding only. SkyRL's Megatron packing keeps token padding inside a fixed `[1, T]` packed transport and does not exhibit the separate dummy-BSHD-row issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FSDP dense forward tensor layouts and restores logprob/value widths, which can affect memory, packing, and output contracts if trim/restore is wrong. Scope is gated off packed/Megatron paths and covered by CPU layout tests, not GPU parity.
> 
> **Overview**
> Dense FSDP microbatches no longer inherit the controller's global sequence/response widths. After sample- or token-based binning, each microbatch is sliced to its own longest real sequence and response so short bins do not run at an unrelated sample's pad width.
> 
> Policy, critic, and ref inference outputs are left-padded back to the controller response width before recombination, so advantage/dispatch/replay still see one rectangular batch. Trimming is gated to FSDP with `remove_microbatch_padding=False`; packed rows, DP dummy microbatches, SFT without `response_mask`, and Megatron are unchanged. Forward passes now also receive `response_mask` so the response boundary can be recovered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0253d945147ddddc2e72cb1702055618dc448cd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
