### PR TITLE
Add stage-aware Tinker database diagnostics

### DIFF
--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -8,6 +8,7 @@ import signal
 import threading
 from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timedelta, timezone
+from time import monotonic
 from typing import Annotated, Any, AsyncGenerator, ClassVar, Literal
 from uuid import uuid4
 
@@ -27,7 +28,7 @@ from pydantic import (
     ValidationError,
     model_validator,
 )
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -44,6 +45,10 @@ from skyrl.tinker.db_models import (
     SessionDB,
     enable_sqlite_wal,
     get_async_database_url,
+)
+from skyrl.tinker.db_observability import (
+    database_pool_status,
+    enable_database_observability,
 )
 from skyrl.tinker.extra import (
     ExternalInferenceClient,
@@ -176,6 +181,15 @@ async def poll_futures(
                             waiter.set_result(outcome)
         except asyncio.CancelledError:
             raise
+        except SQLAlchemyError as error:
+            # Cursor events cannot observe a timeout waiting for pool checkout.
+            logger.error(
+                "Future poller database failure failure_stage=future_poller awaited_futures=%s "
+                "pool=%s error_type=%s",
+                len(waiters),
+                database_pool_status(db_engine),
+                type(error).__name__,
+            )
         except Exception:
             # Keep the poller alive; waiters fall back on their own timeouts.
             logger.exception("Future poller iteration failed")
@@ -235,6 +249,7 @@ async def lifespan(app: FastAPI):
     db_url = get_async_database_url(app.state.engine_config.database_url)
     app.state.db_engine = create_async_engine(db_url, echo=False)
     enable_sqlite_wal(app.state.db_engine.sync_engine)
+    enable_database_observability(app.state.db_engine)
 
     async with app.state.db_engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
@@ -341,6 +356,25 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="Tinker API Mock", version="0.0.1", lifespan=lifespan)
+
+
+@app.middleware("http")
+async def log_database_request_failure(request: Request, call_next):
+    """Add endpoint and pool context to database failures."""
+    started = monotonic()
+    try:
+        return await call_next(request)
+    except SQLAlchemyError as error:
+        logger.error(
+            "API database failure failure_stage=api_database method=%s path=%s "
+            "elapsed_seconds=%.3f pool=%s error_type=%s",
+            request.method,
+            request.url.path,
+            monotonic() - started,
+            database_pool_status(request.app.state.db_engine),
+            type(error).__name__,
+        )
+        raise
 
 
 async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:

--- a/skyrl/tinker/db_observability.py
+++ b/skyrl/tinker/db_observability.py
@@ -1,0 +1,64 @@
+"""Low-volume diagnostics for Tinker database contention."""
+
+from time import monotonic
+from typing import Any
+
+from sqlalchemy import event
+
+from skyrl.utils.log import logger
+
+SLOW_DATABASE_SECONDS = 1.0
+
+
+def database_pool_status(engine: Any) -> str:
+    """Return pool occupancy without exposing database connection details."""
+    if engine is None:
+        return "unavailable"
+    return engine.sync_engine.pool.status()
+
+
+def enable_database_observability(engine: Any) -> None:
+    """Log slow statements and statement failures for an async engine."""
+    sync_engine = engine.sync_engine
+    if getattr(sync_engine, "_skyrl_database_observability_enabled", False):
+        return
+    sync_engine._skyrl_database_observability_enabled = True
+
+    @event.listens_for(sync_engine, "before_cursor_execute")
+    def record_query_start(connection, cursor, statement, parameters, context, executemany):
+        connection.info.setdefault("skyrl_query_started_at", []).append(monotonic())
+
+    @event.listens_for(sync_engine, "after_cursor_execute")
+    def log_slow_query(connection, cursor, statement, parameters, context, executemany):
+        started = connection.info["skyrl_query_started_at"].pop()
+        elapsed = monotonic() - started
+        if elapsed < SLOW_DATABASE_SECONDS:
+            return
+        logger.warning(
+            "Slow database statement operation=%s dialect=%s elapsed_seconds=%.3f pool=%s",
+            _statement_operation(statement),
+            sync_engine.dialect.name,
+            elapsed,
+            sync_engine.pool.status(),
+        )
+
+    @event.listens_for(sync_engine, "handle_error")
+    def log_query_failure(exception_context):
+        connection = exception_context.connection
+        started_stack = connection.info.get("skyrl_query_started_at", []) if connection is not None else []
+        elapsed = monotonic() - started_stack.pop() if started_stack else None
+        logger.error(
+            "Database statement failed operation=%s dialect=%s elapsed_seconds=%s pool=%s error_type=%s",
+            _statement_operation(exception_context.statement),
+            sync_engine.dialect.name,
+            f"{elapsed:.3f}" if elapsed is not None else "unknown",
+            sync_engine.pool.status(),
+            type(exception_context.original_exception).__name__,
+        )
+
+
+def _statement_operation(statement: str | None) -> str:
+    if statement is None:
+        return "unknown"
+    words = statement.lstrip().split(None, 1)
+    return words[0].upper() if words else "unknown"

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -6,8 +6,10 @@ Pair to :class:`ExternalInferenceClient`; resolves the target URL from
 
 import asyncio
 from datetime import datetime, timezone
+from time import monotonic
 
 import httpx
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from skyrl.backends.renderer import render_model_input
@@ -15,6 +17,10 @@ from skyrl.backends.utils import convert_vllm_prompt_logprobs
 from skyrl.tinker import types
 from skyrl.tinker.config import EngineConfig
 from skyrl.tinker.db_models import EngineStateDB, FutureDB, RequestStatus
+from skyrl.tinker.db_observability import (
+    SLOW_DATABASE_SECONDS,
+    database_pool_status,
+)
 from skyrl.utils.log import logger
 
 
@@ -72,26 +78,92 @@ class SkyRLTrainInferenceForwardingClient:
         base_model: str | None = None,
     ):
         """Forward a sample request to vLLM and write the result to FutureDB."""
+        forward_started = monotonic()
+        prompt_tokens = sum(len(chunk.tokens) for chunk in sample_req.prompt.chunks if hasattr(chunk, "tokens"))
         try:
             result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
             status = RequestStatus.COMPLETED
+        except SQLAlchemyError as e:
+            logger.error(
+                "Backend-forwarded sample failed failure_stage=proxy_database request_id=%s "
+                "model_id=%s sampling_session_id=%s seq_id=%s prompt_tokens=%s max_tokens=%s "
+                "elapsed_seconds=%.3f pool=%s error_type=%s",
+                request_id,
+                model_id,
+                sample_req.sampling_session_id,
+                sample_req.seq_id,
+                prompt_tokens,
+                sample_req.sampling_params.max_tokens,
+                monotonic() - forward_started,
+                database_pool_status(self.db_engine),
+                type(e).__name__,
+            )
+            result = types.ErrorResponse(error=str(e), status="failed")
+            status = RequestStatus.FAILED
         except Exception as e:
-            logger.exception("Backend-forwarded sample failed (request_id=%s)", request_id)
+            logger.exception(
+                "Backend-forwarded sample failed failure_stage=forward request_id=%s model_id=%s "
+                "sampling_session_id=%s seq_id=%s prompt_tokens=%s max_tokens=%s "
+                "elapsed_seconds=%.3f error_type=%s",
+                request_id,
+                model_id,
+                sample_req.sampling_session_id,
+                sample_req.seq_id,
+                prompt_tokens,
+                sample_req.sampling_params.max_tokens,
+                monotonic() - forward_started,
+                type(e).__name__,
+            )
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
 
-        async with AsyncSession(self.db_engine) as session:
-            future = await session.get(FutureDB, request_id)
-            if future is None:
-                # Row was deleted between scheduling and completion (cancelled
-                # request, stale-session GC). Nothing to write back.
-                logger.warning("FutureDB row %s missing on completion write — skipping", request_id)
-                return
-            # `result_data` is a text column holding pre-serialized JSON.
-            future.result_data = result.model_dump_json()
-            future.status = status
-            future.completed_at = datetime.now(timezone.utc)
-            await session.commit()
+        forward_elapsed = monotonic() - forward_started
+        persistence_started = monotonic()
+        try:
+            async with AsyncSession(self.db_engine) as session:
+                future = await session.get(FutureDB, request_id)
+                if future is None:
+                    # Row was deleted between scheduling and completion (cancelled
+                    # request, stale-session GC). Nothing to write back.
+                    logger.warning("FutureDB row %s missing on completion write — skipping", request_id)
+                    return
+                # `result_data` is a text column holding pre-serialized JSON.
+                future.result_data = result.model_dump_json()
+                future.status = status
+                future.completed_at = datetime.now(timezone.utc)
+                await session.commit()
+        except SQLAlchemyError as error:
+            logger.error(
+                "Forwarded sample failed failure_stage=persistence request_id=%s model_id=%s "
+                "seq_id=%s status=%s prompt_tokens=%s forward_seconds=%.3f "
+                "persistence_seconds=%.3f pool=%s error_type=%s",
+                request_id,
+                model_id,
+                sample_req.seq_id,
+                status.value,
+                prompt_tokens,
+                forward_elapsed,
+                monotonic() - persistence_started,
+                database_pool_status(self.db_engine),
+                type(error).__name__,
+            )
+            raise
+
+        persistence_elapsed = monotonic() - persistence_started
+        if persistence_elapsed >= SLOW_DATABASE_SECONDS:
+            logger.warning(
+                "Slow forwarded sample persistence failure_stage=persistence request_id=%s "
+                "model_id=%s seq_id=%s status=%s prompt_tokens=%s forward_seconds=%.3f "
+                "persistence_seconds=%.3f pool=%s",
+                request_id,
+                model_id,
+                sample_req.seq_id,
+                status.value,
+                prompt_tokens,
+                forward_elapsed,
+                persistence_elapsed,
+                database_pool_status(self.db_engine),
+            )
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
         # httpx.RequestError covers ConnectError, ReadError, TimeoutException, etc.

--- a/tests/tinker/test_db_observability.py
+++ b/tests/tinker/test_db_observability.py
@@ -1,0 +1,252 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import httpx
+import pytest
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from skyrl.tinker import api, db_observability, types
+from skyrl.tinker.db_models import FutureDB, RequestStatus
+from skyrl.tinker.extra import skyrl_train_inference_forwarding
+from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
+    SkyRLTrainInferenceForwardingClient,
+)
+
+
+@pytest.mark.asyncio
+async def test_logs_slow_statement_with_pool_state(monkeypatch, tmp_path):
+    timestamps = iter([10.0, 12.0])
+    logger = Mock()
+    monkeypatch.setattr(db_observability, "monotonic", lambda: next(timestamps))
+    monkeypatch.setattr(db_observability, "logger", logger)
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'slow.db'}")
+    db_observability.enable_database_observability(engine)
+    db_observability.enable_database_observability(engine)
+
+    async with engine.connect() as connection:
+        await connection.exec_driver_sql("SELECT 1")
+    await engine.dispose()
+
+    assert logger.warning.call_count == 1
+    assert logger.warning.call_args.args[1:4] == ("SELECT", "sqlite", 2.0)
+    assert "Pool size" in logger.warning.call_args.args[4]
+
+
+@pytest.mark.asyncio
+async def test_logs_failed_statement_without_query_values(monkeypatch, tmp_path):
+    timestamps = iter([10.0, 10.25])
+    logger = Mock()
+    monkeypatch.setattr(db_observability, "monotonic", lambda: next(timestamps))
+    monkeypatch.setattr(db_observability, "logger", logger)
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'failed.db'}")
+    db_observability.enable_database_observability(engine)
+
+    with pytest.raises(OperationalError):
+        async with engine.connect() as connection:
+            await connection.exec_driver_sql("SELECT secret_value FROM missing_table")
+    await engine.dispose()
+
+    assert logger.error.call_count == 1
+    assert logger.error.call_args.args[1:4] == ("SELECT", "sqlite", "0.250")
+    assert "secret_value" not in str(logger.error.call_args)
+    assert "missing_table" not in str(logger.error.call_args)
+
+
+async def _create_forwarder_fixture(tmp_path, pool_size=5, pool_timeout=30.0):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'forwarder.db'}",
+        pool_size=pool_size,
+        max_overflow=0,
+        pool_timeout=pool_timeout,
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    async with AsyncSession(engine) as session:
+        future = FutureDB(
+            request_type=types.RequestType.EXTERNAL,
+            model_id="model_a",
+            seq_id=7,
+            request_data={},
+        )
+        session.add(future)
+        await session.commit()
+        await session.refresh(future)
+
+    client = object.__new__(SkyRLTrainInferenceForwardingClient)
+    client.db_engine = engine
+    sample_request = SimpleNamespace(
+        prompt=SimpleNamespace(chunks=[SimpleNamespace(tokens=[1, 2, 3])]),
+        sampling_params=SimpleNamespace(max_tokens=4),
+        sampling_session_id="sampling_a",
+        seq_id=7,
+    )
+    return engine, client, sample_request, future.request_id
+
+
+@pytest.mark.asyncio
+async def test_forwarding_failure_logs_request_dimensions(monkeypatch, tmp_path):
+    engine, client, sample_request, request_id = await _create_forwarder_fixture(tmp_path)
+    timestamps = iter([10.0, 12.0, 12.0, 12.0, 12.1])
+    logger = Mock()
+    client._forward_with_retry = AsyncMock(side_effect=httpx.ReadTimeout("connection reset"))
+    monkeypatch.setattr(skyrl_train_inference_forwarding, "monotonic", lambda: next(timestamps))
+    monkeypatch.setattr(skyrl_train_inference_forwarding, "logger", logger)
+
+    await client.call_and_store_result(request_id, sample_request, "model_a", "weights_a")
+
+    assert logger.exception.call_count == 1
+    assert logger.exception.call_args.args[1:7] == (
+        request_id,
+        "model_a",
+        "sampling_a",
+        7,
+        3,
+        4,
+    )
+    async with AsyncSession(engine) as session:
+        future = await session.get(FutureDB, request_id)
+        assert future.status == RequestStatus.FAILED
+        assert "connection reset" in future.result_data
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_proxy_database_failure_has_distinct_stage(monkeypatch, tmp_path):
+    engine, client, sample_request, request_id = await _create_forwarder_fixture(tmp_path)
+    logger = Mock()
+    client._forward_with_retry = AsyncMock(side_effect=SQLAlchemyTimeoutError("proxy pool exhausted"))
+    monkeypatch.setattr(skyrl_train_inference_forwarding, "logger", logger)
+
+    await client.call_and_store_result(request_id, sample_request, "model_a", "weights_a")
+
+    assert logger.error.call_count == 1
+    assert "failure_stage=proxy_database" in logger.error.call_args.args[0]
+    assert "Pool size" in logger.error.call_args.args[8]
+    assert logger.error.call_args.args[9] == "TimeoutError"
+    assert "proxy pool exhausted" not in str(logger.error.call_args)
+    async with AsyncSession(engine) as session:
+        future = await session.get(FutureDB, request_id)
+        assert future.status == RequestStatus.FAILED
+        assert "proxy pool exhausted" in future.result_data
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_slow_completion_write_logs_pool_and_timing(monkeypatch, tmp_path):
+    engine, client, sample_request, request_id = await _create_forwarder_fixture(tmp_path)
+    timestamps = iter([10.0, 10.1, 10.1, 11.5])
+    logger = Mock()
+    client._forward_with_retry = AsyncMock(return_value=types.SampleOutput(sequences=[]))
+    monkeypatch.setattr(skyrl_train_inference_forwarding, "monotonic", lambda: next(timestamps))
+    monkeypatch.setattr(skyrl_train_inference_forwarding, "logger", logger)
+
+    await client.call_and_store_result(request_id, sample_request, "model_a", "weights_a")
+
+    assert logger.warning.call_count == 1
+    assert logger.warning.call_args.args[1:8] == (
+        request_id,
+        "model_a",
+        7,
+        RequestStatus.COMPLETED.value,
+        3,
+        pytest.approx(0.1),
+        pytest.approx(1.4),
+    )
+    assert "Pool size" in logger.warning.call_args.args[8]
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_pool_exhaustion_logs_failing_future(monkeypatch, tmp_path):
+    engine, client, sample_request, request_id = await _create_forwarder_fixture(
+        tmp_path,
+        pool_size=1,
+        pool_timeout=0.01,
+    )
+    logger = Mock()
+    client._forward_with_retry = AsyncMock(return_value=types.SampleOutput(sequences=[]))
+    monkeypatch.setattr(skyrl_train_inference_forwarding, "logger", logger)
+
+    with pytest.raises(SQLAlchemyTimeoutError):
+        async with engine.connect():
+            await client.call_and_store_result(
+                request_id,
+                sample_request,
+                "model_a",
+                "weights_a",
+            )
+
+    assert logger.error.call_count == 1
+    assert logger.error.call_args.args[1:6] == (
+        request_id,
+        "model_a",
+        7,
+        RequestStatus.COMPLETED.value,
+        3,
+    )
+    assert "Pool size: 1" in logger.error.call_args.args[8]
+    assert logger.error.call_args.args[9] == "TimeoutError"
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_poller_logs_pool_checkout_timeout(monkeypatch, tmp_path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'poller.db'}",
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.01,
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    logger = Mock()
+    monkeypatch.setattr(api, "logger", logger)
+    waiter = asyncio.get_running_loop().create_future()
+
+    async with engine.connect():
+        poller = asyncio.create_task(api.poll_futures(engine, {1: {waiter}}, 0.001))
+        await asyncio.sleep(0.03)
+        poller.cancel()
+        await asyncio.gather(poller, return_exceptions=True)
+
+    messages = [call.args[0] for call in logger.error.call_args_list]
+    expected_message = (
+        "Future poller database failure failure_stage=future_poller awaited_futures=%s " "pool=%s error_type=%s"
+    )
+    assert expected_message in messages
+    matching = next(call for call in logger.error.call_args_list if call.args[0] == expected_message)
+    assert matching.args[1] == 1
+    assert "Pool size: 1" in matching.args[2]
+    assert matching.args[3] == "TimeoutError"
+    waiter.cancel()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_api_boundary_logs_database_failure(monkeypatch, tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'api.db'}")
+    logger = Mock()
+    monkeypatch.setattr(api, "logger", logger)
+    request = SimpleNamespace(
+        method="POST",
+        url=SimpleNamespace(path="/api/v1/asample"),
+        app=SimpleNamespace(state=SimpleNamespace(db_engine=engine)),
+    )
+
+    async def fail_request(_request):
+        raise SQLAlchemyTimeoutError("pool exhausted")
+
+    with pytest.raises(SQLAlchemyTimeoutError):
+        await api.log_database_request_failure(request, fail_request)
+
+    assert logger.error.call_count == 1
+    assert logger.error.call_args.args[1:3] == ("POST", "/api/v1/asample")
+    assert "Pool size" in logger.error.call_args.args[4]
+    assert logger.error.call_args.args[5] == "TimeoutError"
+    assert "pool exhausted" not in str(logger.error.call_args)
+    await engine.dispose()


### PR DESCRIPTION
- Adds low-volume SQL timing plus pool state at the API, future-poller, proxy-resolution, and completion-persistence boundaries without logging SQL or values.
- Separates proxy-database, inference-forwarding, and persistence failures so a failed-future 400 has an attributable upstream stage.
- Paired repro: https://github.com/Trajectorylabs/trajectory/pull/4218. This targets current `main`; adopting #2097 must move batch timing into `ExternalFutureStore._persist`.

### Testing

`uv run pre-commit run --files skyrl/tinker/api.py skyrl/tinker/db_observability.py skyrl/tinker/extra/skyrl_train_inference_forwarding.py tests/tinker/test_db_observability.py`

`uv run --isolated --extra dev --extra tinker --extra jax pytest -q tests/tinker/test_db_observability.py tests/tinker/test_future_waiting.py tests/tinker/test_training_request_idempotency.py`

All hooks passed; 22 tests passed.