### PR TITLE
[ci] make sure ci doesn't unnecessarily retry

### DIFF
--- a/.github/workflows/gpu_ci_h100.yaml
+++ b/.github/workflows/gpu_ci_h100.yaml
@@ -22,11 +22,14 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
-# A re-label while a run is still going supersedes it rather than queueing a second
-# GPU cluster. Keyed on the PR, since `github.ref` is the base branch under
-# pull_request_target and would collide across every open PR.
+# Re-applying the gating label supersedes a run that is still going rather than
+# queueing a second GPU cluster. The group must include the label: a run started by
+# *another* label is skipped by the gate below, and without the label in the key it
+# would cancel the in-flight GPU job on its way to skipping. Keyed on the PR because
+# `github.ref` is the base branch under pull_request_target.
 concurrency:
-  group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:
@@ -81,3 +84,11 @@ jobs:
           JOB_NAME="skyrl-train-gpu-ci-h100-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_h100_envsubst.yaml "$JOB_NAME" 5400
           rm -f ci/anyscale_gpu_ci_h100_envsubst.yaml
+      # Cancelling the run stops the runner, not the cluster. GitHub still runs
+      # `if: cancelled()` steps, so this is where an orphaned GPU job gets reaped.
+      - name: Terminate Anyscale jobs on cancellation
+        if: cancelled()
+        env:
+          ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
+          ANYSCALE_HOST: https://console.anyscale.com
+        run: bash ci/terminate_anyscale_jobs.sh

--- a/.github/workflows/gpu_ci_h100.yaml
+++ b/.github/workflows/gpu_ci_h100.yaml
@@ -22,16 +22,30 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
+# `types: [labeled]` delivers one event per label added, so applying several at
+# once starts several runs of this workflow. The label gate below drops the ones
+# fired by an unrelated label; this drops the rest -- a re-label while a run is
+# still going supersedes it instead of queueing a second GPU cluster. Keyed on the
+# PR, since `github.ref` is the *base* branch for pull_request_target and would
+# collide across every open PR.
+concurrency:
+  group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   skyrl_train_tests_h100:
+    # Gate on the label that fired *this* event, not on the label set. With
+    # `contains(...labels.*.name, ...)` every `labeled` event whose payload
+    # happens to include the gating label passes, so adding N labels at once
+    # launched N identical GPU runs.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'run_h100_gpu_ci')
+        github.event.label.name == 'run_h100_gpu_ci'
       )
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/gpu_ci_h100.yaml
+++ b/.github/workflows/gpu_ci_h100.yaml
@@ -22,12 +22,9 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
-# `types: [labeled]` delivers one event per label added, so applying several at
-# once starts several runs of this workflow. The label gate below drops the ones
-# fired by an unrelated label; this drops the rest -- a re-label while a run is
-# still going supersedes it instead of queueing a second GPU cluster. Keyed on the
-# PR, since `github.ref` is the *base* branch for pull_request_target and would
-# collide across every open PR.
+# A re-label while a run is still going supersedes it rather than queueing a second
+# GPU cluster. Keyed on the PR, since `github.ref` is the base branch under
+# pull_request_target and would collide across every open PR.
 concurrency:
   group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -35,10 +32,9 @@ concurrency:
 jobs:
 
   skyrl_train_tests_h100:
-    # Gate on the label that fired *this* event, not on the label set. With
-    # `contains(...labels.*.name, ...)` every `labeled` event whose payload
-    # happens to include the gating label passes, so adding N labels at once
-    # launched N identical GPU runs.
+    # Gate on the label that fired this event. `types: [labeled]` delivers one event
+    # per label added, and `contains(...labels.*.name, ...)` tests the whole label
+    # set, so labelling in bulk launched one identical GPU run per label.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -22,11 +22,14 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
-# A re-label while a run is still going supersedes it rather than queueing a second
-# GPU cluster. Keyed on the PR, since `github.ref` is the base branch under
-# pull_request_target and would collide across every open PR.
+# Re-applying the gating label supersedes a run that is still going rather than
+# queueing a second GPU cluster. The group must include the label: a run started by
+# *another* label is skipped by the gate below, and without the label in the key it
+# would cancel the in-flight GPU job on its way to skipping. Keyed on the PR because
+# `github.ref` is the base branch under pull_request_target.
 concurrency:
-  group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:
@@ -82,3 +85,11 @@ jobs:
           JOB_NAME="skyrl-train-gpu-ci-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_skyrl_train_envsubst.yaml "$JOB_NAME" 12000
           rm -f ci/anyscale_gpu_ci_skyrl_train_envsubst.yaml
+      # Cancelling the run stops the runner, not the cluster. GitHub still runs
+      # `if: cancelled()` steps, so this is where an orphaned GPU job gets reaped.
+      - name: Terminate Anyscale jobs on cancellation
+        if: cancelled()
+        env:
+          ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
+          ANYSCALE_HOST: https://console.anyscale.com
+        run: bash ci/terminate_anyscale_jobs.sh

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -22,16 +22,30 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
+# `types: [labeled]` delivers one event per label added, so applying several at
+# once starts several runs of this workflow. The label gate below drops the ones
+# fired by an unrelated label; this drops the rest -- a re-label while a run is
+# still going supersedes it instead of queueing a second GPU cluster. Keyed on the
+# PR, since `github.ref` is the *base* branch for pull_request_target and would
+# collide across every open PR.
+concurrency:
+  group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   
   skyrl_train_tests:
+    # Gate on the label that fired *this* event, not on the label set. With
+    # `contains(...labels.*.name, ...)` every `labeled` event whose payload
+    # happens to include the gating label passes, so adding N labels at once
+    # launched N identical GPU runs.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'run_train_gpu_ci')
+        github.event.label.name == 'run_train_gpu_ci'
       )
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -22,12 +22,9 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
-# `types: [labeled]` delivers one event per label added, so applying several at
-# once starts several runs of this workflow. The label gate below drops the ones
-# fired by an unrelated label; this drops the rest -- a re-label while a run is
-# still going supersedes it instead of queueing a second GPU cluster. Keyed on the
-# PR, since `github.ref` is the *base* branch for pull_request_target and would
-# collide across every open PR.
+# A re-label while a run is still going supersedes it rather than queueing a second
+# GPU cluster. Keyed on the PR, since `github.ref` is the base branch under
+# pull_request_target and would collide across every open PR.
 concurrency:
   group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -35,10 +32,9 @@ concurrency:
 jobs:
   
   skyrl_train_tests:
-    # Gate on the label that fired *this* event, not on the label set. With
-    # `contains(...labels.*.name, ...)` every `labeled` event whose payload
-    # happens to include the gating label passes, so adding N labels at once
-    # launched N identical GPU runs.
+    # Gate on the label that fired this event. `types: [labeled]` delivers one event
+    # per label added, and `contains(...labels.*.name, ...)` tests the whole label
+    # set, so labelling in bulk launched one identical GPU run per label.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -24,16 +24,30 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
+# `types: [labeled]` delivers one event per label added, so applying several at
+# once starts several runs of this workflow. The label gate below drops the ones
+# fired by an unrelated label; this drops the rest -- a re-label while a run is
+# still going supersedes it instead of queueing a second GPU cluster. Keyed on the
+# PR, since `github.ref` is the *base* branch for pull_request_target and would
+# collide across every open PR.
+concurrency:
+  group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   
   skyrl_train_tests_megatron:
+    # Gate on the label that fired *this* event, not on the label set. With
+    # `contains(...labels.*.name, ...)` every `labeled` event whose payload
+    # happens to include the gating label passes, so adding N labels at once
+    # launched N identical GPU runs.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'run_train_megatron_gpu_ci')
+        github.event.label.name == 'run_train_megatron_gpu_ci'
       )
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -24,11 +24,14 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
-# A re-label while a run is still going supersedes it rather than queueing a second
-# GPU cluster. Keyed on the PR, since `github.ref` is the base branch under
-# pull_request_target and would collide across every open PR.
+# Re-applying the gating label supersedes a run that is still going rather than
+# queueing a second GPU cluster. The group must include the label: a run started by
+# *another* label is skipped by the gate below, and without the label in the key it
+# would cancel the in-flight GPU job on its way to skipping. Keyed on the PR because
+# `github.ref` is the base branch under pull_request_target.
 concurrency:
-  group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:
@@ -84,3 +87,11 @@ jobs:
           JOB_NAME="skyrl-train-gpu-ci-megatron-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_skyrl_train_megatron_envsubst.yaml "$JOB_NAME" 12000
           rm -f ci/anyscale_gpu_ci_skyrl_train_megatron_envsubst.yaml
+      # Cancelling the run stops the runner, not the cluster. GitHub still runs
+      # `if: cancelled()` steps, so this is where an orphaned GPU job gets reaped.
+      - name: Terminate Anyscale jobs on cancellation
+        if: cancelled()
+        env:
+          ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
+          ANYSCALE_HOST: https://console.anyscale.com
+        run: bash ci/terminate_anyscale_jobs.sh

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -24,12 +24,9 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
-# `types: [labeled]` delivers one event per label added, so applying several at
-# once starts several runs of this workflow. The label gate below drops the ones
-# fired by an unrelated label; this drops the rest -- a re-label while a run is
-# still going supersedes it instead of queueing a second GPU cluster. Keyed on the
-# PR, since `github.ref` is the *base* branch for pull_request_target and would
-# collide across every open PR.
+# A re-label while a run is still going supersedes it rather than queueing a second
+# GPU cluster. Keyed on the PR, since `github.ref` is the base branch under
+# pull_request_target and would collide across every open PR.
 concurrency:
   group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -37,10 +34,9 @@ concurrency:
 jobs:
   
   skyrl_train_tests_megatron:
-    # Gate on the label that fired *this* event, not on the label set. With
-    # `contains(...labels.*.name, ...)` every `labeled` event whose payload
-    # happens to include the gating label passes, so adding N labels at once
-    # launched N identical GPU runs.
+    # Gate on the label that fired this event. `types: [labeled]` delivers one event
+    # per label added, and `contains(...labels.*.name, ...)` tests the whole label
+    # set, so labelling in bulk launched one identical GPU run per label.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/gpu_skyrl_train_megatron_models.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron_models.yaml
@@ -24,16 +24,30 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
+# `types: [labeled]` delivers one event per label added, so applying several at
+# once starts several runs of this workflow. The label gate below drops the ones
+# fired by an unrelated label; this drops the rest -- a re-label while a run is
+# still going supersedes it instead of queueing a second GPU cluster. Keyed on the
+# PR, since `github.ref` is the *base* branch for pull_request_target and would
+# collide across every open PR.
+concurrency:
+  group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   
   skyrl_train_tests_megatron_models:
+    # Gate on the label that fired *this* event, not on the label set. With
+    # `contains(...labels.*.name, ...)` every `labeled` event whose payload
+    # happens to include the gating label passes, so adding N labels at once
+    # launched N identical GPU runs.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'run_train_megatron_gpu_ci_models')
+        github.event.label.name == 'run_train_megatron_gpu_ci_models'
       )
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/gpu_skyrl_train_megatron_models.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron_models.yaml
@@ -24,11 +24,14 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
-# A re-label while a run is still going supersedes it rather than queueing a second
-# GPU cluster. Keyed on the PR, since `github.ref` is the base branch under
-# pull_request_target and would collide across every open PR.
+# Re-applying the gating label supersedes a run that is still going rather than
+# queueing a second GPU cluster. The group must include the label: a run started by
+# *another* label is skipped by the gate below, and without the label in the key it
+# would cancel the in-flight GPU job on its way to skipping. Keyed on the PR because
+# `github.ref` is the base branch under pull_request_target.
 concurrency:
-  group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:
@@ -84,3 +87,11 @@ jobs:
           JOB_NAME="skyrl-train-gpu-ci-megatron-models-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_gpu_ci_skyrl_train_megatron_models_envsubst.yaml "$JOB_NAME" 2500
           rm -f ci/anyscale_gpu_ci_skyrl_train_megatron_models_envsubst.yaml
+      # Cancelling the run stops the runner, not the cluster. GitHub still runs
+      # `if: cancelled()` steps, so this is where an orphaned GPU job gets reaped.
+      - name: Terminate Anyscale jobs on cancellation
+        if: cancelled()
+        env:
+          ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
+          ANYSCALE_HOST: https://console.anyscale.com
+        run: bash ci/terminate_anyscale_jobs.sh

--- a/.github/workflows/gpu_skyrl_train_megatron_models.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron_models.yaml
@@ -24,12 +24,9 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
-# `types: [labeled]` delivers one event per label added, so applying several at
-# once starts several runs of this workflow. The label gate below drops the ones
-# fired by an unrelated label; this drops the rest -- a re-label while a run is
-# still going supersedes it instead of queueing a second GPU cluster. Keyed on the
-# PR, since `github.ref` is the *base* branch for pull_request_target and would
-# collide across every open PR.
+# A re-label while a run is still going supersedes it rather than queueing a second
+# GPU cluster. Keyed on the PR, since `github.ref` is the base branch under
+# pull_request_target and would collide across every open PR.
 concurrency:
   group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -37,10 +34,9 @@ concurrency:
 jobs:
   
   skyrl_train_tests_megatron_models:
-    # Gate on the label that fired *this* event, not on the label set. With
-    # `contains(...labels.*.name, ...)` every `labeled` event whose payload
-    # happens to include the gating label passes, so adding N labels at once
-    # launched N identical GPU runs.
+    # Gate on the label that fired this event. `types: [labeled]` delivers one event
+    # per label added, and `contains(...labels.*.name, ...)` tests the whole label
+    # set, so labelling in bulk launched one identical GPU run per label.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
+++ b/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
@@ -25,11 +25,14 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
-# A re-label while a run is still going supersedes it rather than queueing a second
-# GPU cluster. Keyed on the PR, since `github.ref` is the base branch under
-# pull_request_target and would collide across every open PR.
+# Re-applying the gating label supersedes a run that is still going rather than
+# queueing a second GPU cluster. The group must include the label: a run started by
+# *another* label is skipped by the gate below, and without the label in the key it
+# would cancel the in-flight GPU job on its way to skipping. Keyed on the PR because
+# `github.ref` is the base branch under pull_request_target.
 concurrency:
-  group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:
@@ -85,3 +88,11 @@ jobs:
           JOB_NAME="tinker-skyrl-train-backend-gpu-${COMMIT_SHA:0:7}-${{ github.run_id }}-${{ github.run_attempt }}"
           bash ci/submit_anyscale_job.sh ci/anyscale_tinker_skyrl_train_backend_gpu_envsubst.yaml "$JOB_NAME" 5000
           rm -f ci/anyscale_tinker_skyrl_train_backend_gpu_envsubst.yaml
+      # Cancelling the run stops the runner, not the cluster. GitHub still runs
+      # `if: cancelled()` steps, so this is where an orphaned GPU job gets reaped.
+      - name: Terminate Anyscale jobs on cancellation
+        if: cancelled()
+        env:
+          ANYSCALE_CLI_TOKEN: ${{ secrets.ANYSCALE_CLI_TOKEN }}
+          ANYSCALE_HOST: https://console.anyscale.com
+        run: bash ci/terminate_anyscale_jobs.sh

--- a/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
+++ b/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
@@ -25,12 +25,9 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
-# `types: [labeled]` delivers one event per label added, so applying several at
-# once starts several runs of this workflow. The label gate below drops the ones
-# fired by an unrelated label; this drops the rest -- a re-label while a run is
-# still going supersedes it instead of queueing a second GPU cluster. Keyed on the
-# PR, since `github.ref` is the *base* branch for pull_request_target and would
-# collide across every open PR.
+# A re-label while a run is still going supersedes it rather than queueing a second
+# GPU cluster. Keyed on the PR, since `github.ref` is the base branch under
+# pull_request_target and would collide across every open PR.
 concurrency:
   group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -38,10 +35,9 @@ concurrency:
 jobs:
 
   tinker_skyrl_train_backend_gpu_tests:
-    # Gate on the label that fired *this* event, not on the label set. With
-    # `contains(...labels.*.name, ...)` every `labeled` event whose payload
-    # happens to include the gating label passes, so adding N labels at once
-    # launched N identical GPU runs.
+    # Gate on the label that fired this event. `types: [labeled]` delivers one event
+    # per label added, and `contains(...labels.*.name, ...)` tests the whole label
+    # set, so labelling in bulk launched one identical GPU run per label.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
+++ b/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
@@ -25,16 +25,30 @@ permissions:
   checks: write   # for status checks to appear
   contents: read
 
+# `types: [labeled]` delivers one event per label added, so applying several at
+# once starts several runs of this workflow. The label gate below drops the ones
+# fired by an unrelated label; this drops the rest -- a re-label while a run is
+# still going supersedes it instead of queueing a second GPU cluster. Keyed on the
+# PR, since `github.ref` is the *base* branch for pull_request_target and would
+# collide across every open PR.
+concurrency:
+  group: skyrl-gpu-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   tinker_skyrl_train_backend_gpu_tests:
+    # Gate on the label that fired *this* event, not on the label set. With
+    # `contains(...labels.*.name, ...)` every `labeled` event whose payload
+    # happens to include the gating label passes, so adding N labels at once
+    # launched N identical GPU runs.
     if: >
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'run_tinker_skyrl_train_backend_gpu_ci')
+        github.event.label.name == 'run_tinker_skyrl_train_backend_gpu_ci'
       )
     runs-on: ubuntu-latest
     defaults:

--- a/ci/submit_anyscale_job.sh
+++ b/ci/submit_anyscale_job.sh
@@ -20,17 +20,12 @@
 # never got GPUs and we resubmit; if it failed with one, the tests really failed and
 # we report it as-is.
 #
-# A CLI call failing is NOT that signal either, and this is the subtle one. Every job
-# lookup goes through `_resolve_to_job_model`, which rewrites *any* exception out of
-# `get_job` into `RuntimeError: Job with name '<name>' was not found.` -- including
-# `ValueError: Rate limit exceeded (user scope)`, which the client raises with no
-# retry of its own whenever enough GPU workflows poll concurrently. A rate-limited
-# `job wait` therefore returns instantly, looking exactly like a cluster that died in
-# STARTING. So control-plane calls are retried with backoff here (`anyscale_retry`),
-# an unreadable state is never treated as a dead job, and -- because `job terminate`
-# rate-limits the same way -- a resubmit only happens after the previous job is
-# *confirmed* terminal. Fire-and-forget termination is how one H100 run ended up with
-# four clusters queued against the same scarce instance type at once.
+# A failed CLI call is not that signal either. `_resolve_to_job_model` rewrites any
+# exception out of `get_job` -- including the `ValueError: Rate limit exceeded (user
+# scope)` that concurrent GPU workflows provoke -- into `RuntimeError: Job with name
+# '<name>' was not found.` A rate-limited `job wait` returns instantly and looks just
+# like a cluster that died in STARTING. Hence the retries below, and the rule that we
+# only resubmit once the previous job is confirmed terminal.
 #
 # Usage: ci/submit_anyscale_job.sh <config-file> <job-name> <run-timeout-s> [start-timeout-s]
 #
@@ -44,7 +39,7 @@
 #   ANYSCALE_CLOUD           cloud to submit to (default sky-anyscale-aws-us-east-1)
 #   CAPACITY_MAX_ATTEMPTS    submissions before giving up (default 5)
 #   CAPACITY_RETRY_DELAY_S   sleep between attempts (default 300)
-#   ANYSCALE_API_ATTEMPTS    tries per control-plane call before it is inconclusive
+#   ANYSCALE_API_ATTEMPTS    tries per control-plane call (default 6)
 
 set -euo pipefail
 
@@ -75,10 +70,8 @@ UNKNOWN_POLL_LIMIT="${ANYSCALE_UNKNOWN_POLL_LIMIT:-10}"
 API_ERR_LOG="$(mktemp)"
 trap 'rm -f "$API_ERR_LOG"' EXIT
 
-# Run a control-plane command, retrying transient failures with exponential backoff.
-# The rate limit the CLI hits under concurrent CI advertises a retry-after of a few
-# seconds, so a handful of tries clears it. stdout is forwarded only on success --
-# callers parse it as JSON, so stderr is kept out of it.
+# Retry a control-plane call with exponential backoff; the rate limit advertises a
+# retry-after of a few seconds. Only stdout is forwarded, since callers parse it as JSON.
 anyscale_retry() {
     local out delay=5 i
     for ((i = 1; i <= API_ATTEMPTS; i++)); do
@@ -98,11 +91,9 @@ anyscale_retry() {
     return 1
 }
 
-# Echoes "<state> <run-count>" for a job. A run is created when the entrypoint is
-# submitted to a live cluster, so zero runs means provisioning never finished. Both
-# come from one status call: the decision below needs both, and halving the request
-# count is the difference between tripping the rate limit and not. Unreadable status
-# yields "UNKNOWN unknown" -- an answer of "we don't know", never "the job is gone".
+# Echoes "<state> <run-count>". A run is created once the entrypoint is submitted to a
+# live cluster, so zero runs means provisioning never finished. Both come from a single
+# status call to halve the request count. Unreadable status is "UNKNOWN unknown".
 job_status() {
     local json
     if ! json="$(anyscale_retry anyscale job status --cloud "$CLOUD" --name "$1" --json)"; then
@@ -154,11 +145,9 @@ entrypoint_ran() {
     fi
 }
 
-# Wait for a job to settle, resuming the wait when the CLI call -- not the job --
-# is what failed. `anyscale job wait` exits non-zero for a terminal state, for its
-# own timeout, and for a rate-limited lookup alike; only the job's actual state
-# tells them apart. Returns 0 if <target> was reached (empty target = any terminal
-# state), non-zero if the job settled elsewhere or the deadline passed.
+# Wait for a job to settle, resuming when the CLI call rather than the job is what
+# failed: `job wait` exits non-zero for a terminal state, its own timeout and a
+# rate-limited lookup alike. Returns 0 if <target> (empty = any terminal state) is hit.
 wait_for_state() {
     local name="$1" target="$2" timeout_s="$3"
     local deadline=$((SECONDS + timeout_s))
@@ -178,15 +167,10 @@ wait_for_state() {
         if is_terminal "$state"; then
             return 1
         fi
-        # STARTING/RUNNING (the wait call itself broke) or UNKNOWN (the control
-        # plane is unreachable). Either way the job is not known to be dead, so
-        # back off and keep waiting rather than abandoning a live cluster.
+        # The wait call broke (STARTING/RUNNING) or the control plane is unreachable
+        # (UNKNOWN). Neither means the job is dead, so keep waiting -- but bound the
+        # unreadable case so a down control plane can't hold us for the full timeout.
         if [[ "$state" == "UNKNOWN" ]]; then
-            # Bounded separately: a state we can read means real progress is being
-            # observed, but a control plane that stays unreadable would otherwise
-            # hold us here for the whole timeout. Give up on waiting instead --
-            # the caller still has to confirm the job is terminal before it can
-            # resubmit, so bailing early leaks nothing.
             unreadable=$((unreadable + 1))
             if ((unreadable >= UNKNOWN_POLL_LIMIT)); then
                 echo "Job ${name} state unreadable ${unreadable}x in a row; stopping the wait." >&2
@@ -200,9 +184,9 @@ wait_for_state() {
     done
 }
 
-# Drive a job to a terminal state, verifying that it got there. Required before any
-# resubmit: a `job wait` timeout leaves the job running -- it only stops the client
-# polling -- and `job terminate` can silently no-op under a rate limit.
+# Drive a job to a terminal state and verify it got there. Required before a resubmit:
+# a `job wait` timeout only stops the client polling, and `job terminate` can no-op
+# under a rate limit.
 ensure_terminal() {
     local name="$1" state i
     for ((i = 1; i <= TERMINATE_ATTEMPTS; i++)); do
@@ -251,9 +235,8 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
     echo "treating this as a GPU capacity failure." >&2
 
     if ! ensure_terminal "$run_name"; then
-        echo "Could not confirm ${run_name} is terminated. Refusing to resubmit: a second" >&2
-        echo "cluster would compete for the same scarce instance type and run tests whose" >&2
-        echo "result nobody reads. Terminate it by hand if it is still alive." >&2
+        echo "Could not confirm ${run_name} is terminated; refusing to resubmit and" >&2
+        echo "leave a second cluster competing for the same instance type." >&2
         exit 1
     fi
 

--- a/ci/submit_anyscale_job.sh
+++ b/ci/submit_anyscale_job.sh
@@ -40,6 +40,8 @@
 #   CAPACITY_MAX_ATTEMPTS    submissions before giving up (default 5)
 #   CAPACITY_RETRY_DELAY_S   sleep between attempts (default 300)
 #   ANYSCALE_API_ATTEMPTS    tries per control-plane call (default 6)
+#   ANYSCALE_JOBS_FILE       where submitted job names are recorded, for
+#                            ci/terminate_anyscale_jobs.sh to clean up after a cancel
 
 set -euo pipefail
 
@@ -68,7 +70,32 @@ TERMINATE_ATTEMPTS="${ANYSCALE_TERMINATE_ATTEMPTS:-5}"
 UNKNOWN_POLL_LIMIT="${ANYSCALE_UNKNOWN_POLL_LIMIT:-10}"
 
 API_ERR_LOG="$(mktemp)"
+
+# Every name we submit, so a cancelled run can still be cleaned up. Cancelling a
+# workflow (`cancel-in-progress`, the UI button, a job timeout) kills this script,
+# not the cluster it is waiting on -- the GPUs stay allocated until someone
+# terminates the job.
+JOBS_FILE="${ANYSCALE_JOBS_FILE:-${RUNNER_TEMP:-/tmp}/anyscale-submitted-jobs.txt}"
+: > "$JOBS_FILE"
+
+CURRENT_RUN_NAME=""
+
+# Best-effort terminate on the way out. The runner allows only a short grace period
+# after signalling, so this gets two quick tries rather than the usual backoff; the
+# `if: cancelled()` cleanup step in the workflow is the reliable backstop.
+on_signal() {
+    trap - INT TERM
+    if [[ -n "$CURRENT_RUN_NAME" ]]; then
+        echo "Interrupted -- terminating ${CURRENT_RUN_NAME}." >&2
+        anyscale job terminate --cloud "$CLOUD" --name "$CURRENT_RUN_NAME" \
+            || anyscale job terminate --cloud "$CLOUD" --name "$CURRENT_RUN_NAME" \
+            || echo "Terminate failed; ci/terminate_anyscale_jobs.sh must finish the job off." >&2
+    fi
+    exit 143
+}
+
 trap 'rm -f "$API_ERR_LOG"' EXIT
+trap on_signal INT TERM
 
 # Retry a control-plane call with exponential backoff; the rate limit advertises a
 # retry-after of a few seconds. Only stdout is forwarded, since callers parse it as JSON.
@@ -208,6 +235,10 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
     fi
 
     echo "--- Anyscale job attempt ${attempt}/${MAX_ATTEMPTS}: ${run_name}"
+    # Recorded before submitting: a submit that times out client-side may still have
+    # created the job, and an unrecorded job is one nobody will clean up.
+    echo "$run_name" >> "$JOBS_FILE"
+    CURRENT_RUN_NAME="$run_name"
     anyscale job submit -f "$CONFIG_FILE" --name "$run_name" --timeout "$RUN_TIMEOUT_S"
 
     if wait_for_state "$run_name" RUNNING "$START_TIMEOUT_S"; then
@@ -234,7 +265,9 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
     echo "Job ${run_name} failed (state: ${state}) without ever running its entrypoint:" >&2
     echo "treating this as a GPU capacity failure." >&2
 
-    if ! ensure_terminal "$run_name"; then
+    if ensure_terminal "$run_name"; then
+        CURRENT_RUN_NAME=""
+    else
         echo "Could not confirm ${run_name} is terminated; refusing to resubmit and" >&2
         echo "leave a second cluster competing for the same instance type." >&2
         exit 1

--- a/ci/submit_anyscale_job.sh
+++ b/ci/submit_anyscale_job.sh
@@ -165,6 +165,9 @@ wait_for_state() {
         fi
         state="$(job_state "$name")"
         if is_terminal "$state"; then
+            if [[ -z "$target" ]]; then
+                return 0
+            fi
             return 1
         fi
         # The wait call broke (STARTING/RUNNING) or the control plane is unreachable

--- a/ci/submit_anyscale_job.sh
+++ b/ci/submit_anyscale_job.sh
@@ -20,6 +20,18 @@
 # never got GPUs and we resubmit; if it failed with one, the tests really failed and
 # we report it as-is.
 #
+# A CLI call failing is NOT that signal either, and this is the subtle one. Every job
+# lookup goes through `_resolve_to_job_model`, which rewrites *any* exception out of
+# `get_job` into `RuntimeError: Job with name '<name>' was not found.` -- including
+# `ValueError: Rate limit exceeded (user scope)`, which the client raises with no
+# retry of its own whenever enough GPU workflows poll concurrently. A rate-limited
+# `job wait` therefore returns instantly, looking exactly like a cluster that died in
+# STARTING. So control-plane calls are retried with backoff here (`anyscale_retry`),
+# an unreadable state is never treated as a dead job, and -- because `job terminate`
+# rate-limits the same way -- a resubmit only happens after the previous job is
+# *confirmed* terminal. Fire-and-forget termination is how one H100 run ended up with
+# four clusters queued against the same scarce instance type at once.
+#
 # Usage: ci/submit_anyscale_job.sh <config-file> <job-name> <run-timeout-s> [start-timeout-s]
 #
 # <job-name> must be unique to the invocation. `job status` and `job wait` resolve a
@@ -30,8 +42,9 @@
 #
 # Env overrides:
 #   ANYSCALE_CLOUD           cloud to submit to (default sky-anyscale-aws-us-east-1)
-#   CAPACITY_MAX_ATTEMPTS    submissions before giving up (default 10)
+#   CAPACITY_MAX_ATTEMPTS    submissions before giving up (default 5)
 #   CAPACITY_RETRY_DELAY_S   sleep between attempts (default 300)
+#   ANYSCALE_API_ATTEMPTS    tries per control-plane call before it is inconclusive
 
 set -euo pipefail
 
@@ -53,22 +66,71 @@ START_TIMEOUT_S="${4:-$RUN_TIMEOUT_S}"
 CLOUD="${ANYSCALE_CLOUD:-sky-anyscale-aws-us-east-1}"
 MAX_ATTEMPTS="${CAPACITY_MAX_ATTEMPTS:-5}"
 RETRY_DELAY_S="${CAPACITY_RETRY_DELAY_S:-300}"
+API_ATTEMPTS="${ANYSCALE_API_ATTEMPTS:-6}"
+# Tries at getting the job into a terminal state before we refuse to resubmit.
+TERMINATE_ATTEMPTS="${ANYSCALE_TERMINATE_ATTEMPTS:-5}"
+# Consecutive unreadable status polls before we stop waiting on a job.
+UNKNOWN_POLL_LIMIT="${ANYSCALE_UNKNOWN_POLL_LIMIT:-10}"
 
-# Current state of a job by name. `job status` resolves the most recently created
-# job with that name, which is why each attempt gets a unique name below.
-job_state() {
-    anyscale job status --cloud "$CLOUD" --name "$1" --json 2>/dev/null \
-        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state", "UNKNOWN"))' 2>/dev/null \
-        || echo "UNKNOWN"
+API_ERR_LOG="$(mktemp)"
+trap 'rm -f "$API_ERR_LOG"' EXIT
+
+# Run a control-plane command, retrying transient failures with exponential backoff.
+# The rate limit the CLI hits under concurrent CI advertises a retry-after of a few
+# seconds, so a handful of tries clears it. stdout is forwarded only on success --
+# callers parse it as JSON, so stderr is kept out of it.
+anyscale_retry() {
+    local out delay=5 i
+    for ((i = 1; i <= API_ATTEMPTS; i++)); do
+        if out="$("$@" 2>"$API_ERR_LOG")"; then
+            printf '%s' "$out"
+            return 0
+        fi
+        if ((i < API_ATTEMPTS)); then
+            echo "  control-plane call failed (${i}/${API_ATTEMPTS}), retrying in ${delay}s: $*" >&2
+            sleep "$delay"
+            delay=$((delay * 2))
+            if ((delay > 60)); then delay=60; fi
+        fi
+    done
+    echo "  control-plane call failed after ${API_ATTEMPTS} attempts: $*" >&2
+    cat "$API_ERR_LOG" >&2
+    return 1
 }
 
-# Number of job runs Anyscale created for a job, or "unknown" if the status call
-# failed. A run is created when the entrypoint is submitted to a live cluster, so
-# zero runs means provisioning never finished.
-job_run_count() {
-    anyscale job status --cloud "$CLOUD" --name "$1" --json 2>/dev/null \
-        | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("runs") or []))' 2>/dev/null \
-        || echo "unknown"
+# Echoes "<state> <run-count>" for a job. A run is created when the entrypoint is
+# submitted to a live cluster, so zero runs means provisioning never finished. Both
+# come from one status call: the decision below needs both, and halving the request
+# count is the difference between tripping the rate limit and not. Unreadable status
+# yields "UNKNOWN unknown" -- an answer of "we don't know", never "the job is gone".
+job_status() {
+    local json
+    if ! json="$(anyscale_retry anyscale job status --cloud "$CLOUD" --name "$1" --json)"; then
+        echo "UNKNOWN unknown"
+        return 0
+    fi
+    printf '%s' "$json" | python3 -c '
+import json, sys
+
+try:
+    doc = json.load(sys.stdin)
+    print(doc.get("state") or "UNKNOWN", len(doc.get("runs") or []))
+except Exception:
+    print("UNKNOWN unknown")
+'
+}
+
+job_state() {
+    local state runs
+    read -r state runs <<<"$(job_status "$1")"
+    echo "$state"
+}
+
+is_terminal() {
+    case "$1" in
+        SUCCEEDED | FAILED | TERMINATED) return 0 ;;
+        *) return 1 ;;
+    esac
 }
 
 # True when the entrypoint produced output, i.e. the cluster really did come up.
@@ -76,7 +138,7 @@ job_run_count() {
 # credential type than `job status` on some tokens, hence not using it as primary.
 entrypoint_produced_logs() {
     local logs
-    logs="$(anyscale job logs --cloud "$CLOUD" --name "$1" --head --max-lines 5 2>/dev/null || true)"
+    logs="$(anyscale_retry anyscale job logs --cloud "$CLOUD" --name "$1" --head --max-lines 5 || true)"
     [[ -n "${logs//[[:space:]]/}" ]]
 }
 
@@ -84,13 +146,75 @@ entrypoint_produced_logs() {
 # both misreading a fast entrypoint crash as a capacity failure and misreading a
 # capacity failure's transient RUNNING as a real test failure.
 entrypoint_ran() {
-    local runs
-    runs="$(job_run_count "$1")"
+    local runs="$1" name="$2"
     if [[ "$runs" == "unknown" ]]; then
-        entrypoint_produced_logs "$1"
+        entrypoint_produced_logs "$name"
     else
         [[ "$runs" -gt 0 ]]
     fi
+}
+
+# Wait for a job to settle, resuming the wait when the CLI call -- not the job --
+# is what failed. `anyscale job wait` exits non-zero for a terminal state, for its
+# own timeout, and for a rate-limited lookup alike; only the job's actual state
+# tells them apart. Returns 0 if <target> was reached (empty target = any terminal
+# state), non-zero if the job settled elsewhere or the deadline passed.
+wait_for_state() {
+    local name="$1" target="$2" timeout_s="$3"
+    local deadline=$((SECONDS + timeout_s))
+    local remaining state unreadable=0
+    while true; do
+        remaining=$((deadline - SECONDS))
+        if ((remaining <= 0)); then
+            return 1
+        fi
+        if [[ -n "$target" ]]; then
+            anyscale job wait --cloud "$CLOUD" --name "$name" \
+                --state "$target" --timeout "$remaining" && return 0
+        else
+            anyscale job wait --cloud "$CLOUD" --name "$name" --timeout "$remaining" && return 0
+        fi
+        state="$(job_state "$name")"
+        if is_terminal "$state"; then
+            return 1
+        fi
+        # STARTING/RUNNING (the wait call itself broke) or UNKNOWN (the control
+        # plane is unreachable). Either way the job is not known to be dead, so
+        # back off and keep waiting rather than abandoning a live cluster.
+        if [[ "$state" == "UNKNOWN" ]]; then
+            # Bounded separately: a state we can read means real progress is being
+            # observed, but a control plane that stays unreadable would otherwise
+            # hold us here for the whole timeout. Give up on waiting instead --
+            # the caller still has to confirm the job is terminal before it can
+            # resubmit, so bailing early leaks nothing.
+            unreadable=$((unreadable + 1))
+            if ((unreadable >= UNKNOWN_POLL_LIMIT)); then
+                echo "Job ${name} state unreadable ${unreadable}x in a row; stopping the wait." >&2
+                return 1
+            fi
+        else
+            unreadable=0
+        fi
+        echo "Wait on ${name} returned early in state ${state}; resuming." >&2
+        sleep 15
+    done
+}
+
+# Drive a job to a terminal state, verifying that it got there. Required before any
+# resubmit: a `job wait` timeout leaves the job running -- it only stops the client
+# polling -- and `job terminate` can silently no-op under a rate limit.
+ensure_terminal() {
+    local name="$1" state i
+    for ((i = 1; i <= TERMINATE_ATTEMPTS; i++)); do
+        state="$(job_state "$name")"
+        if is_terminal "$state"; then
+            return 0
+        fi
+        anyscale_retry anyscale job terminate --cloud "$CLOUD" --name "$name" >/dev/null || true
+        sleep 15
+    done
+    state="$(job_state "$name")"
+    is_terminal "$state"
 }
 
 for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
@@ -102,20 +226,14 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
     echo "--- Anyscale job attempt ${attempt}/${MAX_ATTEMPTS}: ${run_name}"
     anyscale job submit -f "$CONFIG_FILE" --name "$run_name" --timeout "$RUN_TIMEOUT_S"
 
-    started=1
-    anyscale job wait --cloud "$CLOUD" --name "$run_name" \
-        --state RUNNING --timeout "$START_TIMEOUT_S" || started=0
-
-    if [[ "$started" -eq 1 ]]; then
+    if wait_for_state "$run_name" RUNNING "$START_TIMEOUT_S"; then
         # Provisional -- see the note at the top on RUNNING being reported for a
         # cluster that is actually tearing down after failing to provision.
         echo "Job ${run_name} reached RUNNING, waiting for it to finish."
-        if anyscale job wait --cloud "$CLOUD" --name "$run_name" --timeout "$RUN_TIMEOUT_S"; then
-            exit 0
-        fi
+        wait_for_state "$run_name" "" "$RUN_TIMEOUT_S" || true
     fi
 
-    state="$(job_state "$run_name")"
+    read -r state runs <<<"$(job_status "$run_name")"
 
     # A job can pass through RUNNING between two 10s `job wait` polls, so a missed
     # RUNNING with a terminal SUCCEEDED still means we got GPUs.
@@ -124,21 +242,21 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
         exit 0
     fi
 
-    if entrypoint_ran "$run_name"; then
+    if entrypoint_ran "$runs" "$run_name"; then
         echo "Job ${run_name} failed (state: ${state}) but the entrypoint ran -- real failure, not retrying." >&2
         exit 1
     fi
 
     echo "Job ${run_name} failed (state: ${state}) without ever running its entrypoint:" >&2
     echo "treating this as a GPU capacity failure." >&2
-    # A `job wait` timeout leaves the job running -- it only stops the client
-    # polling. Terminate before resubmitting so we never leave a second cluster
-    # competing for the same scarce instance type (or silently running tests
-    # whose result nobody reads).
-    case "$state" in
-        SUCCEEDED | FAILED | TERMINATED) ;;
-        *) anyscale job terminate --cloud "$CLOUD" --name "$run_name" || true ;;
-    esac
+
+    if ! ensure_terminal "$run_name"; then
+        echo "Could not confirm ${run_name} is terminated. Refusing to resubmit: a second" >&2
+        echo "cluster would compete for the same scarce instance type and run tests whose" >&2
+        echo "result nobody reads. Terminate it by hand if it is still alive." >&2
+        exit 1
+    fi
+
     if [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
         echo "Resubmitting in ${RETRY_DELAY_S}s ..." >&2
         sleep "$RETRY_DELAY_S"

--- a/ci/terminate_anyscale_jobs.sh
+++ b/ci/terminate_anyscale_jobs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Terminate the Anyscale jobs submit_anyscale_job.sh left behind.
+#
+# Cancelling a workflow run -- `cancel-in-progress`, the UI button, a job timeout --
+# stops the runner, not the cluster. The submitting script traps INT/TERM and tries to
+# clean up itself, but the runner only allows a short grace period before SIGKILL, so
+# this runs as an `if: cancelled()` step where GitHub guarantees it gets to finish.
+#
+# Reads the names recorded by submit_anyscale_job.sh. No file means nothing was ever
+# submitted, which is a normal outcome, not an error.
+#
+# Usage: ci/terminate_anyscale_jobs.sh [jobs-file]
+
+set -uo pipefail
+
+CLOUD="${ANYSCALE_CLOUD:-sky-anyscale-aws-us-east-1}"
+JOBS_FILE="${1:-${ANYSCALE_JOBS_FILE:-${RUNNER_TEMP:-/tmp}/anyscale-submitted-jobs.txt}}"
+
+if [[ ! -s "$JOBS_FILE" ]]; then
+    echo "No Anyscale jobs recorded in ${JOBS_FILE}; nothing to clean up."
+    exit 0
+fi
+
+failed=0
+# fd 3, so the anyscale calls below can't swallow the list from stdin.
+while read -r name <&3; do
+    [[ -n "$name" ]] || continue
+
+    state="$(anyscale job status --cloud "$CLOUD" --name "$name" --json 2>/dev/null \
+        | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("state") or "UNKNOWN")
+except Exception:
+    print("UNKNOWN")' 2>/dev/null || echo UNKNOWN)"
+
+    case "$state" in
+        SUCCEEDED | FAILED | TERMINATED)
+            echo "${name}: already ${state}."
+            continue
+            ;;
+    esac
+
+    # UNKNOWN included: a status call that fails under a rate limit is not evidence
+    # the job is gone, and terminating an already-dead job is harmless.
+    echo "${name}: state ${state}, terminating."
+    for attempt in 1 2 3; do
+        if anyscale job terminate --cloud "$CLOUD" --name "$name"; then
+            continue 2
+        fi
+        sleep $((attempt * 5))
+    done
+    echo "${name}: could not terminate -- check it by hand." >&2
+    failed=1
+done 3< "$JOBS_FILE"
+
+exit "$failed"


### PR DESCRIPTION
Also fixes bug that was causing multiple runs for the same workflow when adding a label to a pr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows and the Anyscale submit helper; they reduce duplicate GPU usage and mistaken retries without touching application code.
> 
> **Overview**
> **GPU label workflows** (H100, SkyRL train, Megatron, Megatron models, Tinker backend) now use **per-PR concurrency** with `cancel-in-progress`, so re-applying a label cancels an in-flight run instead of starting another cluster. The `pull_request_target` job gate switches from `contains(...labels...)` to **`github.event.label.name`**, so only the label that triggered the event runs the job—fixing duplicate runs when several labels are added at once.
> 
> **`ci/submit_anyscale_job.sh`** is reworked so capacity retries are not triggered by flaky Anyscale API behavior. Control-plane calls go through **`anyscale_retry`** (exponential backoff); **`wait_for_state`** keeps polling when `job wait` fails early (e.g. rate limits masquerading as missing jobs); **`ensure_terminal`** must succeed before a resubmit. Job state and run count come from a single **`job_status`** call. Documented default **`CAPACITY_MAX_ATTEMPTS`** is **5** (was 10 in comments); new env knobs include **`ANYSCALE_API_ATTEMPTS`**, **`ANYSCALE_TERMINATE_ATTEMPTS`**, and **`ANYSCALE_UNKNOWN_POLL_LIMIT`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae90c1fa8f8ec2660fc35463bb5af7a0318208b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->