### PR TITLE
Target GatedDeltaNet projections with Megatron LoRA

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -208,7 +208,13 @@ def gdn_in_proj_lora_is_safe(bridge) -> bool:
     True for the separate ``in_proj_qkv/z/b/a`` layout (e.g. Qwen3.5) and for
     models without GDN layers (where ``in_proj`` matches nothing).
     """
-    mapping = bridge._model_bridge.mapping_registry().megatron_to_hf_lookup(
+    # `_model_bridge` hands each fresh bridge only the raw HF config; some
+    # bridges' `mapping_registry` inspect the checkpoint through
+    # `hf_pretrained.state` (GLM-4.5's fused-expert probe), so install the
+    # AutoBridge's weights-backed `hf_pretrained` first.
+    model_bridge = bridge._model_bridge
+    model_bridge.hf_pretrained = bridge.hf_pretrained
+    mapping = model_bridge.mapping_registry().megatron_to_hf_lookup(
         # Layer 0 stands in for the wildcard in the bridge's mapping patterns.
         "decoder.layers.0.self_attention.in_proj.weight"
     )

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -198,6 +198,25 @@ def _convert_moe_experts_lora_to_vllm(
     return converted
 
 
+def gdn_in_proj_lora_is_safe(bridge) -> bool:
+    """Whether LoRA on GatedDeltaNet ``in_proj`` can round-trip through weight sync.
+
+    False for models whose bridge maps ``in_proj`` to two fused HF tensors
+    (``in_proj_qkvz``/``in_proj_ba``, e.g. Qwen3-Next): peft_bridge has no
+    fused-adapter split for that layout, so a merged export fails on a shape
+    mismatch and an unmerged export silently drops the ``in_proj_ba`` half.
+    True for the separate ``in_proj_qkv/z/b/a`` layout (e.g. Qwen3.5) and for
+    models without GDN layers (where ``in_proj`` matches nothing).
+    """
+    mapping = bridge._model_bridge.mapping_registry().megatron_to_hf_lookup(
+        # Layer 0 stands in for the wildcard in the bridge's mapping patterns.
+        "decoder.layers.0.self_attention.in_proj.weight"
+    )
+    if mapping is None:
+        return True
+    return isinstance(mapping.hf_param, dict) and set(mapping.hf_param) == {"qkv", "z", "b", "a"}
+
+
 @torch.no_grad()
 def offload_megatron_grads_to_cpu(models):
     for model_chunk in models:

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -27,6 +27,7 @@ from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
     _convert_moe_experts_lora_to_vllm,
     broadcast_object_across_pp_ranks,
     freeze_moe_router,
+    gdn_in_proj_lora_is_safe,
     get_model_config,
     get_moe_metrics,
     print_model_size,
@@ -89,25 +90,6 @@ import skyrl.backends.skyrl_train.workers.megatron.model_bridges  # noqa: F401  
 from skyrl.backends.skyrl_train.workers.megatron.model_bridges import (
     maybe_force_qwen35_text_bridge,
 )
-
-
-def _gdn_in_proj_lora_is_safe(bridge) -> bool:
-    """Whether LoRA on GatedDeltaNet ``in_proj`` can round-trip through weight sync.
-
-    False for models whose bridge maps ``in_proj`` to two fused HF tensors
-    (``in_proj_qkvz``/``in_proj_ba``, e.g. Qwen3-Next): peft_bridge has no
-    fused-adapter split for that layout, so a merged export fails on a shape
-    mismatch and an unmerged export silently drops the ``in_proj_ba`` half.
-    True for the separate ``in_proj_qkv/z/b/a`` layout (e.g. Qwen3.5) and for
-    models without GDN layers (where ``in_proj`` matches nothing).
-    """
-    mapping = bridge._model_bridge.mapping_registry().megatron_to_hf_lookup(
-        # Layer 0 stands in for the wildcard in the bridge's mapping patterns.
-        "decoder.layers.0.self_attention.in_proj.weight"
-    )
-    if mapping is None:
-        return True
-    return isinstance(mapping.hf_param, dict) and set(mapping.hf_param) == {"qkv", "z", "b", "a"}
 
 
 class MegatronWeightExtractor(WeightExtractor):
@@ -579,7 +561,7 @@ class MegatronWorker:
                     "in_proj",
                     "out_proj",
                 ]
-            if not _gdn_in_proj_lora_is_safe(self.bridge):
+            if not gdn_in_proj_lora_is_safe(self.bridge):
                 target_modules.remove("in_proj")
         else:
             target_modules = lora_config.target_modules

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -91,6 +91,25 @@ from skyrl.backends.skyrl_train.workers.megatron.model_bridges import (
 )
 
 
+def _gdn_in_proj_lora_is_safe(bridge) -> bool:
+    """Whether LoRA on GatedDeltaNet ``in_proj`` can round-trip through weight sync.
+
+    False for models whose bridge maps ``in_proj`` to two fused HF tensors
+    (``in_proj_qkvz``/``in_proj_ba``, e.g. Qwen3-Next): peft_bridge has no
+    fused-adapter split for that layout, so a merged export fails on a shape
+    mismatch and an unmerged export silently drops the ``in_proj_ba`` half.
+    True for the separate ``in_proj_qkv/z/b/a`` layout (e.g. Qwen3.5) and for
+    models without GDN layers (where ``in_proj`` matches nothing).
+    """
+    mapping = bridge._model_bridge.mapping_registry().megatron_to_hf_lookup(
+        # Layer 0 stands in for the wildcard in the bridge's mapping patterns.
+        "decoder.layers.0.self_attention.in_proj.weight"
+    )
+    if mapping is None:
+        return True
+    return isinstance(mapping.hf_param, dict) and set(mapping.hf_param) == {"qkv", "z", "b", "a"}
+
+
 class MegatronWeightExtractor(WeightExtractor):
     """Extracts weights from Megatron model-parallel models.
 
@@ -545,13 +564,29 @@ class MegatronWorker:
         self.enable_router_replay = megatron_config.moe_enable_routing_replay
 
     def configure_lora(self, lora_config, lora_type: Optional[str] = "lora"):
+        if lora_config.target_modules == "all-linear":
+            if lora_type == "lora":
+                target_modules = ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2", "in_proj", "out_proj"]
+            else:
+                target_modules = [
+                    "linear_q",
+                    "linear_k",
+                    "linear_v",
+                    "linear_proj",
+                    "linear_fc1_up",
+                    "linear_fc1_gate",
+                    "linear_fc2",
+                    "in_proj",
+                    "out_proj",
+                ]
+            if not _gdn_in_proj_lora_is_safe(self.bridge):
+                target_modules.remove("in_proj")
+        else:
+            target_modules = lora_config.target_modules
+
         if lora_type == "lora":
             self.lora_cls = LoRA(
-                target_modules=(
-                    ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2", "in_proj", "out_proj"]
-                    if lora_config.target_modules == "all-linear"
-                    else lora_config.target_modules
-                ),
+                target_modules=target_modules,
                 dim=lora_config.rank,
                 alpha=lora_config.alpha,
                 dropout=lora_config.dropout,
@@ -562,19 +597,7 @@ class MegatronWorker:
             )
         elif lora_type == "canonical_lora":
             self.lora_cls = CanonicalLoRA(
-                target_modules=(
-                    [
-                        "linear_q",
-                        "linear_k",
-                        "linear_v",
-                        "linear_proj",
-                        "linear_fc1_up",
-                        "linear_fc1_gate",
-                        "linear_fc2",
-                    ]
-                    if lora_config.target_modules == "all-linear"
-                    else lora_config.target_modules
-                ),
+                target_modules=target_modules,
                 dim=lora_config.rank,
                 alpha=lora_config.alpha,
                 dropout=lora_config.dropout,

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -548,7 +548,7 @@ class MegatronWorker:
         if lora_type == "lora":
             self.lora_cls = LoRA(
                 target_modules=(
-                    ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"]
+                    ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2", "in_proj", "out_proj"]
                     if lora_config.target_modules == "all-linear"
                     else lora_config.target_modules
                 ),

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -109,8 +109,9 @@ class SkyRLLoraConfig(BaseConfig):
     Must be accessible to all workers in distributed setups."""
     target_modules: str = "all-linear"
     """Modules to apply LoRA to.
-    ``"all-linear"`` targets every linear layer for FSDP/PEFT, and is remapped to a fixed module list
-    on Megatron. A list of specific module names can be given instead."""
+    ``"all-linear"`` targets every linear layer for FSDP/PEFT, and is remapped to the supported
+    attention, MLP, and GatedDeltaNet projections on Megatron. A list of specific module names can
+    be given instead."""
     exclude_modules: Optional[str] = None
     """Modules to exclude from LoRA."""
     init_method: str = "kaiming"

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -109,9 +109,10 @@ class SkyRLLoraConfig(BaseConfig):
     Must be accessible to all workers in distributed setups."""
     target_modules: str = "all-linear"
     """Modules to apply LoRA to.
-    ``"all-linear"`` targets every linear layer for FSDP/PEFT, and is remapped to the supported
-    attention, MLP, and GatedDeltaNet projections on Megatron. A list of specific module names can
-    be given instead."""
+    ``"all-linear"`` targets every linear layer for FSDP/PEFT, and is remapped to a fixed module
+    list on Megatron (attention, MLP, and GatedDeltaNet projections). GatedDeltaNet ``in_proj``
+    is dropped for models like Qwen3-Next whose fused HF checkpoint layout cannot round-trip a
+    LoRA adapter through Megatron-Bridge. A list of specific module names can be given instead."""
     exclude_modules: Optional[str] = None
     """Modules to exclude from LoRA."""
     init_method: str = "kaiming"

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_lora_gdn_targets.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_lora_gdn_targets.py
@@ -1,0 +1,130 @@
+"""GDN LoRA target safety check against the real Megatron-Bridge classes.
+
+Pins the two facts the ``all-linear`` remap in ``configure_lora`` relies on:
+
+1. The bridges' GDN ``in_proj`` mappings keep their hf_param layouts
+   (four separate tensors for Qwen3.5's ``GDNLinearMappingSeparate``, two
+   fused tensors for Qwen3-Next's ``GDNLinearMapping``), and
+   ``_gdn_in_proj_lora_is_safe`` classifies them accordingly.
+2. peft_bridge still cannot handle a fused-layout (Qwen3-Next) ``in_proj``
+   adapter: the merged export shape-mismatches and the unmerged export has no
+   fused-adapter split for it. If these assertions start failing after a
+   Megatron-Bridge bump, the bridge learned the fused layout and ``in_proj``
+   can stop being removed for it in ``configure_lora``.
+
+Run with:
+uv run --isolated --extra dev --extra megatron -- pytest -s tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_lora_gdn_targets.py
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from megatron.bridge.models.conversion.mapping_registry import MegatronMappingRegistry
+from megatron.bridge.models.conversion.param_mapping import (
+    GDNLinearMapping,
+    GDNLinearMappingSeparate,
+)
+from megatron.bridge.models.conversion.peft_bridge import (
+    AdapterWeight,
+    MegatronPeftBridge,
+)
+
+from skyrl.backends.skyrl_train.workers.megatron.megatron_worker import (
+    _gdn_in_proj_lora_is_safe,
+)
+
+pytestmark = pytest.mark.megatron
+
+HIDDEN = 64
+RANK = 8
+# Tiny GDN geometry: qk_dim = 2 heads * 16, v_dim = 4 heads * 16.
+QK_DIM, V_DIM, NUM_V_HEADS = 32, 64, 4
+FUSED_DIM = 2 * QK_DIM + 2 * V_DIM + 2 * NUM_V_HEADS  # Megatron in_proj rows
+QKVZ_DIM = 2 * QK_DIM + 2 * V_DIM  # HF in_proj_qkvz rows
+BA_DIM = 2 * NUM_V_HEADS  # HF in_proj_ba rows
+
+QWEN3_NEXT_NAMES = [
+    "model.layers.0.linear_attn.in_proj_qkvz.weight",
+    "model.layers.0.linear_attn.in_proj_ba.weight",
+]
+QWEN35_NAMES = [
+    "model.layers.0.linear_attn.in_proj_qkv.weight",
+    "model.layers.0.linear_attn.in_proj_z.weight",
+    "model.layers.0.linear_attn.in_proj_b.weight",
+    "model.layers.0.linear_attn.in_proj_a.weight",
+]
+
+
+def _bridge_with_registry(registry: MegatronMappingRegistry):
+    return SimpleNamespace(_model_bridge=SimpleNamespace(mapping_registry=lambda: registry))
+
+
+def _fused_in_proj_adapter() -> AdapterWeight:
+    return AdapterWeight(
+        global_base_prefix="decoder.layers.0.self_attention.in_proj",
+        adapter_key=None,
+        alpha=16,
+        dim=RANK,
+        linear_in_weight=SimpleNamespace(weight=torch.randn(RANK, HIDDEN)),
+        linear_out_weight=SimpleNamespace(weight=torch.randn(FUSED_DIM, RANK)),
+    )
+
+
+def test_in_proj_lora_unsafe_for_qwen3_next_style_registry():
+    registry = MegatronMappingRegistry(
+        GDNLinearMapping(
+            megatron_param="decoder.layers.*.self_attention.in_proj.weight",
+            qkvz="model.layers.*.linear_attn.in_proj_qkvz.weight",
+            ba="model.layers.*.linear_attn.in_proj_ba.weight",
+        ),
+    )
+    assert not _gdn_in_proj_lora_is_safe(_bridge_with_registry(registry))
+
+
+def test_in_proj_lora_safe_for_qwen35_style_registry():
+    registry = MegatronMappingRegistry(
+        GDNLinearMappingSeparate(
+            megatron_param="decoder.layers.*.self_attention.in_proj.weight",
+            qkv="model.layers.*.linear_attn.in_proj_qkv.weight",
+            z="model.layers.*.linear_attn.in_proj_z.weight",
+            b="model.layers.*.linear_attn.in_proj_b.weight",
+            a="model.layers.*.linear_attn.in_proj_a.weight",
+        ),
+    )
+    assert _gdn_in_proj_lora_is_safe(_bridge_with_registry(registry))
+
+
+def test_in_proj_lora_safe_for_non_gdn_registry():
+    # No GDN layers: in_proj matches nothing, so keeping it in the target
+    # list is harmless.
+    assert _gdn_in_proj_lora_is_safe(_bridge_with_registry(MegatronMappingRegistry()))
+
+
+def test_peft_bridge_recognizes_only_the_separate_gdn_layout():
+    pb = MegatronPeftBridge()
+    assert pb._is_gdn_in_proj_split(QWEN35_NAMES)
+    assert not pb._is_gdn_in_proj_split(QWEN3_NEXT_NAMES)
+
+
+def test_fused_gdn_in_proj_adapter_has_no_export_split():
+    # With no fused-adapter split for the qkvz/ba layout, the unmerged export
+    # generator falls through to yielding the full fused lora_B under the
+    # first HF name only, dropping the in_proj_ba contribution.
+    pb = MegatronPeftBridge()
+    adapter = _fused_in_proj_adapter()
+    megatron_model = [SimpleNamespace(config=SimpleNamespace(num_moe_experts=None))]
+    slices = pb._get_fused_adapter_linear_out_slices(megatron_model, QWEN3_NEXT_NAMES, adapter.linear_out_weight.weight)
+    assert slices is None
+
+
+def test_fused_gdn_in_proj_adapter_merge_shape_mismatches():
+    pb = MegatronPeftBridge()
+    adapter = _fused_in_proj_adapter()
+    megatron_model = [SimpleNamespace(config=SimpleNamespace(num_moe_experts=None))]
+    converted = {
+        QWEN3_NEXT_NAMES[0]: torch.zeros(QKVZ_DIM, HIDDEN),
+        QWEN3_NEXT_NAMES[1]: torch.zeros(BA_DIM, HIDDEN),
+    }
+    with pytest.raises(RuntimeError):
+        pb._merge_lora_adapter_weights(megatron_model, converted, [adapter])


### PR DESCRIPTION
## Summary

- Include GatedDeltaNet `in_proj` and `out_proj` modules in Megatron’s existing `all-linear` LoRA target expansion.
- This enables ordinary LoRA adapters on hybrid Qwen3.5/3.6 GDN layers without adding an algorithm-specific training path.

## Testing

```bash
uvx --from ruff==0.11.9 ruff check skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py skyrl/train/config/config.py
```

Ruff passes. End-to-end Qwen3.6-27B B300 runs validated TP4 training, GDN adapter attachment, 2xTP2 vLLM loading and live adapter sync for both standard LoRA and PiSSA; the matched 100-step GPQA runs completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which modules receive LoRA and adapter export/sync for GDN layers; wrong classification could break training or silently omit adapter weights on Qwen3-Next-style models.
> 
> **Overview**
> Megatron **`all-linear`** LoRA now also targets GatedDeltaNet **`in_proj`** and **`out_proj`** (standard and canonical LoRA lists), so hybrid models like Qwen3.5 can train GDN adapters through the existing Megatron path.
> 
> **`in_proj`** is removed from that list when **`gdn_in_proj_lora_is_safe`** reports the bridge uses the fused Qwen3-Next-style **`in_proj_qkvz`/`in_proj_ba`** mapping—PEFT export cannot split or merge those adapters correctly. Separate **qkv/z/b/a** layouts and models without GDN mappings still get **`in_proj`**.
> 
> Config docs for **`target_modules`** describe this behavior. New Megatron GPU CI tests pin bridge classification and document that fused-layout **`in_proj`** adapters still fail or drop weights on export until Megatron-Bridge gains support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d7fa6cdda26ecaee223369332463e9631a4c5ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->