### PR TITLE
[Tinker] Keep active sampler state in process

### DIFF
--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -6,7 +6,9 @@ import re
 import shutil
 import signal
 import threading
+from collections import OrderedDict
 from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, AsyncGenerator, ClassVar, Literal
 from uuid import uuid4
@@ -81,6 +83,32 @@ FUTURE_POLL_INTERVAL_SECONDS = 0.05
 
 # Statuses a request never moves out of, i.e. the ones a waiter resolves on.
 TERMINAL_STATUSES = (RequestStatus.COMPLETED, RequestStatus.FAILED)
+
+
+@dataclass(frozen=True)
+class ReadySamplingRoute:
+    model_id: str
+    checkpoint_id: str
+
+
+class ReadySamplingRoutes:
+    """Bounded hot-path cache for sampler sessions returned by completed weight saves."""
+
+    def __init__(self, max_entries: int = 10_000):
+        self._routes: OrderedDict[str, ReadySamplingRoute] = OrderedDict()
+        self._max_entries = max_entries
+
+    def remember(self, sampling_session_id: str, model_id: str, checkpoint_id: str) -> None:
+        self._routes[sampling_session_id] = ReadySamplingRoute(model_id, checkpoint_id)
+        self._routes.move_to_end(sampling_session_id)
+        while len(self._routes) > self._max_entries:
+            self._routes.popitem(last=False)
+
+    def get(self, sampling_session_id: str) -> ReadySamplingRoute | None:
+        route = self._routes.get(sampling_session_id)
+        if route is not None:
+            self._routes.move_to_end(sampling_session_id)
+        return route
 
 
 def raw_json_response(payload: str | None) -> Response:
@@ -274,11 +302,13 @@ async def lifespan(app: FastAPI):
     # when the operator explicitly sets it to False.
     is_colocated = bool(backend_cfg.get("trainer.placement.colocate_all", True))
     app.state.external_future_store = None
+    app.state.ready_sampling_routes = None
     if app.state.engine_config.external_inference_url:
         app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
         app.state.external_future_store = ExternalFutureStore()
+        app.state.ready_sampling_routes = ReadySamplingRoutes()
         app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
             app.state.engine_config,
             app.state.db_engine,
@@ -1292,7 +1322,11 @@ async def save_weights(request: SaveWeightsRequest, session: AsyncSession = Depe
 
 
 @app.post("/api/v1/save_weights_for_sampler", response_model=FutureResponse)
-async def save_weights_for_sampler(request: SaveWeightsForSamplerRequest, session: AsyncSession = Depends(get_session)):
+async def save_weights_for_sampler(
+    request: SaveWeightsForSamplerRequest,
+    req: Request,
+    session: AsyncSession = Depends(get_session),
+):
     """Saves weights in a format compatible with sampling/inference servers."""
     # Get the model (validates it exists and gives us the session_id)
     model = await get_model(session, request.model_id)
@@ -1333,6 +1367,12 @@ async def save_weights_for_sampler(request: SaveWeightsForSamplerRequest, sessio
 
     await session.commit()
 
+    ready_sampling_routes = req.app.state.ready_sampling_routes
+    if sampling_session_id is not None and ready_sampling_routes is not None:
+        # The SDK only learns this random id from the completed save future, after
+        # the checkpoint is ready. Its samples can therefore bypass three DB reads.
+        ready_sampling_routes.remember(sampling_session_id, request.model_id, checkpoint_id)
+
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
@@ -1356,27 +1396,41 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
             detail="sampling_session_id must not contain ':' (the routing-key delimiter)",
         )
 
-    base_model, model_path = await get_sampling_model(request, session)
-
-    if base_model:
-        model_id = checkpoint_id = ""
+    ready_sampling_routes = req.app.state.ready_sampling_routes
+    ready_route = (
+        ready_sampling_routes.get(request.sampling_session_id)
+        if ready_sampling_routes is not None and request.sampling_session_id is not None
+        else None
+    )
+    used_database = False
+    if ready_route is not None:
+        base_model = None
+        model_id = ready_route.model_id
+        checkpoint_id = ready_route.checkpoint_id
     else:
-        assert model_path is not None
-        path = types.TinkerPath.parse(model_path)
-        if (
-            not path
-            # Accept either tinker://model_id/checkpoint_id or tinker://model_id/sampler_weights/checkpoint_id
-            or path.kind not in ("", "sampler_weights")
-            or not (model_id := path.primary_id)
-            or not (checkpoint_id := path.secondary_id)
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail="model_path must be tinker://model_id/checkpoint_id or tinker://model_id/sampler_weights/checkpoint_id",
-            )
-        await get_model(session, model_id)
-        # Validate that the checkpoint exists and is ready
-        await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
+        base_model, model_path = await get_sampling_model(request, session)
+        used_database = request.sampling_session_id is not None
+
+        if base_model:
+            model_id = checkpoint_id = ""
+        else:
+            assert model_path is not None
+            path = types.TinkerPath.parse(model_path)
+            if (
+                not path
+                # Accept either tinker://model_id/checkpoint_id or tinker://model_id/sampler_weights/checkpoint_id
+                or path.kind not in ("", "sampler_weights")
+                or not (model_id := path.primary_id)
+                or not (checkpoint_id := path.secondary_id)
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail="model_path must be tinker://model_id/checkpoint_id or tinker://model_id/sampler_weights/checkpoint_id",
+                )
+            await get_model(session, model_id)
+            # Validate that the checkpoint exists and is ready
+            await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
+            used_database = True
 
     sample_input = types.SampleInput(
         base_model=base_model,
@@ -1411,8 +1465,10 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
             model_id=model_id,
             request_data=sample_input,
         )
+        used_database = True
 
-    await session.commit()
+    if used_database:
+        await session.commit()
 
     if req.app.state.external_inference_client:
         asyncio.create_task(

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -45,6 +45,10 @@ from skyrl.tinker.db_models import (
     enable_sqlite_wal,
     get_async_database_url,
 )
+from skyrl.tinker.external_future_store import (
+    ExternalFutureStore,
+    SequenceConflictError,
+)
 from skyrl.tinker.extra import (
     ExternalInferenceClient,
     SkyRLTrainInferenceForwardingClient,
@@ -90,7 +94,10 @@ def raw_json_response(payload: str | None) -> Response:
     """
     # `null` keeps the response valid JSON when a completed future stored no
     # result body, matching what encoding `None` would have produced.
-    return Response(content=payload if payload is not None else "null", media_type="application/json")
+    return Response(
+        content=payload if payload is not None else "null",
+        media_type="application/json",
+    )
 
 
 async def wait_for_future(
@@ -127,7 +134,9 @@ async def wait_for_future(
 
 
 async def poll_futures(
-    db_engine, waiters: dict[int, set[asyncio.Future]], poll_interval_sec: float = FUTURE_POLL_INTERVAL_SECONDS
+    db_engine,
+    waiters: dict[int, set[asyncio.Future]],
+    poll_interval_sec: float = FUTURE_POLL_INTERVAL_SECONDS,
 ) -> None:
     """Resolve the requests awaited in ``waiters`` as they finish, until cancelled.
 
@@ -153,7 +162,10 @@ async def poll_futures(
                     # by SQLite (since 3.32) and 65535 by Postgres -- far above
                     # any plausible number of in-flight requests.
                     statement = select(
-                        FutureDB.request_id, FutureDB.status, FutureDB.request_type, FutureDB.result_data
+                        FutureDB.request_id,
+                        FutureDB.status,
+                        FutureDB.request_type,
+                        FutureDB.result_data,
                     ).where(FutureDB.request_id.in_(awaited))
                     rows = (await session.exec(statement)).all()
 
@@ -261,12 +273,16 @@ async def lifespan(app: FastAPI):
     # SkyRL-Train default is colocate_all=True; only opt into forwarding
     # when the operator explicitly sets it to False.
     is_colocated = bool(backend_cfg.get("trainer.placement.colocate_all", True))
+    app.state.external_future_store = None
     if app.state.engine_config.external_inference_url:
         app.state.external_inference_client = ExternalInferenceClient(app.state.engine_config, app.state.db_engine)
         logger.info(f"External engine configured: {app.state.engine_config.external_inference_url}")
     elif backend_name in ("megatron", "fsdp") and not is_colocated:
+        app.state.external_future_store = ExternalFutureStore()
         app.state.external_inference_client = SkyRLTrainInferenceForwardingClient(
-            app.state.engine_config, app.state.db_engine
+            app.state.engine_config,
+            app.state.db_engine,
+            app.state.external_future_store,
         )
         logger.info(
             "SkyRL-Train inference forwarding client enabled for non-colocated backend=%s",
@@ -435,14 +451,16 @@ async def create_checkpoint(
             raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")
         else:
             raise HTTPException(
-                status_code=409, detail=f"Checkpoint '{checkpoint_id}' already exists for model '{model_id}'"
+                status_code=409,
+                detail=f"Checkpoint '{checkpoint_id}' already exists for model '{model_id}'",
             )
 
 
 class LoRAConfig(BaseModel):
     rank: int
     seed: int | None = Field(
-        default=None, description="Seed for LoRA weight initialization. If None, a random seed is used."
+        default=None,
+        description="Seed for LoRA weight initialization. If None, a random seed is used.",
     )
 
 
@@ -619,7 +637,15 @@ class ForwardBackwardInput(BaseModel):
     }
 
     data: list[Datum]
-    loss_fn: Literal["cross_entropy", "importance_sampling", "ppo", "gspo", "cispo", "ppo_critic", "dppo"]
+    loss_fn: Literal[
+        "cross_entropy",
+        "importance_sampling",
+        "ppo",
+        "gspo",
+        "cispo",
+        "ppo_critic",
+        "dppo",
+    ]
     loss_fn_config: dict[str, float] | None = None
 
     @model_validator(mode="after")
@@ -944,7 +970,10 @@ async def create_sampling_session(request: CreateSamplingSessionRequest, session
         raise HTTPException(status_code=404, detail="Session not found")
     # Exactly one of base_model or model_path must be provided
     if (request.base_model is None) == (request.model_path is None):
-        raise HTTPException(status_code=400, detail="Exactly one of base_model or model_path must be provided")
+        raise HTTPException(
+            status_code=400,
+            detail="Exactly one of base_model or model_path must be provided",
+        )
     sampling_session_id = f"sampling_{uuid4().hex[:8]}"
     sampling_db = SamplingSessionDB(
         sampling_session_id=sampling_session_id,
@@ -1058,7 +1087,9 @@ async def get_model_info(request: GetInfoRequest, session: AsyncSession = Depend
 
     lora_config = types.LoraConfig.model_validate(model.lora_config)
     model_data = ModelData(
-        base_model=model.base_model, lora_config=LoRAConfig(rank=lora_config.rank), model_name=model.base_model
+        base_model=model.base_model,
+        lora_config=LoRAConfig(rank=lora_config.rank),
+        model_name=model.base_model,
     )
 
     return ModelInfoResponse(model_id=model.model_id, status=model.status, model_data=model_data)
@@ -1093,7 +1124,9 @@ async def get_training_run(model_id: str, session: AsyncSession = Depends(get_se
 _MAX_FWDBWD_BODY_BYTES = 1 << 30  # 1 GiB
 
 
-async def _read_forward_backward_request(request: Request) -> tuple[ForwardBackwardRequest, bool]:
+async def _read_forward_backward_request(
+    request: Request,
+) -> tuple[ForwardBackwardRequest, bool]:
     """Read a forward_backward body in either wire format.
 
     tinker SDK >= 0.25.0 submits the body as protobuf and routes forward-only
@@ -1180,7 +1213,11 @@ async def optim_step(request: OptimStepRequest, session: AsyncSession = Depends(
 
 
 @app.post("/api/v1/load_weights", response_model=FutureResponse)
-async def load_weights(request: LoadWeightsRequest, req: Request, session: AsyncSession = Depends(get_session)):
+async def load_weights(
+    request: LoadWeightsRequest,
+    req: Request,
+    session: AsyncSession = Depends(get_session),
+):
     """Loads weights and training state.
 
     Matching the Tinker service, LoadWeights is only permitted as a model's first
@@ -1209,7 +1246,8 @@ async def load_weights(request: LoadWeightsRequest, req: Request, session: Async
         or not (checkpoint_id := path.secondary_id)
     ):
         raise HTTPException(
-            status_code=400, detail="request.path must be in format tinker://source_model_id/weights/checkpoint_id"
+            status_code=400,
+            detail="request.path must be in format tinker://source_model_id/weights/checkpoint_id",
         )
 
     await validate_checkpoint(req, source_model_id, checkpoint_id, types.CheckpointType.TRAINING, session)
@@ -1340,26 +1378,39 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
         # Validate that the checkpoint exists and is ready
         await validate_checkpoint(req, model_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
 
-    request_id = await create_future(
-        session=session,
-        request_type=(
-            types.RequestType.EXTERNAL if req.app.state.external_inference_client else types.RequestType.SAMPLE
-        ),
-        model_id=model_id,
-        request_data=types.SampleInput(
-            base_model=base_model,
-            prompt=request.prompt.to_types(),
-            sampling_params=request.sampling_params.to_types(),
-            num_samples=request.num_samples,
-            checkpoint_id=checkpoint_id,
-            # A positive topk implies prompt logprobs: both are read off the same
-            # prompt forward pass, so asking for one asks for the other.
-            prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
-            topk_prompt_logprobs=request.topk_prompt_logprobs,
-            seq_id=request.seq_id,
-            sampling_session_id=request.sampling_session_id,
-        ),
+    sample_input = types.SampleInput(
+        base_model=base_model,
+        prompt=request.prompt.to_types(),
+        sampling_params=request.sampling_params.to_types(),
+        num_samples=request.num_samples,
+        checkpoint_id=checkpoint_id,
+        # A positive topk implies prompt logprobs: both are read off the same
+        # prompt forward pass, so asking for one asks for the other.
+        prompt_logprobs=bool(request.prompt_logprobs) or request.topk_prompt_logprobs > 0,
+        topk_prompt_logprobs=request.topk_prompt_logprobs,
+        seq_id=request.seq_id,
+        sampling_session_id=request.sampling_session_id,
     )
+    future_store = req.app.state.external_future_store
+    if future_store is not None:
+        try:
+            request_id = future_store.create(
+                types.RequestType.EXTERNAL,
+                model_id,
+                sample_input,
+                seq_id=request.seq_id,
+            )
+        except SequenceConflictError as error:
+            raise HTTPException(status_code=409, detail=str(error)) from error
+    else:
+        request_id = await create_future(
+            session=session,
+            request_type=(
+                types.RequestType.EXTERNAL if req.app.state.external_inference_client else types.RequestType.SAMPLE
+            ),
+            model_id=model_id,
+            request_data=sample_input,
+        )
 
     await session.commit()
 
@@ -1391,10 +1442,20 @@ async def retrieve_future(request: RetrieveFutureRequest, req: Request):
     """Retrieve the result of an async operation, waiting until it's available."""
     request_id = int(request.request_id)
 
+    future_store = req.app.state.external_future_store
     try:
-        row = await wait_for_future(req.app.state.future_waiters, request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        if future_store is not None and request_id in future_store:
+            row = await future_store.wait(request_id, RETRIEVE_FUTURE_TIMEOUT_SECONDS)
+        else:
+            row = await wait_for_future(
+                req.app.state.future_waiters,
+                request_id,
+                RETRIEVE_FUTURE_TIMEOUT_SECONDS,
+            )
     except KeyError:
         raise HTTPException(status_code=404, detail="Future not found")
+    except asyncio.TimeoutError:
+        row = None
 
     if row is None:
         raise HTTPException(status_code=408, detail="Timeout waiting for result")
@@ -1432,7 +1493,11 @@ async def send_telemetry(request: TelemetryRequest):
 
 
 async def validate_checkpoint(
-    request: Request, unique_id: str, checkpoint_id: str, checkpoint_type: types.CheckpointType, session: AsyncSession
+    request: Request,
+    unique_id: str,
+    checkpoint_id: str,
+    checkpoint_type: types.CheckpointType,
+    session: AsyncSession,
 ):
     """Validate that a model and checkpoint exist in the database, returning the checkpoint path."""
     checkpoint_db = await session.get(CheckpointDB, (unique_id, checkpoint_id, checkpoint_type))
@@ -1444,13 +1509,19 @@ async def validate_checkpoint(
         raise HTTPException(status_code=425, detail="Checkpoint is still being created")
 
     if checkpoint_db.status == CheckpointStatus.FAILED:
-        raise HTTPException(status_code=500, detail=f"Checkpoint creation failed: {checkpoint_db.error_message}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Checkpoint creation failed: {checkpoint_db.error_message}",
+        )
 
     return checkpoint_file_path(request, unique_id, checkpoint_id, checkpoint_type)
 
 
 def checkpoint_file_path(
-    request: Request, unique_id: str, checkpoint_id: str, checkpoint_type: types.CheckpointType
+    request: Request,
+    unique_id: str,
+    checkpoint_id: str,
+    checkpoint_type: types.CheckpointType,
 ) -> Any:
     checkpoint_dir = request.app.state.engine_config.checkpoints_base / unique_id
     if checkpoint_type == types.CheckpointType.SAMPLER:
@@ -1533,7 +1604,8 @@ async def list_training_runs(
         )
 
     return TrainingRunsResponse(
-        training_runs=training_runs, cursor=Cursor(offset=offset, limit=limit, total_count=total_count)
+        training_runs=training_runs,
+        cursor=Cursor(offset=offset, limit=limit, total_count=total_count),
     )
 
 
@@ -1548,7 +1620,13 @@ async def get_checkpoint_archive_url(
     await validate_checkpoint(request, unique_id, checkpoint_id, types.CheckpointType.SAMPLER, session)
 
     # Generate URL to the download endpoint and return 302 redirect
-    download_url = str(request.url_for("download_checkpoint_archive", unique_id=unique_id, checkpoint_id=checkpoint_id))
+    download_url = str(
+        request.url_for(
+            "download_checkpoint_archive",
+            unique_id=unique_id,
+            checkpoint_id=checkpoint_id,
+        )
+    )
     expires = datetime.utcnow() + timedelta(minutes=120)
 
     response = RedirectResponse(url=download_url, status_code=302)
@@ -1579,7 +1657,10 @@ async def download_checkpoint_archive(
     return StreamingResponse(file_buffer, media_type="application/octet-stream", headers=headers)
 
 
-@app.delete("/api/v1/training_runs/{unique_id}/checkpoints/{checkpoint_path:path}", status_code=204)
+@app.delete(
+    "/api/v1/training_runs/{unique_id}/checkpoints/{checkpoint_path:path}",
+    status_code=204,
+)
 async def delete_checkpoint(
     request: Request,
     unique_id: str = fastapi.Path(..., pattern=ID_PATTERN, max_length=ID_MAX_LENGTH),
@@ -1661,13 +1742,18 @@ async def list_checkpoints_models(
 
 
 @app.post("/api/v1/weights_info", response_model=WeightsInfoResponse)
-async def get_weights_info(request: WeightsInfoRequest, req: Request, session: AsyncSession = Depends(get_session)):
+async def get_weights_info(
+    request: WeightsInfoRequest,
+    req: Request,
+    session: AsyncSession = Depends(get_session),
+):
     """Get information about weights/checkpoint from a tinker path."""
     path = types.TinkerPath.parse(request.tinker_path)
 
     if not path or path.kind != "weights":
         raise HTTPException(
-            status_code=400, detail="Invalid tinker path format. Expected: tinker://model_id/weights/checkpoint_id"
+            status_code=400,
+            detail="Invalid tinker path format. Expected: tinker://model_id/weights/checkpoint_id",
         )
 
     model_id = path.primary_id

--- a/skyrl/tinker/external_future_store.py
+++ b/skyrl/tinker/external_future_store.py
@@ -1,0 +1,106 @@
+import asyncio
+import itertools
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+from skyrl.tinker import types
+from skyrl.tinker.db_models import RequestStatus
+
+
+class SequenceConflictError(ValueError):
+    """Raised when a sequence number is reused for a different request."""
+
+
+@dataclass
+class _ExternalFuture:
+    request_type: types.RequestType
+    request_data: Any
+    status: RequestStatus
+    event: asyncio.Event
+    result_data: str | None = None
+    completed_at: float | None = None
+    sequence_key: tuple[str, int] | None = None
+
+
+class ExternalFutureStore:
+    """In-process futures for samples forwarded directly to inference."""
+
+    def __init__(self, *, terminal_retention_seconds: float = 600, max_entries: int = 10_000):
+        self._next_id = itertools.count(start=2**31)
+        self._futures: dict[int, _ExternalFuture] = {}
+        self._sequences: dict[tuple[str, int], int] = {}
+        self._terminal: deque[int] = deque()
+        self._terminal_retention_seconds = terminal_retention_seconds
+        self._max_entries = max_entries
+
+    def create(
+        self,
+        request_type: types.RequestType,
+        model_id: str,
+        request_data: Any,
+        *,
+        seq_id: int | None = None,
+    ) -> int:
+        """Create a future, returning the original ID for an identical retry."""
+        self._cleanup()
+        sequence_key = (model_id, seq_id) if seq_id is not None else None
+        if sequence_key is not None and (request_id := self._sequences.get(sequence_key)) is not None:
+            future = self._futures[request_id]
+            if future.request_type != request_type or future.request_data != request_data:
+                raise SequenceConflictError("Training request sequence number was reused")
+            return request_id
+
+        request_id = next(self._next_id)
+        self._futures[request_id] = _ExternalFuture(
+            request_type=request_type,
+            request_data=request_data,
+            status=RequestStatus.PENDING,
+            event=asyncio.Event(),
+            sequence_key=sequence_key,
+        )
+        if sequence_key is not None:
+            self._sequences[sequence_key] = request_id
+        self._cleanup()
+        return request_id
+
+    def complete(self, request_id: int, status: RequestStatus, result_data: str) -> bool:
+        """Complete a future, returning false if it has already expired."""
+        future = self._futures.get(request_id)
+        if future is None:
+            return False
+        future.status = status
+        future.result_data = result_data
+        if future.completed_at is None:
+            future.completed_at = time.monotonic()
+            self._terminal.append(request_id)
+        future.event.set()
+        return True
+
+    async def wait(self, request_id: int, timeout: float) -> tuple[RequestStatus, types.RequestType, str | None]:
+        """Wait for a future, raising KeyError or TimeoutError when unavailable."""
+        future = self._futures[request_id]
+        if future.status == RequestStatus.PENDING:
+            await asyncio.wait_for(future.event.wait(), timeout)
+        return future.status, future.request_type, future.result_data
+
+    def __contains__(self, request_id: int) -> bool:
+        return request_id in self._futures
+
+    def _cleanup(self) -> None:
+        now = time.monotonic()
+        while self._terminal:
+            request_id = self._terminal[0]
+            future = self._futures[request_id]
+            assert future.completed_at is not None
+            expired = now - future.completed_at > self._terminal_retention_seconds
+            if not expired and len(self._futures) <= self._max_entries:
+                break
+            self._terminal.popleft()
+            self._drop(request_id)
+
+    def _drop(self, request_id: int) -> None:
+        future = self._futures.pop(request_id)
+        if future.sequence_key is not None:
+            del self._sequences[future.sequence_key]

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -6,6 +6,7 @@ Pair to :class:`ExternalInferenceClient`; resolves the target URL from
 
 import asyncio
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 import httpx
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -17,13 +18,22 @@ from skyrl.tinker.config import EngineConfig
 from skyrl.tinker.db_models import EngineStateDB, FutureDB, RequestStatus
 from skyrl.utils.log import logger
 
+if TYPE_CHECKING:
+    from skyrl.tinker.external_future_store import ExternalFutureStore
+
 
 class SkyRLTrainInferenceForwardingClient:
     """Forwards EXTERNAL sample requests to the SkyRL-Train-managed vLLM."""
 
-    def __init__(self, engine_config: EngineConfig, db_engine):
+    def __init__(
+        self,
+        engine_config: EngineConfig,
+        db_engine,
+        external_future_store: "ExternalFutureStore | None" = None,
+    ):
         self.engine_config = engine_config
         self.db_engine = db_engine
+        self.external_future_store = external_future_store
         self._cached_proxy_url: str | None = None
         self._cache_lock = asyncio.Lock()
         # Backpressure layered: httpx pool -> vllm-router -> vLLM max_num_seqs.
@@ -71,7 +81,7 @@ class SkyRLTrainInferenceForwardingClient:
         *,
         base_model: str | None = None,
     ):
-        """Forward a sample request to vLLM and write the result to FutureDB."""
+        """Forward a sample request to vLLM and resolve its future."""
         try:
             result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
             status = RequestStatus.COMPLETED
@@ -79,6 +89,12 @@ class SkyRLTrainInferenceForwardingClient:
             logger.exception("Backend-forwarded sample failed (request_id=%s)", request_id)
             result = types.ErrorResponse(error=str(e), status="failed")
             status = RequestStatus.FAILED
+
+        result_data = result.model_dump_json()
+        if self.external_future_store is not None and self.external_future_store.complete(
+            request_id, status, result_data
+        ):
+            return
 
         async with AsyncSession(self.db_engine) as session:
             future = await session.get(FutureDB, request_id)
@@ -88,7 +104,7 @@ class SkyRLTrainInferenceForwardingClient:
                 logger.warning("FutureDB row %s missing on completion write — skipping", request_id)
                 return
             # `result_data` is a text column holding pre-serialized JSON.
-            future.result_data = result.model_dump_json()
+            future.result_data = result_data
             future.status = status
             future.completed_at = datetime.now(timezone.utc)
             await session.commit()

--- a/tests/tinker/skyrl_train/test_async_sample_routing.py
+++ b/tests/tinker/skyrl_train/test_async_sample_routing.py
@@ -9,8 +9,8 @@ bypassing the engine subprocess's serial scheduling loop.
 Coverage:
   - test_engine_state_published: after ``save_weights_for_sampler``, the
     engine's vLLM proxy URL is written to ``EngineStateDB``.
-  - test_sample_uses_external_path: an issued sample creates a future of
-    type ``EXTERNAL`` (not ``SAMPLE``) and resolves successfully.
+  - test_sample_bypasses_future_database: an issued sample resolves through
+    the forwarding path without creating a database-backed future.
   - test_sample_concurrent_with_training_is_fast: the central
     parallelism test. While a long-running stream of ``forward_backward``
     + ``optim_step`` calls is in flight, a sample request resolves in
@@ -169,21 +169,6 @@ def _read_engine_state(db_path: str):
         engine.dispose()
 
 
-def _read_future_request_type(db_path: str, request_id: int) -> str:
-    """Read the request_type of a single future from the test server's DB."""
-    from sqlmodel import Session, create_engine
-
-    from skyrl.tinker.db_models import FutureDB
-
-    engine = create_engine(f"sqlite:///{db_path}", echo=False)
-    try:
-        with Session(engine) as session:
-            row = session.get(FutureDB, request_id)
-            return None if row is None else str(row.request_type)
-    finally:
-        engine.dispose()
-
-
 def _train_one_step(tc, tok):
     """Run one tiny forward_backward + optim_step. Used for warm-up."""
     data = [_make_datum(tok, "Hello", "world")]
@@ -210,12 +195,8 @@ def test_engine_state_published(server_db_path):
     ), f"expected an http(s) proxy URL, got {row.inference_proxy_url!r}"
 
 
-def test_sample_uses_external_path(server_db_path):
-    """A sample issued through the SDK creates a FutureDB row of type EXTERNAL.
-
-    This is the "test" half of the design: the API hoists the sample off
-    the engine's serial loop and into the API process's asyncio loop.
-    """
+def test_sample_bypasses_future_database(server_db_path):
+    """A forwarded sample resolves without creating a FutureDB row."""
     from sqlmodel import Session, create_engine, func, select
 
     from skyrl.tinker import types as skyrl_types
@@ -229,8 +210,7 @@ def test_sample_uses_external_path(server_db_path):
     _train_one_step(tc, tok)
     sampler = tc.save_weights_and_get_sampling_client(name="external_path_a")
 
-    # Snapshot the max future_id before submitting our sample so we can
-    # filter out any EXTERNAL futures from earlier tests.
+    # Snapshot the max future_id before submitting the sample.
     eng = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(eng) as s:
@@ -245,8 +225,8 @@ def test_sample_uses_external_path(server_db_path):
     ).result()
     assert len(out.sequences) == 1
 
-    # Look for an EXTERNAL future with id > max_before. If async routing
-    # is on, every sample creates exactly one such row.
+    # Forwarded samples use the in-process store instead of the shared
+    # database, so no new EXTERNAL row is created.
     eng = create_engine(f"sqlite:///{db_path}", echo=False)
     try:
         with Session(eng) as s:
@@ -259,10 +239,7 @@ def test_sample_uses_external_path(server_db_path):
     finally:
         eng.dispose()
 
-    assert len(rows) >= 1, (
-        f"expected at least one EXTERNAL future to be created by the sample call, "
-        f"found {len(rows)}; async sample routing may not be active"
-    )
+    assert rows == []
 
 
 def test_sample_concurrent_with_training_is_fast(server_db_path):

--- a/tests/tinker/test_external_future_store.py
+++ b/tests/tinker/test_external_future_store.py
@@ -1,0 +1,72 @@
+import asyncio
+
+import pytest
+
+from skyrl.tinker import types
+from skyrl.tinker.db_models import RequestStatus
+from skyrl.tinker.external_future_store import (
+    ExternalFutureStore,
+    SequenceConflictError,
+)
+
+
+@pytest.mark.asyncio
+async def test_external_future_store_completes_without_database_polling() -> None:
+    store = ExternalFutureStore()
+    request = {"prompt": [1, 2, 3]}
+    request_id = store.create(types.RequestType.EXTERNAL, "model", request)
+
+    waiter = asyncio.create_task(store.wait(request_id, timeout=1))
+    assert store.complete(request_id, RequestStatus.COMPLETED, '{"sequences": []}')
+
+    assert await waiter == (
+        RequestStatus.COMPLETED,
+        types.RequestType.EXTERNAL,
+        '{"sequences": []}',
+    )
+
+
+@pytest.mark.asyncio
+async def test_external_future_store_keeps_identical_sequence_retries_idempotent() -> None:
+    store = ExternalFutureStore()
+    request = {"prompt": [1, 2, 3]}
+
+    first = store.create(types.RequestType.EXTERNAL, "model", request, seq_id=7)
+    retry = store.create(types.RequestType.EXTERNAL, "model", request, seq_id=7)
+
+    assert retry == first
+    with pytest.raises(SequenceConflictError, match="sequence number was reused"):
+        store.create(types.RequestType.EXTERNAL, "model", {"prompt": [4]}, seq_id=7)
+
+
+@pytest.mark.asyncio
+async def test_external_future_store_reports_missing_and_timed_out_futures() -> None:
+    store = ExternalFutureStore()
+
+    with pytest.raises(KeyError):
+        await store.wait(123, timeout=0)
+
+    request_id = store.create(types.RequestType.EXTERNAL, "model", {})
+    with pytest.raises(asyncio.TimeoutError):
+        await store.wait(request_id, timeout=0)
+
+
+def test_external_future_store_drops_oldest_completed_entry_at_capacity() -> None:
+    store = ExternalFutureStore(max_entries=1)
+    first = store.create(types.RequestType.EXTERNAL, "model", {})
+    assert store.complete(first, RequestStatus.COMPLETED, "{}")
+
+    second = store.create(types.RequestType.EXTERNAL, "model", {})
+
+    assert first not in store
+    assert second in store
+
+
+def test_external_future_store_expires_completed_sequence() -> None:
+    store = ExternalFutureStore(terminal_retention_seconds=0)
+    first = store.create(types.RequestType.EXTERNAL, "model", {}, seq_id=1)
+    assert store.complete(first, RequestStatus.COMPLETED, "{}")
+
+    retry = store.create(types.RequestType.EXTERNAL, "model", {}, seq_id=1)
+
+    assert retry != first

--- a/tests/tinker/test_future_waiting.py
+++ b/tests/tinker/test_future_waiting.py
@@ -17,6 +17,7 @@ from skyrl.tinker.db_models import (
     enable_sqlite_wal,
     get_async_database_url,
 )
+from skyrl.tinker.external_future_store import ExternalFutureStore
 
 
 @pytest.fixture()
@@ -187,11 +188,22 @@ async def test_query_count_does_not_scale_with_waiters(waiters, sync_engine, asy
     assert 0 < len(statements) < 50
 
 
-def _stub_request(async_engine, waiters, headers: dict | None = None):
+def _stub_request(
+    async_engine,
+    waiters,
+    headers: dict | None = None,
+    external_future_store: ExternalFutureStore | None = None,
+):
     from types import SimpleNamespace
 
     return SimpleNamespace(
-        app=SimpleNamespace(state=SimpleNamespace(db_engine=async_engine, future_waiters=waiters)),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                db_engine=async_engine,
+                external_future_store=external_future_store,
+                future_waiters=waiters,
+            )
+        ),
         headers=headers or {},
     )
 
@@ -260,6 +272,35 @@ async def test_retrieve_future_serves_proto_when_accepted(waiters, async_engine,
     result = await api.retrieve_future(
         api.RetrieveFutureRequest(request_id=str(request_id)),
         _stub_request(async_engine, waiters, headers={"accept": "application/x-protobuf, application/json"}),
+    )
+
+    assert result.media_type == "application/x-protobuf"
+    response = deserialize_proto_response(result.body, SampleResponse)
+    assert response.sequences[0].tokens == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_external_future_serves_proto_when_accepted(waiters, async_engine):
+    from tinker import SampleResponse
+    from tinker.proto.response_conv import deserialize_proto_response
+
+    from skyrl.tinker import api
+
+    store = ExternalFutureStore()
+    request_id = store.create(types.RequestType.EXTERNAL, "model_a", {"prompt": [1]})
+    result_data = types.SampleOutput(
+        sequences=[types.GeneratedSequence(stop_reason="stop", tokens=[1, 2], logprobs=[-0.5, -1.0])]
+    ).model_dump_json()
+    store.complete(request_id, RequestStatus.COMPLETED, result_data)
+
+    result = await api.retrieve_future(
+        api.RetrieveFutureRequest(request_id=str(request_id)),
+        _stub_request(
+            async_engine,
+            waiters,
+            headers={"accept": "application/x-protobuf, application/json"},
+            external_future_store=store,
+        ),
     )
 
     assert result.media_type == "application/x-protobuf"

--- a/tests/tinker/test_ready_sampling_routes.py
+++ b/tests/tinker/test_ready_sampling_routes.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+
+from skyrl.tinker import api, types
+
+
+class _CapturingFutureStore:
+    def __init__(self) -> None:
+        self.created = None
+
+    def create(self, request_type, model_id, request_data, *, seq_id=None):
+        self.created = (request_type, model_id, request_data, seq_id)
+        return 42
+
+
+class _NoDatabaseSession:
+    async def commit(self) -> None:
+        raise AssertionError("a cached sampling route must not check out a database connection")
+
+
+def test_ready_sampling_routes_evict_the_least_recently_used_entry() -> None:
+    routes = api.ReadySamplingRoutes(max_entries=2)
+    routes.remember("sampling-a", "model-a", "checkpoint-a")
+    routes.remember("sampling-b", "model-b", "checkpoint-b")
+    assert routes.get("sampling-a") == api.ReadySamplingRoute("model-a", "checkpoint-a")
+
+    routes.remember("sampling-c", "model-c", "checkpoint-c")
+
+    assert routes.get("sampling-b") is None
+    assert routes.get("sampling-a") is not None
+    assert routes.get("sampling-c") is not None
+
+
+@pytest.mark.asyncio
+async def test_cached_sampling_route_keeps_asample_off_the_database() -> None:
+    routes = api.ReadySamplingRoutes()
+    routes.remember("sampling-ready", "model-ready", "checkpoint-ready")
+    futures = _CapturingFutureStore()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            ready_sampling_routes=routes,
+            external_future_store=futures,
+            external_inference_client=None,
+        )
+    )
+    req = Request({"type": "http", "app": app})
+    sample = api.SampleRequest(
+        prompt=api.ModelInput(chunks=[api.EncodedTextChunk(tokens=[1, 2])]),
+        sampling_params=api.SamplingParams(max_tokens=4, seed=0),
+        sampling_session_id="sampling-ready",
+        seq_id=7,
+    )
+
+    response = await api.asample(sample, req, _NoDatabaseSession())
+
+    assert response.request_id == "42"
+    request_type, model_id, sample_input, seq_id = futures.created
+    assert request_type == types.RequestType.EXTERNAL
+    assert model_id == "model-ready"
+    assert sample_input.checkpoint_id == "checkpoint-ready"
+    assert seq_id == 7


### PR DESCRIPTION
## Summary

- keep non-colocated forwarded sample futures in the API process instead of the shared SQL future table
- cache ready sampling-session routes in a bounded in-process LRU so hot `/asample` requests avoid sampling-session, model, and checkpoint database reads
- retain sequence idempotency, bounded retention/eviction, protobuf content negotiation, and database fallback for evicted routes
- leave database-backed behavior unchanged for other request and backend paths

## Why

Four concurrent LoRA trainers first saturated the SQLite connection pool through forwarded sampling futures. Moving those futures in process removed that path, but live validation showed `/asample` still exhausted the same pool while resolving a sampling session through three database reads. The SDK cannot sample until the random session ID has been returned by `save_weights_for_sampler`, so caching that route after the save commit is safe and removes the remaining hot-path database contention.

## Validation

- 98 passed, 23 skipped: full `tests/tinker` suite
- 7 passed: focused external future-store, ready-route LRU, and cached `/asample` tests
- cached-route test proves `/asample` does not query or commit through the database session
- Ruff and Black checks passed

## Deployment status

Draft pending an immutable image built from commit `9fc5579e9` and live multi-LoRA GPU validation. The paired Trajectory PR will pin the resulting digest and cross-link this PR.