### PR TITLE
perf(train): make sequence packing alignment-aware

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -38,7 +38,8 @@ from megatron.core.transformer.moe.moe_utils import (
 from megatron.core.utils import get_attr_wrapped_model, unwrap_model
 
 from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import (
-    get_packed_seq_align_size,
+    get_packing_align_size_sequence,
+    get_packing_align_size_total,
     get_unpacked_seq_align_size,
 )
 
@@ -439,11 +440,9 @@ def preprocess_packed_seqs(
       per row. This is the historical SkyRL behavior used by the RL path
       and the existing SFT path without mini-batch packing.
     - ``sub_seq_lengths is not None``: each row may contain multiple
-      sub-sequences. ``sub_seq_lengths[r]`` lists their valid token counts.
-      Each sub-sequence begins at the next ``align_size`` boundary, so internal
-      alignment padding may separate adjacent sub-sequences; any remaining
-      trailing tokens are pad. ``cu_seqlens`` enumerates every sub-sequence
-      across every row.
+      sub-sequences. They are laid out in order with any required CP gaps
+      between them; aggregate TP/FP8 padding follows the final sequence.
+      ``cu_seqlens`` enumerates every sub-sequence across every row.
 
     CP splits sequence into CP*2 chunks, and each GPU gets 2 chunks (GPU0
     gets first and last chunks, GPU1 gets second and second last chunks,
@@ -453,7 +452,10 @@ def preprocess_packed_seqs(
     tp_size = mpu.get_tensor_model_parallel_world_size()
     cp_size = mpu.get_context_parallel_world_size()
     cp_rank = mpu.get_context_parallel_rank()
-    align_size = get_packed_seq_align_size(tp_size, cp_size, fp8_enabled=fp8_enabled, fp8_recipe=fp8_recipe)
+    packing_align_size_sequence = get_packing_align_size_sequence(tp_size, cp_size)
+    packing_align_size_total = get_packing_align_size_total(
+        tp_size, cp_size, fp8_enabled=fp8_enabled, fp8_recipe=fp8_recipe
+    )
 
     batch_size = input_ids.shape[0]
 
@@ -467,7 +469,7 @@ def preprocess_packed_seqs(
         # Per-row, per-sub-seq starting column within the original padded row.
         # We need this to gather sub-seq tokens from the padded input_ids.
         # NOTE: the controller-side collator (``PackedDataCollator``)
-        # advances ``row_offset += round_up(length, align_size)`` between
+        # advances ``row_offset += round_up(length, packing_align_size_sequence)`` between
         # consecutive sub-sequences in the same row so that flash-attn varlen
         # sees TP/CP-aligned segment boundaries. We MUST mirror that here —
         # otherwise sub-seq i (for i > 0) would be read starting inside the
@@ -481,9 +483,11 @@ def preprocess_packed_seqs(
                 flat_seqlens.append(length_int)
                 row_index_of_subseq.append(r)
                 intra_row_offset_of_subseq.append(running)
-                # Pad each sub-seq independently to align_size, matching the
+                # Pad each sub-seq independently to packing_align_size_sequence, matching the
                 # collator's row layout.
-                pad = (align_size - length_int % align_size) % align_size
+                pad = (
+                    packing_align_size_sequence - length_int % packing_align_size_sequence
+                ) % packing_align_size_sequence
                 running += length_int + pad
 
         seqlens_in_batch = torch.tensor(flat_seqlens, dtype=torch.int32, device=input_ids.device)
@@ -492,8 +496,14 @@ def preprocess_packed_seqs(
         seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
         num_subseqs = batch_size
 
-    pad_size = (align_size - seqlens_in_batch % align_size) % align_size
+    pad_size = (
+        packing_align_size_sequence - seqlens_in_batch % packing_align_size_sequence
+    ) % packing_align_size_sequence
     seqlens_in_batch_padded = seqlens_in_batch + pad_size
+    # TP and FP8 operate on the aggregate local token slab. Attach their tail
+    # padding once to the final sequence rather than to every sequence.
+    aggregate_pad_size = (-seqlens_in_batch_padded.sum()) % packing_align_size_total
+    seqlens_in_batch_padded[-1] += aggregate_pad_size
 
     cu_seqlens = torch.zeros(num_subseqs + 1, dtype=torch.int32, device=input_ids.device)
     cu_seqlens[1:] = torch.cumsum(seqlens_in_batch, dim=0)

--- a/skyrl/backends/skyrl_train/distributed/megatron/packing_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/packing_utils.py
@@ -19,10 +19,19 @@ def _fp8_token_align(tp_size: int, cp_size: int, fp8_recipe: Any) -> int:
     return 16 * cp_size
 
 
-def get_packed_seq_align_size(
+def get_packing_align_size_sequence(tp_size: int, cp_size: int) -> int:
+    """Return the alignment required independently for each packed sequence."""
+    if tp_size < 1 or cp_size < 1:
+        raise ValueError(f"tp_size and cp_size must be positive, got tp_size={tp_size}, cp_size={cp_size}")
+    if cp_size > 1:
+        return tp_size * cp_size * 2
+    return 1
+
+
+def get_packing_align_size_total(
     tp_size: int, cp_size: int, fp8_enabled: bool = False, fp8_recipe: Optional[str] = None
 ) -> int:
-    """Return the global alignment unit for packed TP/CP/FP8 sequences."""
+    """Return the alignment required for the aggregate packed token slab."""
     if tp_size < 1 or cp_size < 1:
         raise ValueError(f"tp_size and cp_size must be positive, got tp_size={tp_size}, cp_size={cp_size}")
     if cp_size > 1:

--- a/skyrl/backends/skyrl_train/distributed/megatron/token_metadata.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/token_metadata.py
@@ -6,7 +6,8 @@ from typing import Optional
 import torch
 
 from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import (
-    get_packed_seq_align_size,
+    get_packing_align_size_sequence,
+    get_packing_align_size_total,
     get_unpacked_seq_align_size,
 )
 
@@ -65,8 +66,13 @@ def build_token_metadata_layout(
         )
 
     cp_size = mpu.get_context_parallel_world_size()
-    align_size = get_packed_seq_align_size(tp_size, cp_size, fp8_enabled=fp8_enabled, fp8_recipe=fp8_recipe)
-    padded_sequence_lengths_tensor = sequence_lengths_tensor + (-sequence_lengths_tensor % align_size)
+    packing_align_size_sequence = get_packing_align_size_sequence(tp_size, cp_size)
+    packing_align_size_total = get_packing_align_size_total(
+        tp_size, cp_size, fp8_enabled=fp8_enabled, fp8_recipe=fp8_recipe
+    )
+    padded_sequence_lengths_tensor = sequence_lengths_tensor + (-sequence_lengths_tensor % packing_align_size_sequence)
+    aggregate_pad_size = (-padded_sequence_lengths_tensor.sum()) % packing_align_size_total
+    padded_sequence_lengths_tensor[-1] += aggregate_pad_size
     padded_sequence_lengths = padded_sequence_lengths_tensor.tolist()
     cu_seqlens_padded = torch.cat(
         (

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_model_wrapper.py
@@ -110,8 +110,8 @@ def _build_packed_valid_mask(
 ) -> torch.Tensor:
     """Build a ``[1, T]`` real-token mask aligned to the packed (THD) logits layout.
 
-    1.0 for real tokens, 0.0 for the per-segment alignment padding that ``preprocess_packed_seqs``
-    inserts between sub-sequences. This is the packed counterpart of the ``[batch, seq]``
+    1.0 for real tokens, 0.0 for the layout gaps and aggregate tail padding that
+    ``preprocess_packed_seqs`` inserts. This is the packed counterpart of the ``[batch, seq]``
     ``attention_mask`` the decoupled MTP draft loss uses to mask invalid positions; mirrors the
     index math of :func:`_build_packed_targets` but scatters ones instead of token ids.
     """

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -40,7 +40,12 @@ from skyrl.backends.skyrl_train.distributed.megatron.optimizer import (
     get_megatron_optimizer_param_scheduler,
     init_megatron_optim_config,
 )
+from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import (
+    get_packing_align_size_sequence,
+    get_packing_align_size_total,
+)
 from skyrl.backends.skyrl_train.distributed.megatron.quantization_utils import (
+    is_fp8_enabled,
     resolve_auto_fp8_recipe,
     validate_concrete_fp8_recipe,
 )
@@ -411,6 +416,20 @@ class MegatronWeightExtractor(WeightExtractor):
 
 
 class MegatronWorker:
+    def _packed_sequence_length_multiples(self) -> tuple[int, int]:
+        """Return per-sequence and aggregate packed THD alignments."""
+        if not self.cfg.remove_microbatch_padding:
+            return 1, 1
+        model_config = get_model_config(self.actor_module[0])
+        tp_size = mpu.get_tensor_model_parallel_world_size()
+        cp_size = mpu.get_context_parallel_world_size()
+        return get_packing_align_size_sequence(tp_size, cp_size), get_packing_align_size_total(
+            tp_size,
+            cp_size,
+            fp8_enabled=is_fp8_enabled(model_config.fp8),
+            fp8_recipe=getattr(model_config, "fp8_recipe", None),
+        )
+
     def _maybe_setup_fake_int4_qat(self):
         """Wire up INT4-served training and return the BF16 bridge-weights path.
 
@@ -798,10 +817,13 @@ class MegatronWorker:
         use_token_batching = self.cfg.max_tokens_per_microbatch > 0
 
         if use_token_batching:
+            sequence_length_multiple, packed_length_multiple = self._packed_sequence_length_multiples()
             microbatch_iterator = get_microbatch_iterator(
                 data,
                 micro_batch_size=self.cfg.micro_forward_batch_size_per_gpu,
                 max_tokens_per_microbatch=self.cfg.max_tokens_per_microbatch,
+                sequence_length_multiple=sequence_length_multiple,
+                packed_length_multiple=packed_length_multiple,
             )
         else:
             microbatch_iterator = None
@@ -1318,10 +1340,13 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         use_token_batching = self.cfg.max_tokens_per_microbatch > 0
 
         if use_token_batching:
+            sequence_length_multiple, packed_length_multiple = self._packed_sequence_length_multiples()
             microbatch_iterator = get_microbatch_iterator(
                 data,
                 micro_batch_size=self.cfg.micro_train_batch_size_per_gpu,
                 max_tokens_per_microbatch=self.cfg.max_tokens_per_microbatch,
+                sequence_length_multiple=sequence_length_multiple,
+                packed_length_multiple=packed_length_multiple,
             )
         else:
             microbatch_iterator = None

--- a/skyrl/backends/skyrl_train/workers/worker_utils.py
+++ b/skyrl/backends/skyrl_train/workers/worker_utils.py
@@ -257,11 +257,17 @@ class TokenBasedBatchIterator(BaseBatchIterator):
         self,
         data: TrainingInputBatch,
         max_tokens_per_microbatch: int,
+        sequence_length_multiple: int = 1,
+        packed_length_multiple: int = 1,
     ):
         """
         Args:
             data: The training input batch to chunk.
             max_tokens_per_microbatch: Maximum number of tokens per microbatch.
+            sequence_length_multiple: Round each sequence's packing footprint
+                up to this multiple.
+            packed_length_multiple: Round the aggregate microbatch footprint
+                up to this multiple.
         """
         super().__init__(data)
         self._max_tokens_per_microbatch = max_tokens_per_microbatch
@@ -273,7 +279,12 @@ class TokenBasedBatchIterator(BaseBatchIterator):
         # Create microbatches based on token count. The "balanced" packer treats
         # the token budget as a soft cap: a sequence longer than the budget gets
         # its own (over-budget) microbatch rather than raising.
-        packer = make_seq_packer("balanced", bin_capacity=self._max_tokens_per_microbatch)
+        packer = make_seq_packer(
+            "balanced",
+            bin_capacity=self._max_tokens_per_microbatch,
+            sequence_length_multiple=sequence_length_multiple,
+            packed_length_multiple=packed_length_multiple,
+        )
         self._microbatches = packer.pack(self._token_counts)
 
         # Synchronize the number of microbatches across all DP workers
@@ -438,7 +449,11 @@ class TokenBasedBatchIterator(BaseBatchIterator):
 
 
 def get_microbatch_iterator(
-    data: TrainingInputBatch, micro_batch_size: int, max_tokens_per_microbatch: int
+    data: TrainingInputBatch,
+    micro_batch_size: int,
+    max_tokens_per_microbatch: int,
+    sequence_length_multiple: int = 1,
+    packed_length_multiple: int = 1,
 ) -> BaseBatchIterator:
     """Factory function to get the appropriate microbatch iterator.
 
@@ -446,11 +461,20 @@ def get_microbatch_iterator(
         data: The training input batch.
         micro_batch_size: Number of samples per microbatch (used if max_tokens_per_microbatch <= 0).
         max_tokens_per_microbatch: Maximum tokens per microbatch. If > 0, uses token-based batching.
+        sequence_length_multiple: Round each sequence's packing footprint up
+            to this multiple for token-based batching.
+        packed_length_multiple: Round each aggregate microbatch footprint up
+            to this multiple for token-based batching.
 
     Returns:
         A BaseBatchIterator instance.
     """
     if max_tokens_per_microbatch > 0:
-        return TokenBasedBatchIterator(data, max_tokens_per_microbatch=max_tokens_per_microbatch)
+        return TokenBasedBatchIterator(
+            data,
+            max_tokens_per_microbatch=max_tokens_per_microbatch,
+            sequence_length_multiple=sequence_length_multiple,
+            packed_length_multiple=packed_length_multiple,
+        )
     else:
         return SampleBasedBatchIterator(data, sample_batch_size=micro_batch_size, drop_last=False)

--- a/skyrl/train/dataset/bin_packing.py
+++ b/skyrl/train/dataset/bin_packing.py
@@ -47,15 +47,23 @@ class SeqPacker(ABC):
         bin_capacity: int,
         min_bin_count: Optional[int] = None,
         bin_count_multiple: Optional[int] = None,
+        sequence_length_multiple: int = 1,
+        packed_length_multiple: int = 1,
     ):
         if min_bin_count is not None and min_bin_count < 0:
             raise ValueError("min_bin_count must be nonnegative")
         if bin_count_multiple is not None and bin_count_multiple < 1:
             raise ValueError("bin_count_multiple must be positive")
+        if sequence_length_multiple < 1:
+            raise ValueError("sequence_length_multiple must be positive")
+        if packed_length_multiple < 1:
+            raise ValueError("packed_length_multiple must be positive")
 
         self.bin_capacity = bin_capacity
         self.min_bin_count = min_bin_count
         self.bin_count_multiple = bin_count_multiple
+        self.sequence_length_multiple = sequence_length_multiple
+        self.packed_length_multiple = packed_length_multiple
 
     @abstractmethod
     def _pack_implementation(self, sequence_lengths: List[int]) -> List[List[int]]:
@@ -63,8 +71,13 @@ class SeqPacker(ABC):
 
     def _validate_sequence_lengths(self, sequence_lengths: List[int]) -> None:
         for length in sequence_lengths:
-            if length > self.bin_capacity:
+            if self._packed_length(length) > self.bin_capacity:
                 raise ValueError(f"Sequence length {length} exceeds bin capacity {self.bin_capacity}")
+
+    def _packed_length(self, sequence_length_sum: int) -> int:
+        """Return the physical footprint after aggregate tail padding."""
+        multiple = self.packed_length_multiple
+        return sequence_length_sum + (-sequence_length_sum % multiple)
 
     def _adjust_bin_count(self, bins: List[List[int]]) -> List[List[int]]:
         """Pad the bin list to a multiple of ``bin_count_multiple``.
@@ -123,8 +136,10 @@ class SeqPacker(ABC):
         return adjusted_bins
 
     def pack(self, sequence_lengths: List[int]) -> List[List[int]]:
-        """Pack ``sequence_lengths`` into bins and apply DP-symmetry adjustment."""
-        bins = self._pack_implementation(sequence_lengths)
+        """Pack layout-aligned sequences and apply aggregate tail padding."""
+        multiple = self.sequence_length_multiple
+        packing_lengths = [length + (-length % multiple) for length in sequence_lengths]
+        bins = self._pack_implementation(packing_lengths)
         bins = self._adjust_bin_count(bins)
         return bins
 
@@ -144,19 +159,20 @@ class FirstFitDecreasing(SeqPacker):
         indexed.sort(reverse=True)
 
         bins: List[List[int]] = []
-        bin_remaining: List[int] = []
+        bin_lengths: List[int] = []
 
         for length, idx in indexed:
             placed = False
-            for i, remaining in enumerate(bin_remaining):
-                if remaining >= length:
+            for i, bin_length in enumerate(bin_lengths):
+                new_length = bin_length + length
+                if self._packed_length(new_length) <= self.bin_capacity:
                     bins[i].append(idx)
-                    bin_remaining[i] -= length
+                    bin_lengths[i] = new_length
                     placed = True
                     break
             if not placed:
                 bins.append([idx])
-                bin_remaining.append(self.bin_capacity - length)
+                bin_lengths.append(length)
 
         return bins
 
@@ -199,7 +215,7 @@ class Balanced(SeqPacker):
             if bin_tokens_heap:
                 bin_tokens, bin_idx = bin_tokens_heap[0]
                 new_bin_tokens = bin_tokens + length
-                if new_bin_tokens <= self.bin_capacity:
+                if self._packed_length(new_bin_tokens) <= self.bin_capacity:
                     bins[bin_idx].append(idx)
                     heapq.heapreplace(bin_tokens_heap, (new_bin_tokens, bin_idx))
                     placed = True
@@ -222,6 +238,8 @@ def make_seq_packer(
     bin_capacity: int,
     min_bin_count: Optional[int] = None,
     bin_count_multiple: Optional[int] = None,
+    sequence_length_multiple: int = 1,
+    packed_length_multiple: int = 1,
 ) -> SeqPacker:
     """Factory returning a configured :class:`SeqPacker` instance.
 
@@ -234,6 +252,10 @@ def make_seq_packer(
             ``dp_size``).
         bin_count_multiple: Force the total bin count to be a multiple of
             this value (typically ``dp_size``).
+        sequence_length_multiple: Round each sequence's packing footprint up
+            to this multiple before placement.
+        packed_length_multiple: Round each bin's aggregate footprint up to
+            this multiple when checking capacity.
     """
     if isinstance(algorithm, str):
         try:
@@ -250,4 +272,6 @@ def make_seq_packer(
         bin_capacity=bin_capacity,
         min_bin_count=min_bin_count,
         bin_count_multiple=bin_count_multiple,
+        sequence_length_multiple=sequence_length_multiple,
+        packed_length_multiple=packed_length_multiple,
     )

--- a/skyrl/train/dataset/collators.py
+++ b/skyrl/train/dataset/collators.py
@@ -25,7 +25,8 @@ import torch
 from loguru import logger
 
 from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import (
-    get_packed_seq_align_size,
+    get_packing_align_size_sequence,
+    get_packing_align_size_total,
 )
 from skyrl.backends.skyrl_train.training_batch import TensorList, TrainingInputBatch
 
@@ -72,8 +73,8 @@ class PackedDataCollator:
     Flow:
 
     1. Compute per-example sequence lengths.
-    2. FFD-pack using each sequence's alignment-padded footprint and
-       ``bin_capacity = max(max_tokens_per_microbatch, align_size)``,
+    2. FFD-pack using per-sequence layout footprints and
+       ``bin_capacity = max(max_tokens_per_microbatch, aggregate_alignment)``,
        ``min_bin_count = dp_size``, ``bin_count_multiple = dp_size``.
     3. Round-robin assign bins to DP shards (this happens implicitly inside
        ``MeshDispatch.dispatch`` because the rows are laid out in shard-major
@@ -135,23 +136,23 @@ class PackedDataCollator:
         tp_size = self.tp_size
         pp_size = self.pp_size
         cp_size = self.cp_size
-        # Each sub-seq's padded length must satisfy these divisibility
-        # constraints, which is why ``align_size`` carries all required factors:
-        #   - Sequence Parallelism (auto-on when tp>1) shards along the seq
-        #     dim, so each segment must be divisible by ``tp_size``.
+        # CP/SP layout constraints apply independently to each sub-sequence.
+        # TP without CP and FP8 constrain only the final packed token slab.
         #   - Context Parallelism splits each segment into ``2*cp_size`` equal
-        #     load-balanced causal chunks, so each segment must be divisible by
-        #     ``2*cp_size``.
-        #   - FP8: TE with fp8_recipe=blockwise needs 16-token local slabs at
-        #     TP=1 and quantizes sequence-parallel all-gather inputs in
-        #     128-token blocks (so the global segment includes the TP and CP
-        #     shard factors); fp8_recipe=mxfp8 quantizes in 1x32 tiles, so the
-        #     TP=1 slab grows to 32.
+        #     load-balanced causal chunks. With SP, each chunk is also sharded
+        #     across ``tp_size``.
+        #   - When FP8 is enabled, Transformer Engine GEMMs require each CP
+        #     rank's aggregate token slab to be 16-aligned; globally this means
+        #     the final packed length is divisible by ``16*cp_size``.
         # This MUST stay in lockstep with the worker's preprocess_packed_seqs
         # (megatron_utils.py): if the divisors drift, the per-rank CP/SP
         # gather/scatter offsets silently corrupt loss/grads (no crash).
-        align_size = get_packed_seq_align_size(
-            tp_size, cp_size, fp8_enabled=self.fp8_enabled, fp8_recipe=self.fp8_recipe
+        packing_align_size_sequence = get_packing_align_size_sequence(tp_size, cp_size)
+        packing_align_size_total = get_packing_align_size_total(
+            tp_size,
+            cp_size,
+            fp8_enabled=self.fp8_enabled,
+            fp8_recipe=self.fp8_recipe,
         )
 
         def _round_up(x: int, multiple: int) -> int:
@@ -189,26 +190,19 @@ class PackedDataCollator:
         # same number of micro-batches. Forcing the global bin count to a
         # multiple of ``dp_size`` makes the per-DP-rank bin count (and thus
         # ``num_microbatches``) identical across ranks.
-        # Under FP8, pack each sequence's *aligned* footprint rather than its raw
-        # length: align_size is 128*tp*cp (vs tp*cp*2 without FP8), so per-sequence
-        # padding can otherwise push a bin far past max_tokens_per_microbatch and
-        # overflow the row budget. Also allow at least one alignment unit per bin,
-        # since a single padded sub-seq already costs align_size tokens.
-        # Non-FP8 keeps upstream's raw-length packing byte-for-byte.
-        if self.fp8_enabled:
-            packing_lengths = [_round_up(length, align_size) for length in seq_lengths]
-            packing_capacity = max(bin_capacity, align_size)
-        else:
-            packing_lengths = seq_lengths
-            packing_capacity = bin_capacity
+        # The aggregate alignment can exceed the requested token budget; allow one
+        # physical slab while keeping placement based on the requested capacity.
+        packing_capacity = max(bin_capacity, packing_align_size_total)
         bin_count_multiple = dp_size
         packer = make_seq_packer(
             "first_fit_decreasing",
             bin_capacity=packing_capacity,
             min_bin_count=bin_count_multiple,
             bin_count_multiple=bin_count_multiple,
+            sequence_length_multiple=packing_align_size_sequence,
+            packed_length_multiple=packing_align_size_total,
         )
-        bins: List[List[int]] = packer.pack(packing_lengths)
+        bins: List[List[int]] = packer.pack(seq_lengths)
 
         # Assign bins to DP shards via round-robin (bin_idx % shards).
         # Concretely we want the resulting layout to be shard-major:
@@ -225,16 +219,15 @@ class PackedDataCollator:
             flat_bins.extend(shard_bins[shard_idx])
 
         # ------------------------------------------------------------------
-        # 3. Compute packed-row lengths (with align_size padding per sub-seq)
-        #    and the global max packed length (for PP > 1 uniform padding).
+        # 3. Compute packed-row lengths with per-sequence layout padding and
+        #    one aggregate tail pad, plus the global max packed length.
         # ------------------------------------------------------------------
         bin_packed_lengths: List[int] = []
         bin_subseq_lengths: List[List[int]] = []  # one list per bin row
         for bin_indices in flat_bins:
             subseq_lens = [seq_lengths[idx] for idx in bin_indices]
-            # Each sub-seq's length is independently aligned to align_size
-            # (matches preprocess_packed_seqs behavior).
-            packed_len = sum(_round_up(s, align_size) for s in subseq_lens)
+            sequence_aligned_len = sum(_round_up(s, packing_align_size_sequence) for s in subseq_lens)
+            packed_len = _round_up(sequence_aligned_len, packing_align_size_total)
             bin_packed_lengths.append(packed_len)
             bin_subseq_lengths.append(subseq_lens)
 
@@ -242,8 +235,7 @@ class PackedDataCollator:
             # Pad all packed rows to the global max so Megatron's
             # pipeline schedule sees uniform shapes.
             max_packed_len = max(bin_packed_lengths) if bin_packed_lengths else 0
-            # Also align the global max to align_size to keep layouts uniform.
-            max_packed_len = _round_up(max_packed_len, align_size)
+            max_packed_len = _round_up(max_packed_len, packing_align_size_total)
         else:
             max_packed_len = max(bin_packed_lengths) if bin_packed_lengths else 0
 
@@ -263,8 +255,7 @@ class PackedDataCollator:
         n_samples = len(examples)
         logger.info(
             f"sequence packing | packed {n_samples} samples into {num_bins} bins "
-            f"(~{num_bins // dp_size}/DP rank, bin_capacity={packing_capacity}"
-            f"{' aligned' if self.fp8_enabled else ''} tokens)"
+            f"(~{num_bins // dp_size}/DP rank, bin_capacity={packing_capacity} tokens)"
         )
 
         # Fill NumPy buffers by slice, then convert once.
@@ -290,8 +281,7 @@ class PackedDataCollator:
                     if n_write > 0:
                         loss_mask_np[row_idx, row_offset:write_end] = full_loss_masks[ex_idx][1 : 1 + n_write]
 
-                # Match the aligned footprint consumed by preprocess_packed_seqs.
-                row_offset += _round_up(s, align_size)
+                row_offset += _round_up(s, packing_align_size_sequence)
 
         # Count response-token loss slots before normalization. The vectorized
         # build makes this exact, so no post-hoc reconciliation is needed.

--- a/tests/backends/skyrl_train/distributed/test_bin_packing.py
+++ b/tests/backends/skyrl_train/distributed/test_bin_packing.py
@@ -7,6 +7,7 @@ Run with:
 import pytest
 
 from skyrl.train.dataset.bin_packing import (
+    Balanced,
     FirstFitDecreasing,
     PackingStrategy,
     make_seq_packer,
@@ -96,6 +97,41 @@ class TestFirstFitDecreasing:
         with pytest.raises(ValueError, match="Cannot create"):
             FirstFitDecreasing(bin_capacity=100, min_bin_count=5).pack([10, 20])
 
+    def test_sequence_length_multiple_uses_aligned_footprints(self):
+        packer = FirstFitDecreasing(bin_capacity=16, sequence_length_multiple=8)
+
+        assert packer.pack([9, 7]) == [[0], [1]]
+
+    def test_aligned_oversized_sequence_raises(self):
+        with pytest.raises(ValueError, match="exceeds bin capacity"):
+            FirstFitDecreasing(bin_capacity=15, sequence_length_multiple=8).pack([9])
+
+    def test_packed_length_multiple_is_paid_once_per_bin(self):
+        packer = FirstFitDecreasing(bin_capacity=16, packed_length_multiple=16)
+
+        assert packer.pack([9, 7]) == [[0, 1]]
+
+    def test_aggregate_padding_can_make_sequence_oversized(self):
+        with pytest.raises(ValueError, match="exceeds bin capacity"):
+            FirstFitDecreasing(bin_capacity=15, packed_length_multiple=16).pack([9])
+
+
+class TestBalanced:
+    def test_sequence_length_multiple_uses_aligned_footprints(self):
+        packer = Balanced(bin_capacity=16, sequence_length_multiple=8)
+
+        assert packer.pack([9, 7]) == [[0], [1]]
+
+    def test_aligned_oversized_sequence_keeps_soft_cap(self):
+        packer = Balanced(bin_capacity=15, sequence_length_multiple=8)
+
+        assert packer.pack([9]) == [[0]]
+
+    def test_packed_length_multiple_is_paid_once_per_bin(self):
+        packer = Balanced(bin_capacity=16, packed_length_multiple=16)
+
+        assert packer.pack([9, 7]) == [[0, 1]]
+
 
 class TestMakeSeqPackerFactory:
     def test_enum_value(self):
@@ -120,7 +156,19 @@ class TestMakeSeqPackerFactory:
             bin_capacity=100,
             min_bin_count=4,
             bin_count_multiple=2,
+            sequence_length_multiple=8,
+            packed_length_multiple=16,
         )
         assert packer.bin_capacity == 100
         assert packer.min_bin_count == 4
         assert packer.bin_count_multiple == 2
+        assert packer.sequence_length_multiple == 8
+        assert packer.packed_length_multiple == 16
+
+    def test_rejects_nonpositive_sequence_length_multiple(self):
+        with pytest.raises(ValueError, match="sequence_length_multiple must be positive"):
+            make_seq_packer("first_fit_decreasing", bin_capacity=100, sequence_length_multiple=0)
+
+    def test_rejects_nonpositive_packed_length_multiple(self):
+        with pytest.raises(ValueError, match="packed_length_multiple must be positive"):
+            make_seq_packer("first_fit_decreasing", bin_capacity=100, packed_length_multiple=0)

--- a/tests/backends/skyrl_train/distributed/test_packing_utils.py
+++ b/tests/backends/skyrl_train/distributed/test_packing_utils.py
@@ -1,21 +1,27 @@
 import pytest
 
 from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import (
-    get_packed_seq_align_size,
+    get_packing_align_size_sequence,
+    get_packing_align_size_total,
     get_unpacked_seq_align_size,
 )
 
 
 def test_packed_alignment_uses_layout_only_without_fp8():
-    assert get_packed_seq_align_size(tp_size=4, cp_size=1) == 4
-    assert get_packed_seq_align_size(tp_size=1, cp_size=2) == 4
+    assert get_packing_align_size_total(tp_size=4, cp_size=1) == 4
+    assert get_packing_align_size_total(tp_size=1, cp_size=2) == 4
+
+
+def test_per_sequence_layout_alignment_only_applies_with_cp():
+    assert get_packing_align_size_sequence(tp_size=4, cp_size=1) == 1
+    assert get_packing_align_size_sequence(tp_size=4, cp_size=2) == 16
 
 
 def test_packed_alignment_adds_fp8_local_rank_multiple():
-    assert get_packed_seq_align_size(tp_size=4, cp_size=1, fp8_enabled=True) == 512
-    assert get_packed_seq_align_size(tp_size=1, cp_size=2, fp8_enabled=True) == 32
-    assert get_packed_seq_align_size(tp_size=2, cp_size=1, fp8_enabled=True) == 256
-    assert get_packed_seq_align_size(tp_size=2, cp_size=2, fp8_enabled=True) == 512
+    assert get_packing_align_size_total(tp_size=4, cp_size=1, fp8_enabled=True) == 512
+    assert get_packing_align_size_total(tp_size=1, cp_size=2, fp8_enabled=True) == 32
+    assert get_packing_align_size_total(tp_size=2, cp_size=1, fp8_enabled=True) == 256
+    assert get_packing_align_size_total(tp_size=2, cp_size=2, fp8_enabled=True) == 512
 
 
 def test_unpacked_alignment_adds_fp8_multiple_only_when_enabled():
@@ -27,22 +33,22 @@ def test_unpacked_alignment_adds_fp8_multiple_only_when_enabled():
 
 def test_mxfp8_recipe_aligns_to_32_token_local_shards():
     # 32*tp*cp at any TP, never the blockwise 128*tp*cp segments.
-    assert get_packed_seq_align_size(tp_size=1, cp_size=1, fp8_enabled=True, fp8_recipe="mxfp8") == 32
-    assert get_packed_seq_align_size(tp_size=1, cp_size=2, fp8_enabled=True, fp8_recipe="mxfp8") == 64
-    assert get_packed_seq_align_size(tp_size=2, cp_size=1, fp8_enabled=True, fp8_recipe="mxfp8") == 64
-    assert get_packed_seq_align_size(tp_size=2, cp_size=2, fp8_enabled=True, fp8_recipe="mxfp8") == 128
-    assert get_packed_seq_align_size(tp_size=4, cp_size=1, fp8_enabled=True, fp8_recipe="mxfp8") == 128
+    assert get_packing_align_size_total(tp_size=1, cp_size=1, fp8_enabled=True, fp8_recipe="mxfp8") == 32
+    assert get_packing_align_size_total(tp_size=1, cp_size=2, fp8_enabled=True, fp8_recipe="mxfp8") == 64
+    assert get_packing_align_size_total(tp_size=2, cp_size=1, fp8_enabled=True, fp8_recipe="mxfp8") == 64
+    assert get_packing_align_size_total(tp_size=2, cp_size=2, fp8_enabled=True, fp8_recipe="mxfp8") == 128
+    assert get_packing_align_size_total(tp_size=4, cp_size=1, fp8_enabled=True, fp8_recipe="mxfp8") == 128
     assert get_unpacked_seq_align_size(tp_size=1, fp8_enabled=True, fp8_recipe="mxfp8") == 32
     assert get_unpacked_seq_align_size(tp_size=2, fp8_enabled=True, fp8_recipe="mxfp8") == 64
     # Non-mx recipes keep the blockwise constants.
-    assert get_packed_seq_align_size(tp_size=1, cp_size=1, fp8_enabled=True, fp8_recipe="blockwise") == 16
+    assert get_packing_align_size_total(tp_size=1, cp_size=1, fp8_enabled=True, fp8_recipe="blockwise") == 16
     assert get_unpacked_seq_align_size(tp_size=1, fp8_enabled=True, fp8_recipe=None) == 16
 
 
 @pytest.mark.parametrize(("tp_size", "cp_size"), [(0, 1), (1, 0), (-1, 1)])
 def test_packed_alignment_rejects_nonpositive_parallel_sizes(tp_size, cp_size):
     with pytest.raises(ValueError, match="must be positive"):
-        get_packed_seq_align_size(tp_size, cp_size, fp8_enabled=True)
+        get_packing_align_size_total(tp_size, cp_size, fp8_enabled=True)
 
 
 def test_unpacked_alignment_rejects_nonpositive_tp_size():

--- a/tests/backends/skyrl_train/distributed/test_preprocess_packed_seqs_cp.py
+++ b/tests/backends/skyrl_train/distributed/test_preprocess_packed_seqs_cp.py
@@ -141,7 +141,7 @@ class TestPreprocessPackedSeqsShortSequencesCP:
 
                 assert result_ids.shape[0] == 1  # unsqueezed
                 assert result_ids.shape[1] % 16 == 0
-                assert packed_params.max_seqlen_q % (16 * cp_size) == 0
+                assert packed_params.total_tokens % (16 * cp_size) == 0
                 assert packed_params.qkv_format == "thd"
 
     def test_remove_left_padding_tp1_aligns_only_for_fp8(self):

--- a/tests/backends/skyrl_train/distributed/test_preprocess_packed_seqs_multiseq.py
+++ b/tests/backends/skyrl_train/distributed/test_preprocess_packed_seqs_multiseq.py
@@ -15,7 +15,8 @@ import pytest
 import torch
 
 from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import (
-    get_packed_seq_align_size,
+    get_packing_align_size_sequence,
+    get_packing_align_size_total,
 )
 
 
@@ -92,10 +93,6 @@ def _mock_mpu(tp_size: int = 1, cp_size: int = 1, cp_rank: int = 0):
     return mock
 
 
-def _get_align_size(tp_size: int, cp_size: int, fp8_enabled: bool = False) -> int:
-    return get_packed_seq_align_size(tp_size, cp_size, fp8_enabled=fp8_enabled)
-
-
 class TestSubSeqLengths:
     """preprocess_packed_seqs with sub_seq_lengths enumerates every sub-seq."""
 
@@ -155,13 +152,13 @@ class TestSubSeqLengths:
         batch_size = 1
 
         # Bin row contains two sub-seqs of length 3 and 4 concatenated.
-        align_size = _get_align_size(tp_size=1, cp_size=1, fp8_enabled=True)
+        packing_align_size_sequence = get_packing_align_size_sequence(tp_size=1, cp_size=1)
         input_ids = torch.zeros(batch_size, seq_len, dtype=torch.long)
         input_ids[0, :3] = torch.tensor([11, 12, 13])
-        input_ids[0, align_size : align_size + 4] = torch.tensor([21, 22, 23, 24])
+        input_ids[0, 3:7] = torch.tensor([21, 22, 23, 24])
         attention_mask = torch.zeros(batch_size, seq_len, dtype=torch.bool)
         attention_mask[0, :3] = True
-        attention_mask[0, align_size : align_size + 4] = True
+        attention_mask[0, 3:7] = True
 
         with patch(
             "skyrl.backends.skyrl_train.distributed.megatron.megatron_utils.mpu",
@@ -175,42 +172,29 @@ class TestSubSeqLengths:
                 fp8_enabled=True,
             )
 
-        assert params.cu_seqlens_q.tolist() == [0, 16, 32]
-        assert params.total_tokens == 32
-        assert packed.shape == (1, 32)
+        assert packing_align_size_sequence == 1
+        assert params.cu_seqlens_q.tolist() == [0, 3, 16]
+        assert params.total_tokens == 16
+        assert packed.shape == (1, 16)
         assert packed[0, :3].tolist() == [11, 12, 13]
-        assert packed[0, 16:20].tolist() == [21, 22, 23, 24]
+        assert packed[0, 3:7].tolist() == [21, 22, 23, 24]
 
-    def test_multiseq_with_tp_alignment(self):
-        """Each sub-seq is independently padded to a multiple of tp_size.
-
-        The intra-row offsets read by preprocess must match the
-        collator's row layout, which advances ``row_offset += round_up(s,
-        align_size)`` between sub-seqs. So with sub-seqs of length 3 and
-        5 and tp_size=4, the collator places sub-seq 1 at row column
-        ``align_size`` after the FP8/TP alignment gap, not row column 3.
-        """
+    def test_multiseq_with_tp_and_fp8_aggregate_alignment(self):
+        """TP and FP8 align the aggregate slab when CP is disabled."""
         from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
             preprocess_packed_seqs,
         )
 
         batch_size = 1
-
-        # Each sequence uses a global footprint that leaves TP-local inputs
-        # aligned to 128 tokens.
-        align_size = _get_align_size(tp_size=4, cp_size=1, fp8_enabled=True)
-        seq_len = 2 * align_size
-        # Row layout mirrors what PackedDataCollator produces:
-        # row[0:3]                         = sub-seq 0 tokens
-        # row[3:align_size]                = alignment pad (zero)
-        # row[align_size:align_size + 5]   = sub-seq 1 tokens
-        # row[align_size + 5:2*align_size] = alignment pad (zero)
+        aggregate_align = get_packing_align_size_total(tp_size=4, cp_size=1, fp8_enabled=True)
+        seq_len = aggregate_align
+        # The valid sequences are contiguous; padding follows the final one.
         input_ids = torch.zeros(batch_size, seq_len, dtype=torch.long)
         input_ids[0, :3] = torch.tensor([1, 2, 3])
-        input_ids[0, align_size : align_size + 5] = torch.tensor([10, 11, 12, 13, 14])
+        input_ids[0, 3:8] = torch.tensor([10, 11, 12, 13, 14])
         attention_mask = torch.zeros(batch_size, seq_len, dtype=torch.bool)
         attention_mask[0, :3] = True
-        attention_mask[0, align_size : align_size + 5] = True
+        attention_mask[0, 3:8] = True
 
         with patch(
             "skyrl.backends.skyrl_train.distributed.megatron.megatron_utils.mpu",
@@ -224,11 +208,11 @@ class TestSubSeqLengths:
                 fp8_enabled=True,
             )
 
-        assert params.cu_seqlens_q.tolist() == [0, align_size, 2 * align_size]
-        assert packed.shape == (1, 2 * align_size)
+        assert params.cu_seqlens_q.tolist() == [0, 3, aggregate_align]
+        assert packed.shape == (1, aggregate_align)
         assert packed[0, :3].tolist() == [1, 2, 3]
-        assert packed[0, 3:align_size].tolist() == [0] * (align_size - 3)
-        assert packed[0, align_size : align_size + 5].tolist() == [10, 11, 12, 13, 14]
+        assert packed[0, 3:8].tolist() == [10, 11, 12, 13, 14]
+        assert packed[0, 8:aggregate_align].tolist() == [0] * (aggregate_align - 8)
 
     def test_multiple_bin_rows(self):
         """Two bin rows, each with two sub-seqs, produce 4+1 cu_seqlens entries."""
@@ -239,17 +223,16 @@ class TestSubSeqLengths:
         seq_len = 48
         batch_size = 2
 
-        align_size = _get_align_size(tp_size=1, cp_size=1, fp8_enabled=True)
         input_ids = torch.zeros(batch_size, seq_len, dtype=torch.long)
         input_ids[0, :2] = torch.tensor([1, 2])
-        input_ids[0, align_size : align_size + 3] = torch.tensor([3, 4, 5])
+        input_ids[0, 2:5] = torch.tensor([3, 4, 5])
         input_ids[1, :4] = torch.tensor([10, 11, 12, 13])
-        input_ids[1, align_size : align_size + 2] = torch.tensor([20, 21])
+        input_ids[1, 4:6] = torch.tensor([20, 21])
         attention_mask = torch.zeros(batch_size, seq_len, dtype=torch.bool)
         attention_mask[0, :2] = True
-        attention_mask[0, align_size : align_size + 3] = True
+        attention_mask[0, 2:5] = True
         attention_mask[1, :4] = True
-        attention_mask[1, align_size : align_size + 2] = True
+        attention_mask[1, 4:6] = True
 
         with patch(
             "skyrl.backends.skyrl_train.distributed.megatron.megatron_utils.mpu",
@@ -263,12 +246,12 @@ class TestSubSeqLengths:
                 fp8_enabled=True,
             )
 
-        assert params.cu_seqlens_q.tolist() == [0, 16, 32, 48, 64]
-        assert packed.shape == (1, 64)
+        assert params.cu_seqlens_q.tolist() == [0, 2, 5, 9, 16]
+        assert packed.shape == (1, 16)
         assert packed[0, :2].tolist() == [1, 2]
-        assert packed[0, 16:19].tolist() == [3, 4, 5]
-        assert packed[0, 32:36].tolist() == [10, 11, 12, 13]
-        assert packed[0, 48:50].tolist() == [20, 21]
+        assert packed[0, 2:5].tolist() == [3, 4, 5]
+        assert packed[0, 5:9].tolist() == [10, 11, 12, 13]
+        assert packed[0, 9:11].tolist() == [20, 21]
 
 
 class TestMultiSeqCPLayout:
@@ -283,11 +266,11 @@ class TestMultiSeqCPLayout:
     @staticmethod
     def _build_batch(tp_size, cp_size, sub_seq_lengths, seq_len=64, fp8_enabled=True):
         """Build (input_ids, attention_mask) whose row layout matches the
-        PackedDataCollator: each sub-seq padded to align_size,
+        PackedDataCollator: each sub-seq padded to its layout alignment,
         laid out back-to-back from column 0. Real tokens get unique nonzero
         ids so reassembly is exactly verifiable.
         """
-        align_size = _get_align_size(tp_size, cp_size, fp8_enabled=fp8_enabled)
+        align_size = get_packing_align_size_sequence(tp_size, cp_size)
 
         def round_up(x, m):
             return ((x + m - 1) // m) * m
@@ -320,7 +303,7 @@ class TestMultiSeqCPLayout:
 
         # ---- ground truth: the full (un-sharded) padded THD layout ----
         # Under the identity model, analytically reassembling each row's
-        # sub-seqs (each padded to align_size) back-to-back from column 0 with
+        # sub-seqs (each padded to layout align_size) back-to-back from column 0 with
         # the rest zero should recover ``input_ids`` cast to float.
         # NOTE: we deliberately do NOT use the cp_size==1 path as ground truth
         # here -- the cp==1 and cp>1 paths use different divisors, so the two
@@ -390,12 +373,16 @@ class TestMultiSeqCPLayout:
                     tmp[
                         padded_segment_len - (cp_rank + 1) * half_seqlen : padded_segment_len - cp_rank * half_seqlen
                     ] = back
-                output[row_idx, dest_off : dest_off + padded_segment_len] = tmp
+                # Aggregate TP/FP8 padding is attached to the final segment but
+                # lies beyond the source row; discard that tail when rebuilding
+                # the original fixed-width batch layout.
+                write_len = min(padded_segment_len, seq_len - dest_off)
+                output[row_idx, dest_off : dest_off + write_len] = tmp[:write_len]
 
         return output
 
     def test_roundtrip_recovers_full_layout_cp2(self):
-        # tp=1, cp=2 -> align_size=32. Sub-seq lengths chosen so each row has
+        # tp=1, cp=2 -> layout align_size=4. Sub-seq lengths chosen so each row has
         # multiple sub-seqs of differing lengths.
         gt, recovered = self._run_roundtrip(tp_size=1, cp_size=2, sub_seq_lengths=[[6, 5], [7, 3]])
         assert torch.equal(recovered, gt), (
@@ -415,12 +402,12 @@ class TestMultiSeqCPLayout:
         assert torch.equal(recovered, gt)
 
     def test_roundtrip_recovers_full_layout_tp2_cp2(self):
-        # tp=2, cp=2 -> align_size=32.
+        # tp=2, cp=2 -> layout align_size=8.
         gt, recovered = self._run_roundtrip(tp_size=2, cp_size=2, sub_seq_lengths=[[5, 9], [3, 6]])
         assert torch.equal(recovered, gt)
 
     def test_roundtrip_cp4(self):
-        # tp=1, cp=4 -> align_size=64. Exercises >2 CP ranks so the per-rank
+        # tp=1, cp=4 -> layout align_size=8. Exercises >2 CP ranks so the per-rank
         # zigzag chunk assignment (ranks 0..3 hold chunks {0,7},{1,6},{2,5},{3,4})
         # is genuinely tested, not just the symmetric cp=2 case.
         gt, recovered = self._run_roundtrip(tp_size=1, cp_size=4, sub_seq_lengths=[[10, 6], [13, 3]])
@@ -440,11 +427,11 @@ class TestMultiSeqCPLayout:
         sub_seq_lengths = [[6, 5], [7, 3]]
         _, recovered = self._run_roundtrip(tp_size, cp_size, sub_seq_lengths)
 
-        # align_size=32: row0 starts sub-seqs at offsets 0 and 32; row1 does
+        # layout align_size=4: row0 starts sub-seqs at offsets 0 and 8; row1 does
         # the same with its own token ids.
         assert recovered[0, 0:6].tolist() == [1.0, 2, 3, 4, 5, 6]
-        assert recovered[0, 6:32].tolist() == [0.0] * 26
-        assert recovered[0, 32:37].tolist() == [7.0, 8, 9, 10, 11]
+        assert recovered[0, 6:8].tolist() == [0.0] * 2
+        assert recovered[0, 8:13].tolist() == [7.0, 8, 9, 10, 11]
         assert recovered[1, 0:7].tolist() == [12.0, 13, 14, 15, 16, 17, 18]
-        assert recovered[1, 7:32].tolist() == [0.0] * 25
-        assert recovered[1, 32:35].tolist() == [19.0, 20, 21]
+        assert recovered[1, 7:8].tolist() == [0.0]
+        assert recovered[1, 8:11].tolist() == [19.0, 20, 21]

--- a/tests/backends/skyrl_train/distributed/test_token_metadata.py
+++ b/tests/backends/skyrl_train/distributed/test_token_metadata.py
@@ -28,7 +28,7 @@ def parallel_state(monkeypatch):
 
 
 def test_microbatch_rows_share_one_packed_layout(monkeypatch, parallel_state):
-    monkeypatch.setattr(token_metadata, "get_packed_seq_align_size", lambda *args, **kwargs: 4)
+    monkeypatch.setattr(token_metadata, "get_packing_align_size_total", lambda *args, **kwargs: 4)
     attention_mask = torch.tensor([[0, 1, 1, 1], [0, 0, 1, 1]])
     routes = torch.tensor(
         [
@@ -56,18 +56,18 @@ def test_microbatch_rows_share_one_packed_layout(monkeypatch, parallel_state):
         [10, 11],
         [12, 13],
         [14, 15],
-        [0, 1],
         [20, 21],
         [22, 23],
         [0, 1],
         [0, 1],
+        [0, 1],
     ]
-    assert packed_mask.tolist() == [[False, False, True, True, False, False, True, True]]
-    assert layout.cu_seqlens_padded.tolist() == [0, 4, 8]
+    assert packed_mask.tolist() == [[False, False, True, False, False, True, True, True]]
+    assert layout.cu_seqlens_padded.tolist() == [0, 3, 8]
 
 
 def test_packed_layout_aligns_next_token_metadata_and_scatters_rows(monkeypatch, parallel_state):
-    monkeypatch.setattr(token_metadata, "get_packed_seq_align_size", lambda *args, **kwargs: 4)
+    monkeypatch.setattr(token_metadata, "get_packing_align_size_total", lambda *args, **kwargs: 4)
     attention_mask = torch.tensor([[0, 1, 1, 1], [0, 0, 1, 1]])
     metadata = torch.tensor([[0, 10, 11, 12], [0, 0, 20, 21]], dtype=torch.int32)
     layout = token_metadata.build_token_metadata_layout(
@@ -84,5 +84,21 @@ def test_packed_layout_aligns_next_token_metadata_and_scatters_rows(monkeypatch,
         0,
     )
 
-    assert aligned.tolist() == [[11, 12, -1, -1, 21, -1, -1, -1]]
-    assert batch_values.tolist() == [[0.0, 1.0, 2.0], [0.0, 0.0, 5.0]]
+    assert aligned.tolist() == [[11, 12, -1, 21, -1, -1, -1, -1]]
+    assert batch_values.tolist() == [[0.0, 1.0, 2.0], [0.0, 0.0, 4.0]]
+
+
+def test_cp_layout_keeps_per_sequence_gaps_and_one_fp8_tail(monkeypatch, parallel_state):
+    monkeypatch.setattr(parallel_state, "get_context_parallel_world_size", lambda: 2)
+    attention_mask = torch.tensor([[1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1]])
+
+    layout = token_metadata.build_token_metadata_layout(
+        attention_mask,
+        attention_mask.device,
+        packed=True,
+        fp8_enabled=True,
+    )
+
+    assert layout.padded_sequence_lengths == [8, 24]
+    assert layout.cu_seqlens_padded.tolist() == [0, 8, 32]
+    assert layout.aligned_sequence_length // layout.context_parallel_size == 16

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_sft_packing_parity.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_sft_packing_parity.py
@@ -21,7 +21,8 @@ import torch
 
 from skyrl.backends.skyrl_train.distributed.dispatch import WorkerOutput
 from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import (
-    get_packed_seq_align_size,
+    get_packing_align_size_sequence,
+    get_packing_align_size_total,
 )
 from skyrl.backends.skyrl_train.distributed.megatron.quantization_utils import (
     is_fp8_enabled,
@@ -486,12 +487,7 @@ def test_sft_packing_cp_logprob_parity(ray_init_fixture):
             # Recompute flat_bins + align_size deterministically (same FFD call).
             flat_bins = _recompute_flat_bins(trainer, examples)
             tp = 1
-            transformer_config_kwargs = sft_cfg.megatron_config.transformer_config_kwargs or {}
-            align_size = get_packed_seq_align_size(
-                tp,
-                cp,
-                fp8_enabled=is_fp8_enabled(transformer_config_kwargs.get("fp8")),
-            )
+            align_size = get_packing_align_size_sequence(tp, cp)
             collated.metadata["align_size"] = align_size
         else:
             collated = collate_sft_batch(examples, tokenizer)
@@ -590,11 +586,23 @@ def _recompute_flat_bins(trainer: SFTTrainer, examples: List[dict]) -> List[List
     seq_lengths = [len(ex["input_ids"]) for ex in examples]
     dp_size = trainer._dp_size()
     bin_count_multiple = dp_size
+    tp_size = trainer.sft_cfg.megatron_config.tensor_model_parallel_size
+    cp_size = trainer.sft_cfg.megatron_config.context_parallel_size
+    transformer_config_kwargs = trainer.sft_cfg.megatron_config.transformer_config_kwargs or {}
+    fp8_enabled = is_fp8_enabled(transformer_config_kwargs.get("fp8"))
+    packing_align_size_total = get_packing_align_size_total(
+        tp_size,
+        cp_size,
+        fp8_enabled=fp8_enabled,
+        fp8_recipe=transformer_config_kwargs.get("fp8_recipe"),
+    )
     packer = make_seq_packer(
         "first_fit_decreasing",
-        bin_capacity=trainer.sft_cfg.resolved_bin_capacity(),
+        bin_capacity=max(trainer.sft_cfg.resolved_bin_capacity(), packing_align_size_total),
         min_bin_count=bin_count_multiple,
         bin_count_multiple=bin_count_multiple,
+        sequence_length_multiple=get_packing_align_size_sequence(tp_size, cp_size),
+        packed_length_multiple=packing_align_size_total,
     )
     bins = packer.pack(seq_lengths)
     shard_bins: List[List[List[int]]] = [[] for _ in range(dp_size)]

--- a/tests/backends/skyrl_train/test_token_based_batching_utils.py
+++ b/tests/backends/skyrl_train/test_token_based_batching_utils.py
@@ -139,6 +139,16 @@ class TestTokenBasedBatchIterator:
             if microbatch["loss_mask"].sum() > 0:  # not a padding batch
                 assert token_count <= 15
 
+    def test_iterator_pays_aggregate_alignment_once(self):
+        batch = self._make_batch([9, 7])
+        iterator = TokenBasedBatchIterator(
+            batch,
+            max_tokens_per_microbatch=16,
+            packed_length_multiple=16,
+        )
+
+        assert iterator._microbatches == [[0, 1]]
+
     def test_len_matches_iteration(self):
         batch = self._make_batch([10, 10, 5, 5])
         iterator = TokenBasedBatchIterator(batch, max_tokens_per_microbatch=15)

--- a/tests/train/test_collation_vectorization_equivalence.py
+++ b/tests/train/test_collation_vectorization_equivalence.py
@@ -282,7 +282,7 @@ def _ref_packed_rows(collator: PackedDataCollator, examples, max_packed_len, fla
     def _round_up(x, m):
         return ((x + m - 1) // m) * m
 
-    align_size = collator.tp_size * collator.cp_size * 2 if collator.cp_size > 1 else collator.tp_size
+    align_size = collator.tp_size * collator.cp_size * 2 if collator.cp_size > 1 else 1
     full_loss_masks = []
     for ex in examples:
         n_pad = len(ex["input_ids"]) - ex["num_actions"]
@@ -348,7 +348,16 @@ def test_packed_collator_bit_identical(seed, tp, pp, cp, dp):
     from skyrl.train.dataset.bin_packing import make_seq_packer
 
     seq_lengths = [len(ex["input_ids"]) for ex in examples]
-    packer = make_seq_packer("first_fit_decreasing", bin_capacity=bin_capacity, min_bin_count=dp, bin_count_multiple=dp)
+    align_size = tp * cp * 2 if cp > 1 else 1
+    packing_align_size_total = tp * cp * 2 if cp > 1 else tp
+    packer = make_seq_packer(
+        "first_fit_decreasing",
+        bin_capacity=bin_capacity,
+        min_bin_count=dp,
+        bin_count_multiple=dp,
+        sequence_length_multiple=align_size,
+        packed_length_multiple=packing_align_size_total,
+    )
     bins = packer.pack(seq_lengths)
     shard_bins: List[List[List[int]]] = [[] for _ in range(dp)]
     for bin_idx, bi in enumerate(bins):
@@ -360,10 +369,12 @@ def test_packed_collator_bit_identical(seed, tp, pp, cp, dp):
     def _round_up(x, m):
         return ((x + m - 1) // m) * m
 
-    align_size = tp * cp * 2 if cp > 1 else tp
-    bin_packed_lengths = [sum(_round_up(seq_lengths[idx], align_size) for idx in bi) for bi in flat_bins]
+    bin_packed_lengths = [
+        _round_up(sum(_round_up(seq_lengths[idx], align_size) for idx in bi), packing_align_size_total)
+        for bi in flat_bins
+    ]
     if pp > 1:
-        max_packed_len = _round_up(max(bin_packed_lengths), align_size)
+        max_packed_len = _round_up(max(bin_packed_lengths), packing_align_size_total)
     else:
         max_packed_len = max(bin_packed_lengths)
 

--- a/tests/train/test_packing_round_trip.py
+++ b/tests/train/test_packing_round_trip.py
@@ -4,11 +4,9 @@ These tests exercise the *collator output -> preprocess* path with
 multi-subseq rows under both ``mbs > 1`` and ``tp_size > 1``, asserting the
 invariants at that interface:
 
-  preprocess — the controller-side collator advances
-    ``row_offset += round_up(s, align_size)`` between sub-seqs in the
-    same row. ``preprocess_packed_seqs`` advances by the same padded
-    length, so for ``tp_size > 1`` and multi-subseq rows sub-seq
-    ``i > 0`` starts past the TP-alignment pad gap of sub-seq ``i - 1``.
+  preprocess — the controller-side collator and ``preprocess_packed_seqs``
+    use identical per-sequence layout offsets, while TP/FP8 alignment is
+    appended once to the aggregate token slab.
 
 The configuration here (``mbs=2``, ``tp_size=4``, two multi-subseq rows
 with sub-seq lengths ``[7, 5]`` and ``[3, 11]``) exercises both at once.
@@ -30,7 +28,8 @@ import pytest
 import torch
 
 from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import (
-    get_packed_seq_align_size,
+    get_packing_align_size_sequence,
+    get_packing_align_size_total,
 )
 
 
@@ -109,10 +108,6 @@ def _mock_mpu(tp_size: int = 1, cp_size: int = 1, cp_rank: int = 0):
     return mock
 
 
-def _get_align_size(tp_size: int, cp_size: int, fp8_enabled: bool = False) -> int:
-    return get_packed_seq_align_size(tp_size, cp_size, fp8_enabled=fp8_enabled)
-
-
 def _build_collator_layout(
     sub_seq_token_lists: list[list[list[int]]],
     *,
@@ -154,7 +149,7 @@ class TestPreprocessPackedRows:
         """The exact configuration that would have caught both bugs.
 
         - ``mbs = 2`` so the THD offset stride matters per micro-batch row.
-        - ``tp_size = 4`` so the TP-alignment padding inside rows kicks in.
+        - ``tp_size = 4`` so the final packed slab needs aggregate alignment.
         - Multi-subseq rows ``[(7, 5)]`` and ``[(3, 11)]`` to expose offset
           mismatches in both directions (none of the lengths are alignment
           multiples, and row 1's first sub-seq is shorter than its second).
@@ -164,7 +159,7 @@ class TestPreprocessPackedRows:
         )
 
         tp_size = 4
-        align_size = _get_align_size(tp_size, cp_size=1, fp8_enabled=True)
+        align_size = get_packing_align_size_sequence(tp_size, cp_size=1)
         # Distinct unique tokens per sub-seq so we can spot off-by-one bugs.
         row_0_sub_0 = [101, 102, 103, 104, 105, 106, 107]  # len 7
         row_0_sub_1 = [201, 202, 203, 204, 205]  # len 5
@@ -177,15 +172,12 @@ class TestPreprocessPackedRows:
         )
 
         # Sanity: collator layout matches what PackedDataCollator does.
-        assert sequences.shape == (2, 2 * align_size)
+        # With CP disabled, sub-sequences are contiguous within each row.
+        assert sequences.shape == (2, 14)
         assert sequences[0, :7].tolist() == row_0_sub_0
-        assert sequences[0, 7:align_size].tolist() == [0] * (align_size - 7)
-        assert sequences[0, align_size : align_size + 5].tolist() == row_0_sub_1
+        assert sequences[0, 7:12].tolist() == row_0_sub_1
         assert sequences[1, :3].tolist() == row_1_sub_0
-        assert sequences[1, 3:align_size].tolist() == [0] * (align_size - 3)
-        assert sequences[1, align_size : align_size + 11].tolist() == row_1_sub_1
-        # attention_mask is True ONLY at valid slots (NOT at TP-alignment gaps).
-        assert attention_mask[0, 7:align_size].any().item() is False
+        assert sequences[1, 3:14].tolist() == row_1_sub_1
         assert attention_mask[0].sum().item() == 7 + 5
         assert attention_mask[1].sum().item() == 3 + 11
 
@@ -204,15 +196,15 @@ class TestPreprocessPackedRows:
                 fp8_enabled=True,
             )
 
-        # cu_seqlens_q (== cu_seqlens_q_padded for THD) enumerates 4 sub-seqs:
-        assert params.cu_seqlens_q.tolist() == [i * align_size for i in range(5)]
-        # Verify valid tokens are read from offsets produced by alignment padding.
-        assert packed.shape == (1, 4 * align_size)
-        assert packed[0, :7].tolist() == row_0_sub_0
-        assert packed[0, 7:align_size].tolist() == [0] * (align_size - 7)
-        assert packed[0, align_size : align_size + 5].tolist() == row_0_sub_1
-        assert packed[0, 2 * align_size : 2 * align_size + 3].tolist() == row_1_sub_0
-        assert packed[0, 3 * align_size : 3 * align_size + 11].tolist() == row_1_sub_1
+        # cu_seqlens_q_padded enumerates four sub-sequences and one aggregate tail pad.
+        aggregate_align = get_packing_align_size_total(tp_size, cp_size=1, fp8_enabled=True)
+        assert params.cu_seqlens_q.tolist() == [0, 7, 12, 15, aggregate_align]
+        assert packed.shape == (1, aggregate_align)
+        assert packed[0, :7].tolist() == row_0_sub_0  # row 0 sub 0
+        assert packed[0, 7:12].tolist() == row_0_sub_1  # row 0 sub 1
+        assert packed[0, 12:15].tolist() == row_1_sub_0  # row 1 sub 0
+        assert packed[0, 15:26].tolist() == row_1_sub_1  # row 1 sub 1
+        assert packed[0, 26:aggregate_align].tolist() == [0] * (aggregate_align - 26)
 
     def test_mbs2_tp1_singlesubseq_rows_match_legacy_preprocess_path(self):
         """No regression in the legacy path: when each row has 1 sub-seq and tp_size=1."""
@@ -221,7 +213,8 @@ class TestPreprocessPackedRows:
         )
 
         sequences, attention_mask, sub_seq_lengths = _build_collator_layout(
-            [[[1, 2, 3, 4, 5]], [[10, 11, 12]]], align_size=_get_align_size(1, 1, fp8_enabled=True)
+            [[[1, 2, 3, 4, 5]], [[10, 11, 12]]],
+            align_size=get_packing_align_size_sequence(1, 1),
         )
 
         with patch(

--- a/tests/train/test_sft_packing_collate.py
+++ b/tests/train/test_sft_packing_collate.py
@@ -196,34 +196,31 @@ class TestPackingCollator:
         row_widths = [batch["sequences"][r].shape[0] for r in range(batch.batch_size)]
         assert len(set(row_widths)) == 1
 
-    def test_tp_alignment_pads_each_sub_seq(self):
-        """With tp_size > 1, each sub-seq's footprint in the row is
-        rounded up to a multiple of tp_size."""
+    def test_tp_alignment_pads_the_aggregate(self):
+        """Without CP, TP alignment is paid once for the packed row."""
         # Need num_gpus % (tp*pp*cp) == 0; use 4 GPUs with tp=4 -> dp=1.
         collator = _make_collator(num_gpus=4, batch_size=2, max_length=128, tp=4)
         examples = [
-            _make_example(7, 3),  # 7 tokens -> rounded to 8
-            _make_example(5, 3),  # 5 tokens -> rounded to 8
+            _make_example(7, 3),
+            _make_example(5, 3),
         ]
         batch = collator(examples, batch_size=2)
-        # BF16/layout-only path: two sub-seqs each padded to 8.
-        assert batch["sequences"].shape[1] == 16
+        assert batch["sequences"].shape[1] == 12
         # Both seqs are in the same row.
         subseq_lengths = batch["sub_seq_lengths"][0].tolist()
         assert sum(subseq_lengths) == 12  # raw, un-padded
 
-    def test_fp8_tp_alignment_cost_prevents_overpacking(self):
-        """Packing uses each sequence's aligned FP8/TP footprint."""
+    def test_fp8_tp_alignment_pads_the_aggregate(self):
+        """FP8 rounds the combined TP-only row once at the aggregate boundary."""
         collator = _make_collator(num_gpus=4, batch_size=2, max_length=128, tp=4, fp8="hybrid")
         examples = [
             _make_example(7, 3),
             _make_example(5, 3),
         ]
         batch = collator(examples, batch_size=2)
-        # TP4 gives each sequence a 512-token footprint, so the 128-token budget
-        # expands to one footprint without packing both sequences together.
-        assert batch["sequences"].shape == (2, 512)
-        assert sorted(lengths.tolist() for lengths in batch["sub_seq_lengths"]) == [[5], [7]]
+        assert batch["sequences"].shape == (1, 512)
+        subseq_lengths = batch["sub_seq_lengths"][0].tolist()
+        assert sum(subseq_lengths) == 12
 
     def test_bf16_cp_alignment_does_not_apply_fp8_padding(self):
         """With CP>1 and BF16, keep only TP/CP layout padding."""
@@ -237,25 +234,41 @@ class TestPackingCollator:
         subseq_lengths = batch["sub_seq_lengths"][0].tolist()
         assert sorted(subseq_lengths) == [5, 6]
 
-    def test_fp8_cp_alignment_pads_each_sub_seq(self):
-        """With cp_size > 1, each sub-seq's footprint is rounded up to a
-        multiple that leaves each CP rank's local shard 16-aligned."""
-        # tp=1, cp=2 -> align_size = lcm(1*2*2, 16*2) = 32.
+    def test_aligned_subsequences_respect_bin_capacity(self):
+        """FFD budgets the TP/CP-aligned footprint, not only raw tokens."""
+        tokenizer = MagicMock()
+        tokenizer.pad_token_id = 0
+        collator = PackedDataCollator(
+            tokenizer=tokenizer,
+            batch_size=2,
+            max_tokens_per_microbatch=32,
+            tp_size=4,
+            pp_size=1,
+            cp_size=2,
+            dp_size=1,
+            micro_train_batch_size_per_gpu=1,
+        )
+        examples = [_make_example(17, 8), _make_example(15, 7)]
+
+        batch = collator(examples, batch_size=2)
+
+        assert batch.batch_size == 2
+        assert batch["sequences"].shape[1] == 32
+        assert sorted(lengths.item() for lengths in batch["sub_seq_lengths"]) == [15, 17]
+
+    def test_fp8_cp_alignment_pads_the_aggregate(self):
+        """FP8 padding is paid once after CP-aligning each sub-sequence."""
+        # tp=1, cp=2 -> per-sequence layout alignment 4, aggregate alignment 32.
         collator = _make_collator(num_gpus=2, batch_size=2, max_length=128, cp=2, fp8="hybrid")
         examples = [
-            _make_example(6, 3),  # 6 tokens -> rounded up to 32
-            _make_example(5, 3),  # 5 tokens -> rounded up to 32
+            _make_example(6, 3),
+            _make_example(5, 3),
         ]
         batch = collator(examples, batch_size=2)
-        # Both sub-seqs in one row (dp=1), each padded to 32 -> row width >= 64.
-        assert batch["sequences"].shape[1] >= 64
+        # Per-sequence footprints are 8 + 8; the aggregate is padded once to 32.
+        assert batch["sequences"].shape[1] == 32
         subseq_lengths = batch["sub_seq_lengths"][0].tolist()
         assert sorted(subseq_lengths) == [5, 6]  # raw, un-padded
-        # Each sub-seq's padded footprint must produce 16-aligned local CP rank
-        # slabs after dividing by cp_size=2.
-        for s in subseq_lengths:
-            padded = ((s + 31) // 32) * 32
-            assert (padded // 2) % 16 == 0
 
     def test_fp8_alignment_is_conditional(self):
         examples = [
@@ -271,8 +284,8 @@ class TestPackingCollator:
 
         fp8 = _make_collator(num_gpus=1, batch_size=2, max_length=64, fp8=True)
         fp8_batch = fp8(examples, batch_size=2)
-        assert fp8_batch["sequences"].shape[1] == 32
-        fp8_chunks = [fp8_batch["sequences"][0, :3].tolist(), fp8_batch["sequences"][0, 16:19].tolist()]
+        assert fp8_batch["sequences"].shape[1] == 16
+        fp8_chunks = [fp8_batch["sequences"][0, :3].tolist(), fp8_batch["sequences"][0, 3:6].tolist()]
         assert sorted(fp8_chunks) == [[100, 101, 102], [200, 201, 202]]
 
     def test_tp_gt_1_fp8_alignment_uses_local_128(self):
@@ -285,8 +298,8 @@ class TestPackingCollator:
         fp8 = _make_collator(num_gpus=2, batch_size=2, max_length=512, tp=2, fp8=True)
         fp8_batch = fp8(examples, batch_size=2)
 
-        assert fp8_batch["sequences"].shape[1] == 512
-        fp8_chunks = [fp8_batch["sequences"][0, :3].tolist(), fp8_batch["sequences"][0, 256:259].tolist()]
+        assert fp8_batch["sequences"].shape[1] == 256
+        fp8_chunks = [fp8_batch["sequences"][0, :3].tolist(), fp8_batch["sequences"][0, 3:6].tolist()]
         assert sorted(fp8_chunks) == [[100, 101, 102], [200, 201, 202]]
 
     def test_eval_path_falls_back_to_super(self):


### PR DESCRIPTION
## Summary

- distinguish per-sequence layout alignment from aggregate packed-slab alignment
- make FFD capacity checks account for the physical aligned footprint used by packed SFT batches
- make balanced token batching use the same alignment-aware accounting on Megatron workers
- apply aggregate TP/FP8 tail padding once, rather than padding every sequence to that multiple
- keep the collator, packed preprocessing, token metadata, and target layouts in lockstep

## Alignment model

Two constraints have different scopes:

- `packing_align_size_sequence`: alignment required independently by each sequence. This is `2 * tp_size * cp_size` when context parallelism is active, because each sequence must support the CP/SP layout; otherwise it is 1.
- `packing_align_size_total`: alignment required by the final packed token slab. This covers TP divisibility and the Transformer Engine FP8 requirement (`16 * cp_size`) and is paid once after the per-sequence footprints are summed.

The packers expose matching `sequence_length_multiple` and `packed_length_multiple` inputs. They first align each sequence to the former, then round each candidate bin total to the latter for capacity checks. This avoids both underestimating CP layout gaps and overestimating TP/FP8 padding by charging only CP/SP alignment per sequence and TP/FP8 alignment once per packed bin.

## Relationship to the general FP8 training PR

[#1898](https://github.com/NovaSky-AI/SkyRL/pull/1898) adds broad end-to-end FP8 training and rollout support. Its packing changes add FP8-recipe-specific tile requirements and make SFT bin packing account for aligned lengths, but combine CP/SP, TP, and FP8 into one alignment paid independently by every packed sequence.

This PR addresses a different scope question: CP/SP layout gaps are genuinely per-sequence, while TP and FP8 constrain the aggregate local token slab and should be paid once per packed bin or microbatch. It also moves this two-level accounting into the generic packers, covering non-FP8 CP/TP layouts and worker-side balanced token batching in addition to controller-side FP8 SFT packing.

The changes are complementary rather than replacements. When the branches are reconciled, #1898’s recipe-specific blockwise/MXFP8 tile requirement should feed `packing_align_size_total`, while this PR’s `packing_align_size_sequence` versus `packing_align_size_total` split determines where that padding is charged.

## Affected paths

- controller-level SFT packing (`PackedDataCollator`, FFD)
- worker-side token-based microbatching (`TokenBasedBatchIterator`, balanced packing)
- Megatron packed-sequence preprocessing and CP sharding
- packed token metadata, targets, masks, and GPU parity references

## Testing

- `pytest -q tests/backends/skyrl_train/distributed/test_bin_packing.py` (24 passed)
- added focused tests for CP per-sequence gaps, aggregate TP/FP8 tails, FFD capacity, balanced batching, packed metadata, and round trips
- Ruff lint
- Black formatting check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes divisibility and padding across collator, bin-packing, and Megatron THD preprocessing; misalignment can corrupt CP/FP8 training without obvious crashes.
> 
> **Overview**
> Splits Megatron sequence packing into **per-sequence layout alignment** (CP/SP gaps via `get_packing_align_size_sequence`) versus **one aggregate slab alignment** for TP and FP8 (`get_packing_align_size_total`), replacing the single `get_packed_seq_align_size` knob.
> 
> **Packing and batching** now round each sequence to the layout multiple and charge TP/FP8 padding once per bin/microbatch: `SeqPacker` / FFD / balanced packers, `PackedDataCollator`, `TokenBasedBatchIterator`, and `MegatronWorker` token microbatching all pass `sequence_length_multiple` and `packed_length_multiple` so capacity matches the physical footprint.
> 
> **Runtime layout** stays consistent end-to-end: `preprocess_packed_seqs`, packed token metadata, and packed valid masks use the same rules (contiguous sub-sequences when CP is off; CP gaps only where required; tail pad on the last segment). Docs and tests were updated for the new invariants and smaller row widths when TP/FP8 no longer pad every sub-sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc619d646dc726865024498cd91b0a72f9d84c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->