### PR TITLE
[fix][sft] Locate the assistant response boundary instead of subtracting prompt length

### DIFF
--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -56,6 +56,7 @@ from skyrl.train.config.sft_config import (
 from skyrl.train.dataset.pretokenized import load_from_pretokenized
 from skyrl.train.dataset.sft_dataset import ConcatSFTDataset, SFTDataset, TextDataset
 from skyrl.train.generators.utils import (
+    _find_generation_prompt_boundary,
     get_response_ids_and_loss_mask_from_messages,
 )
 from skyrl.train.utils import get_ray_pg_ready_with_timeout
@@ -547,6 +548,11 @@ def _tokenize_chat_last_assistant(
 ) -> dict | None:
     """Tokenize a conversation and compute loss only on the last assistant message.
 
+    The assistant response boundary is located in the full token sequence so
+    tokenizers that merge the generation prompt with leading response
+    whitespace still include the merged token in the supervised window. If
+    the prompt cannot be located, falls back to the length-based boundary.
+
     Args:
         messages: Full conversation (must end with an assistant message).
         tokenizer: HuggingFace tokenizer with ``apply_chat_template``.
@@ -610,9 +616,17 @@ def _tokenize_chat_last_assistant(
             image_grid_thw=full_ids["image_grid_thw"],
         )
 
-    num_actions = len(full_input_ids) - len(full_prompt_ids)
-    if num_actions <= 0:
+    # Truncation can cap both encodings at max_length, leaving no response tokens.
+    if len(full_input_ids) <= len(full_prompt_ids):
         return None
+
+    try:
+        prompt_boundary = _find_generation_prompt_boundary(full_input_ids, full_prompt_ids)
+    except AssertionError:
+        logger.warning("Could not find the generation prompt in the full conversation; using its tokenized length")
+        prompt_boundary = len(full_prompt_ids)
+
+    num_actions = len(full_input_ids) - prompt_boundary
 
     return {
         "input_ids": full_input_ids,

--- a/tests/train/test_sft_tokenization.py
+++ b/tests/train/test_sft_tokenization.py
@@ -18,6 +18,7 @@ from skyrl.train.sft_trainer import (
     tokenize_chat_example,
     tokenize_sft_example,
 )
+from skyrl.utils.tok import get_tokenizer
 
 
 @pytest.fixture(scope="module")
@@ -34,6 +35,12 @@ def vlm_processor():
     if proc.tokenizer.pad_token is None:
         proc.tokenizer.pad_token = proc.tokenizer.eos_token
     return proc
+
+
+@pytest.fixture(scope="module")
+def qwen25_tokenizer():
+    tok = get_tokenizer("Qwen/Qwen2.5-0.5B-Instruct")
+    return tok
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +131,66 @@ def test_chat_truncation(tokenizer):
         assert len(result["input_ids"]) <= 32
         assert result["num_actions"] > 0
     # If the prompt alone fills the budget, result is None -- also acceptable
+
+
+def test_chat_truncation_prompt_fills_budget(qwen25_tokenizer):
+    """Returns None when truncation removes the complete assistant response."""
+    messages = [
+        {"role": "user", "content": "Tell me a story."},
+        {"role": "assistant", "content": "Once upon a time."},
+    ]
+    prompt_ids = qwen25_tokenizer.apply_chat_template(
+        messages[:-1],
+        add_generation_prompt=True,
+        tokenize=True,
+    )["input_ids"]
+
+    result = tokenize_chat_example(
+        {"messages": messages},
+        qwen25_tokenizer,
+        max_length=len(prompt_ids),
+    )
+
+    assert result is None
+
+
+def test_last_assistant_leading_newline_merge(qwen25_tokenizer):
+    """A merged prompt boundary token belongs to the assistant response."""
+    messages = [
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "\nHello world"},
+    ]
+
+    result = tokenize_chat_example({"messages": messages}, qwen25_tokenizer)
+
+    assert result is not None
+    expected_response_ids = [271, 9707, 1879, 151645, 198]
+    assert result["num_actions"] == len(expected_response_ids) == 5
+    assert result["input_ids"][-result["num_actions"] :] == expected_response_ids
+    assert qwen25_tokenizer.decode(expected_response_ids) == "\n\nHello world<|im_end|>\n"
+
+
+def test_last_assistant_without_newline_merge(qwen25_tokenizer):
+    """A prefix-matching prompt keeps the existing response boundary."""
+    messages = [
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "Hello world"},
+    ]
+
+    prompt_ids = qwen25_tokenizer.apply_chat_template(messages[:-1], add_generation_prompt=True, tokenize=True)[
+        "input_ids"
+    ]
+    full_ids = qwen25_tokenizer.apply_chat_template(messages, add_generation_prompt=False, tokenize=True)["input_ids"]
+    assert full_ids[: len(prompt_ids)] == prompt_ids
+    prefix_num_actions = len(full_ids) - len(prompt_ids)
+
+    result = tokenize_chat_example({"messages": messages}, qwen25_tokenizer)
+
+    assert result is not None
+    assert result["num_actions"] == prefix_num_actions == 4
+    expected_response_ids = [9707, 1879, 151645, 198]
+    assert result["input_ids"][-result["num_actions"] :] == expected_response_ids
+    assert qwen25_tokenizer.decode(expected_response_ids) == "Hello world<|im_end|>\n"
 
 
 # NOTE: This test requires torchvision and thus torch - we use the vllm marker so that the test is run with the appropriate extras


### PR DESCRIPTION
## Summary

`_tokenize_chat_last_assistant` derives the supervised window by tokenizing the conversation twice and subtracting encoded lengths:

```python
num_actions = len(full_input_ids) - len(full_prompt_ids)
```

That is only correct when the generation-prompt encoding is a token *prefix* of the full-conversation encoding. It isn't when the tokenizer merges the prompt's trailing `\n` with the response's leading whitespace into one `\n\n` token — the exact merge `_find_generation_prompt_boundary` was added to handle for `ALL_ASSISTANT_MESSAGES` in #1611. The last-assistant path never got that treatment, so on those rows the prompt is one token longer than the corresponding span of the full sequence, `num_actions` comes out one short, and the first token the assistant actually generated silently trains with weight 0.

On `Qwen/Qwen2.5-0.5B-Instruct` with `[{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "\nHello world"}]` (the leading-newline shape TULU3-style data produces):

| | |
|---|---|
| prompt, `add_generation_prompt=True` | 30 tokens |
| full conversation | 34 tokens |
| supervised before | 4 → `'Hello world<\|im_end\|>\n'` |
| true response | 5 → `'\n\nHello world<\|im_end\|>\n'` |

The merged `\n\n` (id 271) belongs to the assistant but is never supervised. With `"Hello world"` the prompt *is* a prefix and the subtraction is right, so only the merge case is affected.

So instead of subtracting lengths, locate where the prompt actually ends inside the full sequence:

```python
prompt_boundary = _find_generation_prompt_boundary(full_input_ids, full_prompt_ids)
num_actions = len(full_input_ids) - prompt_boundary
```

The merged boundary token gets weight 1, i.e. attributed to the assistant's generation — the same choice the all-assistant path makes, so both `train_on_what` modes now supervise the same tokens for a given conversation.

Two details worth calling out:

- The helper raises when neither the exact-prefix nor the merge pattern matches. That is caught, logged, and falls back to the previous length-based boundary, so an unusual chat template degrades to today's behavior instead of aborting a run partway through a dataset.
- A guard returns `None` when truncation caps both encodings at `max_length` and leaves no response tokens. That keeps truncation out of the boundary lookup (it isn't a merge, and would otherwise warn on every over-length row) and makes the old `num_actions <= 0` check unreachable, so it is removed.

`ALL_ASSISTANT_MESSAGES` is untouched.

## Test plan

- [x] `uv run --isolated --extra dev --extra fsdp pytest tests/train/test_sft_tokenization.py -v` — 38 passed
- [x] `uv run --isolated --extra dev --extra fsdp pytest tests/train/generators/test_utils.py -v` — 58 passed
- [x] `ruff` / `black` / secret check via pre-commit

New CPU tests, all on the smallest Qwen2.5 instruct model:

- `test_last_assistant_leading_newline_merge` — supervised window is exactly `[271, 9707, 1879, 151645, 198]` (`'\n\nHello world<|im_end|>\n'`), including the merged boundary token. Fails on `main` with `num_actions == 4`.
- `test_last_assistant_without_newline_merge` — control: with prefix-matching encodings `num_actions` still equals `len(full) - len(prompt)`, so the common path is unmoved.
- `test_chat_truncation_prompt_fills_budget` — `max_length` at the prompt length returns `None`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tokens receive loss in last-assistant SFT for merge-prone chat templates; behavior is intentional but will alter gradients on affected rows compared to main.
> 
> **Overview**
> Fixes **last-assistant** SFT tokenization so the supervised window matches the real assistant span when the chat template **merges** the generation prompt’s trailing newline with leading response whitespace (e.g. Qwen2.5 + `\nHello world`).
> 
> **`_tokenize_chat_last_assistant`** no longer uses `len(full) - len(prompt)`; it calls **`_find_generation_prompt_boundary`** (same helper as the all-assistant path) so the merged boundary token is included in `num_actions` / `loss_mask`. If the boundary cannot be found, it **logs and falls back** to the old length-based split. Truncation that leaves **no response tokens** now returns **`None`** via an explicit length check instead of `num_actions <= 0`.
> 
> Adds **Qwen2.5** CPU tests for the merge case, the prefix-matching control, and truncation when `max_length` equals prompt length.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0befcdffeb062f5c3412357a072f3a84f1fa527c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->