### PR TITLE
Raise a clear error when a batch is smaller than the DP shard stride

### DIFF
--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -630,6 +630,11 @@ class RayPPOTrainer:
         Each prompt produces `n_samples_per_prompt` samples. For data-parallel
         training we care that the total number of samples is nicely splittable
         across the (combined) data-parallel size of all enabled models.
+
+        Raises:
+            ValueError: If the batch has fewer prompts than the shard stride, so
+                truncation would leave zero prompts and the training step would
+                fail much later in rollout-metrics aggregation.
         """
         lcm_dp_size = self.dispatch.get_lcm_dp_size()
 
@@ -646,6 +651,15 @@ class RayPPOTrainer:
             return entries
 
         kept_prompts = (len(entries) // stride) * stride
+        if kept_prompts == 0:
+            raise ValueError(
+                f"Batch of {len(entries)} prompts cannot be sharded evenly: with the combined "
+                f"data-parallel size of the enabled models (lcm_dp_size={lcm_dp_size}) and "
+                f"generator.n_samples_per_prompt={n_samples_per_prompt}, the number of prompts "
+                f"per batch must be a multiple of {stride}. Increase trainer.train_batch_size "
+                f"to at least {stride}, or adjust the placement or n_samples_per_prompt so that "
+                f"fewer prompts are required per batch."
+            )
         return entries[:kept_prompts]
 
     def build_models(self, PolicyWorker, CriticWorker, RefWorker):

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -651,7 +651,9 @@ class RayPPOTrainer:
             return entries
 
         kept_prompts = (len(entries) // stride) * stride
-        if kept_prompts == 0:
+        # An already-empty batch is passed through unchanged: zero prompts shard
+        # evenly, and it is not the truncation failure this error is about.
+        if entries and kept_prompts == 0:
             raise ValueError(
                 f"Batch of {len(entries)} prompts cannot be sharded evenly: with the combined "
                 f"data-parallel size of the enabled models (lcm_dp_size={lcm_dp_size}) and "

--- a/tests/train/test_remove_tail_data.py
+++ b/tests/train/test_remove_tail_data.py
@@ -49,3 +49,10 @@ def test_raises_when_batch_is_smaller_than_stride():
     stub = _stub_trainer(lcm_dp_size=6, n_samples_per_prompt=4)
     with pytest.raises(ValueError, match="train_batch_size"):
         RayPPOTrainer._remove_tail_data(stub, list(range(2)))
+
+
+def test_empty_batch_passes_through():
+    # An empty batch shards evenly and is not the truncation failure above,
+    # so it keeps its previous behaviour of being returned unchanged.
+    stub = _stub_trainer(lcm_dp_size=6, n_samples_per_prompt=4)
+    assert RayPPOTrainer._remove_tail_data(stub, []) == []

--- a/tests/train/test_remove_tail_data.py
+++ b/tests/train/test_remove_tail_data.py
@@ -1,0 +1,51 @@
+"""
+Tests for RayPPOTrainer._remove_tail_data.
+
+Covers the batch/DP-shard truncation logic, including the case from
+https://github.com/NovaSky-AI/SkyRL/issues/1609 where a batch smaller than
+the shard stride was silently truncated to zero prompts and the run crashed
+much later inside rollout-metrics aggregation.
+
+uv run --extra dev pytest tests/train/test_remove_tail_data.py -v
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from skyrl.train.trainer import RayPPOTrainer
+
+
+def _stub_trainer(lcm_dp_size: int, n_samples_per_prompt: int) -> SimpleNamespace:
+    """Build a minimal stand-in for the trainer with just the attributes
+    _remove_tail_data reads."""
+    stub = SimpleNamespace()
+    stub.dispatch = MagicMock()
+    stub.dispatch.get_lcm_dp_size = MagicMock(return_value=lcm_dp_size)
+    stub.cfg = SimpleNamespace(generator=SimpleNamespace(n_samples_per_prompt=n_samples_per_prompt))
+    return stub
+
+
+def test_truncates_to_multiple_of_stride():
+    # lcm_dp_size=6, n_samples_per_prompt=4 -> stride=3: 7 prompts keep 6.
+    stub = _stub_trainer(lcm_dp_size=6, n_samples_per_prompt=4)
+    entries = list(range(7))
+    assert RayPPOTrainer._remove_tail_data(stub, entries) == list(range(6))
+
+
+def test_keeps_all_entries_when_stride_is_one():
+    # lcm_dp_size divides n_samples_per_prompt -> stride=1: nothing removed.
+    stub = _stub_trainer(lcm_dp_size=4, n_samples_per_prompt=4)
+    entries = list(range(5))
+    assert RayPPOTrainer._remove_tail_data(stub, entries) == entries
+
+
+def test_raises_when_batch_is_smaller_than_stride():
+    # Repro from issue #1609: lcm_dp_size=6, n_samples_per_prompt=4 ->
+    # stride=3, but train_batch_size=2. Previously this returned an empty
+    # list and the run died later with an opaque
+    # "zero-size array to reduction operation minimum" ValueError.
+    stub = _stub_trainer(lcm_dp_size=6, n_samples_per_prompt=4)
+    with pytest.raises(ValueError, match="train_batch_size"):
+        RayPPOTrainer._remove_tail_data(stub, list(range(2)))


### PR DESCRIPTION
## Summary

- Fixes #1609: when `train_batch_size` is smaller than the DP shard stride (`lcm_dp_size / gcd(lcm_dp_size, n_samples_per_prompt)`), `RayPPOTrainer._remove_tail_data` silently truncated the batch to zero prompts, and the run died much later in `get_rollout_metrics` with an opaque `ValueError: zero-size array to reduction operation minimum which has no identity`.
- Raise a clear `ValueError` at the truncation point instead, naming the stride, the quantities it derives from, and the config knobs that fix it (`trainer.train_batch_size`, placement, `generator.n_samples_per_prompt`). This fires on the first batch of step 1, before any generation.
- `_remove_tail_data` is the single choke point: the sync trainer, the async example trainer, and the skyrl-agent integration all route through it. The train dataloader uses `drop_last=True` and the fully-async trainer (batch size 1) does not call this method, so a batch smaller than the stride is always a config error — there is no legitimate partial-tail case that could hit the new raise.

## Testing

New unit test `tests/train/test_remove_tail_data.py` covering the truncation behavior, the `stride <= 1` passthrough, and the issue's exact repro config (`lcm_dp_size=6`, `n_samples_per_prompt=4`, batch of 2 → stride 3):

```bash
uv run --extra dev --extra skyrl-train pytest tests/train/test_remove_tail_data.py -v
```

- Verified red/green: on `main` the new raise test fails with `DID NOT RAISE`; with this change all 3 pass.
- `uv run --extra dev --extra skyrl-train pytest tests/train/` on this branch: 743 passed, 1 skipped, and one pre-existing `ImportError` in `test_sft_tokenization.py::test_chat_vlm` that reproduces identically on `main` (4298730) in my environment (WSL Ubuntu, CPU-only).
- `pre-commit` (ruff, black, secrets) passes on the changed files.

Prepared with Claude Code (agent-assisted); all verification above was run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change at an existing batch-truncation choke point; no change to successful sharding paths beyond clearer failure for invalid configs.
> 
> **Overview**
> Fixes **#1609** by changing `RayPPOTrainer._remove_tail_data` so a misconfigured batch no longer becomes an empty prompt list and fails later in rollout metrics.
> 
> When the prompt count is **non-zero** but below the DP shard stride (`lcm_dp_size / gcd(lcm_dp_size, n_samples_per_prompt)`), the method now raises a **`ValueError`** on step 1 (before generation) that names the stride, `lcm_dp_size`, `n_samples_per_prompt`, and suggests fixing **`trainer.train_batch_size`**, placement, or **`n_samples_per_prompt`**. **Empty** batches are still returned unchanged.
> 
> Adds **`tests/train/test_remove_tail_data.py`** for normal truncation, `stride <= 1` passthrough, the issue repro (batch of 2 with stride 3), and empty-batch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3582a1f88172947ffe1ba510bfed90d38d4b61c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->