### PR TITLE
[fix][megatron] Restore token-batched output order

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1268,6 +1268,9 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
             for k, v in metrics.items():
                 all_metrics[k].append(v)
 
+        if use_token_batching and microbatch_iterator is not None and all_loss_fn_outputs:
+            all_loss_fn_outputs = microbatch_iterator.restore_padded_microbatch_order(all_loss_fn_outputs, micro_bsz)
+
         # Reduce across microbatches and all-reduce metrics across DP ranks
         # (metrics should be identical within DP groups, i.e., across TP/PP/SP ranks)
         # NOTE: Sum loss metrics because scaling is already applied before the worker reduction.

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, Iterator, List, Optional
+from typing import Dict, Iterator, List, Optional, TypeVar
 
 import torch
 import torch.distributed as dist
@@ -28,6 +28,8 @@ MINIBATCH_ROLLOUT_LOGPROB_DIFF_SQ_MEAN_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_P
 MINIBATCH_ROLLOUT_LOGPROB_DIFF_MAX_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_max"
 MINIBATCH_ROLLOUT_LOGPROB_DIFF_MIN_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_min"
 MINIBATCH_ROLLOUT_LOGPROB_DIFF_STD_KEY = f"{MINIBATCH_ROLLOUT_LOGPROB_DIFF_PREFIX}_std"
+
+T = TypeVar("T")
 
 
 @torch.no_grad()
@@ -423,6 +425,20 @@ class TokenBasedBatchIterator(BaseBatchIterator):
         reordered_batch = type(ref_microbatch)(reordered_data)
         reordered_batch.metadata = ref_microbatch.metadata
         return reordered_batch
+
+    def restore_padded_microbatch_order(self, values: List[T], padded_microbatch_size: int) -> List[T]:
+        """Restore flattened padded microbatch values to the input sample order."""
+        expected_values = len(self) * padded_microbatch_size
+        if len(values) != expected_values:
+            raise ValueError(f"Expected {expected_values} microbatch values, got {len(values)}.")
+
+        values_by_original_index = {}
+        for microbatch_idx, original_indices in enumerate(self._microbatches):
+            microbatch_start = microbatch_idx * padded_microbatch_size
+            for sample_idx, original_idx in enumerate(original_indices):
+                values_by_original_index[original_idx] = values[microbatch_start + sample_idx]
+
+        return [values_by_original_index[i] for i in range(len(self._token_counts))]
 
 
 def get_microbatch_iterator(

--- a/tests/backends/skyrl_train/test_token_based_batching_utils.py
+++ b/tests/backends/skyrl_train/test_token_based_batching_utils.py
@@ -160,6 +160,25 @@ class TestTokenBasedBatchIterator:
         for i in range(batch.batch_size):
             assert torch.equal(reordered["sequences"][i], batch["sequences"][i])
 
+    def test_restore_padded_microbatch_order_removes_padding(self):
+        batch = self._make_batch([10, 3, 8, 5])
+        iterator = TokenBasedBatchIterator(batch, max_tokens_per_microbatch=12)
+        iterator._num_padding_microbatches = 1
+
+        padded_microbatch_size = max(len(indices) for indices in iterator._microbatches)
+        values = []
+        for original_indices in iterator._microbatches:
+            values.extend([f"sample-{i}" for i in original_indices])
+            values.extend(["padded"] * (padded_microbatch_size - len(original_indices)))
+        values.extend(["padding-microbatch"] * padded_microbatch_size)
+
+        assert iterator.restore_padded_microbatch_order(values, padded_microbatch_size) == [
+            "sample-0",
+            "sample-1",
+            "sample-2",
+            "sample-3",
+        ]
+
     def test_get_microbatch_iterator_factory(self):
         batch = self._make_batch([10, 10, 5, 5])
 


### PR DESCRIPTION
- Restores per-sample forward/backward outputs to input order after token-balanced microbatch packing, matching the order expected by Tinker and the forward-only path.
- Drops dummy padded rows and padding-microbatch outputs before returning learner log-probabilities.

## Testing

```bash
uv run --isolated --extra dev --extra ray --with jaxtyping --with loguru pytest tests/backends/skyrl_train/test_token_based_batching_utils.py
```

All 18 token-batching tests pass; the new case covers uneven microbatches, padded rows, a padding microbatch, and original-order restoration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes incorrect per-sample learner outputs under token batching, which could silently corrupt on-policy training; scope is limited to Megatron token-batched forward_backward aggregation.
> 
> **Overview**
> When **token-based microbatching** is enabled, Megatron pads microbatches to a uniform size and may append **padding microbatches** for DP alignment. Per-sample **`loss_fn_outputs`** were accumulated in padded microbatch order, so downstream callers (e.g. Tinker) could see **wrong sample-to-logprob mapping** and extra dummy entries.
> 
> This PR adds **`restore_padded_microbatch_order`** on **`TokenBasedBatchIterator`**, which strips per-microbatch pad slots and ignores padding-microbatch outputs, then rebuilds the list in **original input sample order**. **`MegatronPolicyWorkerBase.forward_backward`** invokes it on aggregated outputs before returning **`WorkerOutput`**, aligning the training backward path with the existing forward-only reorder logic.
> 
> A unit test covers uneven microbatches, intra-microbatch padding, a padding microbatch, and order restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1fa133ae2c3e3ebb40185009de54df50a6e67b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->