### PR TITLE
fix(tinker): avoid SQLite pool exhaustion under rollout load

### DIFF
--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -243,6 +243,9 @@ async def lifespan(app: FastAPI):
     app.state.future_waiters = {}
     app.state.future_poller = asyncio.create_task(poll_futures(app.state.db_engine, app.state.future_waiters))
     app.state.external_future_store = None
+    app.state.db_write_lock = asyncio.Lock()
+    app.state.sampling_model_cache = {}
+    app.state.sampling_model_cache_lock = asyncio.Lock()
 
     # Setup external inference client if configured.
     #
@@ -267,7 +270,9 @@ async def lifespan(app: FastAPI):
         app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
-        app.state.external_future_store = ExternalFutureStore(app.state.db_engine)
+        app.state.external_future_store = ExternalFutureStore(
+            app.state.db_engine, app.state.db_write_lock
+        )
         await app.state.external_future_store.start()
         app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
             app.state.engine_config, app.state.db_engine, app.state.external_future_store
@@ -932,14 +937,19 @@ async def create_session(request: CreateSessionRequest, session: AsyncSession = 
 
 
 @app.post("/api/v1/session_heartbeat", response_model=SessionHeartbeatResponse)
-async def session_heartbeat(request: SessionHeartbeatRequest, session: AsyncSession = Depends(get_session)):
+async def session_heartbeat(
+    request: SessionHeartbeatRequest,
+    raw_request: Request,
+    session: AsyncSession = Depends(get_session),
+):
     """Heartbeat for an active session to keep it alive."""
-    session_db = await session.get(SessionDB, request.session_id)
-    if session_db is None:
-        raise HTTPException(status_code=404, detail="Session not found")
-    session_db.last_heartbeat_at = datetime.now(timezone.utc)
-    session_db.heartbeat_count += 1
-    await session.commit()
+    async with raw_request.app.state.db_write_lock:
+        session_db = await session.get(SessionDB, request.session_id)
+        if session_db is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        session_db.last_heartbeat_at = datetime.now(timezone.utc)
+        session_db.heartbeat_count += 1
+        await session.commit()
     return SessionHeartbeatResponse()
 
 
@@ -1305,15 +1315,36 @@ async def save_weights_for_sampler(request: SaveWeightsForSamplerRequest, sessio
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
-async def get_sampling_model(request: SampleRequest, session: AsyncSession) -> (str | None, str | None):
+async def get_sampling_model(
+    request: SampleRequest,
+    req: Request,
+    session: AsyncSession,
+) -> tuple[str | None, str | None]:
     """Return (base_model, model_path) for a sampling request."""
-    # Resolve model/base from sampling_session_id if provided
-    if request.sampling_session_id is not None:
-        sampling_session = await session.get(SamplingSessionDB, request.sampling_session_id)
+    sampling_session_id = request.sampling_session_id
+    if sampling_session_id is None:
+        return (request.base_model, request.model_path)
+
+    cache = req.app.state.sampling_model_cache
+    cached = cache.get(sampling_session_id)
+    if cached is not None:
+        return cached
+
+    async with req.app.state.sampling_model_cache_lock:
+        cached = cache.get(sampling_session_id)
+        if cached is not None:
+            return cached
+        sampling_session = await session.get(
+            SamplingSessionDB, sampling_session_id
+        )
         if sampling_session is None:
             raise HTTPException(status_code=404, detail="Sampling session not found")
-        return (sampling_session.base_model, sampling_session.model_path)
-    return (request.base_model, request.model_path)
+        sampling_model = (
+            sampling_session.base_model,
+            sampling_session.model_path,
+        )
+        cache[sampling_session_id] = sampling_model
+        return sampling_model
 
 
 @app.post("/api/v1/asample", response_model=FutureResponse)
@@ -1325,7 +1356,7 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
             detail="sampling_session_id must not contain ':' (the routing-key delimiter)",
         )
 
-    base_model, model_path = await get_sampling_model(request, session)
+    base_model, model_path = await get_sampling_model(request, req, session)
 
     if base_model:
         model_id = checkpoint_id = ""

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -246,6 +246,8 @@ async def lifespan(app: FastAPI):
     app.state.db_write_lock = asyncio.Lock()
     app.state.sampling_model_cache = {}
     app.state.sampling_model_cache_lock = asyncio.Lock()
+    app.state.validated_sampler_checkpoints = set()
+    app.state.sampler_checkpoint_validation_lock = asyncio.Lock()
 
     # Setup external inference client if configured.
     #
@@ -1346,6 +1348,32 @@ async def get_sampling_model(
         return sampling_model
 
 
+async def validate_sampler_checkpoint_once(
+    request: Request,
+    model_id: str,
+    checkpoint_id: str,
+    session: AsyncSession,
+) -> None:
+    """Validate an immutable sampler checkpoint once before serving it."""
+    key = (model_id, checkpoint_id)
+    validated = request.app.state.validated_sampler_checkpoints
+    if key in validated:
+        return
+
+    async with request.app.state.sampler_checkpoint_validation_lock:
+        if key in validated:
+            return
+        await get_model(session, model_id)
+        await validate_checkpoint(
+            request,
+            model_id,
+            checkpoint_id,
+            types.CheckpointType.SAMPLER,
+            session,
+        )
+        validated.add(key)
+
+
 @app.post("/api/v1/asample", response_model=FutureResponse)
 async def asample(request: SampleRequest, req: Request, session: AsyncSession = Depends(get_session)):
     """Generates samples from the model (async version)."""
@@ -1373,9 +1401,7 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
                 status_code=400,
                 detail="model_path must be tinker://model_id/checkpoint_id or tinker://model_id/sampler_weights/checkpoint_id",
             )
-        await get_model(session, model_id)
-        # Validate that the checkpoint exists and is ready
-        await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
+        await validate_sampler_checkpoint_once(req, model_id, checkpoint_id, session)
 
     sample_input = types.SampleInput(
         base_model=base_model,
@@ -1401,8 +1427,7 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
             model_id=model_id,
             request_data=sample_input,
         )
-
-    await session.commit()
+        await session.commit()
 
     if req.app.state.external_inference_client:
         asyncio.create_task(

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -338,7 +338,7 @@ async def lifespan(app: FastAPI):
         app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
-        app.state.external_future_store = ExternalFutureStore(app.state.db_engine, app.state.db_write_lock)
+        app.state.external_future_store = ExternalFutureStore()
         await app.state.external_future_store.start()
         app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
             app.state.engine_config, app.state.db_engine, app.state.external_future_store

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -287,7 +287,6 @@ async def lifespan(app: FastAPI):
     app.state.sampling_model_cache_lock = asyncio.Lock()
     app.state.validated_sampler_checkpoints = set()
     app.state.sampler_checkpoint_validation_lock = asyncio.Lock()
-    app.state.proto_serialization_lock = asyncio.Lock()
 
     # Setup external inference client if configured.
     #
@@ -1505,14 +1504,19 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
             types.RequestType(request_type) in PROTO_SERIALIZABLE_REQUEST_TYPES
             and PROTO_CONTENT_TYPE in req.headers.get("accept", "").lower()
         ):
-            async with req.app.state.proto_serialization_lock:
-                content = await asyncio.to_thread(
-                    _serialize_proto_result,
-                    types.RequestType(request_type),
-                    result_data,
-                )
-            return Response(content=content, media_type=PROTO_CONTENT_TYPE)
-        return raw_json_response(result_data)
+            content = await asyncio.to_thread(
+                _serialize_proto_result,
+                types.RequestType(request_type),
+                result_data,
+            )
+            response: Response = Response(content=content, media_type=PROTO_CONTENT_TYPE)
+        else:
+            response = raw_json_response(result_data)
+        # Start the retry-grace clock now that the response is built and about to
+        # be sent, so a large result is never evicted mid-delivery.
+        if found_in_memory:
+            external_future_store.mark_retrieved(request_id)
+        return response
 
     # Return 400 for handled errors (validation, etc.), 500 for unexpected failures.
     # Every writer of a FAILED row stores a types.ErrorResponse, so decode it as

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -45,6 +45,7 @@ from skyrl.tinker.db_models import (
     enable_sqlite_wal,
     get_async_database_url,
 )
+from skyrl.tinker.external_future_store import ExternalFutureStore
 from skyrl.tinker.extra import (
     ExternalInferenceClient,
     SkyRLTrainInferenceForwardingClient,
@@ -241,6 +242,7 @@ async def lifespan(app: FastAPI):
 
     app.state.future_waiters = {}
     app.state.future_poller = asyncio.create_task(poll_futures(app.state.db_engine, app.state.future_waiters))
+    app.state.external_future_store = None
 
     # Setup external inference client if configured.
     #
@@ -265,8 +267,10 @@ async def lifespan(app: FastAPI):
         app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
+        app.state.external_future_store = ExternalFutureStore(app.state.db_engine)
+        await app.state.external_future_store.start()
         app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
-            app.state.engine_config, app.state.db_engine
+            app.state.engine_config, app.state.db_engine, app.state.external_future_store
         )
         logger.info(
             "SkyRL-Train inference forwarding client enabled for non-colocated backend=%s",
@@ -318,6 +322,9 @@ async def lifespan(app: FastAPI):
     app.state.future_poller.cancel()
     with suppress(asyncio.CancelledError):
         await app.state.future_poller
+
+    if app.state.external_future_store is not None:
+        await app.state.external_future_store.close()
 
     # Close the forwarding client's persistent httpx connection pool if we
     # installed one. Cheap no-op when external_inference_client doesn't own
@@ -1340,26 +1347,30 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
         # Validate that the checkpoint exists and is ready
         await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
 
-    request_id = await create_future(
-        session=session,
-        request_type=(
-            types.RequestType.EXTERNAL if req.app.state.external_inference_client else types.RequestType.SAMPLE
-        ),
-        model_id=model_id,
-        request_data=types.SampleInput(
-            base_model=base_model,
-            prompt=request.prompt.to_types(),
-            sampling_params=request.sampling_params.to_types(),
-            num_samples=request.num_samples,
-            checkpoint_id=checkpoint_id,
-            # A positive topk implies prompt logprobs: both are read off the same
-            # prompt forward pass, so asking for one asks for the other.
-            prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
-            topk_prompt_logprobs=request.topk_prompt_logprobs,
-            seq_id=request.seq_id,
-            sampling_session_id=request.sampling_session_id,
-        ),
+    sample_input = types.SampleInput(
+        base_model=base_model,
+        prompt=request.prompt.to_types(),
+        sampling_params=request.sampling_params.to_types(),
+        num_samples=request.num_samples,
+        checkpoint_id=checkpoint_id,
+        # A positive topk implies prompt logprobs: both are read off the same
+        # prompt forward pass, so asking for one asks for the other.
+        prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
+        topk_prompt_logprobs=request.topk_prompt_logprobs,
+        seq_id=request.seq_id,
+        sampling_session_id=request.sampling_session_id,
     )
+    if req.app.state.external_future_store is not None:
+        request_id = req.app.state.external_future_store.create(model_id, sample_input)
+    else:
+        request_id = await create_future(
+            session=session,
+            request_type=(
+                types.RequestType.EXTERNAL if req.app.state.external_inference_client else types.RequestType.SAMPLE
+            ),
+            model_id=model_id,
+            request_data=sample_input,
+        )
 
     await session.commit()
 
@@ -1391,10 +1402,19 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     """Retrieve the result of an async operation, waiting until it's available."""
     request_id = int(request.request_id)
 
-    try:
-        row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
-    except KeyError:
-        raise HTTPException(status_code=404, detail="Future not found")
+    found_in_memory = False
+    external_future_store = req.app.state.external_future_store
+    if external_future_store is not None:
+        try:
+            row = await external_future_store.wait(request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+            found_in_memory = True
+        except KeyError:
+            pass
+    if not found_in_memory:
+        try:
+            row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        except KeyError:
+            raise HTTPException(status_code=404, detail="Future not found")
 
     if row is None:
         raise HTTPException(status_code=408, detail="Timeout waiting for result")

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -71,6 +71,9 @@ SHUTDOWN_TIMEOUT_SECONDS = 10
 # How long retrieve_future waits for a result before returning 408
 RETRIEVE_FUTURE_TIMEOUT_SECONDS = 300
 
+# How long shutdown waits for in-flight forwarding tasks before cancelling them
+FORWARDING_SHUTDOWN_TIMEOUT_SECONDS = 10
+
 # How often poll_futures looks for newly finished requests. A single query
 # covers every waiter, so this can stay tight without the load scaling up with
 # the number of in-flight requests.
@@ -203,7 +206,14 @@ def _start_forwarding_task(app: FastAPI, operation: Awaitable[None]) -> None:
 
 async def _close_external_inference(app: FastAPI) -> None:
     if app.state.forwarding_tasks:
-        await asyncio.gather(*tuple(app.state.forwarding_tasks), return_exceptions=True)
+        # Bounded wait: a hung inference backend must not stall shutdown for the
+        # full httpx timeout (with retries, ~10 minutes per task).
+        _, pending = await asyncio.wait(tuple(app.state.forwarding_tasks), timeout=FORWARDING_SHUTDOWN_TIMEOUT_SECONDS)
+        if pending:
+            logger.warning(f"Cancelling {len(pending)} forwarding tasks still in flight at shutdown")
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
 
     inference_client = getattr(app.state, "external_inference_client", None)
     aclose = getattr(inference_client, "aclose", None)

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -451,7 +451,7 @@ async def create_future(
         if request_id is None:
             raise
         return request_id
-    assert future_db.request_id
+    assert future_db.request_id is not None
     return future_db.request_id
 
 

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -211,6 +211,22 @@ async def _close_external_inference(app: FastAPI) -> None:
         await app.state.external_future_store.close()
 
 
+async def _close_runtime(app: FastAPI, background_engine: asyncio.subprocess.Process) -> None:
+    try:
+        await _close_external_inference(app)
+    finally:
+        logger.info(f"Stopping background engine (PID {background_engine.pid})")
+        with suppress(ProcessLookupError):
+            background_engine.terminate()
+            try:
+                await asyncio.wait_for(background_engine.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                logger.warning(f"Background engine (PID {background_engine.pid}) did not terminate gracefully, killing")
+                background_engine.kill()
+                await background_engine.wait()
+        logger.info("Background engine stopped")
+
+
 def _get_db_write_context(db_engine):
     if db_engine.dialect.name == "sqlite":
         return asyncio.Lock()
@@ -363,18 +379,7 @@ async def lifespan(app: FastAPI):
     with suppress(asyncio.CancelledError):
         await app.state.future_poller
 
-    await _close_external_inference(app)
-
-    logger.info(f"Stopping background engine (PID {app.state.background_engine.pid})")
-    with suppress(ProcessLookupError):
-        background_engine.terminate()
-        try:
-            await asyncio.wait_for(background_engine.wait(), timeout=5)
-        except asyncio.TimeoutError:
-            logger.warning(f"Background engine (PID {background_engine.pid}) did not terminate gracefully, killing")
-            background_engine.kill()
-            await background_engine.wait()
-    logger.info("Background engine stopped")
+    await _close_runtime(app, background_engine)
 
 
 app = FastAPI(title="Tinker API Mock", version="0.0.1", lifespan=lifespan)

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -8,7 +8,7 @@ import signal
 import threading
 from contextlib import asynccontextmanager, nullcontext, suppress
 from datetime import datetime, timedelta, timezone
-from typing import Annotated, Any, AsyncGenerator, Awaitable, ClassVar, Literal
+from typing import Annotated, Any, AsyncGenerator, ClassVar, Literal
 from uuid import uuid4
 
 import fastapi
@@ -70,9 +70,6 @@ SHUTDOWN_TIMEOUT_SECONDS = 10
 
 # How long retrieve_future waits for a result before returning 408
 RETRIEVE_FUTURE_TIMEOUT_SECONDS = 300
-
-# How long shutdown waits for in-flight forwarding tasks before cancelling them
-FORWARDING_SHUTDOWN_TIMEOUT_SECONDS = 10
 
 # How often poll_futures looks for newly finished requests. A single query
 # covers every waiter, so this can stay tight without the load scaling up with
@@ -186,43 +183,21 @@ async def poll_futures(
         await asyncio.sleep(poll_interval_sec)
 
 
-def _finish_forwarding_task(tasks: set[asyncio.Task], task: asyncio.Task) -> None:
-    tasks.discard(task)
-    if task.cancelled():
-        return
-    if error := task.exception():
-        logger.error("Forwarding task failed: %r", error)
-
-
 def _serialize_proto_result(request_type: types.RequestType, result_data: str) -> bytes:
     return serialize_result(request_type, json.loads(result_data))
 
 
-def _start_forwarding_task(app: FastAPI, operation: Awaitable[None]) -> None:
-    task = asyncio.create_task(operation)
-    app.state.forwarding_tasks.add(task)
-    task.add_done_callback(lambda done: _finish_forwarding_task(app.state.forwarding_tasks, done))
-
-
 async def _close_external_inference(app: FastAPI) -> None:
-    if app.state.forwarding_tasks:
-        # Bounded wait: a hung inference backend must not stall shutdown for the
-        # full httpx timeout (with retries, ~10 minutes per task).
-        _, pending = await asyncio.wait(tuple(app.state.forwarding_tasks), timeout=FORWARDING_SHUTDOWN_TIMEOUT_SECONDS)
-        if pending:
-            logger.warning(f"Cancelling {len(pending)} forwarding tasks still in flight at shutdown")
-            for task in pending:
-                task.cancel()
-            await asyncio.gather(*pending, return_exceptions=True)
+    # The store drains its forwarding tasks before anything else so no task is
+    # still using the inference client's connections when it closes.
+    if app.state.external_future_store is not None:
+        await app.state.external_future_store.close()
 
     inference_client = getattr(app.state, "external_inference_client", None)
     aclose = getattr(inference_client, "aclose", None)
     if aclose is not None:
         with suppress(Exception):
             await aclose()
-
-    if app.state.external_future_store is not None:
-        await app.state.external_future_store.close()
 
 
 async def _close_runtime(app: FastAPI, background_engine: asyncio.subprocess.Process) -> None:
@@ -306,7 +281,6 @@ async def lifespan(app: FastAPI):
 
     app.state.future_waiters = {}
     app.state.future_poller = asyncio.create_task(poll_futures(app.state.db_engine, app.state.future_waiters))
-    app.state.forwarding_tasks = set()
     app.state.external_future_store = None
     app.state.db_write_lock = _get_db_write_context(app.state.db_engine)
     app.state.sampling_model_cache = {}
@@ -335,7 +309,11 @@ async def lifespan(app: FastAPI):
     # when the operator explicitly sets it to False.
     is_colocated = bool(backend_cfg.get("trainer.placement.colocate_all", True))
     if app.state.engine_config.external_inference_url:
-        app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
+        app.state.external_future_store = ExternalFutureStore()
+        await app.state.external_future_store.start()
+        app.state.external_inference_client = ExternalInferenceClient(
+            app.state.engine_config, app.state.db_engine, app.state.external_future_store
+        )
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
         app.state.external_future_store = ExternalFutureStore()
@@ -1461,26 +1439,24 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
         seq_id=request.seq_id,
         sampling_session_id=request.sampling_session_id,
     )
-    if req.app.state.external_future_store is not None:
-        request_id = req.app.state.external_future_store.create(model_id, sample_input)
+    external_future_store = req.app.state.external_future_store
+    if external_future_store is not None:
+        # Every external inference mode has a store, so this branch covers all
+        # forwarded samples; the DB path below is only for the internal engine.
+        request_id = external_future_store.create(model_id, sample_input)
+        external_future_store.spawn_forwarding_task(
+            req.app.state.external_inference_client.call_and_store_result(
+                request_id, request, model_id, checkpoint_id, base_model=base_model
+            )
+        )
     else:
         request_id = await create_future(
             session=session,
-            request_type=(
-                types.RequestType.EXTERNAL if req.app.state.external_inference_client else types.RequestType.SAMPLE
-            ),
+            request_type=types.RequestType.SAMPLE,
             model_id=model_id,
             request_data=sample_input,
         )
         await session.commit()
-
-    if req.app.state.external_inference_client:
-        _start_forwarding_task(
-            req.app,
-            req.app.state.external_inference_client.call_and_store_result(
-                request_id, request, model_id, checkpoint_id, base_model=base_model
-            ),
-        )
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -281,6 +281,7 @@ async def lifespan(app: FastAPI):
 
     app.state.future_waiters = {}
     app.state.future_poller = asyncio.create_task(poll_futures(app.state.db_engine, app.state.future_waiters))
+    app.state.proto_serialization_lock = asyncio.Lock()
     app.state.external_future_store = None
     app.state.db_write_lock = _get_db_write_context(app.state.db_engine)
     app.state.sampling_model_cache = {}
@@ -1504,11 +1505,12 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
             types.RequestType(request_type) in PROTO_SERIALIZABLE_REQUEST_TYPES
             and PROTO_CONTENT_TYPE in req.headers.get("accept", "").lower()
         ):
-            content = await asyncio.to_thread(
-                _serialize_proto_result,
-                types.RequestType(request_type),
-                result_data,
-            )
+            async with req.app.state.proto_serialization_lock:
+                content = await asyncio.to_thread(
+                    _serialize_proto_result,
+                    types.RequestType(request_type),
+                    result_data,
+                )
             response: Response = Response(content=content, media_type=PROTO_CONTENT_TYPE)
         else:
             response = raw_json_response(result_data)

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1205,19 +1205,23 @@ async def forward_backward(request: Request, session: AsyncSession = Depends(get
 
 
 @app.post("/api/v1/forward", response_model=FutureResponse)
-async def forward(request: ForwardRequest, session: AsyncSession = Depends(get_session)):
+async def forward(request: ForwardRequest, raw_request: Request, session: AsyncSession = Depends(get_session)):
     """Forward pass to obtain logprobs without accumulating gradients"""
-    await get_model(session, request.model_id)
+    # Serialize before the first SQL statement: AsyncSession checks out its
+    # pool connection lazily, so waiters queue on the lock holding nothing and
+    # a burst of forwards cannot exhaust the connection pool.
+    async with raw_request.app.state.db_write_lock:
+        await get_model(session, request.model_id)
 
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.FORWARD,
-        model_id=request.model_id,
-        request_data=request.forward_input.to_types(),
-        seq_id=request.seq_id,
-    )
+        request_id = await create_future(
+            session=session,
+            request_type=types.RequestType.FORWARD,
+            model_id=request.model_id,
+            request_data=request.forward_input.to_types(),
+            seq_id=request.seq_id,
+        )
 
-    await session.commit()
+        await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -191,6 +191,10 @@ def _finish_forwarding_task(tasks: set[asyncio.Task], task: asyncio.Task) -> Non
         logger.error("Forwarding task failed: %r", error)
 
 
+def _serialize_proto_result(request_type: types.RequestType, result_data: str) -> bytes:
+    return serialize_result(request_type, json.loads(result_data))
+
+
 def _start_forwarding_task(app: FastAPI, operation: Awaitable[None]) -> None:
     task = asyncio.create_task(operation)
     app.state.forwarding_tasks.add(task)
@@ -299,6 +303,7 @@ async def lifespan(app: FastAPI):
     app.state.sampling_model_cache_lock = asyncio.Lock()
     app.state.validated_sampler_checkpoints = set()
     app.state.sampler_checkpoint_validation_lock = asyncio.Lock()
+    app.state.proto_serialization_lock = asyncio.Lock()
 
     # Setup external inference client if configured.
     #
@@ -1510,10 +1515,13 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
             types.RequestType(request_type) in PROTO_SERIALIZABLE_REQUEST_TYPES
             and PROTO_CONTENT_TYPE in req.headers.get("accept", "").lower()
         ):
-            return Response(
-                content=serialize_result(types.RequestType(request_type), json.loads(result_data)),
-                media_type=PROTO_CONTENT_TYPE,
-            )
+            async with req.app.state.proto_serialization_lock:
+                content = await asyncio.to_thread(
+                    _serialize_proto_result,
+                    types.RequestType(request_type),
+                    result_data,
+                )
+            return Response(content=content, media_type=PROTO_CONTENT_TYPE)
         return raw_json_response(result_data)
 
     # Return 400 for handled errors (validation, etc.), 500 for unexpected failures.

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -1145,17 +1145,16 @@ async def _read_forward_backward_request(request: Request) -> tuple[ForwardBackw
 async def forward_backward(request: Request, session: AsyncSession = Depends(get_session)):
     """Compute and accumulate gradients (or run forward-only when the proto body asks for it)."""
     req, forward_only = await _read_forward_backward_request(request)
-    await get_model(session, req.model_id)
-
-    request_id = await create_future(
-        session=session,
-        request_type=types.RequestType.FORWARD if forward_only else types.RequestType.FORWARD_BACKWARD,
-        model_id=req.model_id,
-        request_data=req.forward_backward_input.to_types(),
-        seq_id=req.seq_id,
-    )
-
-    await session.commit()
+    async with request.app.state.db_write_lock:
+        await get_model(session, req.model_id)
+        request_id = await create_future(
+            session=session,
+            request_type=types.RequestType.FORWARD if forward_only else types.RequestType.FORWARD_BACKWARD,
+            model_id=req.model_id,
+            request_data=req.forward_backward_input.to_types(),
+            seq_id=req.seq_id,
+        )
+        await session.commit()
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -6,9 +6,9 @@ import re
 import shutil
 import signal
 import threading
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager, nullcontext, suppress
 from datetime import datetime, timedelta, timezone
-from typing import Annotated, Any, AsyncGenerator, ClassVar, Literal
+from typing import Annotated, Any, AsyncGenerator, Awaitable, ClassVar, Literal
 from uuid import uuid4
 
 import fastapi
@@ -183,6 +183,40 @@ async def poll_futures(
         await asyncio.sleep(poll_interval_sec)
 
 
+def _finish_forwarding_task(tasks: set[asyncio.Task], task: asyncio.Task) -> None:
+    tasks.discard(task)
+    if task.cancelled():
+        return
+    if error := task.exception():
+        logger.error("Forwarding task failed: %r", error)
+
+
+def _start_forwarding_task(app: FastAPI, operation: Awaitable[None]) -> None:
+    task = asyncio.create_task(operation)
+    app.state.forwarding_tasks.add(task)
+    task.add_done_callback(lambda done: _finish_forwarding_task(app.state.forwarding_tasks, done))
+
+
+async def _close_external_inference(app: FastAPI) -> None:
+    if app.state.forwarding_tasks:
+        await asyncio.gather(*tuple(app.state.forwarding_tasks), return_exceptions=True)
+
+    inference_client = getattr(app.state, "external_inference_client", None)
+    aclose = getattr(inference_client, "aclose", None)
+    if aclose is not None:
+        with suppress(Exception):
+            await aclose()
+
+    if app.state.external_future_store is not None:
+        await app.state.external_future_store.close()
+
+
+def _get_db_write_context(db_engine):
+    if db_engine.dialect.name == "sqlite":
+        return asyncio.Lock()
+    return nullcontext()
+
+
 def _get_parent_uv_run_args(parent_cmd: list[str]) -> list[str]:
     """Extract parent `uv run <uv run args>` flags for the engine launch given the parent process's startup command
 
@@ -242,8 +276,9 @@ async def lifespan(app: FastAPI):
 
     app.state.future_waiters = {}
     app.state.future_poller = asyncio.create_task(poll_futures(app.state.db_engine, app.state.future_waiters))
+    app.state.forwarding_tasks = set()
     app.state.external_future_store = None
-    app.state.db_write_lock = asyncio.Lock()
+    app.state.db_write_lock = _get_db_write_context(app.state.db_engine)
     app.state.sampling_model_cache = {}
     app.state.sampling_model_cache_lock = asyncio.Lock()
     app.state.validated_sampler_checkpoints = set()
@@ -272,9 +307,7 @@ async def lifespan(app: FastAPI):
         app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
-        app.state.external_future_store = ExternalFutureStore(
-            app.state.db_engine, app.state.db_write_lock
-        )
+        app.state.external_future_store = ExternalFutureStore(app.state.db_engine, app.state.db_write_lock)
         await app.state.external_future_store.start()
         app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
             app.state.engine_config, app.state.db_engine, app.state.external_future_store
@@ -330,17 +363,7 @@ async def lifespan(app: FastAPI):
     with suppress(asyncio.CancelledError):
         await app.state.future_poller
 
-    if app.state.external_future_store is not None:
-        await app.state.external_future_store.close()
-
-    # Close the forwarding client's persistent httpx connection pool if we
-    # installed one. Cheap no-op when external_inference_client doesn't own
-    # an httpx client (ExternalInferenceClient creates one per call).
-    inference_client = getattr(app.state, "external_inference_client", None)
-    aclose = getattr(inference_client, "aclose", None)
-    if aclose is not None:
-        with suppress(Exception):
-            await aclose()
+    await _close_external_inference(app)
 
     logger.info(f"Stopping background engine (PID {app.state.background_engine.pid})")
     with suppress(ProcessLookupError):
@@ -1335,9 +1358,7 @@ async def get_sampling_model(
         cached = cache.get(sampling_session_id)
         if cached is not None:
             return cached
-        sampling_session = await session.get(
-            SamplingSessionDB, sampling_session_id
-        )
+        sampling_session = await session.get(SamplingSessionDB, sampling_session_id)
         if sampling_session is None:
             raise HTTPException(status_code=404, detail="Sampling session not found")
         sampling_model = (
@@ -1430,10 +1451,11 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
         await session.commit()
 
     if req.app.state.external_inference_client:
-        asyncio.create_task(
+        _start_forwarding_task(
+            req.app,
             req.app.state.external_inference_client.call_and_store_result(
                 request_id, request, model_id, checkpoint_id, base_model=base_model
-            )
+            ),
         )
 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
@@ -1679,19 +1701,24 @@ async def delete_checkpoint(
             ),
         )
 
-    checkpoint_db = await session.get(CheckpointDB, (unique_id, checkpoint_id, resolved_checkpoint_type))
-    if not checkpoint_db:
-        raise HTTPException(status_code=404, detail=f"Checkpoint not found: {unique_id}/{checkpoint_id}")
+    sampler_checkpoint = resolved_checkpoint_type == types.CheckpointType.SAMPLER
+    validation_context = request.app.state.sampler_checkpoint_validation_lock if sampler_checkpoint else nullcontext()
+    async with validation_context:
+        checkpoint_db = await session.get(CheckpointDB, (unique_id, checkpoint_id, resolved_checkpoint_type))
+        if not checkpoint_db:
+            raise HTTPException(status_code=404, detail=f"Checkpoint not found: {unique_id}/{checkpoint_id}")
 
-    if checkpoint_db.status == CheckpointStatus.PENDING:
-        raise HTTPException(status_code=425, detail="Checkpoint is still being created")
+        if checkpoint_db.status == CheckpointStatus.PENDING:
+            raise HTTPException(status_code=425, detail="Checkpoint is still being created")
 
-    # Commit the row deletion before unlinking the artifact. If the commit fails we
-    # leave an orphaned file (GC-able) rather than a row that lists a checkpoint whose
-    # archive is gone, which would make every subsequent download 500.
-    path = checkpoint_file_path(request, unique_id, checkpoint_id, resolved_checkpoint_type)
-    await session.delete(checkpoint_db)
-    await session.commit()
+        # Commit the row deletion before unlinking the artifact. If the commit fails we
+        # leave an orphaned file (GC-able) rather than a row that lists a checkpoint whose
+        # archive is gone, which would make every subsequent download 500.
+        path = checkpoint_file_path(request, unique_id, checkpoint_id, resolved_checkpoint_type)
+        await session.delete(checkpoint_db)
+        await session.commit()
+        if sampler_checkpoint:
+            request.app.state.validated_sampler_checkpoints.discard((unique_id, checkpoint_id))
     await asyncio.to_thread(delete_checkpoint_file, path)
 
 

--- a/skyrl/tinker/external_future_store.py
+++ b/skyrl/tinker/external_future_store.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -15,14 +16,13 @@ from skyrl.utils.log import logger
 class ExternalFuture:
     request_id: int
     model_id: str | None
-    request_data: BaseModel
+    request_data: dict
     status: RequestStatus = RequestStatus.PENDING
     result_data: str | None = None
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: datetime | None = None
     event: asyncio.Event = field(default_factory=asyncio.Event)
-    persisted: bool = False
-    retrieved: bool = False
+    persistence_error: Exception | None = None
 
 
 class ExternalFutureStore:
@@ -31,26 +31,22 @@ class ExternalFutureStore:
     _PERSIST_BATCH_SIZE = 64
     _PERSIST_QUEUE_SIZE = 2048
 
-    def __init__(self, db_engine, db_write_lock: asyncio.Lock):
+    def __init__(self, db_engine, db_write_lock: AbstractAsyncContextManager):
         self.db_engine = db_engine
         self.db_write_lock = db_write_lock
         self._entries: dict[int, ExternalFuture] = {}
-        self._persist_queue: asyncio.Queue[ExternalFuture] = asyncio.Queue(
-            maxsize=self._PERSIST_QUEUE_SIZE
-        )
-        self._persist_workers: list[asyncio.Task] = []
-        self._persist_errors: list[Exception] = []
+        self._persist_queue: asyncio.Queue[ExternalFuture] = asyncio.Queue(maxsize=self._PERSIST_QUEUE_SIZE)
+        self._persist_worker: asyncio.Task | None = None
+        self._persist_error: Exception | None = None
         self._next_request_id = -1
 
     async def start(self) -> None:
         async with AsyncSession(self.db_engine) as session:
-            statement = select(func.min(FutureDB.request_id)).where(
-                FutureDB.request_id < 0
-            )
+            statement = select(func.min(FutureDB.request_id)).where(FutureDB.request_id < 0)
             minimum_request_id = (await session.exec(statement)).one()
         if minimum_request_id is not None:
             self._next_request_id = minimum_request_id - 1
-        self._persist_workers = [asyncio.create_task(self._persist_loop())]
+        self._persist_worker = asyncio.create_task(self._persist_loop())
 
     def create(self, model_id: str | None, request_data: BaseModel) -> int:
         request_id = self._next_request_id
@@ -58,13 +54,11 @@ class ExternalFutureStore:
         self._entries[request_id] = ExternalFuture(
             request_id=request_id,
             model_id=model_id,
-            request_data=request_data,
+            request_data=request_data.model_dump(mode="json"),
         )
         return request_id
 
-    async def wait(
-        self, request_id: int, timeout: float
-    ) -> tuple[RequestStatus, types.RequestType, str | None] | None:
+    async def wait(self, request_id: int, timeout: float) -> tuple[RequestStatus, types.RequestType, str | None] | None:
         entry = self._entries.get(request_id)
         if entry is None:
             raise KeyError(request_id)
@@ -72,34 +66,31 @@ class ExternalFutureStore:
             await asyncio.wait_for(entry.event.wait(), timeout)
         except asyncio.TimeoutError:
             return None
-        entry.retrieved = True
-        self._remove_finished_entry(entry)
+        if entry.persistence_error is not None:
+            self._entries.pop(request_id, None)
+            raise RuntimeError(f"Failed to persist external future {request_id}") from entry.persistence_error
         return entry.status, types.RequestType.EXTERNAL, entry.result_data
 
-    async def complete(
-        self, request_id: int, result_data: BaseModel, status: RequestStatus
-    ) -> None:
+    async def complete(self, request_id: int, result_data: BaseModel, status: RequestStatus) -> None:
         entry = self._entries[request_id]
         entry.result_data = result_data.model_dump_json()
         entry.status = status
         entry.completed_at = datetime.now(timezone.utc)
         await self._persist_queue.put(entry)
-        entry.event.set()
 
     async def flush(self) -> None:
         await self._persist_queue.join()
-        if self._persist_errors:
-            raise RuntimeError(
-                "External future persistence failed"
-            ) from self._persist_errors[0]
+        if self._persist_error is not None:
+            error, self._persist_error = self._persist_error, None
+            raise RuntimeError("External future persistence failed") from error
 
     async def close(self) -> None:
         try:
             await self.flush()
         finally:
-            for worker in self._persist_workers:
-                worker.cancel()
-            await asyncio.gather(*self._persist_workers, return_exceptions=True)
+            if self._persist_worker is not None:
+                self._persist_worker.cancel()
+                await asyncio.gather(self._persist_worker, return_exceptions=True)
 
     async def _persist_loop(self) -> None:
         while True:
@@ -112,16 +103,19 @@ class ExternalFutureStore:
             try:
                 await self._persist(entries)
             except Exception as error:
-                self._persist_errors.append(error)
+                self._persist_error = error
                 logger.exception(
                     "External future persistence failed request_ids=%s..%s",
                     entries[0].request_id,
                     entries[-1].request_id,
                 )
+                for entry in entries:
+                    entry.persistence_error = error
+                    entry.event.set()
             else:
                 for entry in entries:
-                    entry.persisted = True
-                    self._remove_finished_entry(entry)
+                    entry.event.set()
+                    self._entries.pop(entry.request_id, None)
             finally:
                 for _ in entries:
                     self._persist_queue.task_done()
@@ -135,7 +129,7 @@ class ExternalFutureStore:
                             request_id=entry.request_id,
                             request_type=types.RequestType.EXTERNAL,
                             model_id=entry.model_id,
-                            request_data=entry.request_data.model_dump(mode="json"),
+                            request_data=entry.request_data,
                             result_data=entry.result_data,
                             status=entry.status,
                             created_at=entry.created_at,
@@ -145,7 +139,3 @@ class ExternalFutureStore:
                     ]
                 )
                 await session.commit()
-
-    def _remove_finished_entry(self, entry: ExternalFuture) -> None:
-        if entry.persisted and entry.retrieved:
-            self._entries.pop(entry.request_id, None)

--- a/skyrl/tinker/external_future_store.py
+++ b/skyrl/tinker/external_future_store.py
@@ -1,14 +1,12 @@
 import asyncio
-from contextlib import AbstractAsyncContextManager
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 from pydantic import BaseModel
-from sqlmodel import func, select
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from skyrl.tinker import types
-from skyrl.tinker.db_models import FutureDB, RequestStatus
+from skyrl.tinker.db_models import RequestStatus
 from skyrl.utils.log import logger
 
 
@@ -21,32 +19,40 @@ class ExternalFuture:
     result_data: str | None = None
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: datetime | None = None
+    retrieved_at: datetime | None = None
     event: asyncio.Event = field(default_factory=asyncio.Event)
-    persistence_error: Exception | None = None
 
 
 class ExternalFutureStore:
-    """Keeps forwarded sample futures off the database hot path."""
+    """Holds forwarded sample futures purely in memory — they never touch the database.
 
-    _PERSIST_BATCH_SIZE = 64
-    _PERSIST_QUEUE_SIZE = 2048
+    Sample results are transient rollout data: a crash kills the API server and
+    the engine together and the run restarts, so a persisted result would never
+    be read back. Keeping the futures in memory removes sampling from the SQLite
+    write path entirely. Entries are reclaimed by TTL sweeps instead of by a
+    persistence hand-off.
+    """
 
-    def __init__(self, db_engine, db_write_lock: AbstractAsyncContextManager):
-        self.db_engine = db_engine
-        self.db_write_lock = db_write_lock
+    _SWEEP_INTERVAL_SECONDS = 30.0
+    # Retrieved entries linger briefly so an SDK retry after a lost HTTP
+    # response still finds its result.
+    _RETRIEVED_TTL_SECONDS = 60.0
+    # Completed entries whose client never came back for them.
+    _COMPLETED_TTL_SECONDS = 600.0
+    # Pending entries whose forwarding task died without completing them.
+    _PENDING_TTL_SECONDS = 3600.0
+
+    def __init__(self):
         self._entries: dict[int, ExternalFuture] = {}
-        self._persist_queue: asyncio.Queue[ExternalFuture] = asyncio.Queue(maxsize=self._PERSIST_QUEUE_SIZE)
-        self._persist_worker: asyncio.Task | None = None
-        self._persist_error: Exception | None = None
-        self._next_request_id = -1
+        # Boot-epoch id space: each server process starts below every id an
+        # earlier process could plausibly have handed out (2^20 ids per
+        # millisecond of uptime), so a client polling a pre-restart id gets an
+        # honest 404 instead of another request's result.
+        self._next_request_id = -(int(time.time() * 1000) << 20) - 1
+        self._sweeper: asyncio.Task | None = None
 
     async def start(self) -> None:
-        async with AsyncSession(self.db_engine) as session:
-            statement = select(func.min(FutureDB.request_id)).where(FutureDB.request_id < 0)
-            minimum_request_id = (await session.exec(statement)).one()
-        if minimum_request_id is not None:
-            self._next_request_id = minimum_request_id - 1
-        self._persist_worker = asyncio.create_task(self._persist_loop())
+        self._sweeper = asyncio.create_task(self._sweep_loop())
 
     def create(self, model_id: str | None, request_data: BaseModel) -> int:
         request_id = self._next_request_id
@@ -66,85 +72,40 @@ class ExternalFutureStore:
             await asyncio.wait_for(entry.event.wait(), timeout)
         except asyncio.TimeoutError:
             return None
-        if entry.persistence_error is not None:
-            self._entries.pop(request_id, None)
-            raise RuntimeError(f"Failed to persist external future {request_id}") from entry.persistence_error
+        entry.retrieved_at = datetime.now(timezone.utc)
         return entry.status, types.RequestType.EXTERNAL, entry.result_data
 
     async def complete(self, request_id: int, result_data: BaseModel, status: RequestStatus) -> None:
-        entry = self._entries[request_id]
+        entry = self._entries.get(request_id)
+        if entry is None:
+            # Swept as abandoned before the forwarding task finished.
+            logger.warning("External future %s was evicted before its result arrived — dropping", request_id)
+            return
         entry.result_data = result_data.model_dump_json()
         entry.status = status
         entry.completed_at = datetime.now(timezone.utc)
-        await self._persist_queue.put(entry)
-
-    async def flush(self) -> None:
-        await self._persist_queue.join()
-        if self._persist_error is not None:
-            error, self._persist_error = self._persist_error, None
-            raise RuntimeError("External future persistence failed") from error
+        entry.event.set()
 
     async def close(self) -> None:
-        try:
-            await self.flush()
-        finally:
-            if self._persist_worker is not None:
-                self._persist_worker.cancel()
-                await asyncio.gather(self._persist_worker, return_exceptions=True)
+        if self._sweeper is not None:
+            self._sweeper.cancel()
+            await asyncio.gather(self._sweeper, return_exceptions=True)
 
-    async def _persist_loop(self) -> None:
+    def _sweep(self, now: datetime) -> None:
+        def expired(entry: ExternalFuture) -> bool:
+            if entry.retrieved_at is not None:
+                return (now - entry.retrieved_at).total_seconds() > self._RETRIEVED_TTL_SECONDS
+            if entry.completed_at is not None:
+                return (now - entry.completed_at).total_seconds() > self._COMPLETED_TTL_SECONDS
+            return (now - entry.created_at).total_seconds() > self._PENDING_TTL_SECONDS
+
+        expired_ids = [request_id for request_id, entry in self._entries.items() if expired(entry)]
+        for request_id in expired_ids:
+            del self._entries[request_id]
+        if expired_ids:
+            logger.info("Evicted %d expired external futures", len(expired_ids))
+
+    async def _sweep_loop(self) -> None:
         while True:
-            entries = [await self._persist_queue.get()]
-            while len(entries) < self._PERSIST_BATCH_SIZE:
-                try:
-                    entries.append(self._persist_queue.get_nowait())
-                except asyncio.QueueEmpty:
-                    break
-            try:
-                await self._persist(entries)
-            except Exception:
-                # One bad row or transient error must not poison the whole
-                # batch: retry each entry on its own and fail only the ones
-                # that cannot be persisted individually.
-                logger.exception(
-                    "Batched external future persistence failed request_ids=%s..%s, retrying individually",
-                    entries[0].request_id,
-                    entries[-1].request_id,
-                )
-                for entry in entries:
-                    try:
-                        await self._persist([entry])
-                    except Exception as error:
-                        self._persist_error = error
-                        entry.persistence_error = error
-                        logger.exception("External future persistence failed request_id=%s", entry.request_id)
-                    entry.event.set()
-                    if entry.persistence_error is None:
-                        self._entries.pop(entry.request_id, None)
-            else:
-                for entry in entries:
-                    entry.event.set()
-                    self._entries.pop(entry.request_id, None)
-            finally:
-                for _ in entries:
-                    self._persist_queue.task_done()
-
-    async def _persist(self, entries: list[ExternalFuture]) -> None:
-        async with self.db_write_lock:
-            async with AsyncSession(self.db_engine) as session:
-                session.add_all(
-                    [
-                        FutureDB(
-                            request_id=entry.request_id,
-                            request_type=types.RequestType.EXTERNAL,
-                            model_id=entry.model_id,
-                            request_data=entry.request_data,
-                            result_data=entry.result_data,
-                            status=entry.status,
-                            created_at=entry.created_at,
-                            completed_at=entry.completed_at,
-                        )
-                        for entry in entries
-                    ]
-                )
-                await session.commit()
+            await asyncio.sleep(self._SWEEP_INTERVAL_SECONDS)
+            self._sweep(datetime.now(timezone.utc))

--- a/skyrl/tinker/external_future_store.py
+++ b/skyrl/tinker/external_future_store.py
@@ -1,0 +1,149 @@
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from pydantic import BaseModel
+from sqlmodel import func, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from skyrl.tinker import types
+from skyrl.tinker.db_models import FutureDB, RequestStatus
+from skyrl.utils.log import logger
+
+
+@dataclass
+class ExternalFuture:
+    request_id: int
+    model_id: str | None
+    request_data: BaseModel
+    status: RequestStatus = RequestStatus.PENDING
+    result_data: str | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    completed_at: datetime | None = None
+    event: asyncio.Event = field(default_factory=asyncio.Event)
+    persisted: bool = False
+    retrieved: bool = False
+
+
+class ExternalFutureStore:
+    """Keeps forwarded sample futures off the database hot path."""
+
+    _PERSIST_BATCH_SIZE = 64
+    _PERSIST_QUEUE_SIZE = 2048
+
+    def __init__(self, db_engine):
+        self.db_engine = db_engine
+        self._entries: dict[int, ExternalFuture] = {}
+        self._persist_queue: asyncio.Queue[ExternalFuture] = asyncio.Queue(
+            maxsize=self._PERSIST_QUEUE_SIZE
+        )
+        self._persist_workers: list[asyncio.Task] = []
+        self._persist_errors: list[Exception] = []
+        self._next_request_id = -1
+
+    async def start(self) -> None:
+        async with AsyncSession(self.db_engine) as session:
+            statement = select(func.min(FutureDB.request_id)).where(
+                FutureDB.request_id < 0
+            )
+            minimum_request_id = (await session.exec(statement)).one()
+        if minimum_request_id is not None:
+            self._next_request_id = minimum_request_id - 1
+        self._persist_workers = [asyncio.create_task(self._persist_loop())]
+
+    def create(self, model_id: str | None, request_data: BaseModel) -> int:
+        request_id = self._next_request_id
+        self._next_request_id -= 1
+        self._entries[request_id] = ExternalFuture(
+            request_id=request_id,
+            model_id=model_id,
+            request_data=request_data,
+        )
+        return request_id
+
+    async def wait(
+        self, request_id: int, timeout: float
+    ) -> tuple[RequestStatus, types.RequestType, str | None] | None:
+        entry = self._entries.get(request_id)
+        if entry is None:
+            raise KeyError(request_id)
+        try:
+            await asyncio.wait_for(entry.event.wait(), timeout)
+        except asyncio.TimeoutError:
+            return None
+        entry.retrieved = True
+        self._remove_finished_entry(entry)
+        return entry.status, types.RequestType.EXTERNAL, entry.result_data
+
+    async def complete(
+        self, request_id: int, result_data: BaseModel, status: RequestStatus
+    ) -> None:
+        entry = self._entries[request_id]
+        entry.result_data = result_data.model_dump_json()
+        entry.status = status
+        entry.completed_at = datetime.now(timezone.utc)
+        await self._persist_queue.put(entry)
+        entry.event.set()
+
+    async def flush(self) -> None:
+        await self._persist_queue.join()
+        if self._persist_errors:
+            raise RuntimeError(
+                "External future persistence failed"
+            ) from self._persist_errors[0]
+
+    async def close(self) -> None:
+        try:
+            await self.flush()
+        finally:
+            for worker in self._persist_workers:
+                worker.cancel()
+            await asyncio.gather(*self._persist_workers, return_exceptions=True)
+
+    async def _persist_loop(self) -> None:
+        while True:
+            entries = [await self._persist_queue.get()]
+            while len(entries) < self._PERSIST_BATCH_SIZE:
+                try:
+                    entries.append(self._persist_queue.get_nowait())
+                except asyncio.QueueEmpty:
+                    break
+            try:
+                await self._persist(entries)
+            except Exception as error:
+                self._persist_errors.append(error)
+                logger.exception(
+                    "External future persistence failed request_ids=%s..%s",
+                    entries[0].request_id,
+                    entries[-1].request_id,
+                )
+            else:
+                for entry in entries:
+                    entry.persisted = True
+                    self._remove_finished_entry(entry)
+            finally:
+                for _ in entries:
+                    self._persist_queue.task_done()
+
+    async def _persist(self, entries: list[ExternalFuture]) -> None:
+        async with AsyncSession(self.db_engine) as session:
+            session.add_all(
+                [
+                    FutureDB(
+                        request_id=entry.request_id,
+                        request_type=types.RequestType.EXTERNAL,
+                        model_id=entry.model_id,
+                        request_data=entry.request_data.model_dump(mode="json"),
+                        result_data=entry.result_data,
+                        status=entry.status,
+                        created_at=entry.created_at,
+                        completed_at=entry.completed_at,
+                    )
+                    for entry in entries
+                ]
+            )
+            await session.commit()
+
+    def _remove_finished_entry(self, entry: ExternalFuture) -> None:
+        if entry.persisted and entry.retrieved:
+            self._entries.pop(entry.request_id, None)

--- a/skyrl/tinker/external_future_store.py
+++ b/skyrl/tinker/external_future_store.py
@@ -31,8 +31,9 @@ class ExternalFutureStore:
     _PERSIST_BATCH_SIZE = 64
     _PERSIST_QUEUE_SIZE = 2048
 
-    def __init__(self, db_engine):
+    def __init__(self, db_engine, db_write_lock: asyncio.Lock):
         self.db_engine = db_engine
+        self.db_write_lock = db_write_lock
         self._entries: dict[int, ExternalFuture] = {}
         self._persist_queue: asyncio.Queue[ExternalFuture] = asyncio.Queue(
             maxsize=self._PERSIST_QUEUE_SIZE
@@ -126,23 +127,24 @@ class ExternalFutureStore:
                     self._persist_queue.task_done()
 
     async def _persist(self, entries: list[ExternalFuture]) -> None:
-        async with AsyncSession(self.db_engine) as session:
-            session.add_all(
-                [
-                    FutureDB(
-                        request_id=entry.request_id,
-                        request_type=types.RequestType.EXTERNAL,
-                        model_id=entry.model_id,
-                        request_data=entry.request_data.model_dump(mode="json"),
-                        result_data=entry.result_data,
-                        status=entry.status,
-                        created_at=entry.created_at,
-                        completed_at=entry.completed_at,
-                    )
-                    for entry in entries
-                ]
-            )
-            await session.commit()
+        async with self.db_write_lock:
+            async with AsyncSession(self.db_engine) as session:
+                session.add_all(
+                    [
+                        FutureDB(
+                            request_id=entry.request_id,
+                            request_type=types.RequestType.EXTERNAL,
+                            model_id=entry.model_id,
+                            request_data=entry.request_data.model_dump(mode="json"),
+                            result_data=entry.result_data,
+                            status=entry.status,
+                            created_at=entry.created_at,
+                            completed_at=entry.completed_at,
+                        )
+                        for entry in entries
+                    ]
+                )
+                await session.commit()
 
     def _remove_finished_entry(self, entry: ExternalFuture) -> None:
         if entry.persisted and entry.retrieved:

--- a/skyrl/tinker/external_future_store.py
+++ b/skyrl/tinker/external_future_store.py
@@ -102,16 +102,25 @@ class ExternalFutureStore:
                     break
             try:
                 await self._persist(entries)
-            except Exception as error:
-                self._persist_error = error
+            except Exception:
+                # One bad row or transient error must not poison the whole
+                # batch: retry each entry on its own and fail only the ones
+                # that cannot be persisted individually.
                 logger.exception(
-                    "External future persistence failed request_ids=%s..%s",
+                    "Batched external future persistence failed request_ids=%s..%s, retrying individually",
                     entries[0].request_id,
                     entries[-1].request_id,
                 )
                 for entry in entries:
-                    entry.persistence_error = error
+                    try:
+                        await self._persist([entry])
+                    except Exception as error:
+                        self._persist_error = error
+                        entry.persistence_error = error
+                        logger.exception("External future persistence failed request_id=%s", entry.request_id)
                     entry.event.set()
+                    if entry.persistence_error is None:
+                        self._entries.pop(entry.request_id, None)
             else:
                 for entry in entries:
                     entry.event.set()

--- a/skyrl/tinker/external_future_store.py
+++ b/skyrl/tinker/external_future_store.py
@@ -1,7 +1,9 @@
 import asyncio
 import time
+from collections.abc import Coroutine
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -33,6 +35,10 @@ class ExternalFutureStore:
     persistence hand-off.
     """
 
+    # How long close() waits for in-flight forwarding tasks before cancelling
+    # them: a hung inference backend must not stall shutdown for the full
+    # httpx timeout (with retries, potentially many minutes per task).
+    _FORWARDING_SHUTDOWN_TIMEOUT_SECONDS = 10.0
     _SWEEP_INTERVAL_SECONDS = 30.0
     # Retrieved entries linger briefly so an SDK retry after a lost HTTP
     # response still finds its result.
@@ -50,6 +56,7 @@ class ExternalFutureStore:
         # honest 404 instead of another request's result.
         self._next_request_id = -(int(time.time() * 1000) << 20) - 1
         self._sweeper: asyncio.Task | None = None
+        self._forwarding_tasks: set[asyncio.Task] = set()
 
     async def start(self) -> None:
         self._sweeper = asyncio.create_task(self._sweep_loop())
@@ -86,7 +93,29 @@ class ExternalFutureStore:
         entry.completed_at = datetime.now(timezone.utc)
         entry.event.set()
 
+    def spawn_forwarding_task(self, operation: Coroutine[Any, Any, None]) -> None:
+        """Run a forwarding operation in the background, tracked for shutdown."""
+        task = asyncio.create_task(operation)
+        self._forwarding_tasks.add(task)
+        task.add_done_callback(self._finish_forwarding_task)
+
+    def _finish_forwarding_task(self, task: asyncio.Task) -> None:
+        self._forwarding_tasks.discard(task)
+        if task.cancelled():
+            return
+        if error := task.exception():
+            logger.error("Forwarding task failed: %r", error)
+
     async def close(self) -> None:
+        if self._forwarding_tasks:
+            _, pending = await asyncio.wait(
+                tuple(self._forwarding_tasks), timeout=self._FORWARDING_SHUTDOWN_TIMEOUT_SECONDS
+            )
+            if pending:
+                logger.warning(f"Cancelling {len(pending)} forwarding tasks still in flight at shutdown")
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
         if self._sweeper is not None:
             self._sweeper.cancel()
             await asyncio.gather(self._sweeper, return_exceptions=True)

--- a/skyrl/tinker/external_future_store.py
+++ b/skyrl/tinker/external_future_store.py
@@ -40,10 +40,14 @@ class ExternalFutureStore:
     # httpx timeout (with retries, potentially many minutes per task).
     _FORWARDING_SHUTDOWN_TIMEOUT_SECONDS = 10.0
     _SWEEP_INTERVAL_SECONDS = 30.0
-    # Retrieved entries linger briefly so an SDK retry after a lost HTTP
-    # response still finds its result.
-    _RETRIEVED_TTL_SECONDS = 60.0
-    # Completed entries whose client never came back for them.
+    # Grace kept after a result has been *delivered* to the client, so an SDK
+    # retry following a lost HTTP response still finds it. Measured from
+    # delivery (mark_retrieved), never from the in-store read: a large result
+    # can spend minutes being serialized and sent, and starting the clock at
+    # read would evict it mid-delivery.
+    _RETRIEVED_TTL_SECONDS = 120.0
+    # Completed but not yet delivered — governs the read/serialize/send window
+    # and clients that never come back.
     _COMPLETED_TTL_SECONDS = 600.0
     # Pending entries whose forwarding task died without completing them.
     _PENDING_TTL_SECONDS = 3600.0
@@ -79,8 +83,19 @@ class ExternalFutureStore:
             await asyncio.wait_for(entry.event.wait(), timeout)
         except asyncio.TimeoutError:
             return None
-        entry.retrieved_at = datetime.now(timezone.utc)
         return entry.status, types.RequestType.EXTERNAL, entry.result_data
+
+    def mark_retrieved(self, request_id: int) -> None:
+        """Record that a result was delivered, starting its retry-grace clock.
+
+        Called by the endpoint after the response is serialized and handed to
+        the transport — not by wait() — so the short retrieved-TTL measures time
+        since delivery, and a slow in-flight delivery is never swept out from
+        under a retrying client.
+        """
+        entry = self._entries.get(request_id)
+        if entry is not None:
+            entry.retrieved_at = datetime.now(timezone.utc)
 
     async def complete(self, request_id: int, result_data: BaseModel, status: RequestStatus) -> None:
         entry = self._entries.get(request_id)

--- a/skyrl/tinker/extra/external_inference.py
+++ b/skyrl/tinker/extra/external_inference.py
@@ -41,12 +41,13 @@ def _extract_checkpoint_sync(checkpoint_path: AnyPath, target_dir: Path) -> None
 class ExternalInferenceClient:
     """Client for calling external inference engines (e.g., vLLM)."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(self, engine_config: EngineConfig, db_engine, external_future_store=None):
         self.base_url = f"{engine_config.external_inference_url}/v1"
         self.api_key = engine_config.external_inference_api_key
         self.checkpoints_base = engine_config.checkpoints_base
         self.lora_base_dir = engine_config.external_inference_lora_base
         self.db_engine = db_engine
+        self.external_future_store = external_future_store
 
     async def call_and_store_result(
         self,
@@ -72,6 +73,10 @@ class ExternalInferenceClient:
             logger.exception("External engine error")
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
+
+        if self.external_future_store is not None:
+            await self.external_future_store.complete(request_id, result, status)
+            return
 
         async with AsyncSession(self.db_engine) as session:
             future = await session.get(FutureDB, request_id)

--- a/skyrl/tinker/extra/external_inference.py
+++ b/skyrl/tinker/extra/external_inference.py
@@ -41,6 +41,9 @@ def _extract_checkpoint_sync(checkpoint_path: AnyPath, target_dir: Path) -> None
 class ExternalInferenceClient:
     """Client for calling external inference engines (e.g., vLLM)."""
 
+    # TODO: make `external_future_store` required and remove the FutureDB
+    # write-back path in `call_and_store_result` — every production
+    # construction (api.py lifespan) already passes a store.
     def __init__(self, engine_config: EngineConfig, db_engine, external_future_store=None):
         self.base_url = f"{engine_config.external_inference_url}/v1"
         self.api_key = engine_config.external_inference_api_key
@@ -78,6 +81,8 @@ class ExternalInferenceClient:
             await self.external_future_store.complete(request_id, result, status)
             return
 
+        # TODO: remove this FutureDB write-back once `external_future_store`
+        # is required (see __init__).
         async with AsyncSession(self.db_engine) as session:
             future = await session.get(FutureDB, request_id)
             # `result_data` is a text column holding pre-serialized JSON.

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -78,7 +78,11 @@ class SkyRLTrainInferenceForwardingClient:
         *,
         base_model: str | None = None,
     ):
-        """Forward a sample request to vLLM and write the result to FutureDB."""
+        """Forward a sample request to vLLM and resolve its future.
+
+        With an ExternalFutureStore the result stays in memory; without one it
+        is written back to the request's FutureDB row.
+        """
         try:
             result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
             status = RequestStatus.COMPLETED

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -22,6 +22,9 @@ from skyrl.utils.log import logger
 class SkyRLTrainInferenceForwardingClient:
     """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM."""
 
+    # TODO: make `external_future_store` required and remove the FutureDB
+    # write-back path in `call_and_store_result` — every production
+    # construction (api.py lifespan) already passes a store.
     def __init__(
         self,
         engine_config: EngineConfig,
@@ -95,6 +98,8 @@ class SkyRLTrainInferenceForwardingClient:
             await self.external_future_store.complete(request_id, result, status)
             return
 
+        # TODO: remove this FutureDB write-back once `external_future_store`
+        # is required (see __init__).
         async with AsyncSession(self.db_engine) as session:
             future = await session.get(FutureDB, request_id)
             if future is None:

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -15,15 +15,22 @@ from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
 from skyrl.tinker.db_models import EngineStateDB, FutureDB, RequestStatus
+from skyrl.tinker.external_future_store import ExternalFutureStore
 from skyrl.utils.log import logger
 
 
 class SkyRLTrainInferenceForwardingClient:
     """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(
+        self,
+        engine_config: EngineConfig,
+        db_engine,
+        external_future_store: ExternalFutureStore | None = None,
+    ):
         self.engine_config = engine_config
         self.db_engine = db_engine
+        self.external_future_store = external_future_store
         self._cached_proxy_url: str | None = None
         self._cache_lock = asyncio.Lock()
         # Backpressure layered: httpx pool -> vllm-router -> vLLM max_num_seqs.
@@ -79,6 +86,10 @@ class SkyRLTrainInferenceForwardingClient:
             logger.exception("Backend-forwarded sample failed (request_id=%s)", request_id)
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
+
+        if self.external_future_store is not None:
+            await self.external_future_store.complete(request_id, result, status)
+            return
 
         async with AsyncSession(self.db_engine) as session:
             future = await session.get(FutureDB, request_id)

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -9,8 +9,9 @@ bypassing the engine subprocess's serial scheduling loop.
 Coverage:
   - test_engine_state_published: after ``save_weights_for_sampler``, the
     engine's vLLM proxy URL is written to ``EngineStateDB``.
-  - test_sample_uses_external_path: an issued sample creates a future of
-    type ``EXTERNAL`` (not ``SAMPLE``) and resolves successfully.
+  - test_sample_uses_external_path: an issued sample resolves successfully
+    without writing any ``FutureDB`` row — external sample futures live
+    purely in the API process's in-memory store.
   - test_sample_concurrent_with_training_is_fast: the central
     parallelism test. While a long-running stream of ``forward_backward``
     + ``optim_step`` calls is in flight, a sample request resolves in
@@ -212,10 +213,12 @@ def test_engine_state_published(server_db_path):
 
 
 def test_sample_uses_external_path(server_db_path):
-    """A sample issued through the SDK creates a FutureDB row of type EXTERNAL.
+    """A sample issued through the SDK resolves without writing any FutureDB row.
 
     This is the "test" half of the design: the API hoists the sample off
-    the engine's serial loop and into the API process's asyncio loop.
+    the engine's serial loop and into the API process's in-memory store, so
+    the sample never touches the database. A regression that re-routes
+    samples through the DB path would leave a new EXTERNAL row behind.
     """
     proc, db_path, _ = server_db_path
     sc = tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
@@ -234,16 +237,15 @@ def test_sample_uses_external_path(server_db_path):
     ).result()
     assert len(out.sequences) == 1
 
-    # Terminal rows flush asynchronously, and in-memory futures use negative IDs
-    # so they cannot collide with the database's positive autoincrement sequence.
-    found_new_future = wait_for_condition(
-        lambda: bool(_read_external_future_ids(db_path) - future_ids_before),
-        timeout_sec=10,
-        poll_interval_sec=0.1,
+    # The result was delivered (asserted above), so if the store path were
+    # inactive the fallback DB row would already be terminal — give any stray
+    # write a moment to land, then require that none appeared.
+    time.sleep(2)
+    new_future_ids = _read_external_future_ids(db_path) - future_ids_before
+    assert not new_future_ids, (
+        f"expected no new EXTERNAL FutureDB rows after the sample call, found {new_future_ids}; "
+        "samples should resolve purely from the in-memory store"
     )
-    assert (
-        found_new_future
-    ), "expected a new EXTERNAL future after the sample call; async sample routing may not be active"
 
 
 def test_sample_concurrent_with_training_is_fast(server_db_path):

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -169,17 +169,18 @@ def _read_engine_state(db_path: str):
         engine.dispose()
 
 
-def _read_future_request_type(db_path: str, request_id: int) -> str:
-    """Read the request_type of a single future from the test server's DB."""
-    from sqlmodel import Session, create_engine
+def _read_external_future_ids(db_path: str) -> set[int]:
+    """Read the IDs of terminal EXTERNAL futures from the test server's DB."""
+    from sqlmodel import Session, create_engine, select
 
+    from skyrl.tinker import types as skyrl_types
     from skyrl.tinker.db_models import FutureDB
 
     engine = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(engine) as session:
-            row = session.get(FutureDB, request_id)
-            return None if row is None else str(row.request_type)
+            statement = select(FutureDB.request_id).where(FutureDB.request_type == skyrl_types.RequestType.EXTERNAL)
+            return set(session.exec(statement).all())
     finally:
         engine.dispose()
 
@@ -216,11 +217,6 @@ def test_sample_uses_external_path(server_db_path):
     This is the "test" half of the design: the API hoists the sample off
     the engine's serial loop and into the API process's asyncio loop.
     """
-    from sqlmodel import Session, create_engine, func, select
-
-    from skyrl.tinker import types as skyrl_types
-    from skyrl.tinker.db_models import FutureDB
-
     proc, db_path, _ = server_db_path
     sc = tinker.ServiceClient(base_url=f"http://0.0.0.0:{TEST_PORT}/", api_key=TINKER_API_KEY)
     tc = sc.create_lora_training_client(base_model=BASE_MODEL, rank=8)
@@ -229,14 +225,7 @@ def test_sample_uses_external_path(server_db_path):
     _train_one_step(tc, tok)
     sampler = tc.save_weights_and_get_sampling_client(name="external_path_a")
 
-    # Snapshot the max future_id before submitting our sample so we can
-    # filter out any EXTERNAL futures from earlier tests.
-    eng = create_engine(f"sqlite:///{db_path}", echo=False)
-    try:
-        with Session(eng) as s:
-            max_before = s.exec(select(func.max(FutureDB.request_id))).one() or 0
-    finally:
-        eng.dispose()
+    future_ids_before = _read_external_future_ids(db_path)
 
     out = sampler.sample(
         prompt=tinker_types.ModelInput.from_ints(tok.encode("Hi", add_special_tokens=True)),
@@ -245,23 +234,15 @@ def test_sample_uses_external_path(server_db_path):
     ).result()
     assert len(out.sequences) == 1
 
-    # Look for an EXTERNAL future with id > max_before. If async routing
-    # is on, every sample creates exactly one such row.
-    eng = create_engine(f"sqlite:///{db_path}", echo=False)
-    try:
-        with Session(eng) as s:
-            stmt = (
-                select(FutureDB.request_id, FutureDB.request_type)
-                .where(FutureDB.request_id > max_before)
-                .where(FutureDB.request_type == skyrl_types.RequestType.EXTERNAL)
-            )
-            rows = s.exec(stmt).all()
-    finally:
-        eng.dispose()
-
-    assert len(rows) >= 1, (
-        f"expected at least one EXTERNAL future to be created by the sample call, "
-        f"found {len(rows)}; async sample routing may not be active"
+    # Terminal rows flush asynchronously, and in-memory futures use negative IDs
+    # so they cannot collide with the database's positive autoincrement sequence.
+    found_new_future = wait_for_condition(
+        lambda: bool(_read_external_future_ids(db_path) - future_ids_before),
+        timeout_sec=10,
+        poll_interval_sec=0.1,
+    )
+    assert found_new_future, (
+        "expected a new EXTERNAL future after the sample call; async sample routing may not be active"
     )
 
 

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -241,9 +241,9 @@ def test_sample_uses_external_path(server_db_path):
         timeout_sec=10,
         poll_interval_sec=0.1,
     )
-    assert found_new_future, (
-        "expected a new EXTERNAL future after the sample call; async sample routing may not be active"
-    )
+    assert (
+        found_new_future
+    ), "expected a new EXTERNAL future after the sample call; async sample routing may not be active"
 
 
 def test_sample_concurrent_with_training_is_fast(server_db_path):

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -112,7 +113,7 @@ async def future_store(tmp_path):
         await connection.run_sync(SQLModel.metadata.create_all)
 
     db_write_lock = asyncio.Lock()
-    store = ExternalFutureStore(engine, db_write_lock)
+    store = ExternalFutureStore()
     await store.start()
     yield store, engine, db_write_lock
     await store.close()
@@ -229,7 +230,7 @@ async def test_sustained_model_path_rollouts_training_futures_and_heartbeats(fut
                 )
             )
             assert all(response.body == expected_sample for response in retrievals)
-            assert not store._entries
+            assert all(store._entries[request_id].retrieved_at is not None for request_id in request_ids)
 
         repeated = await api.retrieve_future(api.RetrieveFutureRequest(request_id=str(request_ids[-1])), sample_request)
         assert repeated.body == expected_sample
@@ -237,14 +238,14 @@ async def test_sustained_model_path_rollouts_training_futures_and_heartbeats(fut
         future_poller.cancel()
         await asyncio.gather(future_poller, return_exceptions=True)
 
-    await store.flush()
     async with AsyncSession(engine) as session:
         persisted_by_type = dict(
             (await session.exec(select(FutureDB.request_type, func.count()).group_by(FutureDB.request_type))).all()
         )
         session_db = await session.get(SessionDB, "session_a")
 
-    assert persisted_by_type[types.RequestType.EXTERNAL] == 2048
+    # External sample futures live purely in memory — nothing reaches the DB.
+    assert types.RequestType.EXTERNAL not in persisted_by_type
     assert persisted_by_type[types.RequestType.FORWARD_BACKWARD] == 2048
     assert session_db is not None
     assert session_db.heartbeat_count == 128
@@ -546,68 +547,68 @@ async def test_forwarding_client_completes_in_memory_future(future_store, monkey
 
 
 @pytest.mark.asyncio
-async def test_persistence_failure_is_reported_to_waiter(future_store, monkeypatch):
+async def test_sweep_evicts_entries_by_ttl(future_store):
     store, _, _ = future_store
-    request_id = store.create("model_a", _sample_input(1))
+    result = types.SampleOutput(sequences=[])
 
-    async def fail_persistence(entries):
-        raise RuntimeError("database unavailable")
+    retrieved_id = store.create("model_a", _sample_input(1))
+    await store.complete(retrieved_id, result, RequestStatus.COMPLETED)
+    await store.wait(retrieved_id, timeout=1)
+    completed_id = store.create("model_a", _sample_input(2))
+    await store.complete(completed_id, result, RequestStatus.COMPLETED)
+    pending_id = store.create("model_a", _sample_input(3))
 
-    monkeypatch.setattr(store, "_persist", fail_persistence)
-    await store.complete(request_id, types.SampleOutput(sequences=[]), RequestStatus.COMPLETED)
+    now = datetime.now(timezone.utc)
+    store._sweep(now)
+    assert set(store._entries) == {retrieved_id, completed_id, pending_id}
 
-    with pytest.raises(RuntimeError, match=f"Failed to persist external future {request_id}"):
-        await store.wait(request_id, timeout=1)
-    with pytest.raises(RuntimeError, match="External future persistence failed"):
-        await store.flush()
+    store._sweep(now + timedelta(seconds=ExternalFutureStore._RETRIEVED_TTL_SECONDS + 1))
+    assert set(store._entries) == {completed_id, pending_id}
+
+    store._sweep(now + timedelta(seconds=ExternalFutureStore._COMPLETED_TTL_SECONDS + 1))
+    assert set(store._entries) == {pending_id}
+
+    store._sweep(now + timedelta(seconds=ExternalFutureStore._PENDING_TTL_SECONDS + 1))
+    assert not store._entries
+
+    # A forwarding task finishing after its entry was swept is dropped, not an error.
+    await store.complete(pending_id, result, RequestStatus.COMPLETED)
 
 
 @pytest.mark.asyncio
-async def test_batch_persist_failure_does_not_poison_other_entries(future_store, monkeypatch):
-    store, engine, _ = future_store
-    good_ids = [store.create("model_a", _sample_input(1)), store.create("model_a", _sample_input(3))]
-    bad_id = store.create("model_a", _sample_input(2))
+async def test_request_ids_do_not_repeat_across_restarts(monkeypatch):
+    import skyrl.tinker.external_future_store as store_module
 
-    async def persist_rejecting_bad_entry(entries):
-        if any(entry.request_id == bad_id for entry in entries):
-            raise RuntimeError("database unavailable")
-        await ExternalFutureStore._persist(store, entries)
+    monkeypatch.setattr(store_module.time, "time", lambda: 1_000.0)
+    first_boot = ExternalFutureStore()
+    first_ids = [first_boot.create("model_a", _sample_input(index)) for index in range(3)]
 
-    monkeypatch.setattr(store, "_persist", persist_rejecting_bad_entry)
+    monkeypatch.setattr(store_module.time, "time", lambda: 1_000.001)
+    second_boot = ExternalFutureStore()
+    second_ids = [second_boot.create("model_a", _sample_input(index)) for index in range(3)]
 
-    # complete() never suspends on a non-full queue, so all three entries are
-    # enqueued before the persist worker wakes and drains them as one batch.
-    result = types.SampleOutput(sequences=[])
-    for request_id in (good_ids[0], bad_id, good_ids[1]):
-        await store.complete(request_id, result, RequestStatus.COMPLETED)
-
-    for good_id in good_ids:
-        assert await store.wait(good_id, timeout=1) == (
-            RequestStatus.COMPLETED,
-            types.RequestType.EXTERNAL,
-            result.model_dump_json(),
-        )
-    with pytest.raises(RuntimeError, match=f"Failed to persist external future {bad_id}"):
-        await store.wait(bad_id, timeout=1)
-
-    async with AsyncSession(engine) as session:
-        statement = select(FutureDB.request_id).where(FutureDB.request_id.in_(good_ids + [bad_id]))
-        persisted = set((await session.exec(statement)).all())
-    assert persisted == set(good_ids)
-
-    with pytest.raises(RuntimeError, match="External future persistence failed"):
-        await store.flush()
+    assert all(request_id < 0 for request_id in first_ids + second_ids)
+    # A later boot starts below every id the earlier process handed out, so a
+    # client polling a pre-restart id can never receive another request's result.
+    assert max(second_ids) < min(first_ids)
 
 
 @pytest.mark.asyncio
 async def test_create_future_accepts_request_id_zero_after_negative_rows(future_store):
-    # SQLite assigns max(rowid)+1, so when the table holds only the store's
-    # negative request_ids the first autoincremented FutureDB row gets id 0.
-    store, engine, _ = future_store
-    request_id = store.create("model_a", _sample_input(1))
-    assert request_id < 0
-    await store.complete(request_id, types.SampleOutput(sequences=[]), RequestStatus.COMPLETED)
-    await store.flush()
+    # SQLite assigns max(rowid)+1, so when the table holds only negative
+    # request_ids (written by a pre-memory-only server version) the first
+    # autoincremented FutureDB row gets id 0.
+    _, engine, _ = future_store
+    async with AsyncSession(engine) as session:
+        session.add(
+            FutureDB(
+                request_id=-1,
+                request_type=types.RequestType.EXTERNAL,
+                request_data={},
+                status=RequestStatus.COMPLETED,
+            )
+        )
+        await session.commit()
 
     async with AsyncSession(engine) as session:
         created_id = await api.create_future(

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -11,6 +11,8 @@ from starlette.requests import Request
 from skyrl.tinker import api, types
 from skyrl.tinker.config import EngineConfig
 from skyrl.tinker.db_models import (
+    CheckpointDB,
+    CheckpointStatus,
     FutureDB,
     ModelDB,
     RequestStatus,
@@ -228,7 +230,7 @@ async def test_two_full_rollout_waves_complete_and_persist(future_store):
 
 
 @pytest.mark.asyncio
-async def test_sustained_rollouts_training_futures_and_heartbeats(future_store):
+async def test_sustained_model_path_rollouts_training_futures_and_heartbeats(future_store):
     store, engine, db_write_lock = future_store
     forwarder = _CompletingForwarder(store)
     sample_request = SimpleNamespace(
@@ -236,9 +238,12 @@ async def test_sustained_rollouts_training_futures_and_heartbeats(future_store):
             state=SimpleNamespace(
                 external_future_store=store,
                 external_inference_client=forwarder,
+                engine_config=EngineConfig(base_model="model_a"),
                 db_write_lock=db_write_lock,
                 sampling_model_cache={},
                 sampling_model_cache_lock=asyncio.Lock(),
+                validated_sampler_checkpoints=set(),
+                sampler_checkpoint_validation_lock=asyncio.Lock(),
             )
         )
     )
@@ -257,7 +262,7 @@ async def test_sustained_rollouts_training_futures_and_heartbeats(future_store):
                 sampling_session_id="session_a",
                 session_id="session_a",
                 sampling_session_seq_id=0,
-                base_model="model_a",
+                model_path="tinker://model_a/sampler_weights/weights_a",
             )
         )
         session.add(
@@ -268,6 +273,14 @@ async def test_sustained_rollouts_training_futures_and_heartbeats(future_store):
                 status="ready",
                 request_id=0,
                 session_id="session_a",
+            )
+        )
+        session.add(
+            CheckpointDB(
+                model_id="model_a",
+                checkpoint_id="weights_a",
+                checkpoint_type=types.CheckpointType.SAMPLER,
+                status=CheckpointStatus.COMPLETED,
             )
         )
         await session.commit()
@@ -327,6 +340,9 @@ async def test_sustained_rollouts_training_futures_and_heartbeats(future_store):
     assert persisted_by_type[types.RequestType.FORWARD_BACKWARD] == 2048
     assert session_db is not None
     assert session_db.heartbeat_count == 128
+    assert sample_request.app.state.validated_sampler_checkpoints == {
+        ("model_a", "weights_a")
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -268,6 +268,9 @@ async def test_retrieve_future_bounds_protobuf_serialization_off_event_loop(monk
                 types.SampleOutput(sequences=[]).model_dump_json(),
             )
 
+        def mark_retrieved(self, request_id):
+            pass
+
     def serialize_result_in_thread(request_type, result_data):
         nonlocal active_serializations, max_active_serializations
         serialization_thread_ids.append(threading.get_ident())
@@ -547,6 +550,7 @@ async def test_sweep_evicts_entries_by_ttl(future_store):
     retrieved_id = store.create("model_a", _sample_input(1))
     await store.complete(retrieved_id, result, RequestStatus.COMPLETED)
     await store.wait(retrieved_id, timeout=1)
+    store.mark_retrieved(retrieved_id)
     completed_id = store.create("model_a", _sample_input(2))
     await store.complete(completed_id, result, RequestStatus.COMPLETED)
     pending_id = store.create("model_a", _sample_input(3))
@@ -555,6 +559,9 @@ async def test_sweep_evicts_entries_by_ttl(future_store):
     store._sweep(now)
     assert set(store._entries) == {retrieved_id, completed_id, pending_id}
 
+    # A completed-but-undelivered entry (read via wait() but never marked
+    # delivered) must NOT be governed by the short retrieved-TTL: a slow
+    # in-flight delivery would otherwise be evicted out from under the client.
     store._sweep(now + timedelta(seconds=ExternalFutureStore._RETRIEVED_TTL_SECONDS + 1))
     assert set(store._entries) == {completed_id, pending_id}
 

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -1,0 +1,231 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel, func, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from skyrl.tinker import api, types
+from skyrl.tinker.config import EngineConfig
+from skyrl.tinker.db_models import (
+    FutureDB,
+    RequestStatus,
+    SamplingSessionDB,
+    enable_sqlite_wal,
+    get_async_database_url,
+)
+from skyrl.tinker.external_future_store import ExternalFutureStore
+from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
+    SkyRLTrainInferenceForwardingClient,
+)
+
+
+def _sample_input(seq_id: int) -> types.SampleInput:
+    return types.SampleInput(
+        base_model="model_a",
+        prompt=types.ModelInput(chunks=[types.EncodedTextChunk(tokens=[seq_id])]),
+        sampling_params=types.SamplingParams(
+            temperature=0.0, max_tokens=1, seed=seq_id
+        ),
+        num_samples=1,
+        checkpoint_id="",
+        prompt_logprobs=False,
+        seq_id=seq_id,
+    )
+
+
+class _CompletingForwarder:
+    def __init__(self, store: ExternalFutureStore):
+        self.store = store
+        self.gate = asyncio.Event()
+
+    async def call_and_store_result(
+        self,
+        request_id: int,
+        sample_req,
+        model_id: str,
+        checkpoint_id: str,
+        base_model: str | None = None,
+    ) -> None:
+        await self.gate.wait()
+        await self.store.complete(
+            request_id,
+            types.SampleOutput(sequences=[]),
+            RequestStatus.COMPLETED,
+        )
+
+
+@pytest_asyncio.fixture()
+async def future_store(tmp_path):
+    db_url = get_async_database_url(f"sqlite:///{tmp_path / 'tinker.db'}")
+    engine = create_async_engine(db_url, pool_size=1, max_overflow=0)
+    enable_sqlite_wal(engine.sync_engine)
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+
+    store = ExternalFutureStore(engine)
+    await store.start()
+    yield store, engine
+    await store.close()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_two_full_rollout_waves_complete_and_persist(future_store):
+    store, engine = future_store
+    forwarder = _CompletingForwarder(store)
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                external_future_store=store,
+                external_inference_client=forwarder,
+            )
+        )
+    )
+    result_data = types.SampleOutput(sequences=[]).model_dump_json()
+
+    async with AsyncSession(engine) as session:
+        session.add(
+            SamplingSessionDB(
+                sampling_session_id="session_a",
+                session_id="session_a",
+                sampling_session_seq_id=0,
+                base_model="model_a",
+            )
+        )
+        await session.commit()
+
+    for wave in range(2):
+        forwarder.gate.clear()
+
+        async def create_sample(index: int) -> int:
+            async with AsyncSession(engine) as session:
+                response = await api.asample(
+                    api.SampleRequest(
+                        prompt=api.ModelInput(
+                            chunks=[api.EncodedTextChunk(tokens=[index])]
+                        ),
+                        sampling_params=api.SamplingParams(
+                            temperature=0.0, max_tokens=1, seed=index
+                        ),
+                        sampling_session_id="session_a",
+                        seq_id=wave * 512 + index,
+                    ),
+                    request,
+                    session,
+                )
+            return int(response.request_id)
+
+        request_ids = await asyncio.gather(
+            *(create_sample(index) for index in range(512))
+        )
+        waiters = [
+            asyncio.create_task(store.wait(request_id, timeout=5))
+            for request_id in request_ids
+        ]
+
+        async with AsyncSession(engine) as session:
+            pending_after_creation = (
+                await session.exec(
+                    select(func.count())
+                    .select_from(FutureDB)
+                    .where(FutureDB.status == RequestStatus.PENDING)
+                )
+            ).one()
+        assert pending_after_creation == 0
+
+        forwarder.gate.set()
+        results = await asyncio.gather(*waiters)
+
+        assert all(
+            result == (RequestStatus.COMPLETED, types.RequestType.EXTERNAL, result_data)
+            for result in results
+        )
+
+    await store.flush()
+    async with AsyncSession(engine) as session:
+        persisted = (
+            await session.exec(select(func.count()).select_from(FutureDB))
+        ).one()
+        pending = (
+            await session.exec(
+                select(func.count())
+                .select_from(FutureDB)
+                .where(FutureDB.status == RequestStatus.PENDING)
+            )
+        ).one()
+
+    assert persisted == 1024
+    assert pending == 0
+
+
+@pytest.mark.asyncio
+async def test_forwarding_client_completes_in_memory_future(future_store, monkeypatch):
+    store, engine = future_store
+    request_id = store.create("model_a", _sample_input(1))
+    result = types.SampleOutput(
+        sequences=[
+            types.GeneratedSequence(
+                stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0]
+            )
+        ]
+    )
+    client = SkyRLTrainInferenceForwardingClient(
+        EngineConfig(base_model="model_a"), engine, store
+    )
+
+    async def forward(*args, **kwargs):
+        return result
+
+    monkeypatch.setattr(client, "_forward_with_retry", forward)
+    try:
+        await client.call_and_store_result(
+            request_id,
+            SimpleNamespace(),
+            model_id="model_a",
+            checkpoint_id="",
+        )
+        completed = await store.wait(request_id, timeout=1)
+    finally:
+        await client.aclose()
+
+    assert completed == (
+        RequestStatus.COMPLETED,
+        types.RequestType.EXTERNAL,
+        result.model_dump_json(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_retrieve_future_serializes_in_memory_result_as_proto(future_store):
+    from tinker import SampleResponse
+    from tinker.proto.response_conv import deserialize_proto_response
+
+    store, engine = future_store
+    request_id = store.create("model_a", _sample_input(1))
+    result = types.SampleOutput(
+        sequences=[
+            types.GeneratedSequence(
+                stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0]
+            )
+        ]
+    )
+    await store.complete(request_id, result, RequestStatus.COMPLETED)
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                db_engine=engine, external_future_store=store, future_waiters={}
+            )
+        ),
+        headers={"accept": "application/x-protobuf, application/json"},
+    )
+    response = await api.retrieve_future(
+        api.RetrieveFutureRequest(request_id=str(request_id)), request
+    )
+
+    assert response.media_type == "application/x-protobuf"
+    result = deserialize_proto_response(response.body, SampleResponse)
+    assert result.sequences[0].tokens == [1, 2]

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -344,6 +344,37 @@ async def test_shutdown_waits_for_forwarding_tasks_before_closing_store():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_cancels_hung_forwarding_tasks(monkeypatch):
+    monkeypatch.setattr(api, "FORWARDING_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
+    events = []
+
+    class ClosingStore:
+        async def close(self) -> None:
+            events.append("store_closed")
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            external_inference_client=None,
+            external_future_store=ClosingStore(),
+            forwarding_tasks=set(),
+        )
+    )
+
+    async def hang_forever() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            events.append("forwarding_cancelled")
+            raise
+
+    api._start_forwarding_task(app, hang_forever())
+    await asyncio.wait_for(api._close_external_inference(app), timeout=5)
+
+    assert events == ["forwarding_cancelled", "store_closed"]
+    assert not app.state.forwarding_tasks
+
+
+@pytest.mark.asyncio
 async def test_shutdown_stops_engine_when_future_persistence_failed(monkeypatch):
     events = []
 

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -563,6 +563,43 @@ async def test_persistence_failure_is_reported_to_waiter(future_store, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_batch_persist_failure_does_not_poison_other_entries(future_store, monkeypatch):
+    store, engine, _ = future_store
+    good_ids = [store.create("model_a", _sample_input(1)), store.create("model_a", _sample_input(3))]
+    bad_id = store.create("model_a", _sample_input(2))
+
+    async def persist_rejecting_bad_entry(entries):
+        if any(entry.request_id == bad_id for entry in entries):
+            raise RuntimeError("database unavailable")
+        await ExternalFutureStore._persist(store, entries)
+
+    monkeypatch.setattr(store, "_persist", persist_rejecting_bad_entry)
+
+    # complete() never suspends on a non-full queue, so all three entries are
+    # enqueued before the persist worker wakes and drains them as one batch.
+    result = types.SampleOutput(sequences=[])
+    for request_id in (good_ids[0], bad_id, good_ids[1]):
+        await store.complete(request_id, result, RequestStatus.COMPLETED)
+
+    for good_id in good_ids:
+        assert await store.wait(good_id, timeout=1) == (
+            RequestStatus.COMPLETED,
+            types.RequestType.EXTERNAL,
+            result.model_dump_json(),
+        )
+    with pytest.raises(RuntimeError, match=f"Failed to persist external future {bad_id}"):
+        await store.wait(bad_id, timeout=1)
+
+    async with AsyncSession(engine) as session:
+        statement = select(FutureDB.request_id).where(FutureDB.request_id.in_(good_ids + [bad_id]))
+        persisted = set((await session.exec(statement)).all())
+    assert persisted == set(good_ids)
+
+    with pytest.raises(RuntimeError, match="External future persistence failed"):
+        await store.flush()
+
+
+@pytest.mark.asyncio
 async def test_create_future_accepts_request_id_zero_after_negative_rows(future_store):
     # SQLite assigns max(rowid)+1, so when the table holds only the store's
     # negative request_ids the first autoincremented FutureDB row gets id 0.

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -130,7 +130,6 @@ async def test_sustained_model_path_rollouts_training_futures_and_heartbeats(fut
                 db_engine=engine,
                 external_future_store=store,
                 external_inference_client=forwarder,
-                forwarding_tasks=set(),
                 future_waiters={},
                 engine_config=EngineConfig(base_model="model_a"),
                 db_write_lock=db_write_lock,
@@ -250,7 +249,7 @@ async def test_sustained_model_path_rollouts_training_futures_and_heartbeats(fut
     assert session_db is not None
     assert session_db.heartbeat_count == 128
     assert sample_request.app.state.validated_sampler_checkpoints == {("model_a", "weights_a")}
-    assert not sample_request.app.state.forwarding_tasks
+    assert not store._forwarding_tasks
 
 
 @pytest.mark.asyncio
@@ -308,7 +307,7 @@ async def test_retrieve_future_bounds_protobuf_serialization_off_event_loop(monk
 
 
 @pytest.mark.asyncio
-async def test_shutdown_waits_for_forwarding_tasks_before_closing_store():
+async def test_shutdown_waits_for_forwarding_tasks_before_closing_client():
     release_forwarding = asyncio.Event()
     events = []
 
@@ -316,15 +315,12 @@ async def test_shutdown_waits_for_forwarding_tasks_before_closing_store():
         async def aclose(self) -> None:
             events.append("client_closed")
 
-    class ClosingStore:
-        async def close(self) -> None:
-            events.append("store_closed")
-
+    store = ExternalFutureStore()
+    await store.start()
     app = SimpleNamespace(
         state=SimpleNamespace(
             external_inference_client=ClosingClient(),
-            external_future_store=ClosingStore(),
-            forwarding_tasks=set(),
+            external_future_store=store,
         )
     )
 
@@ -332,7 +328,7 @@ async def test_shutdown_waits_for_forwarding_tasks_before_closing_store():
         await release_forwarding.wait()
         events.append("future_completed")
 
-    api._start_forwarding_task(app, finish_forwarding())
+    store.spawn_forwarding_task(finish_forwarding())
     shutdown = asyncio.create_task(api._close_external_inference(app))
     await asyncio.sleep(0)
     assert not shutdown.done()
@@ -340,24 +336,21 @@ async def test_shutdown_waits_for_forwarding_tasks_before_closing_store():
     release_forwarding.set()
     await shutdown
 
-    assert events == ["future_completed", "client_closed", "store_closed"]
-    assert not app.state.forwarding_tasks
+    assert events == ["future_completed", "client_closed"]
+    assert not store._forwarding_tasks
 
 
 @pytest.mark.asyncio
 async def test_shutdown_cancels_hung_forwarding_tasks(monkeypatch):
-    monkeypatch.setattr(api, "FORWARDING_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(ExternalFutureStore, "_FORWARDING_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
     events = []
 
-    class ClosingStore:
-        async def close(self) -> None:
-            events.append("store_closed")
-
+    store = ExternalFutureStore()
+    await store.start()
     app = SimpleNamespace(
         state=SimpleNamespace(
             external_inference_client=None,
-            external_future_store=ClosingStore(),
-            forwarding_tasks=set(),
+            external_future_store=store,
         )
     )
 
@@ -368,11 +361,11 @@ async def test_shutdown_cancels_hung_forwarding_tasks(monkeypatch):
             events.append("forwarding_cancelled")
             raise
 
-    api._start_forwarding_task(app, hang_forever())
+    store.spawn_forwarding_task(hang_forever())
     await asyncio.wait_for(api._close_external_inference(app), timeout=5)
 
-    assert events == ["forwarding_cancelled", "store_closed"]
-    assert not app.state.forwarding_tasks
+    assert events == ["forwarding_cancelled"]
+    assert not store._forwarding_tasks
 
 
 @pytest.mark.asyncio

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -6,11 +6,13 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
+from starlette.requests import Request
 
 from skyrl.tinker import api, types
 from skyrl.tinker.config import EngineConfig
 from skyrl.tinker.db_models import (
     FutureDB,
+    ModelDB,
     RequestStatus,
     SamplingSessionDB,
     SessionDB,
@@ -54,6 +56,47 @@ class _CompletingForwarder:
             types.SampleOutput(sequences=[]),
             RequestStatus.COMPLETED,
         )
+
+
+def _forward_backward_request(seq_id: int, db_write_lock: asyncio.Lock) -> Request:
+    body = api.ForwardBackwardRequest(
+        model_id="model_a",
+        seq_id=seq_id,
+        forward_backward_input=api.ForwardBackwardInput(
+            data=[
+                api.Datum(
+                    model_input=api.ModelInput(
+                        chunks=[api.EncodedTextChunk(tokens=[1, 2])]
+                    ),
+                    loss_fn_inputs={
+                        "target_tokens": api.TensorData(data=[2, 3]),
+                        "weights": api.TensorData(data=[1.0, 1.0]),
+                    },
+                )
+            ],
+            loss_fn="cross_entropy",
+        ),
+    ).model_dump_json().encode()
+    body_sent = False
+
+    async def receive():
+        nonlocal body_sent
+        if body_sent:
+            return {"type": "http.disconnect"}
+        body_sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    app = SimpleNamespace(state=SimpleNamespace(db_write_lock=db_write_lock))
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v1/forward_backward",
+            "headers": [(b"content-type", b"application/json")],
+            "app": app,
+        },
+        receive,
+    )
 
 
 @pytest_asyncio.fixture()
@@ -182,6 +225,108 @@ async def test_two_full_rollout_waves_complete_and_persist(future_store):
     assert pending == 0
     assert session_db is not None
     assert session_db.heartbeat_count == 64
+
+
+@pytest.mark.asyncio
+async def test_sustained_rollouts_training_futures_and_heartbeats(future_store):
+    store, engine, db_write_lock = future_store
+    forwarder = _CompletingForwarder(store)
+    sample_request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                external_future_store=store,
+                external_inference_client=forwarder,
+                db_write_lock=db_write_lock,
+                sampling_model_cache={},
+                sampling_model_cache_lock=asyncio.Lock(),
+            )
+        )
+    )
+
+    async with AsyncSession(engine) as session:
+        session.add(
+            SessionDB(
+                session_id="session_a",
+                tags=[],
+                user_metadata={},
+                sdk_version="test",
+            )
+        )
+        session.add(
+            SamplingSessionDB(
+                sampling_session_id="session_a",
+                session_id="session_a",
+                sampling_session_seq_id=0,
+                base_model="model_a",
+            )
+        )
+        session.add(
+            ModelDB(
+                model_id="model_a",
+                base_model="model_a",
+                lora_config={},
+                status="ready",
+                request_id=0,
+                session_id="session_a",
+            )
+        )
+        await session.commit()
+
+    for wave in range(4):
+        async def create_sample(index: int) -> None:
+            async with AsyncSession(engine) as session:
+                await api.asample(
+                    api.SampleRequest(
+                        prompt=api.ModelInput(
+                            chunks=[api.EncodedTextChunk(tokens=[index])]
+                        ),
+                        sampling_params=api.SamplingParams(
+                            temperature=0.0, max_tokens=1, seed=index
+                        ),
+                        sampling_session_id="session_a",
+                        seq_id=wave * 512 + index,
+                    ),
+                    sample_request,
+                    session,
+                )
+
+        async def create_training_future(index: int) -> None:
+            async with AsyncSession(engine) as session:
+                await api.forward_backward(
+                    _forward_backward_request(wave * 512 + index, db_write_lock),
+                    session,
+                )
+
+        async def heartbeat() -> None:
+            async with AsyncSession(engine) as session:
+                await api.session_heartbeat(
+                    api.SessionHeartbeatRequest(session_id="session_a"),
+                    sample_request,
+                    session,
+                )
+
+        await asyncio.gather(
+            *(create_sample(index) for index in range(512)),
+            *(create_training_future(index) for index in range(512)),
+            *(heartbeat() for _ in range(32)),
+        )
+
+    await store.flush()
+    async with AsyncSession(engine) as session:
+        persisted_by_type = dict(
+            (
+                await session.exec(
+                    select(FutureDB.request_type, func.count())
+                    .group_by(FutureDB.request_type)
+                )
+            ).all()
+        )
+        session_db = await session.get(SessionDB, "session_a")
+
+    assert persisted_by_type[types.RequestType.EXTERNAL] == 2048
+    assert persisted_by_type[types.RequestType.FORWARD_BACKWARD] == 2048
+    assert session_db is not None
+    assert session_db.heartbeat_count == 128
 
 
 @pytest.mark.asyncio

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -31,9 +31,7 @@ def _sample_input(seq_id: int) -> types.SampleInput:
     return types.SampleInput(
         base_model="model_a",
         prompt=types.ModelInput(chunks=[types.EncodedTextChunk(tokens=[seq_id])]),
-        sampling_params=types.SamplingParams(
-            temperature=0.0, max_tokens=1, seed=seq_id
-        ),
+        sampling_params=types.SamplingParams(temperature=0.0, max_tokens=1, seed=seq_id),
         num_samples=1,
         checkpoint_id="",
         prompt_logprobs=False,
@@ -61,24 +59,26 @@ class _CompletingForwarder:
 
 
 def _forward_backward_request(seq_id: int, db_write_lock: asyncio.Lock) -> Request:
-    body = api.ForwardBackwardRequest(
-        model_id="model_a",
-        seq_id=seq_id,
-        forward_backward_input=api.ForwardBackwardInput(
-            data=[
-                api.Datum(
-                    model_input=api.ModelInput(
-                        chunks=[api.EncodedTextChunk(tokens=[1, 2])]
-                    ),
-                    loss_fn_inputs={
-                        "target_tokens": api.TensorData(data=[2, 3]),
-                        "weights": api.TensorData(data=[1.0, 1.0]),
-                    },
-                )
-            ],
-            loss_fn="cross_entropy",
-        ),
-    ).model_dump_json().encode()
+    body = (
+        api.ForwardBackwardRequest(
+            model_id="model_a",
+            seq_id=seq_id,
+            forward_backward_input=api.ForwardBackwardInput(
+                data=[
+                    api.Datum(
+                        model_input=api.ModelInput(chunks=[api.EncodedTextChunk(tokens=[1, 2])]),
+                        loss_fn_inputs={
+                            "target_tokens": api.TensorData(data=[2, 3]),
+                            "weights": api.TensorData(data=[1.0, 1.0]),
+                        },
+                    )
+                ],
+                loss_fn="cross_entropy",
+            ),
+        )
+        .model_dump_json()
+        .encode()
+    )
     body_sent = False
 
     async def receive():
@@ -104,9 +104,7 @@ def _forward_backward_request(seq_id: int, db_write_lock: asyncio.Lock) -> Reque
 @pytest_asyncio.fixture()
 async def future_store(tmp_path):
     db_url = get_async_database_url(f"sqlite:///{tmp_path / 'tinker.db'}")
-    engine = create_async_engine(
-        db_url, pool_size=5, max_overflow=10, pool_timeout=0.1
-    )
+    engine = create_async_engine(db_url, pool_size=5, max_overflow=10, pool_timeout=0.1)
     enable_sqlite_wal(engine.sync_engine)
     async with engine.begin() as connection:
         await connection.run_sync(SQLModel.metadata.create_all)
@@ -120,124 +118,17 @@ async def future_store(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_two_full_rollout_waves_complete_and_persist(future_store):
-    store, engine, db_write_lock = future_store
-    forwarder = _CompletingForwarder(store)
-    request = SimpleNamespace(
-        app=SimpleNamespace(
-            state=SimpleNamespace(
-                external_future_store=store,
-                external_inference_client=forwarder,
-                db_write_lock=db_write_lock,
-                sampling_model_cache={},
-                sampling_model_cache_lock=asyncio.Lock(),
-            )
-        )
-    )
-    result_data = types.SampleOutput(sequences=[]).model_dump_json()
-
-    async with AsyncSession(engine) as session:
-        session.add(
-            SessionDB(
-                session_id="session_a",
-                tags=[],
-                user_metadata={},
-                sdk_version="test",
-            )
-        )
-        session.add(
-            SamplingSessionDB(
-                sampling_session_id="session_a",
-                session_id="session_a",
-                sampling_session_seq_id=0,
-                base_model="model_a",
-            )
-        )
-        await session.commit()
-
-    for wave in range(2):
-        async def create_sample(index: int) -> int:
-            async with AsyncSession(engine) as session:
-                response = await api.asample(
-                    api.SampleRequest(
-                        prompt=api.ModelInput(
-                            chunks=[api.EncodedTextChunk(tokens=[index])]
-                        ),
-                        sampling_params=api.SamplingParams(
-                            temperature=0.0, max_tokens=1, seed=index
-                        ),
-                        sampling_session_id="session_a",
-                        seq_id=wave * 512 + index,
-                    ),
-                    request,
-                    session,
-                )
-            return int(response.request_id)
-
-        async def heartbeat() -> None:
-            async with AsyncSession(engine) as session:
-                await api.session_heartbeat(
-                    api.SessionHeartbeatRequest(session_id="session_a"),
-                    request,
-                    session,
-                )
-
-        responses = await asyncio.gather(
-            *(create_sample(index) for index in range(512)),
-            *(heartbeat() for _ in range(32)),
-        )
-        request_ids = responses[:512]
-        waiters = [
-            asyncio.create_task(store.wait(request_id, timeout=5))
-            for request_id in request_ids
-        ]
-
-        async with AsyncSession(engine) as session:
-            pending_after_creation = (
-                await session.exec(
-                    select(func.count())
-                    .select_from(FutureDB)
-                    .where(FutureDB.status == RequestStatus.PENDING)
-                )
-            ).one()
-        assert pending_after_creation == 0
-
-        results = await asyncio.gather(*waiters)
-
-        assert all(
-            result == (RequestStatus.COMPLETED, types.RequestType.EXTERNAL, result_data)
-            for result in results
-        )
-
-    await store.flush()
-    async with AsyncSession(engine) as session:
-        persisted = (
-            await session.exec(select(func.count()).select_from(FutureDB))
-        ).one()
-        pending = (
-            await session.exec(
-                select(func.count())
-                .select_from(FutureDB)
-                .where(FutureDB.status == RequestStatus.PENDING)
-            )
-        ).one()
-        session_db = await session.get(SessionDB, "session_a")
-
-    assert persisted == 1024
-    assert pending == 0
-    assert session_db is not None
-    assert session_db.heartbeat_count == 64
-
-
-@pytest.mark.asyncio
 async def test_sustained_model_path_rollouts_training_futures_and_heartbeats(future_store):
     store, engine, db_write_lock = future_store
     forwarder = _CompletingForwarder(store)
     sample_request = SimpleNamespace(
         app=SimpleNamespace(
             state=SimpleNamespace(
+                db_engine=engine,
                 external_future_store=store,
                 external_inference_client=forwarder,
+                forwarding_tasks=set(),
+                future_waiters={},
                 engine_config=EngineConfig(base_model="model_a"),
                 db_write_lock=db_write_lock,
                 sampling_model_cache={},
@@ -245,7 +136,8 @@ async def test_sustained_model_path_rollouts_training_futures_and_heartbeats(fut
                 validated_sampler_checkpoints=set(),
                 sampler_checkpoint_validation_lock=asyncio.Lock(),
             )
-        )
+        ),
+        headers={},
     )
 
     async with AsyncSession(engine) as session:
@@ -285,54 +177,68 @@ async def test_sustained_model_path_rollouts_training_futures_and_heartbeats(fut
         )
         await session.commit()
 
-    for wave in range(4):
-        async def create_sample(index: int) -> None:
-            async with AsyncSession(engine) as session:
-                await api.asample(
-                    api.SampleRequest(
-                        prompt=api.ModelInput(
-                            chunks=[api.EncodedTextChunk(tokens=[index])]
+    future_poller = asyncio.create_task(
+        api.poll_futures(engine, sample_request.app.state.future_waiters, poll_interval_sec=0.001)
+    )
+    expected_sample = types.SampleOutput(sequences=[]).model_dump_json().encode()
+    try:
+        request_ids = []
+        for wave in range(4):
+
+            async def create_sample(index: int) -> int:
+                async with AsyncSession(engine) as session:
+                    response = await api.asample(
+                        api.SampleRequest(
+                            prompt=api.ModelInput(chunks=[api.EncodedTextChunk(tokens=[index])]),
+                            sampling_params=api.SamplingParams(temperature=0.0, max_tokens=1, seed=index),
+                            sampling_session_id="session_a",
+                            seq_id=wave * 512 + index,
                         ),
-                        sampling_params=api.SamplingParams(
-                            temperature=0.0, max_tokens=1, seed=index
-                        ),
-                        sampling_session_id="session_a",
-                        seq_id=wave * 512 + index,
-                    ),
-                    sample_request,
-                    session,
-                )
+                        sample_request,
+                        session,
+                    )
+                return int(response.request_id)
 
-        async def create_training_future(index: int) -> None:
-            async with AsyncSession(engine) as session:
-                await api.forward_backward(
-                    _forward_backward_request(wave * 512 + index, db_write_lock),
-                    session,
-                )
+            async def create_training_future(index: int) -> None:
+                async with AsyncSession(engine) as session:
+                    await api.forward_backward(
+                        _forward_backward_request(wave * 512 + index, db_write_lock),
+                        session,
+                    )
 
-        async def heartbeat() -> None:
-            async with AsyncSession(engine) as session:
-                await api.session_heartbeat(
-                    api.SessionHeartbeatRequest(session_id="session_a"),
-                    sample_request,
-                    session,
-                )
+            async def heartbeat() -> None:
+                async with AsyncSession(engine) as session:
+                    await api.session_heartbeat(
+                        api.SessionHeartbeatRequest(session_id="session_a"),
+                        sample_request,
+                        session,
+                    )
 
-        await asyncio.gather(
-            *(create_sample(index) for index in range(512)),
-            *(create_training_future(index) for index in range(512)),
-            *(heartbeat() for _ in range(32)),
-        )
+            responses = await asyncio.gather(
+                *(create_sample(index) for index in range(512)),
+                *(create_training_future(index) for index in range(512)),
+                *(heartbeat() for _ in range(32)),
+            )
+            request_ids = responses[:512]
+            retrievals = await asyncio.gather(
+                *(
+                    api.retrieve_future(api.RetrieveFutureRequest(request_id=str(request_id)), sample_request)
+                    for request_id in request_ids
+                )
+            )
+            assert all(response.body == expected_sample for response in retrievals)
+            assert not store._entries
+
+        repeated = await api.retrieve_future(api.RetrieveFutureRequest(request_id=str(request_ids[-1])), sample_request)
+        assert repeated.body == expected_sample
+    finally:
+        future_poller.cancel()
+        await asyncio.gather(future_poller, return_exceptions=True)
 
     await store.flush()
     async with AsyncSession(engine) as session:
         persisted_by_type = dict(
-            (
-                await session.exec(
-                    select(FutureDB.request_type, func.count())
-                    .group_by(FutureDB.request_type)
-                )
-            ).all()
+            (await session.exec(select(FutureDB.request_type, func.count()).group_by(FutureDB.request_type))).all()
         )
         session_db = await session.get(SessionDB, "session_a")
 
@@ -340,9 +246,159 @@ async def test_sustained_model_path_rollouts_training_futures_and_heartbeats(fut
     assert persisted_by_type[types.RequestType.FORWARD_BACKWARD] == 2048
     assert session_db is not None
     assert session_db.heartbeat_count == 128
-    assert sample_request.app.state.validated_sampler_checkpoints == {
-        ("model_a", "weights_a")
-    }
+    assert sample_request.app.state.validated_sampler_checkpoints == {("model_a", "weights_a")}
+    assert not sample_request.app.state.forwarding_tasks
+
+
+@pytest.mark.asyncio
+async def test_shutdown_waits_for_forwarding_tasks_before_closing_store():
+    release_forwarding = asyncio.Event()
+    events = []
+
+    class ClosingClient:
+        async def aclose(self) -> None:
+            events.append("client_closed")
+
+    class ClosingStore:
+        async def close(self) -> None:
+            events.append("store_closed")
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            external_inference_client=ClosingClient(),
+            external_future_store=ClosingStore(),
+            forwarding_tasks=set(),
+        )
+    )
+
+    async def finish_forwarding() -> None:
+        await release_forwarding.wait()
+        events.append("future_completed")
+
+    api._start_forwarding_task(app, finish_forwarding())
+    shutdown = asyncio.create_task(api._close_external_inference(app))
+    await asyncio.sleep(0)
+    assert not shutdown.done()
+
+    release_forwarding.set()
+    await shutdown
+
+    assert events == ["future_completed", "client_closed", "store_closed"]
+    assert not app.state.forwarding_tasks
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("dialect", "serializes"), [("sqlite", True), ("postgresql", False)])
+async def test_db_write_context_serializes_only_sqlite(dialect, serializes):
+    context = api._get_db_write_context(SimpleNamespace(dialect=SimpleNamespace(name=dialect)))
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_entered = asyncio.Event()
+
+    async def first_writer() -> None:
+        async with context:
+            first_entered.set()
+            await release_first.wait()
+
+    async def second_writer() -> None:
+        await first_entered.wait()
+        async with context:
+            second_entered.set()
+
+    first = asyncio.create_task(first_writer())
+    second = asyncio.create_task(second_writer())
+    await first_entered.wait()
+    await asyncio.sleep(0)
+    assert second_entered.is_set() is not serializes
+
+    release_first.set()
+    await asyncio.gather(first, second)
+    assert second_entered.is_set()
+
+
+@pytest.mark.asyncio
+async def test_sampler_checkpoint_delete_waits_for_validation_and_invalidates_cache(future_store, monkeypatch):
+    _, engine, _ = future_store
+    validation_started = asyncio.Event()
+    release_validation = asyncio.Event()
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                engine_config=EngineConfig(base_model="model_a"),
+                sampler_checkpoint_validation_lock=asyncio.Lock(),
+                validated_sampler_checkpoints=set(),
+            )
+        )
+    )
+
+    async with AsyncSession(engine) as session:
+        session.add(
+            SessionDB(
+                session_id="session_a",
+                tags=[],
+                user_metadata={},
+                sdk_version="test",
+            )
+        )
+        session.add(
+            ModelDB(
+                model_id="model_a",
+                base_model="model_a",
+                lora_config={},
+                status="ready",
+                request_id=0,
+                session_id="session_a",
+            )
+        )
+        session.add(
+            CheckpointDB(
+                model_id="model_a",
+                checkpoint_id="weights_a",
+                checkpoint_type=types.CheckpointType.SAMPLER,
+                status=CheckpointStatus.COMPLETED,
+            )
+        )
+        await session.commit()
+
+    async def hold_validation(*args) -> None:
+        validation_started.set()
+        await release_validation.wait()
+
+    monkeypatch.setattr(api, "validate_checkpoint", hold_validation)
+    async with AsyncSession(engine) as validation_session, AsyncSession(engine) as deletion_session:
+        validation = asyncio.create_task(
+            api.validate_sampler_checkpoint_once(
+                request,
+                "model_a",
+                "weights_a",
+                validation_session,
+            )
+        )
+        await validation_started.wait()
+        deletion = asyncio.create_task(
+            api.delete_checkpoint(
+                request,
+                "model_a",
+                "weights_a",
+                types.CheckpointType.SAMPLER,
+                deletion_session,
+            )
+        )
+        await asyncio.sleep(0)
+        assert not deletion.done()
+
+        release_validation.set()
+        await asyncio.gather(validation, deletion)
+
+    assert not request.app.state.validated_sampler_checkpoints
+    async with AsyncSession(engine) as session:
+        assert (
+            await session.get(
+                CheckpointDB,
+                ("model_a", "weights_a", types.CheckpointType.SAMPLER),
+            )
+            is None
+        )
 
 
 @pytest.mark.asyncio
@@ -350,15 +406,9 @@ async def test_forwarding_client_completes_in_memory_future(future_store, monkey
     store, engine, _ = future_store
     request_id = store.create("model_a", _sample_input(1))
     result = types.SampleOutput(
-        sequences=[
-            types.GeneratedSequence(
-                stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0]
-            )
-        ]
+        sequences=[types.GeneratedSequence(stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0])]
     )
-    client = SkyRLTrainInferenceForwardingClient(
-        EngineConfig(base_model="model_a"), engine, store
-    )
+    client = SkyRLTrainInferenceForwardingClient(EngineConfig(base_model="model_a"), engine, store)
 
     async def forward(*args, **kwargs):
         return result
@@ -383,6 +433,23 @@ async def test_forwarding_client_completes_in_memory_future(future_store, monkey
 
 
 @pytest.mark.asyncio
+async def test_persistence_failure_is_reported_to_waiter(future_store, monkeypatch):
+    store, _, _ = future_store
+    request_id = store.create("model_a", _sample_input(1))
+
+    async def fail_persistence(entries):
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(store, "_persist", fail_persistence)
+    await store.complete(request_id, types.SampleOutput(sequences=[]), RequestStatus.COMPLETED)
+
+    with pytest.raises(RuntimeError, match=f"Failed to persist external future {request_id}"):
+        await store.wait(request_id, timeout=1)
+    with pytest.raises(RuntimeError, match="External future persistence failed"):
+        await store.flush()
+
+
+@pytest.mark.asyncio
 async def test_retrieve_future_serializes_in_memory_result_as_proto(future_store):
     from tinker import SampleResponse
     from tinker.proto.response_conv import deserialize_proto_response
@@ -390,25 +457,15 @@ async def test_retrieve_future_serializes_in_memory_result_as_proto(future_store
     store, engine, _ = future_store
     request_id = store.create("model_a", _sample_input(1))
     result = types.SampleOutput(
-        sequences=[
-            types.GeneratedSequence(
-                stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0]
-            )
-        ]
+        sequences=[types.GeneratedSequence(stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0])]
     )
     await store.complete(request_id, result, RequestStatus.COMPLETED)
 
     request = SimpleNamespace(
-        app=SimpleNamespace(
-            state=SimpleNamespace(
-                db_engine=engine, external_future_store=store, future_waiters={}
-            )
-        ),
+        app=SimpleNamespace(state=SimpleNamespace(db_engine=engine, external_future_store=store, future_waiters={})),
         headers={"accept": "application/x-protobuf, application/json"},
     )
-    response = await api.retrieve_future(
-        api.RetrieveFutureRequest(request_id=str(request_id)), request
-    )
+    response = await api.retrieve_future(api.RetrieveFutureRequest(request_id=str(request_id)), request)
 
     assert response.media_type == "application/x-protobuf"
     result = deserialize_proto_response(response.body, SampleResponse)

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -288,6 +288,32 @@ async def test_shutdown_waits_for_forwarding_tasks_before_closing_store():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_stops_engine_when_future_persistence_failed(monkeypatch):
+    events = []
+
+    class BackgroundEngine:
+        pid = 123
+
+        def terminate(self) -> None:
+            events.append("engine_terminated")
+
+        async def wait(self) -> int:
+            events.append("engine_waited")
+            return 0
+
+    async def fail_external_close(_app) -> None:
+        events.append("external_close_failed")
+        raise RuntimeError("persistence failed")
+
+    monkeypatch.setattr(api, "_close_external_inference", fail_external_close)
+
+    with pytest.raises(RuntimeError, match="persistence failed"):
+        await api._close_runtime(SimpleNamespace(), BackgroundEngine())
+
+    assert events == ["external_close_failed", "engine_terminated", "engine_waited"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(("dialect", "serializes"), [("sqlite", True), ("postgresql", False)])
 async def test_db_write_context_serializes_only_sqlite(dialect, serializes):
     context = api._get_db_write_context(SimpleNamespace(dialect=SimpleNamespace(name=dialect)))

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -13,6 +13,7 @@ from skyrl.tinker.db_models import (
     FutureDB,
     RequestStatus,
     SamplingSessionDB,
+    SessionDB,
     enable_sqlite_wal,
     get_async_database_url,
 )
@@ -39,7 +40,6 @@ def _sample_input(seq_id: int) -> types.SampleInput:
 class _CompletingForwarder:
     def __init__(self, store: ExternalFutureStore):
         self.store = store
-        self.gate = asyncio.Event()
 
     async def call_and_store_result(
         self,
@@ -49,7 +49,6 @@ class _CompletingForwarder:
         checkpoint_id: str,
         base_model: str | None = None,
     ) -> None:
-        await self.gate.wait()
         await self.store.complete(
             request_id,
             types.SampleOutput(sequences=[]),
@@ -60,33 +59,47 @@ class _CompletingForwarder:
 @pytest_asyncio.fixture()
 async def future_store(tmp_path):
     db_url = get_async_database_url(f"sqlite:///{tmp_path / 'tinker.db'}")
-    engine = create_async_engine(db_url, pool_size=1, max_overflow=0)
+    engine = create_async_engine(
+        db_url, pool_size=5, max_overflow=10, pool_timeout=0.1
+    )
     enable_sqlite_wal(engine.sync_engine)
     async with engine.begin() as connection:
         await connection.run_sync(SQLModel.metadata.create_all)
 
-    store = ExternalFutureStore(engine)
+    db_write_lock = asyncio.Lock()
+    store = ExternalFutureStore(engine, db_write_lock)
     await store.start()
-    yield store, engine
+    yield store, engine, db_write_lock
     await store.close()
     await engine.dispose()
 
 
 @pytest.mark.asyncio
 async def test_two_full_rollout_waves_complete_and_persist(future_store):
-    store, engine = future_store
+    store, engine, db_write_lock = future_store
     forwarder = _CompletingForwarder(store)
     request = SimpleNamespace(
         app=SimpleNamespace(
             state=SimpleNamespace(
                 external_future_store=store,
                 external_inference_client=forwarder,
+                db_write_lock=db_write_lock,
+                sampling_model_cache={},
+                sampling_model_cache_lock=asyncio.Lock(),
             )
         )
     )
     result_data = types.SampleOutput(sequences=[]).model_dump_json()
 
     async with AsyncSession(engine) as session:
+        session.add(
+            SessionDB(
+                session_id="session_a",
+                tags=[],
+                user_metadata={},
+                sdk_version="test",
+            )
+        )
         session.add(
             SamplingSessionDB(
                 sampling_session_id="session_a",
@@ -98,8 +111,6 @@ async def test_two_full_rollout_waves_complete_and_persist(future_store):
         await session.commit()
 
     for wave in range(2):
-        forwarder.gate.clear()
-
         async def create_sample(index: int) -> int:
             async with AsyncSession(engine) as session:
                 response = await api.asample(
@@ -118,9 +129,19 @@ async def test_two_full_rollout_waves_complete_and_persist(future_store):
                 )
             return int(response.request_id)
 
-        request_ids = await asyncio.gather(
-            *(create_sample(index) for index in range(512))
+        async def heartbeat() -> None:
+            async with AsyncSession(engine) as session:
+                await api.session_heartbeat(
+                    api.SessionHeartbeatRequest(session_id="session_a"),
+                    request,
+                    session,
+                )
+
+        responses = await asyncio.gather(
+            *(create_sample(index) for index in range(512)),
+            *(heartbeat() for _ in range(32)),
         )
+        request_ids = responses[:512]
         waiters = [
             asyncio.create_task(store.wait(request_id, timeout=5))
             for request_id in request_ids
@@ -136,7 +157,6 @@ async def test_two_full_rollout_waves_complete_and_persist(future_store):
             ).one()
         assert pending_after_creation == 0
 
-        forwarder.gate.set()
         results = await asyncio.gather(*waiters)
 
         assert all(
@@ -156,14 +176,17 @@ async def test_two_full_rollout_waves_complete_and_persist(future_store):
                 .where(FutureDB.status == RequestStatus.PENDING)
             )
         ).one()
+        session_db = await session.get(SessionDB, "session_a")
 
     assert persisted == 1024
     assert pending == 0
+    assert session_db is not None
+    assert session_db.heartbeat_count == 64
 
 
 @pytest.mark.asyncio
 async def test_forwarding_client_completes_in_memory_future(future_store, monkeypatch):
-    store, engine = future_store
+    store, engine, _ = future_store
     request_id = store.create("model_a", _sample_input(1))
     result = types.SampleOutput(
         sequences=[
@@ -203,7 +226,7 @@ async def test_retrieve_future_serializes_in_memory_result_as_proto(future_store
     from tinker import SampleResponse
     from tinker.proto.response_conv import deserialize_proto_response
 
-    store, engine = future_store
+    store, engine, _ = future_store
     request_id = store.create("model_a", _sample_input(1))
     result = types.SampleOutput(
         sequences=[

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -1,4 +1,6 @@
 import asyncio
+import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -251,6 +253,60 @@ async def test_sustained_model_path_rollouts_training_futures_and_heartbeats(fut
 
 
 @pytest.mark.asyncio
+async def test_retrieve_future_bounds_protobuf_serialization_off_event_loop(monkeypatch):
+    event_loop_thread_id = threading.get_ident()
+    serialization_thread_ids = []
+    serialization_state_lock = threading.Lock()
+    active_serializations = 0
+    max_active_serializations = 0
+
+    class CompletedStore:
+        async def wait(self, request_id, timeout):
+            return (
+                RequestStatus.COMPLETED,
+                types.RequestType.EXTERNAL,
+                types.SampleOutput(sequences=[]).model_dump_json(),
+            )
+
+    def serialize_result_in_thread(request_type, result_data):
+        nonlocal active_serializations, max_active_serializations
+        serialization_thread_ids.append(threading.get_ident())
+        with serialization_state_lock:
+            active_serializations += 1
+            max_active_serializations = max(max_active_serializations, active_serializations)
+        try:
+            time.sleep(0.01)
+            return b"serialized"
+        finally:
+            with serialization_state_lock:
+                active_serializations -= 1
+
+    monkeypatch.setattr(api, "serialize_result", serialize_result_in_thread)
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                external_future_store=CompletedStore(),
+                future_waiters={},
+                proto_serialization_lock=asyncio.Lock(),
+            )
+        ),
+        headers={"accept": api.PROTO_CONTENT_TYPE},
+    )
+
+    responses = await asyncio.gather(
+        *(
+            api.retrieve_future(api.RetrieveFutureRequest(request_id=str(-request_id)), request)
+            for request_id in range(1, 9)
+        )
+    )
+
+    assert all(response.body == b"serialized" for response in responses)
+    assert len(serialization_thread_ids) == len(responses)
+    assert all(thread_id != event_loop_thread_id for thread_id in serialization_thread_ids)
+    assert max_active_serializations == 1
+
+
+@pytest.mark.asyncio
 async def test_shutdown_waits_for_forwarding_tasks_before_closing_store():
     release_forwarding = asyncio.Event()
     events = []
@@ -488,7 +544,14 @@ async def test_retrieve_future_serializes_in_memory_result_as_proto(future_store
     await store.complete(request_id, result, RequestStatus.COMPLETED)
 
     request = SimpleNamespace(
-        app=SimpleNamespace(state=SimpleNamespace(db_engine=engine, external_future_store=store, future_waiters={})),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                db_engine=engine,
+                external_future_store=store,
+                future_waiters={},
+                proto_serialization_lock=asyncio.Lock(),
+            )
+        ),
         headers={"accept": "application/x-protobuf, application/json"},
     )
     response = await api.retrieve_future(api.RetrieveFutureRequest(request_id=str(request_id)), request)

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -532,6 +532,27 @@ async def test_persistence_failure_is_reported_to_waiter(future_store, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_create_future_accepts_request_id_zero_after_negative_rows(future_store):
+    # SQLite assigns max(rowid)+1, so when the table holds only the store's
+    # negative request_ids the first autoincremented FutureDB row gets id 0.
+    store, engine, _ = future_store
+    request_id = store.create("model_a", _sample_input(1))
+    assert request_id < 0
+    await store.complete(request_id, types.SampleOutput(sequences=[]), RequestStatus.COMPLETED)
+    await store.flush()
+
+    async with AsyncSession(engine) as session:
+        created_id = await api.create_future(
+            session,
+            types.RequestType.SAMPLE,
+            model_id=None,
+            request_data=_sample_input(2),
+        )
+        await session.commit()
+    assert created_id == 0
+
+
+@pytest.mark.asyncio
 async def test_retrieve_future_serializes_in_memory_result_as_proto(future_store):
     from tinker import SampleResponse
     from tinker.proto.response_conv import deserialize_proto_response

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -196,6 +196,7 @@ def _stub_request(async_engine, waiters, headers: dict | None = None):
                 db_engine=async_engine,
                 external_future_store=None,
                 future_waiters=waiters,
+                proto_serialization_lock=asyncio.Lock(),
             )
         ),
         headers=headers or {},

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -191,7 +191,13 @@ def _stub_request(async_engine, waiters, headers: dict | None = None):
     from types import SimpleNamespace
 
     return SimpleNamespace(
-        app=SimpleNamespace(state=SimpleNamespace(db_engine=async_engine, future_waiters=waiters)),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                db_engine=async_engine,
+                external_future_store=None,
+                future_waiters=waiters,
+            )
+        ),
         headers=headers or {},
     )
 


### PR DESCRIPTION
## Summary

- Keep externally forwarded sample futures and their terminal results in process for their bounded lifecycle; transient sampling never enters SQLite.
- Serialize the remaining high-concurrency SQLite writes, cache immutable sampler validation, and drain forwarding work during shutdown.
- Preserve Tinker 0.25 protobuf responses while moving CPU-heavy result serialization off the API event loop.

Stock SkyRL exhausts its 5+10 SQLite pool when Tau creates 512 samples alongside training futures and heartbeats. This PR removes sample creation/completion from that database hot path while preserving retry-safe terminal retrieval for the lifetime of the API process.

```text
sample request → in-memory future → vLLM
                                  ↓
client retrieve ← protobuf result ← terminal result
                 (bounded retry TTL; no SQLite write)
```

## Before / after

Each synthetic arm ran four waves of 512 model-path samples, 512 forward/backward futures, and 32 heartbeats.

| Arm | Result |
| --- | --- |
| Stock `27ae52bf` | Pool exhaustion in 4.01s |
| #2059 `92c3628d` | Fails wave 1; validation, training, and heartbeats still contend on SQLite |
| #2061 `2760b587` | Samples 2,048/2,048; training 511/2,048; heartbeats 7/128 |
| This PR through `20db38cf` | Samples 2,048/2,048; training 2,048/2,048; heartbeats 128/128; retry-safe retrieval passes |

[The comparison chart, exact commands, decision report, and raw CSV](https://www.notion.so/3c965e48eeef8192912fd489fec15716) preserve the full ablation.

For 512 simultaneous 8,192-token results, bounded off-event-loop protobuf serialization reduced the maximum event-loop gap from 1.284s to 0.007s (total batch time 1.352s versus 1.284s synchronously).

## Live integration

- [1048276](https://xmanager.trajectory.ai/experiments/1048276) and [1048319](https://xmanager.trajectory.ai/experiments/1048319): independent cold B300 runs; 10/10 steps, checkpoints 0/5/10, eval 500/500.
- [Workflow 33211449869](https://github.com/Trajectorylabs/trajectory/actions/runs/33211449869): deployment 1048624 → [training 1048626](https://wandb.ai/trajectory-ai/verl_examples/runs/1048626); all 67 gates passed. [Artifact 9704611967](https://github.com/Trajectorylabs/trajectory/actions/runs/33211449869/artifacts/9704611967), `sha256:cd787b83dda3ea7e3d92f5824bf558b2c73ac56780197607d5bdeae6c04e3c5a`.
- [Workflow 33232164100](https://github.com/Trajectorylabs/trajectory/actions/runs/33232164100): deployment 1048862 → [training 1048866](https://wandb.ai/trajectory-ai/verl_examples/runs/1048866); all 67 gates passed with exact trajectory accounting and cleanup. [Artifact 9710122086](https://github.com/Trajectorylabs/trajectory/actions/runs/33232164100/artifacts/9710122086), `sha256:72e4a89e5e9e52ac31a74a9b93f877e34b2dda669fb826b8bd0f99176d242906`.

The live runs cover the production success path. Current head `6967327c` additionally fixes request ID zero, bounds cancellation of hung forwarding tasks, and isolates a bad persistence row; focused regressions and exact-head CPU CI cover those failure paths. The separate client warning during large forward/backward uploads is outside this PR; supported retry completed every optimizer update.

## Testing

```bash
uv run --isolated --frozen --extra dev --extra tinker --extra ray --extra jax pytest -q tests/tinker/test_external_future_store.py tests/tinker/test_future_waiting.py tests/tinker/test_proto_serialization.py
uv run --isolated --frozen --extra dev --extra tinker --extra ray --extra jax pytest -q tests/tinker -m "not integration"
```

The focused suite and full non-integration Tinker suite passed before the three final failure-path fixes. At exact head `6967327c`, upstream CPU workflows passed 25 tests (1 skipped) and 208 tests (31 skipped), plus SkyRL-Train code-quality, train, and gym checks. The focused EXTERNAL-future suite passed 23 tests; rebasing the PR onto current SkyRL main passed the same 23 tests with 4 expected integration skips. The fork GPU job exited before tests because `ANYSCALE_CLI_TOKEN` is unavailable; Vercel authorization is unrelated to this Python change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async request routing, SQLite write serialization, and sample result durability (in-memory only for forwarded samples); mistakes could cause pool exhaustion, lost retries, or shutdown hangs, but behavior is heavily regression-tested.
> 
> **Overview**
> This PR keeps **externally forwarded samples** (external vLLM or non-colocated SkyRL-Train forwarding) off the SQLite hot path by routing them through a new **`ExternalFutureStore`**: futures get negative boot-scoped IDs, results are completed in memory, and `retrieve_future` waits there first with retry-friendly TTL eviction after delivery.
> 
> **Concurrency and shutdown:** SQLite gets a process-wide **`db_write_lock`** on heartbeats and forward/forward_backward creation; sampler checkpoint validation is cached and coordinated with deletes. Protobuf result encoding runs **`asyncio.to_thread`** under a single-flight lock so large rollouts do not block the event loop. Lifespan shutdown drains tracked forwarding tasks before closing the httpx client, then stops the engine via **`_close_runtime`**.
> 
> Forwarding clients still support a legacy FutureDB write-back when no store is passed (production always passes one). Integration tests now assert samples resolve **without** new `EXTERNAL` FutureDB rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6967327cc39d4021d549283e31e3abba0bf209a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


