### PR TITLE
[feat]Add Group reward-Decoupled Normalization Policy Optimization

### DIFF
--- a/examples/train/algorithms/gdpo/run_gdpo_gsm8k.sh
+++ b/examples/train/algorithms/gdpo/run_gdpo_gsm8k.sh
@@ -1,0 +1,72 @@
+set -x
+
+# Colocated GDPO training+generation for Qwen2.5-1.5B-Instruct on GSM8K.
+#
+# GDPO (https://arxiv.org/abs/2601.05242) normalizes each reward component separately within a
+# prompt group before summing, so distinct reward combinations keep distinct advantages instead of
+# collapsing onto the same value the way a summed reward does under GRPO.
+#
+# It requires the generator to emit `reward_components` (one score per objective per response), so
+# this uses the `gsm8k_multi_reward` env, which scores format and correctness separately.
+
+# uv run examples/train/gsm8k/gsm8k_dataset.py --output_dir $HOME/data/gsm8k
+# export WANDB_API_KEY=<your_key_here>
+# bash examples/train/algorithms/gdpo/run_gdpo_gsm8k.sh
+
+
+# You can override the default values with e.g.: `NUM_GPUS=1 bash examples/train/algorithms/gdpo/run_gdpo_gsm8k.sh`.
+
+: "${DATA_DIR:="$HOME/data/gsm8k"}"
+: "${NUM_GPUS:=4}"
+: "${LOGGER:=wandb}" # change to "console" to print to stdout
+: "${INFERENCE_BACKEND:=vllm}"
+
+# GDPO parameters
+: "${ADV_ESTIMATOR:=gdpo}"
+# GDPO batch-normalizes the summed per-component advantages itself, so the trainer-level pass stays off.
+: "${ADVANTAGE_BATCH_NORMALIZE:=false}"
+
+# Other algorithm parameters
+: "${USE_KL_LOSS:=true}"
+
+uv run --isolated --extra fsdp -m skyrl.train.entrypoints.main_base \
+  data.train_data="['$DATA_DIR/train.parquet']" \
+  data.val_data="['$DATA_DIR/validation.parquet']" \
+  trainer.algorithm.advantage_estimator="$ADV_ESTIMATOR" \
+  trainer.algorithm.advantage_batch_normalize=$ADVANTAGE_BATCH_NORMALIZE \
+  trainer.policy.model.path="Qwen/Qwen2.5-1.5B-Instruct" \
+  trainer.placement.colocate_all=true \
+  trainer.strategy=fsdp \
+  trainer.placement.policy_num_gpus_per_node=$NUM_GPUS \
+  trainer.placement.critic_num_gpus_per_node=$NUM_GPUS \
+  trainer.placement.ref_num_gpus_per_node=$NUM_GPUS \
+  generator.inference_engine.num_engines=$NUM_GPUS \
+  generator.inference_engine.tensor_parallel_size=1 \
+  trainer.epochs=20 \
+  trainer.eval_batch_size=1024 \
+  trainer.eval_before_train=true \
+  trainer.eval_interval=5 \
+  trainer.update_epochs_per_batch=1 \
+  trainer.train_batch_size=1024 \
+  trainer.policy_mini_batch_size=256 \
+  trainer.micro_forward_batch_size_per_gpu=64 \
+  trainer.micro_train_batch_size_per_gpu=64 \
+  trainer.ckpt_interval=10 \
+  trainer.max_prompt_length=512 \
+  generator.sampling_params.max_generate_length=1024 \
+  trainer.policy.optimizer_config.lr=1.0e-6 \
+  trainer.algorithm.use_kl_loss=$USE_KL_LOSS \
+  generator.inference_engine.backend=$INFERENCE_BACKEND \
+  generator.inference_engine.run_engines_locally=true \
+  generator.inference_engine.weight_sync_backend=nccl \
+  generator.batched=true \
+  environment.env_class=gsm8k_multi_reward \
+  generator.n_samples_per_prompt=5 \
+  generator.inference_engine.gpu_memory_utilization=0.8 \
+  trainer.logger="$LOGGER" \
+  trainer.project_name="gsm8k" \
+  trainer.run_name="gdpo_gsm8k" \
+  trainer.resume_mode=null \
+  trainer.log_path="/tmp/skyrl-logs" \
+  trainer.ckpt_path="$HOME/ckpts/gsm8k_1.5B_ckpt" \
+  "$@"

--- a/skyrl-gym/skyrl_gym/envs/__init__.py
+++ b/skyrl-gym/skyrl_gym/envs/__init__.py
@@ -13,6 +13,11 @@ register(
 )
 
 register(
+    id="gsm8k_multi_reward",
+    entry_point="skyrl_gym.envs.gsm8k.multi_reward_env:GSM8kMultiRewardEnv",
+)
+
+register(
     id="gsm8k_multi_turn",
     entry_point="skyrl_gym.envs.gsm8k.multi_turn_env:GSM8kMultiTurnEnv",
 )

--- a/skyrl-gym/skyrl_gym/envs/base_text_env.py
+++ b/skyrl-gym/skyrl_gym/envs/base_text_env.py
@@ -9,6 +9,9 @@ ConversationType = List[MessageType]
 class BaseTextEnvStepOutput(TypedDict):
     observations: ConversationType  # OpenAI API Messages Format
     reward: float
+    # Breakdown of `reward` into named components, for multi-reward algorithms such as GDPO. Every
+    # step of every trajectory in a run must supply the same component names, or none at all.
+    reward_components: Optional[Dict[str, float]]
     done: bool
     metadata: Dict[str, Any]
     postprocessed_action: Optional[str] = None

--- a/skyrl-gym/skyrl_gym/envs/gsm8k/multi_reward_env.py
+++ b/skyrl-gym/skyrl_gym/envs/gsm8k/multi_reward_env.py
@@ -4,7 +4,11 @@ from typing import Dict, Any
 
 
 class GSM8kMultiRewardEnv(BaseTextEnv):
-    """GSM8k scored as two objectives (``format`` and ``correct``); the reward is their sum.
+    """GSM8k scored as three separate objectives (``correct``, ``format``, ``length``); the reward
+    is their sum.
+
+    Rewards judge the final response and are awarded once per trajectory, so intermediate turns of
+    a multi-turn rollout score zero.
     """
 
     def __init__(self, env_config: Any = None, extras: Dict[str, Any] = {}):
@@ -14,31 +18,41 @@ class GSM8kMultiRewardEnv(BaseTextEnv):
         assert "ground_truth" in extras["reward_spec"], "ground_truth is required in reward_spec field"
         self.ground_truth = extras["reward_spec"]["ground_truth"]
         self.max_turns = int(extras.get("max_turns", 1))
+        self.max_response_chars = int(extras.get("max_response_chars", 1024))
+        self.condition_length_on_correct = bool(extras.get("condition_length_on_correct", False))
 
     def _get_reward_components(self, action: str) -> Dict[str, float]:
-        return utils.compute_score_components(action, self.ground_truth)
+        return utils.compute_score_components(
+            action,
+            self.ground_truth,
+            max_response_chars=self.max_response_chars,
+            condition_length_on_correct=self.condition_length_on_correct,
+        )
 
     def step(self, action: str) -> BaseTextEnvStepOutput:
         self.turns += 1
         reward_components = self._get_reward_components(action)
         done = self.turns >= self.max_turns or reward_components["correct"] > 0
 
-        observations = (
-            []
-            if done
-            else [
-                {
-                    "role": "user",
-                    "content": "That is not correct. Try again, ending with the answer in the exact "
-                    "format: '#### ANSWER'.",
-                }
-            ]
-        )
+        if not done:
+            return BaseTextEnvStepOutput(
+                observations=[
+                    {
+                        "role": "user",
+                        "content": "That is not correct. Try again, ending with the answer in the "
+                        "exact format: '#### ANSWER'.",
+                    }
+                ],
+                reward=0.0,
+                reward_components={name: 0.0 for name in reward_components},
+                done=False,
+                metadata={},
+            )
 
         return BaseTextEnvStepOutput(
-            observations=observations,
+            observations=[],
             reward=sum(reward_components.values()),
             reward_components=reward_components,
-            done=done,
+            done=True,
             metadata={},
         )

--- a/skyrl-gym/skyrl_gym/envs/gsm8k/multi_reward_env.py
+++ b/skyrl-gym/skyrl_gym/envs/gsm8k/multi_reward_env.py
@@ -1,0 +1,29 @@
+from skyrl_gym.envs.base_text_env import BaseTextEnv, BaseTextEnvStepOutput
+from skyrl_gym.envs.gsm8k import utils
+from typing import Dict, Any
+
+
+class GSM8kMultiRewardEnv(BaseTextEnv):
+    """GSM8k scored as two objectives (``format`` and ``correct``) rather than one scalar, for
+    multi-reward algorithms such as GDPO. The reward is their sum."""
+
+    def __init__(self, env_config: Any = None, extras: Dict[str, Any] = {}):
+        super().__init__()
+
+        assert "reward_spec" in extras, "reward_spec field is required"
+        assert "ground_truth" in extras["reward_spec"], "ground_truth is required in reward_spec field"
+        self.ground_truth = extras["reward_spec"]["ground_truth"]
+
+    def _get_reward_components(self, action: str) -> Dict[str, float]:
+        return utils.compute_score_components(action, self.ground_truth)
+
+    def step(self, action: str) -> BaseTextEnvStepOutput:
+        done = True  # always done after one step
+        reward_components = self._get_reward_components(action)
+        return BaseTextEnvStepOutput(
+            observations=[],
+            reward=sum(reward_components.values()),
+            reward_components=reward_components,
+            done=done,
+            metadata={},
+        )

--- a/skyrl-gym/skyrl_gym/envs/gsm8k/multi_reward_env.py
+++ b/skyrl-gym/skyrl_gym/envs/gsm8k/multi_reward_env.py
@@ -4,8 +4,8 @@ from typing import Dict, Any
 
 
 class GSM8kMultiRewardEnv(BaseTextEnv):
-    """GSM8k scored as two objectives (``format`` and ``correct``) rather than one scalar, for
-    multi-reward algorithms such as GDPO. The reward is their sum."""
+    """GSM8k scored as two objectives (``format`` and ``correct``); the reward is their sum.
+    """
 
     def __init__(self, env_config: Any = None, extras: Dict[str, Any] = {}):
         super().__init__()
@@ -13,15 +13,30 @@ class GSM8kMultiRewardEnv(BaseTextEnv):
         assert "reward_spec" in extras, "reward_spec field is required"
         assert "ground_truth" in extras["reward_spec"], "ground_truth is required in reward_spec field"
         self.ground_truth = extras["reward_spec"]["ground_truth"]
+        self.max_turns = int(extras.get("max_turns", 1))
 
     def _get_reward_components(self, action: str) -> Dict[str, float]:
         return utils.compute_score_components(action, self.ground_truth)
 
     def step(self, action: str) -> BaseTextEnvStepOutput:
-        done = True  # always done after one step
+        self.turns += 1
         reward_components = self._get_reward_components(action)
+        done = self.turns >= self.max_turns or reward_components["correct"] > 0
+
+        observations = (
+            []
+            if done
+            else [
+                {
+                    "role": "user",
+                    "content": "That is not correct. Try again, ending with the answer in the exact "
+                    "format: '#### ANSWER'.",
+                }
+            ]
+        )
+
         return BaseTextEnvStepOutput(
-            observations=[],
+            observations=observations,
             reward=sum(reward_components.values()),
             reward_components=reward_components,
             done=done,

--- a/skyrl-gym/skyrl_gym/envs/gsm8k/utils.py
+++ b/skyrl-gym/skyrl_gym/envs/gsm8k/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+from typing import Dict
 
 
 def extract_solution(solution_str, method="strict"):
@@ -39,6 +40,22 @@ def extract_solution(solution_str, method="strict"):
                 if final_answer not in invalid_str:
                     break
     return final_answer
+
+
+def compute_score_components(
+    solution_str: str,
+    ground_truth: str,
+    method: str = "strict",
+    format_score: float = 1.0,
+    score: float = 1.0,
+) -> Dict[str, float]:
+    """Score GSM8k as two separate objectives: ``format`` for emitting an answer in the expected
+    ``#### <number>`` form, and ``correct`` for that answer matching the ground truth."""
+    answer = extract_solution(solution_str=solution_str, method=method)
+    return {
+        "format": format_score if answer is not None else 0.0,
+        "correct": score if answer is not None and answer == ground_truth else 0.0,
+    }
 
 
 def compute_score(solution_str, ground_truth, method="strict", format_score=0.0, score=1.0):

--- a/skyrl-gym/skyrl_gym/envs/gsm8k/utils.py
+++ b/skyrl-gym/skyrl_gym/envs/gsm8k/utils.py
@@ -45,16 +45,30 @@ def extract_solution(solution_str, method="strict"):
 def compute_score_components(
     solution_str: str,
     ground_truth: str,
+    max_response_chars: int,
     method: str = "strict",
-    format_score: float = 1.0,
-    score: float = 1.0,
+    condition_length_on_correct: bool = False,
 ) -> Dict[str, float]:
-    """Score GSM8k as two separate objectives: ``format`` for emitting an answer in the expected
-    ``#### <number>`` form, and ``correct`` for that answer matching the ground truth."""
+    """Score GSM8k as three separate objectives.
+
+    Args:
+        solution_str: the solution text
+        ground_truth: the ground truth
+        max_response_chars: length budget for the ``length`` objective
+        method: the method to extract the solution, choices are 'strict' and 'flexible'
+        condition_length_on_correct: award ``length`` only to correct responses
+
+    Returns:
+        ``correct`` for matching the ground truth, ``format`` for emitting an answer in the
+        ``#### <number>`` form, and ``length`` for staying within ``max_response_chars``.
+    """
     answer = extract_solution(solution_str=solution_str, method=method)
+    is_correct = answer is not None and answer == ground_truth
+    within_length = len(solution_str) <= max_response_chars
     return {
-        "format": format_score if answer is not None else 0.0,
-        "correct": score if answer is not None and answer == ground_truth else 0.0,
+        "correct": 1.0 if is_correct else 0.0,
+        "format": 1.0 if answer is not None else 0.0,
+        "length": 1.0 if within_length and (is_correct or not condition_length_on_correct) else 0.0,
     }
 
 

--- a/skyrl/backends/skyrl_train/training_batch.py
+++ b/skyrl/backends/skyrl_train/training_batch.py
@@ -482,6 +482,7 @@ class TrainingInput(TypedDict, total=False):
     advantages: Float[torch.Tensor, "batch_size response_len"]  # per-token advantage
     kl: Float[torch.Tensor, "batch_size response_len"]  # per-token KL, current vs reference policy
     rewards: Optional[Float[torch.Tensor, "batch_size response_len"]]  # env reward, typically only on the last token
+    reward_components: Optional[Float[torch.Tensor, "batch_size num_components"]]  # per-objective scores
     rollout_logprobs: Optional[Float[torch.Tensor, "batch_size response_len"]]  # sampling policy; off-policy corr.
     rollout_expert_indices: Optional[Integer[torch.Tensor, "batch_size seq_len layer_num topk"]]  # MoE router replay
     router_padding_mask: Optional[Bool[torch.Tensor, "batch_size seq_len"]]  # True = no captured route (skip in replay)

--- a/skyrl/backends/skyrl_train/utils/ppo_utils.py
+++ b/skyrl/backends/skyrl_train/utils/ppo_utils.py
@@ -409,6 +409,7 @@ class AdvantageEstimator(StrEnum):
     RLOO = "rloo"
     REINFORCE_PP = "reinforce++"
     MAXRL = "maxrl"
+    GDPO = "gdpo"
 
 
 class AdvantageEstimatorRegistry(BaseFunctionRegistry):
@@ -436,6 +437,7 @@ class AdvantageEstimatorRegistry(BaseFunctionRegistry):
             "rloo": [AdvantageEstimator.RLOO, compute_rloo_outcome_advantage],
             "reinforce++": [AdvantageEstimator.REINFORCE_PP, compute_reinforce_plus_plus_outcome_advantage],
             "maxrl": [AdvantageEstimator.MAXRL, compute_maxrl_advantage],
+            "gdpo": [AdvantageEstimator.GDPO, compute_gdpo_outcome_advantage],
         }
 
         for ae_name, (ae_type, ae_func) in ae_types.items():
@@ -1428,6 +1430,66 @@ def compute_maxrl_advantage(
     return scores, scores
 
 
+@register_advantage_estimator(AdvantageEstimator.GDPO)
+def compute_gdpo_outcome_advantage(
+    token_level_rewards: torch.Tensor,
+    response_mask: torch.Tensor,
+    index: np.ndarray,
+    epsilon: float = 1e-6,
+    grpo_norm_by_std: bool = True,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Compute advantage for GDPO, operating only on Outcome vector reward.
+
+    Expects:
+        - token_level_rewards: Float[torch.Tensor, "batch_size num_rewards response_len"]
+        - response_mask: Float[torch.Tensor, "batch_size response_len"]
+        - index: np.ndarray (batch_size)
+        - epsilon: float
+        - grpo_norm_by_std: bool
+
+    Returns:
+        - advantages: Float[torch.Tensor, "batch_size response_len"]
+        - returns: Float[torch.Tensor, "batch_size response_len"]
+    """
+    from loguru import (
+        logger as logger_,  # have to do lazy import to avoid pickling error
+    )
+
+    # scores is [bsz, num_rewards]
+    scores = token_level_rewards.sum(dim=-1)
+    bsz, num_rewards = scores.shape
+    id2score = defaultdict(list)
+    id2mean = {}
+    id2std = {}
+
+    with torch.no_grad():
+        for i in range(bsz):
+            id2score[index[i]].append(scores[i])
+        for idx in id2score:
+            if len(id2score[idx]) == 1:
+                id2mean[idx] = torch.zeros(num_rewards, dtype=scores.dtype, device=scores.device)
+                id2std[idx] = torch.ones(num_rewards, dtype=scores.dtype, device=scores.device)
+            else:
+                group_scores = torch.stack(id2score[idx])
+                id2mean[idx] = group_scores.mean(dim=0)
+                id2std[idx] = group_scores.std(dim=0)
+        for i in range(bsz):
+            if grpo_norm_by_std:
+                scores[i] = (scores[i] - id2mean[index[i]]) / (id2std[index[i]] + epsilon)
+            else:
+                scores[i] = scores[i] - id2mean[index[i]]
+        # Normalizing advantages separately
+        scores = scores.sum(dim=-1)
+        if bsz > 1:
+            scores = (scores - scores.mean()) / (scores.std() + epsilon)
+        else:
+            logger_.warning("Skipping GDPO batch normalization: it needs more than one sequence, got 1")
+        scores = scores.unsqueeze(-1) * response_mask
+    return scores, scores
+
+
 def repopulate_all_registries():
     PolicyLossRegistry.repopulate_registry()
     AdvantageEstimatorRegistry.repopulate_registry()
@@ -1443,6 +1505,8 @@ def compute_advantages_and_returns(
     grpo_norm_by_std: bool = True,
     gamma=1.0,
     lambd=1.0,
+    epsilon: float = 1e-6,
+    reward_component_names: Optional[List[str]] = None,
     **kwargs,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     estimator_func = AdvantageEstimatorRegistry.get(adv_estimator)
@@ -1455,6 +1519,8 @@ def compute_advantages_and_returns(
         grpo_norm_by_std=grpo_norm_by_std,
         gamma=gamma,
         lambd=lambd,
+        epsilon=epsilon,
         config=config,
+        reward_component_names=reward_component_names,
         **kwargs,
     )

--- a/skyrl/train/generators/base.py
+++ b/skyrl/train/generators/base.py
@@ -9,6 +9,8 @@ from skyrl.backends.skyrl_train.utils.routed_experts import RoutedExpertIndices
 
 TrainingPhase = Literal["train", "eval"]
 
+TokenLevelReward = List[float]
+
 
 @dataclass
 class TrajectoryID:
@@ -37,7 +39,8 @@ class GeneratorInput(TypedDict):
 class GeneratorOutput(TypedDict):
     prompt_token_ids: List[List[int]]
     response_ids: List[List[int]]
-    rewards: Union[List[float], List[List[float]]]
+    rewards: Union[List[float], List[TokenLevelReward]]
+    reward_components: Optional[List[Dict[str, float]]]
     loss_masks: List[List[int]]
     stop_reasons: Optional[List[str]]
     rollout_metrics: Optional[Dict[str, Any]]

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -52,6 +52,7 @@ class TrajectoryOutput:
     rollout_logprobs: Optional[List[float]]
     env_metrics: Dict[str, Any]
     rollout_expert_indices: Optional[RoutedExpertIndices] = None
+    reward_components: Optional[Dict[str, float]] = None
     pixel_values: Optional[torch.Tensor] = None
     image_grid_thw: Optional[torch.Tensor] = None
     # End-to-end wall-clock time (seconds) to generate this trajectory. Optional: agent loops may
@@ -366,6 +367,7 @@ class SkyRLGymGenerator(GeneratorInterface):
 
             # Accumulate per-step rewards. Format: (reward, response_end_token_idx)
             per_step_rewards: List[Tuple[float, Optional[int]]] = []
+            per_step_reward_components: List[Dict[str, float]] = []
 
             is_step_wise = self.generator_cfg.step_wise_trajectories
 
@@ -448,6 +450,7 @@ class SkyRLGymGenerator(GeneratorInterface):
                 time_splits["env"] += time.monotonic() - env_step_start_time
                 new_obs = env_step_output["observations"]
                 step_reward: float = env_step_output["reward"]
+                step_reward_components = env_step_output.get("reward_components")
                 agent_loop_state.done = env_step_output["done"]
 
                 if env_step_output.get("postprocessed_action", None) is not None:
@@ -486,6 +489,7 @@ class SkyRLGymGenerator(GeneratorInterface):
                     per_step_output = TrajectoryOutput(
                         response_ids=turn_response_ids,
                         reward=step_reward,
+                        reward_components=step_reward_components,
                         loss_mask=turn_loss_mask,
                         prompt_ids=turn_prompt_ids,
                         rollout_logprobs=turn_response_logprobs,
@@ -514,6 +518,8 @@ class SkyRLGymGenerator(GeneratorInterface):
                     )
 
                 per_step_rewards.append((step_reward, agent_loop_state.response_end_idx))
+                if step_reward_components is not None:
+                    per_step_reward_components.append(step_reward_components)
 
             # Get environment-specific metrics after the episode is done
             env_metrics = env.get_metrics()
@@ -582,9 +588,22 @@ class SkyRLGymGenerator(GeneratorInterface):
             else:
                 reward_out = self._build_per_token_rewards(per_step_rewards, response_ids, appended_eos_token)
 
+                trajectory_reward_components = None
+                if per_step_reward_components:
+                    if len(per_step_reward_components) != len(per_step_rewards):
+                        raise ValueError(
+                            f"Only {len(per_step_reward_components)} of {len(per_step_rewards)} turns returned "
+                            "`reward_components`. Either every turn must return them, or none."
+                        )
+                    trajectory_reward_components = {
+                        name: sum(step[name] for step in per_step_reward_components)
+                        for name in per_step_reward_components[0]
+                    }
+
                 agent_loop_output = TrajectoryOutput(
                     response_ids=response_ids,
                     reward=reward_out,
+                    reward_components=trajectory_reward_components,
                     stop_reason=stop_reason,
                     loss_mask=loss_mask,
                     prompt_ids=prompt_ids,
@@ -883,6 +902,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         if self.generator_cfg.step_wise_trajectories:
             responses = []
             rewards = []
+            reward_components = []
             stop_reasons = []
             loss_masks = []
             prompt_token_ids = []
@@ -896,6 +916,8 @@ class SkyRLGymGenerator(GeneratorInterface):
                 for j, step_output in enumerate(output.step_outputs):
                     responses.append(step_output.response_ids)
                     rewards.append(step_output.reward)
+                    if step_output.reward_components is not None:
+                        reward_components.append(step_output.reward_components)
                     stop_reasons.append(step_output.stop_reason)
                     loss_masks.append(step_output.loss_mask)
                     prompt_token_ids.append(step_output.prompt_ids)
@@ -914,6 +936,7 @@ class SkyRLGymGenerator(GeneratorInterface):
         else:
             responses = [output.response_ids for output in all_outputs]
             rewards = [output.reward for output in all_outputs]
+            reward_components = [o.reward_components for o in all_outputs if o.reward_components is not None]
             stop_reasons = [output.stop_reason for output in all_outputs]
             loss_masks = [output.loss_mask for output in all_outputs]
             prompt_token_ids = [output.prompt_ids for output in all_outputs]
@@ -969,15 +992,26 @@ class SkyRLGymGenerator(GeneratorInterface):
         if self.generator_cfg.zero_reward_on_non_stop:
             # set reward to 0 if the stop reason is not "stop"
             rewards = self._zero_reward_if_not_stop(rewards, stop_reasons)
+            reward_components = [
+                {name: 0.0 for name in components} if stop_reason != "stop" else components
+                for components, stop_reason in zip(reward_components, stop_reasons)
+            ]
 
         if self.generator_cfg.apply_overlong_filtering:
             # set loss mask to 0 if the stop reason is not "stop"
             loss_masks = apply_overlong_filtering(loss_masks, stop_reasons)
 
+        if reward_components and len(reward_components) != len(rewards):
+            raise ValueError(
+                f"Only {len(reward_components)} of {len(rewards)} trajectories returned `reward_components`. "
+                "Either every trajectory must return them, or none."
+            )
+
         generator_output: GeneratorOutput = {
             "prompt_token_ids": prompt_token_ids,
             "response_ids": responses,
             "rewards": rewards,
+            "reward_components": reward_components or None,
             "loss_masks": loss_masks,
             "stop_reasons": stop_reasons,
             "rollout_metrics": rollout_metrics,

--- a/skyrl/train/generators/skyrl_gym_generator.py
+++ b/skyrl/train/generators/skyrl_gym_generator.py
@@ -761,6 +761,7 @@ class SkyRLGymGenerator(GeneratorInterface):
 
         truncated_responses = []
         rewards = []
+        reward_components: List[Dict[str, float]] = []
         loss_masks = []
         env_metrics = []
         truncated_logprobs: Optional[List[List[float]]] = [] if logprobs is not None else None
@@ -771,6 +772,9 @@ class SkyRLGymGenerator(GeneratorInterface):
             env_step_output: BaseTextEnvStepOutput = await self._run_in_executor_if_available(env.step, output)
             reward = env_step_output["reward"]
             rewards.append(reward)
+            step_reward_components = env_step_output.get("reward_components")
+            if step_reward_components is not None:
+                reward_components.append(step_reward_components)
 
             if len(response) > max_tokens:
                 response = response[:max_tokens]
@@ -795,10 +799,17 @@ class SkyRLGymGenerator(GeneratorInterface):
             # set loss mask to 0 if the stop reason is not "stop"
             loss_masks = apply_overlong_filtering(loss_masks, stop_reasons)
 
+        if reward_components and len(reward_components) != len(rewards):
+            raise ValueError(
+                f"Only {len(reward_components)} of {len(rewards)} environments returned `reward_components`. "
+                "Either every environment in the batch must return them, or none."
+            )
+
         generator_output: GeneratorOutput = {
             "prompt_token_ids": prompt_token_ids,
             "response_ids": truncated_responses,
             "rewards": rewards,
+            "reward_components": reward_components or None,
             "loss_masks": loss_masks,
             "stop_reasons": stop_reasons,
             "rollout_metrics": rollout_metrics,

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -832,6 +832,7 @@ def _merge_single_trajectory(gen_out: GeneratorOutput) -> GeneratorOutput:
     is_token_level_rewards = isinstance(gen_out["rewards"][0], list)
     has_logprobs = gen_out.get("rollout_logprobs") is not None
     has_stop_reasons = gen_out.get("stop_reasons") is not None
+    has_reward_components = gen_out.get("reward_components") is not None
 
     # Per-field output accumulators.
     # Fields that we take from all the entries in the merge group
@@ -844,6 +845,7 @@ def _merge_single_trajectory(gen_out: GeneratorOutput) -> GeneratorOutput:
 
     # Fields that we only take from the last turn in the merge group
     out_stop_reasons: Optional[List[str]] = [] if has_stop_reasons else None
+    out_reward_components: Optional[List[Dict[str, float]]] = [] if has_reward_components else None
     out_trajectory_ids: list = []
     out_is_last_step: List[bool] = []
 
@@ -865,6 +867,8 @@ def _merge_single_trajectory(gen_out: GeneratorOutput) -> GeneratorOutput:
         out_rewards.append(acc_rewards_tokens if is_token_level_rewards else gen_out["rewards"][last])
         if has_stop_reasons:
             out_stop_reasons.append(gen_out["stop_reasons"][last])
+        if has_reward_components:
+            out_reward_components.append(gen_out["reward_components"][last])
         out_trajectory_ids.append(gen_out["trajectory_ids"][last])
         out_is_last_step.append(gen_out["is_last_step"][last])
 
@@ -912,6 +916,7 @@ def _merge_single_trajectory(gen_out: GeneratorOutput) -> GeneratorOutput:
         "prompt_token_ids": out_prompt_ids,
         "response_ids": out_response_ids,
         "rewards": out_rewards,
+        "reward_components": out_reward_components,
         "loss_masks": out_loss_masks,
         "stop_reasons": out_stop_reasons,
         "rollout_logprobs": out_logprobs,
@@ -953,7 +958,6 @@ def merge_stepwise_output(generator_output: GeneratorOutput) -> GeneratorOutput:
     assert (
         generator_output.get("pixel_values") is None and generator_output.get("image_grid_thw") is None
     ), "pixel_values and image_grid_thw not supported for step-wise training merging"
-    assert generator_output.get("reward_components") is None, "reward_components not supported for prefix-aware merging"
 
     # Split into per-trajectory GeneratorOutputs using is_last_step boundaries
     # (contiguity is guaranteed by validate_generator_output with step_wise=True)

--- a/skyrl/train/generators/utils.py
+++ b/skyrl/train/generators/utils.py
@@ -185,13 +185,22 @@ def get_metrics_from_generator_output(generator_output: GeneratorOutput, uids: L
     """
     Get `mean_raw_reward` (or avg_score), `pass_at_n`, and `mean_positive_reward` from generator output.
 
+    Thin wrapper over `get_metrics_from_rewards` for the batch's primary `rewards` field.
+    """
+    return get_metrics_from_rewards(generator_output["rewards"], uids)
+
+
+@torch.no_grad()
+def get_metrics_from_rewards(rewards: Union[List[float], List[List[float]]], uids: List[str]) -> MetricsOutput:
+    """
+    Get `mean_raw_reward` (or avg_score), `pass_at_n`, and `mean_positive_reward` for one reward signal.
+
     The `n` in `pass_at_n` is the number of trajectories we generate for each example. It is
-    calculated as `len(generator_output["rewards"]) / len(uids)`, where `len(uids)` is the number of
-    unique examples.
+    calculated as `len(rewards) / len(uids)`, where `len(uids)` is the number of unique examples.
 
     Rewards can be either per-trajectory or per-token, and metrics are computed correspondingly.
+    Multi-reward runs call this once per objective to get per-objective metrics.
     """
-    rewards: Union[List[float], List[List[float]]] = generator_output["rewards"]
     if not len(rewards):
         raise ValueError(f"`rewards` must be a non-empty list, got {rewards}")
 
@@ -288,6 +297,7 @@ def concatenate_generator_outputs(generator_outputs: List[GeneratorOutput], step
         "prompt_token_ids": _flatten_field(generator_outputs, "prompt_token_ids"),
         "response_ids": _flatten_field(generator_outputs, "response_ids"),
         "rewards": _flatten_field(generator_outputs, "rewards"),
+        "reward_components": _concat_optional_field(generator_outputs, "reward_components"),
         "loss_masks": _flatten_field(generator_outputs, "loss_masks"),
         "stop_reasons": _concat_optional_field(generator_outputs, "stop_reasons"),
         "rollout_logprobs": _concat_optional_field(generator_outputs, "rollout_logprobs"),
@@ -943,6 +953,7 @@ def merge_stepwise_output(generator_output: GeneratorOutput) -> GeneratorOutput:
     assert (
         generator_output.get("pixel_values") is None and generator_output.get("image_grid_thw") is None
     ), "pixel_values and image_grid_thw not supported for step-wise training merging"
+    assert generator_output.get("reward_components") is None, "reward_components not supported for prefix-aware merging"
 
     # Split into per-trajectory GeneratorOutputs using is_last_step boundaries
     # (contiguity is guaranteed by validate_generator_output with step_wise=True)

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -66,6 +66,7 @@ from skyrl.train.generators.base import (
 )
 from skyrl.train.generators.utils import (
     get_metrics_from_generator_output,
+    get_metrics_from_rewards,
     merge_stepwise_output,
     prepare_generator_input,
 )
@@ -878,6 +879,7 @@ class RayPPOTrainer:
 
         logprobs: Optional[List[List[float]]] = generator_output.get("rollout_logprobs", None)
         rollout_expert_indices = generator_output.get("rollout_expert_indices", None)
+        reward_components: Optional[List[Dict[str, float]]] = generator_output.get("reward_components", None)
 
         pixel_values = generator_output.get("pixel_values", None)
         image_grid_thw = generator_output.get("image_grid_thw", None)
@@ -928,12 +930,22 @@ class RayPPOTrainer:
             assert rollout_logprobs_tensor.shape == loss_masks_tensor.shape, "Logprobs should look like responses"
 
         # 3. Create training input batch.
+        reward_component_names: Optional[List[str]] = None
+        reward_components_tensor = None
+        if reward_components is not None:
+            reward_component_names = sorted(reward_components[0])
+            reward_components_tensor = torch.tensor(
+                [[components[name] for name in reward_component_names] for components in reward_components],
+                dtype=torch.float,
+            )
+
         training_input = TrainingInputBatch(
             {
                 "sequences": sequences_tensor,  # Full trajectories (padded and concatenated prompts and responses)
                 "attention_mask": attention_masks_tensor,
                 "response_mask": response_masks_tensor,
                 "rewards": rewards_tensor,
+                "reward_components": reward_components_tensor,
                 "loss_mask": loss_masks_tensor,
                 "rollout_logprobs": rollout_logprobs_tensor,
                 "rollout_expert_indices": rollout_expert_indices_tensor,
@@ -943,6 +955,8 @@ class RayPPOTrainer:
             },
         )
         training_input.metadata = {"uids": uids}
+        if reward_component_names is not None:
+            training_input.metadata["reward_component_names"] = reward_component_names
         if generator_output.get("is_last_step", None) is not None:
             training_input.metadata["is_last_step"] = generator_output["is_last_step"]
 
@@ -1078,6 +1092,15 @@ class RayPPOTrainer:
             )
             uids = [tid.instance_id for tid in generator_output["trajectory_ids"]]
 
+        assert not (
+            self.cfg.trainer.algorithm.advantage_estimator == ppo_utils.AdvantageEstimator.GDPO
+            and generator_output.get("reward_components") is None
+        ), (
+            "advantage_estimator='gdpo' normalizes each reward component separately, but the generator "
+            "produced no `reward_components`. Have the reward function populate `GeneratorOutput["
+            "'reward_components']`, or use a single-reward estimator such as 'grpo'."
+        )
+
         # these use the full generator output
         rewards: Union[List[float], List[List[float]]] = generator_output["rewards"]
         responses: List[List[int]] = generator_output["response_ids"]
@@ -1121,6 +1144,20 @@ class RayPPOTrainer:
         logger.info(
             f"reward/avg_pass_at_{n_samples_per_prompt}: {overall_metrics['pass_at_n']}, reward/avg_raw_reward: {overall_metrics['avg_score']}, reward/mean_positive_reward: {overall_metrics['mean_positive_reward']}"
         )
+
+        components_for_metrics = generator_output_for_metrics.get("reward_components")
+        if components_for_metrics is not None:
+            for name in sorted(components_for_metrics[0]):
+                component_metrics = get_metrics_from_rewards(
+                    [components[name] for components in components_for_metrics], uids_for_metrics
+                )
+                self.all_metrics.update(
+                    {
+                        f"reward/{name}/avg_pass_at_{n_samples_per_prompt}": component_metrics["pass_at_n"],
+                        f"reward/{name}/avg_raw_reward": component_metrics["avg_score"],
+                        f"reward/{name}/mean_positive_reward": component_metrics["mean_positive_reward"],
+                    }
+                )
         # re-assign reward but now it's per token rewards
         generator_output["rewards"] = per_token_rewards
         return generator_output, uids
@@ -1135,7 +1172,11 @@ class RayPPOTrainer:
             - `["loss_mask"]`: Float[torch.Tensor, "batch_size response_len"]
             - `["values"]`: Float[torch.Tensor, "batch_size response_len"]
             - `["rewards"]`: Float[torch.Tensor, "batch_size response_len"]
+            - `["reward_components"]`: Optional[Float[torch.Tensor, "batch_size num_components"]]. For
+                GDPO this replaces `rewards` as the estimator's `token_level_rewards`, expanded to
+                "batch_size num_components response_len".
             - `.metadata["uids"]`: List[str]
+            - `.metadata["reward_component_names"]`: List[str] naming the `reward_components` columns
             - `.metadata["is_last_step"]`: List[bool] for step-wise training
 
         Adds:
@@ -1143,6 +1184,14 @@ class RayPPOTrainer:
             - `["returns"]`: Float[torch.Tensor, "batch_size response_len"]
         """
         token_level_rewards = data["rewards"]
+        reward_component_names = data.metadata.get("reward_component_names")
+        if self.cfg.trainer.algorithm.advantage_estimator == ppo_utils.AdvantageEstimator.GDPO:
+            # GDPO normalizes each component separately, so it receives the components in place of
+            # the summed reward, with each score on the last position as `rewards` has it.
+            reward_components = data["reward_components"]
+            response_len = data["response_mask"].shape[1]
+            token_level_rewards = torch.zeros(*reward_components.shape, response_len, dtype=reward_components.dtype)
+            token_level_rewards[..., -1] = reward_components
 
         if self.cfg.generator.step_wise_trajectories:
             is_last_step = torch.tensor(data.metadata["is_last_step"], dtype=torch.bool)
@@ -1172,6 +1221,7 @@ class RayPPOTrainer:
                 gamma=self.cfg.trainer.algorithm.gamma,
                 lambd=self.cfg.trainer.algorithm.lambd,
                 grpo_norm_by_std=self.cfg.trainer.algorithm.grpo_norm_by_std,
+                reward_component_names=reward_component_names,
             )
             traj_ids = (
                 torch.cat([torch.tensor([False], device=is_last_step.device), is_last_step[:-1]]).int().cumsum(dim=0)
@@ -1194,6 +1244,7 @@ class RayPPOTrainer:
                 gamma=self.cfg.trainer.algorithm.gamma,
                 lambd=self.cfg.trainer.algorithm.lambd,
                 grpo_norm_by_std=self.cfg.trainer.algorithm.grpo_norm_by_std,
+                reward_component_names=reward_component_names,
             )
         data["returns"] = returns
         data["advantages"] = advantages

--- a/skyrl/train/trainer.py
+++ b/skyrl/train/trainer.py
@@ -932,7 +932,7 @@ class RayPPOTrainer:
         # 3. Create training input batch.
         reward_component_names: Optional[List[str]] = None
         reward_components_tensor = None
-        if reward_components is not None:
+        if reward_components:
             reward_component_names = sorted(reward_components[0])
             reward_components_tensor = torch.tensor(
                 [[components[name] for name in reward_component_names] for components in reward_components],
@@ -1112,14 +1112,22 @@ class RayPPOTrainer:
             per_token_rewards = rewards
         else:
             if self.cfg.trainer.algorithm.zero_variance_filter:
-                kept_indices_set = set(
-                    zero_variance_filter(
-                        rewards,
-                        uids,
-                        loss_masks=generator_output["loss_masks"],
-                        tol=self.cfg.trainer.algorithm.zero_variance_filter_tol,
+                # A group carries signal as long as some component varies, even when the totals match.
+                components = generator_output.get("reward_components")
+                if components:
+                    filter_signals = [[c[name] for c in components] for name in sorted(components[0])]
+                else:
+                    filter_signals = [rewards]
+                kept_indices_set = set()
+                for signal in filter_signals:
+                    kept_indices_set.update(
+                        zero_variance_filter(
+                            signal,
+                            uids,
+                            loss_masks=generator_output["loss_masks"],
+                            tol=self.cfg.trainer.algorithm.zero_variance_filter_tol,
+                        )
                     )
-                )
                 num_groups = len(set(uids))
                 num_kept_groups = len({uids[i] for i in kept_indices_set})
                 self.all_metrics["reward/num_zero_variance_filtered"] = num_groups - num_kept_groups
@@ -1146,7 +1154,7 @@ class RayPPOTrainer:
         )
 
         components_for_metrics = generator_output_for_metrics.get("reward_components")
-        if components_for_metrics is not None:
+        if components_for_metrics:
             for name in sorted(components_for_metrics[0]):
                 component_metrics = get_metrics_from_rewards(
                     [components[name] for components in components_for_metrics], uids_for_metrics
@@ -1185,13 +1193,19 @@ class RayPPOTrainer:
         """
         token_level_rewards = data["rewards"]
         reward_component_names = data.metadata.get("reward_component_names")
+        # GDPO scores the components instead of the summed reward; `token_level_rewards` stays the
+        # summed reward for the metrics below.
+        estimator_rewards = token_level_rewards
         if self.cfg.trainer.algorithm.advantage_estimator == ppo_utils.AdvantageEstimator.GDPO:
-            # GDPO normalizes each component separately, so it receives the components in place of
-            # the summed reward, with each score on the last position as `rewards` has it.
             reward_components = data["reward_components"]
             response_len = data["response_mask"].shape[1]
-            token_level_rewards = torch.zeros(*reward_components.shape, response_len, dtype=reward_components.dtype)
-            token_level_rewards[..., -1] = reward_components
+            estimator_rewards = torch.zeros(
+                *reward_components.shape,
+                response_len,
+                dtype=reward_components.dtype,
+                device=reward_components.device,
+            )
+            estimator_rewards[..., -1] = reward_components
 
         if self.cfg.generator.step_wise_trajectories:
             is_last_step = torch.tensor(data.metadata["is_last_step"], dtype=torch.bool)
@@ -1212,7 +1226,7 @@ class RayPPOTrainer:
             #       (batch_size, response_len):        per-step response mask
             last_step_response_mask = data["response_mask"][is_last_step]
             last_step_advantages, last_step_returns = ppo_utils.compute_advantages_and_returns(
-                token_level_rewards=token_level_rewards[is_last_step],
+                token_level_rewards=estimator_rewards[is_last_step],
                 response_mask=torch.ones_like(last_step_response_mask, dtype=torch.float),
                 index=index[is_last_step.cpu().numpy()],
                 adv_estimator=self.cfg.trainer.algorithm.advantage_estimator,
@@ -1235,7 +1249,7 @@ class RayPPOTrainer:
             returns = last_step_returns[traj_ids] * response_mask_float
         else:
             advantages, returns = ppo_utils.compute_advantages_and_returns(
-                token_level_rewards=token_level_rewards,
+                token_level_rewards=estimator_rewards,
                 response_mask=data["response_mask"],
                 index=data.metadata["uids"],
                 adv_estimator=self.cfg.trainer.algorithm.advantage_estimator,

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -705,6 +705,7 @@ def validate_generator_output(num_prompts: int, generator_output: GeneratorOutpu
             "is_last_step",
             "pixel_values",
             "image_grid_thw",
+            "reward_components",
         ]:
             assert len(generator_output[key]) == len(generator_output["response_ids"]), (
                 f"Generator output {key} length must be equal to response_ids length, "
@@ -746,6 +747,16 @@ def validate_generator_output(num_prompts: int, generator_output: GeneratorOutpu
         assert all(
             not isinstance(reward, list) for reward in rewards
         ), "rewards must be `List[float]` or `List[List[float]]`"
+
+    reward_components = generator_output.get("reward_components")
+    if reward_components is not None:
+        names = set(reward_components[0])
+        assert names, "reward_components entries must be non-empty"
+        for i, components in enumerate(reward_components):
+            assert set(components) == names, (
+                f"Every response must carry the same reward components, "
+                f"but sample {i} has {sorted(components)} and sample 0 has {sorted(names)}"
+            )
 
     if step_wise:
         _validate_step_wise_fields(generator_output, num_responses)

--- a/skyrl/train/utils/trainer_utils.py
+++ b/skyrl/train/utils/trainer_utils.py
@@ -749,7 +749,7 @@ def validate_generator_output(num_prompts: int, generator_output: GeneratorOutpu
         ), "rewards must be `List[float]` or `List[List[float]]`"
 
     reward_components = generator_output.get("reward_components")
-    if reward_components is not None:
+    if reward_components:
         names = set(reward_components[0])
         assert names, "reward_components entries must be non-empty"
         for i, components in enumerate(reward_components):

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -364,6 +364,13 @@ def validate_cfg(cfg: SkyRLTrainConfig):
             f"connection. Use an outcome-based estimator (grpo, rloo, maxrl) or disable "
             f"step_wise_trajectories."
         )
+    if cfg.trainer.algorithm.advantage_estimator == "gdpo" and cfg.trainer.algorithm.advantage_batch_normalize:
+        raise ValueError(
+            "advantage_estimator='gdpo' already batch-normalizes the summed per-component advantages, "
+            "so advantage_batch_normalize=True would normalize them twice. Set "
+            "trainer.algorithm.advantage_batch_normalize=false."
+        )
+
     if cfg.generator.step_wise_trajectories and cfg.trainer.algorithm.loss_reduction == "token_mean_legacy":
         # TODO(Charlie): this can be fixed, can revisit later.
         raise ValueError(

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -371,6 +371,13 @@ def validate_cfg(cfg: SkyRLTrainConfig):
             "trainer.algorithm.advantage_batch_normalize=false."
         )
 
+    if cfg.trainer.algorithm.advantage_estimator == "gdpo" and cfg.trainer.algorithm.use_kl_in_reward:
+        raise ValueError(
+            "advantage_estimator='gdpo' scores the individual reward components, which the "
+            "use_kl_in_reward penalty (applied to the summed reward) never reaches, so the penalty "
+            "would be silently ignored. Use trainer.algorithm.use_kl_loss=true instead."
+        )
+
     if cfg.generator.step_wise_trajectories and cfg.trainer.algorithm.loss_reduction == "token_mean_legacy":
         # TODO(Charlie): this can be fixed, can revisit later.
         raise ValueError(

--- a/tests/backends/skyrl_train/utils/test_ppo_utils.py
+++ b/tests/backends/skyrl_train/utils/test_ppo_utils.py
@@ -18,6 +18,7 @@ from skyrl.backends.skyrl_train.utils.ppo_utils import (
     compute_advantages_and_returns,
     compute_approx_kl,
     compute_gae_advantage_return,
+    compute_gdpo_outcome_advantage,
     compute_grpo_outcome_advantage,
     compute_maxrl_advantage,
     compute_reinforce_plus_plus_outcome_advantage,
@@ -235,6 +236,85 @@ def test_compute_maxrl_advantage():
     assert adv.shape == token_level_rewards.shape
     assert torch.allclose(adv, ret), "Advantages and returns should be equal with MAXRL"
     assert torch.allclose(adv, expected, atol=1e-5), f"Expected {expected}, got {adv}"
+
+
+def _gdpo_token_level_rewards(reward_components: torch.Tensor, response_len: int) -> torch.Tensor:
+    """Lay out per-response reward components the way the trainer does: (bsz, num_rewards, response_len)
+    with each score on the last position."""
+    token_level_rewards = torch.zeros(*reward_components.shape, response_len)
+    token_level_rewards[..., -1] = reward_components
+    return token_level_rewards
+
+
+def test_compute_gdpo_outcome_advantage():
+    # One group of 2, two components. Component 0 is [2.0, 0.0] (mean 1.0, std sqrt(2)), so its
+    # normalized advantages are [1, -1] / sqrt(2). Component 1 is flat, so its std is 0 and the
+    # epsilon guard leaves it contributing 0. Batch normalization of [1, -1] / sqrt(2) is a no-op
+    # since it already has zero mean and unit std.
+    reward_components = torch.tensor([[2.0, 0.0], [0.0, 0.0]])
+    token_level_rewards = _gdpo_token_level_rewards(reward_components, response_len=3)
+    response_mask = torch.ones(2, 3)
+
+    adv, ret = compute_gdpo_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=np.array([0, 0]),
+    )
+
+    expected = torch.tensor([1.0, -1.0]).div(math.sqrt(2.0)).unsqueeze(-1) * response_mask
+
+    assert adv.shape == response_mask.shape
+    assert torch.allclose(adv, ret), "Advantages and returns should be equal with GDPO"
+    assert torch.allclose(adv, expected, atol=1e-5), f"Expected {expected}, got {adv}"
+
+
+def test_compute_gdpo_recovers_signal_that_grpo_collapses():
+    """Group 0's components differ but sum to the same total for every response, so GRPO sees no
+    spread and assigns zero advantage. GDPO normalizes each component separately and keeps the signal."""
+    reward_components = torch.tensor(
+        [
+            [2.0, 0.0, 0.0],  # sum = 2.0, group 0
+            [0.0, 1.0, 1.0],  # sum = 2.0, group 0
+            [1.0, 0.5, 0.5],  # sum = 2.0, group 0
+            [1.0, 1.0, 1.0],  # sum = 3.0, group 1
+            [0.0, 0.0, 0.0],  # sum = 0.0, group 1
+            [1.0, 0.0, 0.0],  # sum = 1.0, group 1
+        ]
+    )
+    response_mask = torch.ones(6, 2)
+    index = np.array([0, 0, 0, 1, 1, 1])
+
+    gdpo_adv, _ = compute_gdpo_outcome_advantage(
+        token_level_rewards=_gdpo_token_level_rewards(reward_components, response_len=2),
+        response_mask=response_mask,
+        index=index,
+    )
+
+    summed_rewards = torch.zeros(6, 2)
+    summed_rewards[:, -1] = reward_components.sum(dim=-1)
+    grpo_adv, _ = compute_grpo_outcome_advantage(
+        token_level_rewards=summed_rewards,
+        response_mask=response_mask,
+        index=index,
+    )
+
+    assert torch.allclose(grpo_adv[:3], torch.zeros(3, 2)), "GRPO should collapse the flat-sum group"
+    assert not torch.allclose(gdpo_adv[:3], torch.zeros(3, 2)), "GDPO should keep the per-component signal"
+    # The two responses that differ only in how the same total is split get opposite advantages.
+    assert gdpo_adv[0, 0] == pytest.approx(-gdpo_adv[1, 0], abs=1e-5)
+
+
+def test_compute_gdpo_single_sequence_skips_batch_normalization():
+    """Batch normalization needs more than one sequence; a single-row batch must not produce nan."""
+    token_level_rewards = _gdpo_token_level_rewards(torch.tensor([[1.0, 0.5]]), response_len=3)
+
+    adv, _ = compute_gdpo_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=torch.ones(1, 3),
+        index=np.array([0]),
+    )
+
+    assert not adv.isnan().any(), f"Single-sequence batch produced nan advantages: {adv}"
 
 
 def test_compute_gae_advantage_return(advantage_test_data):

--- a/tests/train/generators/test_generator_output_utils.py
+++ b/tests/train/generators/test_generator_output_utils.py
@@ -25,6 +25,7 @@ def test_generator_output_concatenation():
         "prompt_token_ids",
         "response_ids",
         "rewards",
+        "reward_components",
         "loss_masks",
         "stop_reasons",
         "rollout_metrics",


### PR DESCRIPTION
# Add GDPO (Group reward-Decoupled Normalization Policy Optimization)

Implements GDPO from [arXiv:2601.05242](https://arxiv.org/abs/2601.05242) as a new advantage
estimator, plus the reward-component plumbing it needs.

## Algorithm

Three steps, all inside the advantage estimator:

1. Normalize each reward component separately within its prompt group:
   `A_k = (r_k - mean_g(r_k)) / (std_g(r_k) + eps)`
2. Sum the normalized components: `A = sum_k A_k`
3. Batch-normalize `A` across the batch, so the summed magnitude does not grow with the number of
   rewards. (Appendix A of the paper: dropping this occasionally causes convergence failure.)

## Changes

**Reward components plumbing.** Rewards were scalar-per-response end to end, so a channel for
per-objective scores had to be added:

- `BaseTextEnvStepOutput.reward_components: Optional[Dict[str, float]]` — environments can now
  report a named breakdown alongside `reward`.
- `GeneratorOutput.reward_components: Optional[List[Dict[str, float]]]` — one dict per response.
  Row-major matches how the generator builds rewards (per-trajectory loop) and cannot go ragged
  silently: `validate_generator_output` rejects a batch whose rows disagree on component names.
- The batched gym generator collects them, and errors if only some environments supply them.
- `convert_to_training_input` turns them into a `(batch_size, num_components)` tensor with column
  names in `metadata["reward_component_names"]` (sorted, so column order is stable).

**Advantage estimator.** `compute_gdpo_outcome_advantage`, registered as `gdpo`. For this estimator
the trainer passes the components in place of the summed reward, expanded to
`(batch_size, num_components, response_len)` with each score on the last position — the same layout
`rewards` uses, so `sum(dim=-1)` recovers the per-response scores exactly as the other outcome
estimators do. The group statistics are `(num_components,)` vectors, so all components are handled
in one pass with no inner loop.

**Metrics.** Per-component `reward/{name}/avg_raw_reward`, `pass_at_n`, and `mean_positive_reward`
are logged alongside the existing aggregates, which are untouched.

**Config validation.** `advantage_estimator=gdpo` with `advantage_batch_normalize=true` is rejected:
the estimator already batch-normalizes, so enabling both would normalize twice.

**Example.** `examples/train/algorithms/gdpo/run_gdpo_gsm8k.sh`, using a new `gsm8k_multi_reward`
environment that scores `format` (an answer in `#### <number>` form) and `correct` (that answer
matching the ground truth) as separate objectives — the same correctness+format split the paper uses
for tool calling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RL training (advantage computation and reward batching); misconfigured GDPO or partial `reward_components` is guarded but wrong env wiring would break training runs.
> 
> **Overview**
> Adds **GDPO** (`advantage_estimator=gdpo`): per-component group normalization within each prompt group, sum of normalized components, then batch normalization—so different reward mixes stay distinguishable when totals match (unlike GRPO on summed rewards).
> 
> **End-to-end `reward_components`:** optional named per-objective scores on `BaseTextEnvStepOutput`, through `GeneratorOutput` and the gym generator (all-or-nothing per batch/turn), into `TrainingInputBatch.reward_components` with stable column order in metadata. GDPO feeds those tensors as outcome rewards on the last token; summed `rewards` still drive existing metrics, plus per-component reward metrics.
> 
> **GSM8K example:** registers `gsm8k_multi_reward` (`correct`, `format`, `length` via `compute_score_components`) and `examples/train/algorithms/gdpo/run_gdpo_gsm8k.sh`. Config guards reject GDPO with `advantage_batch_normalize`, `use_kl_in_reward`, or missing components; zero-variance filtering can use per-component spread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74fee0786701580499b196bbf1c416d4fde74dd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->