### PR TITLE
perf(sft): use modified first-fit decreasing packing

### DIFF
--- a/docs/content/docs/sft/overview.mdx
+++ b/docs/content/docs/sft/overview.mdx
@@ -180,7 +180,7 @@ trained model**.
 
 By default `remove_microbatch_padding=true` packs multiple sequences per
 micro-batch (requires flash attention). The Megatron backend additionally
-supports **controller-level FFD bin-packing** across the global mini-batch with
+supports **controller-level MFFD bin-packing** across the global mini-batch with
 `use_sequence_packing=true`:
 
 ```bash

--- a/examples/train/sft/README.md
+++ b/examples/train/sft/README.md
@@ -175,12 +175,12 @@ python -m skyrl.train.main_sft [key=value overrides...]
 See [`skyrl/train/main_sft.py`](../../../skyrl/train/main_sft.py) for the CLI entrypoint and
 [`skyrl/train/sft_trainer.py`](../../../skyrl/train/sft_trainer.py) for the full implementation.
 
-## Minibatch packing (controller-level FFD, Megatron only)
+## Minibatch packing (controller-level MFFD, Megatron only)
 
 When `use_sequence_packing=true`, `SFTTrainer` collates with
 `PackedDataCollator` instead of `DefaultCollator`. Every training step:
 
-1. The controller's collator runs FFD bin-packing over the global
+1. The controller's collator runs MFFD bin-packing over the global
    mini-batch using `max_length` as the bin capacity.
 2. The bin count is forced to a multiple of `dp_size` via empty-bin
    padding (`min_bin_count`/`bin_count_multiple` knobs in

--- a/skyrl/train/config/sft_config.py
+++ b/skyrl/train/config/sft_config.py
@@ -284,14 +284,14 @@ class SFTConfig(BaseConfig):
     # ---- Packing ----
     remove_microbatch_padding: bool = True  # Pack multiple sequences per microbatch (requires flash_attn)
     use_sequence_packing: bool = False
-    """Enable controller-level FFD bin-packing across the global mini-batch.
+    """Enable controller-level MFFD bin-packing across the global mini-batch.
     Requires ``remove_microbatch_padding=True`` and the Megatron backend. When
     enabled, ``SFTTrainer`` uses ``PackedDataCollator`` instead of
     ``DefaultCollator``. Each bin row becomes one row in the dispatched batch
     and one worker micro-batch.
     """
     max_tokens_per_microbatch: Optional[int] = None
-    """FFD bin capacity (max tokens per bin) when ``use_sequence_packing=True``.
+    """MFFD bin capacity (max tokens per bin) when ``use_sequence_packing=True``.
     Each bin row becomes one worker micro-batch, so this is the token budget for
     one micro-batch. Must be ``>= max_length`` so any single sequence fits in a
     bin. ``None`` (default) resolves to ``max_length`` (each bin holds one
@@ -307,7 +307,7 @@ class SFTConfig(BaseConfig):
     Useful for CI smoke tests and quick validation runs."""
 
     def resolved_bin_capacity(self) -> int:
-        """FFD bin capacity (max tokens per bin) when sequence packing is enabled.
+        """MFFD bin capacity (max tokens per bin) when sequence packing is enabled.
 
         Resolves ``max_tokens_per_microbatch`` against ``max_length``: when the
         token budget is ``None`` it falls back to ``max_length`` (each bin holds
@@ -619,7 +619,7 @@ def validate_sft_cfg(cfg: SFTConfig) -> None:
             cfg.remove_microbatch_padding = True
         if cfg.max_length is None:
             raise ValueError("use_sequence_packing=True requires max_length to be set (it is the bin capacity).")
-        # Resolve and validate the FFD bin capacity (asserts it is >= max_length
+        # Resolve and validate the MFFD bin capacity (asserts it is >= max_length
         # so any single sequence fits in a bin).
         cfg.resolved_bin_capacity()
 

--- a/skyrl/train/dataset/bin_packing.py
+++ b/skyrl/train/dataset/bin_packing.py
@@ -263,11 +263,14 @@ class ModifiedFirstFitDecreasing(SeqPacker):
         bin_lengths = [item[1] for item in large]
 
         for bin_index, bin_items in enumerate(bins):
-            for index, item in enumerate(medium):
-                if self._fits(bin_lengths[bin_index], item):
-                    bin_items.append(medium.pop(index))
-                    bin_lengths[bin_index] += item[1]
-                    break
+            medium_index = next(
+                (index for index, item in enumerate(medium) if self._fits(bin_lengths[bin_index], item)),
+                None,
+            )
+            if medium_index is not None:
+                item = medium.pop(medium_index)
+                bin_items.append(item)
+                bin_lengths[bin_index] += item[1]
 
         for bin_index in range(len(bins) - 1, -1, -1):
             bin_items = bins[bin_index]
@@ -284,8 +287,8 @@ class ModifiedFirstFitDecreasing(SeqPacker):
                 None,
             )
             if second_index is not None:
+                second_small = small.pop(second_index)
                 first_small = small.pop(0)
-                second_small = small.pop(second_index - 1)
                 bin_items.extend((first_small, second_small))
                 bin_lengths[bin_index] += first_small[1] + second_small[1]
 

--- a/skyrl/train/dataset/bin_packing.py
+++ b/skyrl/train/dataset/bin_packing.py
@@ -23,13 +23,17 @@ from __future__ import annotations
 import enum
 import heapq
 from abc import ABC, abstractmethod
+from bisect import bisect_left
 from typing import List, Optional, Tuple
+
+import numpy as np
 
 
 class PackingStrategy(enum.Enum):
     """Supported sequence packing algorithms."""
 
     FIRST_FIT_DECREASING = "first_fit_decreasing"
+    MODIFIED_FIRST_FIT_DECREASING = "modified_first_fit_decreasing"
     BALANCED = "balanced"
 
 
@@ -211,8 +215,121 @@ class Balanced(SeqPacker):
         return bins
 
 
+class ModifiedFirstFitDecreasing(SeqPacker):
+    """Modified First-Fit Decreasing adapted for SkyRL.
+
+    Based on Johnson and Garey's `original MFFD paper
+    <https://www.sciencedirect.com/science/article/pii/0885064X85900226>`_
+    and the `NeMo RL implementation
+    <https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/data/packing/algorithms.py>`_.
+    """
+
+    def _classify_items(
+        self, items: List[Tuple[int, int]]
+    ) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]], List[Tuple[int, int]], List[Tuple[int, int]]]:
+        large: List[Tuple[int, int]] = []
+        medium: List[Tuple[int, int]] = []
+        small: List[Tuple[int, int]] = []
+        tiny: List[Tuple[int, int]] = []
+        capacity = self.bin_capacity
+        for item in items:
+            size = item[1]
+            if size * 2 > capacity:
+                large.append(item)
+            elif size * 3 > capacity:
+                medium.append(item)
+            elif size * 6 > capacity:
+                small.append(item)
+            else:
+                tiny.append(item)
+        return large, medium, small, tiny
+
+    def _fits(self, bin_length: int, *items: Tuple[int, int]) -> bool:
+        return bin_length + sum(size for _, size in items) <= self.bin_capacity
+
+    def _pack_implementation(self, sequence_lengths: List[int]) -> List[List[int]]:
+        if self.bin_capacity <= 0:
+            raise ValueError("bin_capacity must be positive")
+        if any(length <= 0 for length in sequence_lengths):
+            raise ValueError("sequence lengths must be positive")
+        self._validate_sequence_lengths(sequence_lengths)
+
+        items = list(enumerate(sequence_lengths))
+        large, medium, small, tiny = self._classify_items(items)
+        large.sort(key=lambda item: item[1], reverse=True)
+        medium.sort(key=lambda item: item[1], reverse=True)
+        small.sort(key=lambda item: item[1])
+        tiny.sort(key=lambda item: item[1])
+
+        bins: List[List[Tuple[int, int]]] = [[item] for item in large]
+        bin_lengths = [item[1] for item in large]
+
+        for bin_index, bin_items in enumerate(bins):
+            for index, item in enumerate(medium):
+                if self._fits(bin_lengths[bin_index], item):
+                    bin_items.append(medium.pop(index))
+                    bin_lengths[bin_index] += item[1]
+                    break
+
+        for bin_index in range(len(bins) - 1, -1, -1):
+            bin_items = bins[bin_index]
+            has_medium = any(size * 3 > self.bin_capacity and size * 2 <= self.bin_capacity for _, size in bin_items)
+            if has_medium or len(small) < 2:
+                continue
+            first_small = small[0]
+            second_index = next(
+                (
+                    index
+                    for index in range(len(small) - 1, 0, -1)
+                    if self._fits(bin_lengths[bin_index], first_small, small[index])
+                ),
+                None,
+            )
+            if second_index is not None:
+                first_small = small.pop(0)
+                second_small = small.pop(second_index - 1)
+                bin_items.extend((first_small, second_small))
+                bin_lengths[bin_index] += first_small[1] + second_small[1]
+
+        remaining_items = sorted(medium + small + tiny, key=lambda item: item[1], reverse=True)
+        negative_remaining_sizes = [-item[1] for item in remaining_items]
+        for bin_index, bin_items in enumerate(bins):
+            while remaining_items:
+                max_item_size = self.bin_capacity - bin_lengths[bin_index]
+                chosen_index = bisect_left(negative_remaining_sizes, -max_item_size)
+                if chosen_index == len(remaining_items):
+                    break
+                item = remaining_items.pop(chosen_index)
+                negative_remaining_sizes.pop(chosen_index)
+                bin_items.append(item)
+                bin_lengths[bin_index] += item[1]
+
+        # MFFD requires true first-fit placement in bin creation order.
+        leftover_bins: List[List[Tuple[int, int]]] = []
+        leftover_bin_lengths = np.empty(len(remaining_items), dtype=np.int64)
+        for item in remaining_items:
+            size = item[1]
+            bin_count = len(leftover_bins)
+            if bin_count:
+                fitting_bins = np.flatnonzero(leftover_bin_lengths[:bin_count] <= self.bin_capacity - size)
+            else:
+                fitting_bins = np.empty(0, dtype=np.int64)
+
+            if fitting_bins.size:
+                bin_index = int(fitting_bins[0])
+                leftover_bins[bin_index].append(item)
+                leftover_bin_lengths[bin_index] += size
+            else:
+                leftover_bin_lengths[bin_count] = size
+                leftover_bins.append([item])
+        bins.extend(leftover_bins)
+
+        return [[index for index, _ in bin_items] for bin_items in bins if bin_items]
+
+
 _PACKERS = {
     PackingStrategy.FIRST_FIT_DECREASING: FirstFitDecreasing,
+    PackingStrategy.MODIFIED_FIRST_FIT_DECREASING: ModifiedFirstFitDecreasing,
     PackingStrategy.BALANCED: Balanced,
 }
 

--- a/skyrl/train/dataset/bin_packing.py
+++ b/skyrl/train/dataset/bin_packing.py
@@ -26,8 +26,6 @@ from abc import ABC, abstractmethod
 from bisect import bisect_left
 from typing import List, Optional, Tuple
 
-import numpy as np
-
 
 class PackingStrategy(enum.Enum):
     """Supported sequence packing algorithms."""
@@ -306,22 +304,17 @@ class ModifiedFirstFitDecreasing(SeqPacker):
 
         # MFFD requires true first-fit placement in bin creation order.
         leftover_bins: List[List[Tuple[int, int]]] = []
-        leftover_bin_lengths = np.empty(len(remaining_items), dtype=np.int64)
+        leftover_bin_lengths: List[int] = []
         for item in remaining_items:
             size = item[1]
-            bin_count = len(leftover_bins)
-            if bin_count:
-                fitting_bins = np.flatnonzero(leftover_bin_lengths[:bin_count] <= self.bin_capacity - size)
+            for bin_index, bin_length in enumerate(leftover_bin_lengths):
+                if bin_length + size <= self.bin_capacity:
+                    leftover_bins[bin_index].append(item)
+                    leftover_bin_lengths[bin_index] += size
+                    break
             else:
-                fitting_bins = np.empty(0, dtype=np.int64)
-
-            if fitting_bins.size:
-                bin_index = int(fitting_bins[0])
-                leftover_bins[bin_index].append(item)
-                leftover_bin_lengths[bin_index] += size
-            else:
-                leftover_bin_lengths[bin_count] = size
                 leftover_bins.append([item])
+                leftover_bin_lengths.append(size)
         bins.extend(leftover_bins)
 
         return [[index for index, _ in bin_items] for bin_items in bins if bin_items]

--- a/skyrl/train/dataset/collators.py
+++ b/skyrl/train/dataset/collators.py
@@ -4,7 +4,7 @@ Two callables cover the two SFT data paths:
 
 - :class:`DefaultCollator` left-pads sequences to the batch maximum and applies
   the per-non-pad-token loss normalization.
-- :class:`PackedDataCollator` performs controller-level FFD bin-packing
+- :class:`PackedDataCollator` performs controller-level MFFD bin-packing
   (Megatron-only): once per training step it packs sequences into bins of
   capacity ``max_tokens_per_microbatch``, rounds the bin count up to a multiple
   of ``dp_size`` (so every DP rank gets the same number of micro-batches), and
@@ -29,7 +29,7 @@ from skyrl.backends.skyrl_train.distributed.megatron.packing_utils import (
 )
 from skyrl.backends.skyrl_train.training_batch import TensorList, TrainingInputBatch
 
-from .bin_packing import make_seq_packer
+from .bin_packing import PackingStrategy, make_seq_packer
 
 
 class DefaultCollator:
@@ -66,13 +66,13 @@ class DefaultCollator:
 
 
 class PackedDataCollator:
-    """Pack examples into bin rows via FFD and return a :class:`TrainingInputBatch`.
+    """Pack examples into bin rows via MFFD and return a :class:`TrainingInputBatch`.
 
     Activates on the training-step batch (``batch_size == self.batch_size``).
     Flow:
 
     1. Compute per-example sequence lengths.
-    2. FFD-pack using each sequence's alignment-padded footprint and
+    2. MFFD-pack using each sequence's alignment-padded footprint and
        ``bin_capacity = max(max_tokens_per_microbatch, align_size)``,
        ``min_bin_count = dp_size``, ``bin_count_multiple = dp_size``.
     3. Round-robin assign bins to DP shards (this happens implicitly inside
@@ -181,7 +181,7 @@ class PackedDataCollator:
             full_input_ids.append(np.asarray(ex["input_ids"], dtype=np.int64))
 
         # ------------------------------------------------------------------
-        # 2. FFD pack with DP-symmetry constraints
+        # 2. MFFD pack with DP-symmetry constraints
         # ------------------------------------------------------------------
         # Each bin row is one worker micro-batch. Megatron's
         # ``forward_backward_func`` runs one micro-batch per bin on each DP
@@ -203,7 +203,7 @@ class PackedDataCollator:
             packing_capacity = bin_capacity
         bin_count_multiple = dp_size
         packer = make_seq_packer(
-            "first_fit_decreasing",
+            PackingStrategy.MODIFIED_FIRST_FIT_DECREASING,
             bin_capacity=packing_capacity,
             min_bin_count=bin_count_multiple,
             bin_count_multiple=bin_count_multiple,
@@ -252,7 +252,7 @@ class PackedDataCollator:
         # because the redistribution moves one sub-seq into every empty
         # bin. If we ever see one, we widen this assertion.
         for bin_indices in flat_bins:
-            assert bin_indices, "FFD produced an empty bin; _adjust_bin_count should prevent this"
+            assert bin_indices, "MFFD produced an empty bin; _adjust_bin_count should prevent this"
 
         # ------------------------------------------------------------------
         # 4. Build per-row tensors: sequences, attention_mask, loss_mask
@@ -312,7 +312,7 @@ class PackedDataCollator:
         # ------------------------------------------------------------------
         # 6. Pack into TrainingInputBatch with sub_seq_lengths data field
         # ------------------------------------------------------------------
-        # ``sub_seq_lengths`` is genuinely per-sample data: after FFD the
+        # ``sub_seq_lengths`` is genuinely per-sample data: after MFFD the
         # batch's "sample" *is* a bin, so ``len(bin_subseq_lengths) == num_bins
         # == batch_size``, co-indexed with ``sequences[r]``. We store it as a
         # ``TensorList`` (one 1-D int tensor per bin, ragged across bins — same

--- a/skyrl/train/main_sft.py
+++ b/skyrl/train/main_sft.py
@@ -36,7 +36,7 @@ def sft_entrypoint(cfg: SFTConfig, skyrl_cfg: SkyRLTrainConfig):
     need to rebuild the bridge config.
 
     ``SFTTrainer`` selects its batch collator from ``use_sequence_packing``
-    (controller-level FFD bin-packing, Megatron-only, when enabled).
+    (controller-level MFFD bin-packing, Megatron-only, when enabled).
     """
     trainer = SFTTrainer(cfg, skyrl_cfg=skyrl_cfg)
     try:

--- a/skyrl/train/sft_trainer.py
+++ b/skyrl/train/sft_trainer.py
@@ -771,7 +771,7 @@ def collate_sft_examples(
     rows so they contribute no gradient. This lets every example in an epoch be
     trained on (instead of dropping the tail) while still dispatching a full,
     evenly-shardable ``batch_size`` batch. Packed batches are never row-padded
-    (their rows are FFD bins, already rounded to a multiple of ``dp_size``).
+    (their rows are MFFD bins, already rounded to a multiple of ``dp_size``).
     """
     batch = collator(examples, batch_size=batch_size)
     if pad_to_batch_size:
@@ -852,7 +852,7 @@ class SFTTrainer:
     def _build_collator(self, tokenizer):
         """Select the batch collator from the configured packing mode.
 
-        ``PackedDataCollator`` performs controller-level FFD bin-packing
+        ``PackedDataCollator`` performs controller-level MFFD bin-packing
         (Megatron-only, ``use_sequence_packing=True``); ``DefaultCollator``
         left-pads each example. The choice is fixed by static config; the
         ``tokenizer`` is passed in by :meth:`setup` once it is available. The
@@ -1417,7 +1417,7 @@ class SFTTrainer:
         example in an epoch is trained on: a final short batch is padded up to
         ``batch_size`` in :func:`collate_sft_examples` (padded rows are masked
         out of the loss), instead of being dropped. (Packed batches are not
-        row-padded; the FFD packer already handles a short example list.)
+        row-padded; the MFFD packer already handles a short example list.)
 
         Resume note: ``StatefulDataLoader`` restores the *in-progress* epoch
         bit-exactly (the common case). For the built-in ``"random"`` sampler,
@@ -1433,7 +1433,7 @@ class SFTTrainer:
             collate_sft_examples,
             collator=self.collator,
             batch_size=self.sft_cfg.batch_size,
-            # Packed batches dispatch FFD-bin rows (already a multiple of
+            # Packed batches dispatch MFFD-bin rows (already a multiple of
             # dp_size), so only the un-packed path pads to batch_size.
             pad_to_batch_size=not self.sft_cfg.use_sequence_packing,
         )
@@ -1727,7 +1727,7 @@ class SFTTrainer:
             # batch_size >= dp_size (every DP rank needs >= 1 bin) and do NOT
             # require batch_size % micro_train_batch_size_per_gpu == 0, because
             # micro_train_batch_size_per_gpu refers to bins-per-MB, not
-            # examples-per-MB; FFD rounds the bin count up to a multiple of
+            # examples-per-MB; MFFD rounds the bin count up to a multiple of
             # dp_size, and bins/MB is a separate knob.
             dp_size = self._dp_size()
             if batch_size < dp_size:

--- a/tests/backends/skyrl_train/distributed/test_bin_packing.py
+++ b/tests/backends/skyrl_train/distributed/test_bin_packing.py
@@ -14,88 +14,89 @@ from skyrl.train.dataset.bin_packing import (
 )
 
 
-class TestFirstFitDecreasing:
-    def test_deterministic(self):
+@pytest.mark.parametrize("packer_cls", [FirstFitDecreasing, ModifiedFirstFitDecreasing], ids=["ffd", "mffd"])
+class TestFirstFitPackers:
+    def test_deterministic(self, packer_cls):
         # Same input must produce the same bin assignment across runs.
         lengths = [820, 410, 520, 110, 250, 700, 50]
-        p1 = FirstFitDecreasing(bin_capacity=1024)
-        p2 = FirstFitDecreasing(bin_capacity=1024)
+        p1 = packer_cls(bin_capacity=1024)
+        p2 = packer_cls(bin_capacity=1024)
         assert p1.pack(lengths) == p2.pack(lengths)
 
-    def test_no_overflow(self):
+    def test_no_overflow(self, packer_cls):
         # No bin's content may exceed the bin capacity.
         capacity = 100
         lengths = [60, 50, 40, 30, 20, 10, 80, 70, 90, 100, 5]
-        packer = FirstFitDecreasing(bin_capacity=capacity)
+        packer = packer_cls(bin_capacity=capacity)
         bins = packer.pack(lengths)
         for bin_indices in bins:
             assert sum(lengths[i] for i in bin_indices) <= capacity
 
-    def test_all_indices_present(self):
+    def test_all_indices_present(self, packer_cls):
         # Every original index must appear in exactly one bin.
         lengths = [10, 20, 30, 40, 50, 60, 70]
-        packer = FirstFitDecreasing(bin_capacity=100)
+        packer = packer_cls(bin_capacity=100)
         bins = packer.pack(lengths)
         flat = [i for b in bins for i in b]
         assert sorted(flat) == list(range(len(lengths)))
 
-    def test_single_seq_per_bin_when_too_big(self):
-        # If every sequence is half of capacity, FFD pairs them.
+    def test_single_seq_per_bin_when_too_big(self, packer_cls):
+        # If every sequence is half of capacity, the packer pairs them.
         # If every sequence is more than half, each must get its own bin.
         capacity = 100
         lengths = [60, 70, 80]
-        packer = FirstFitDecreasing(bin_capacity=capacity)
+        packer = packer_cls(bin_capacity=capacity)
         bins = packer.pack(lengths)
         assert len(bins) == 3
 
-    def test_overflow_raises(self):
+    def test_overflow_raises(self, packer_cls):
         with pytest.raises(ValueError, match="exceeds bin capacity"):
-            FirstFitDecreasing(bin_capacity=100).pack([150])
+            packer_cls(bin_capacity=100).pack([150])
 
-    def test_min_bin_count(self):
+    def test_min_bin_count(self, packer_cls):
         # min_bin_count forces extra empty (then redistributed) bins.
         capacity = 100
         lengths = [10, 10, 10]  # natural: 1 bin
-        packer = FirstFitDecreasing(bin_capacity=capacity, min_bin_count=3)
+        packer = packer_cls(bin_capacity=capacity, min_bin_count=3)
         bins = packer.pack(lengths)
         assert len(bins) == 3
         flat = [i for b in bins for i in b]
         assert sorted(flat) == [0, 1, 2]
 
-    def test_bin_count_multiple(self):
+    def test_bin_count_multiple(self, packer_cls):
         # bin_count_multiple rounds up to the next multiple. Need enough
         # sequences for empty-bin redistribution to succeed.
         capacity = 100
-        lengths = [40, 30, 20, 10, 5]  # FFD packs into 1 bin (total 105 > 100, so 2)
-        packer = FirstFitDecreasing(bin_capacity=capacity, bin_count_multiple=4)
+        lengths = [40, 30, 20, 10, 5]  # Natural packing uses 2 bins.
+        packer = packer_cls(bin_capacity=capacity, bin_count_multiple=4)
         bins = packer.pack(lengths)
         # 2 bins -> rounds up to 4
         assert len(bins) == 4
         flat = [i for b in bins for i in b]
         assert sorted(flat) == [0, 1, 2, 3, 4]
 
-    def test_combined_min_and_multiple(self):
+    def test_combined_min_and_multiple(self, packer_cls):
         # When both knobs apply, take the larger one and round up to the multiple.
         capacity = 100
         lengths = [10, 20, 30, 40]
-        packer = FirstFitDecreasing(bin_capacity=capacity, min_bin_count=3, bin_count_multiple=4)
+        packer = packer_cls(bin_capacity=capacity, min_bin_count=3, bin_count_multiple=4)
         bins = packer.pack(lengths)
-        # natural FFD on 4 seqs of total 100 -> 1 bin; min=3 -> 3; multiple=4 -> 4.
+        # natural packing on 4 seqs of total 100 -> 1 bin; min=3 -> 3; multiple=4 -> 4.
         assert len(bins) == 4
 
-    def test_redistribute_preserves_capacity(self):
+    def test_redistribute_preserves_capacity(self, packer_cls):
         # Empty-bin redistribution must not push any bin over capacity.
         capacity = 100
-        lengths = [40, 30, 20, 10]  # FFD: 1 bin (total 100)
-        packer = FirstFitDecreasing(bin_capacity=capacity, min_bin_count=2)
+        lengths = [40, 30, 20, 10]  # Natural packing: 1 bin (total 100)
+        packer = packer_cls(bin_capacity=capacity, min_bin_count=2)
         bins = packer.pack(lengths)
         for b in bins:
             assert sum(lengths[i] for i in b) <= capacity
 
-    def test_redistribute_fails_when_too_few_seqs(self):
+    def test_redistribute_fails_when_too_few_seqs(self, packer_cls):
         # Cannot create more bins than sequences.
         with pytest.raises(ValueError, match="Cannot create"):
-            FirstFitDecreasing(bin_capacity=100, min_bin_count=5).pack([10, 20])
+            packer_cls(bin_capacity=100, min_bin_count=5).pack([10, 20])
 
 
 class TestModifiedFirstFitDecreasing:

--- a/tests/backends/skyrl_train/distributed/test_bin_packing.py
+++ b/tests/backends/skyrl_train/distributed/test_bin_packing.py
@@ -109,17 +109,6 @@ class TestModifiedFirstFitDecreasing:
             [4, 5, 6, 7, 8],
         ]
 
-    def test_deterministic_and_preserves_all_indices(self):
-        lengths = [55, 48, 34, 31, 29, 22, 16, 9, 7, 4]
-        packer = ModifiedFirstFitDecreasing(bin_capacity=100)
-
-        first = packer.pack(lengths)
-        second = packer.pack(lengths)
-
-        assert first == second
-        assert sorted(index for bin_indices in first for index in bin_indices) == list(range(len(lengths)))
-        assert all(sum(lengths[index] for index in bin_indices) <= 100 for bin_indices in first)
-
     def test_leftovers_use_first_fit_not_least_loaded(self):
         packer = ModifiedFirstFitDecreasing(bin_capacity=100)
 

--- a/tests/backends/skyrl_train/distributed/test_bin_packing.py
+++ b/tests/backends/skyrl_train/distributed/test_bin_packing.py
@@ -1,4 +1,4 @@
-"""Unit tests for the FFD bin-packing module.
+"""Unit tests for the bin-packing module.
 
 Run with:
   uv run --extra dev -- pytest tests/backends/skyrl_train/distributed/test_bin_packing.py
@@ -8,6 +8,7 @@ import pytest
 
 from skyrl.train.dataset.bin_packing import (
     FirstFitDecreasing,
+    ModifiedFirstFitDecreasing,
     PackingStrategy,
     make_seq_packer,
 )
@@ -97,6 +98,39 @@ class TestFirstFitDecreasing:
             FirstFitDecreasing(bin_capacity=100, min_bin_count=5).pack([10, 20])
 
 
+class TestModifiedFirstFitDecreasing:
+    def test_matches_mffd_phases(self):
+        packer = ModifiedFirstFitDecreasing(bin_capacity=100)
+
+        assert packer.pack([60, 55, 45, 40, 30, 25, 20, 10, 5]) == [
+            [0, 3],
+            [1, 2],
+            [4, 5, 6, 7, 8],
+        ]
+
+    def test_deterministic_and_preserves_all_indices(self):
+        lengths = [55, 48, 34, 31, 29, 22, 16, 9, 7, 4]
+        packer = ModifiedFirstFitDecreasing(bin_capacity=100)
+
+        first = packer.pack(lengths)
+        second = packer.pack(lengths)
+
+        assert first == second
+        assert sorted(index for bin_indices in first for index in bin_indices) == list(range(len(lengths)))
+        assert all(sum(lengths[index] for index in bin_indices) <= 100 for bin_indices in first)
+
+    def test_leftovers_use_first_fit_not_least_loaded(self):
+        packer = ModifiedFirstFitDecreasing(bin_capacity=100)
+
+        bins = packer.pack([14, 91, 25, 37, 33, 22, 34, 99, 30])
+
+        assert bins == [[7], [1], [3, 6, 2], [4, 8, 5, 0]]
+
+    def test_rejects_nonpositive_lengths(self):
+        with pytest.raises(ValueError, match="sequence lengths must be positive"):
+            ModifiedFirstFitDecreasing(bin_capacity=100).pack([0])
+
+
 class TestMakeSeqPackerFactory:
     def test_enum_value(self):
         packer = make_seq_packer(PackingStrategy.FIRST_FIT_DECREASING, bin_capacity=100)
@@ -109,6 +143,11 @@ class TestMakeSeqPackerFactory:
     def test_string_case_insensitive(self):
         packer = make_seq_packer("FIRST_FIT_DECREASING", bin_capacity=100)
         assert isinstance(packer, FirstFitDecreasing)
+
+    def test_modified_first_fit_decreasing(self):
+        packer = make_seq_packer(PackingStrategy.MODIFIED_FIRST_FIT_DECREASING, bin_capacity=100)
+
+        assert isinstance(packer, ModifiedFirstFitDecreasing)
 
     def test_unknown_algorithm(self):
         with pytest.raises(ValueError, match="Unknown packing algorithm"):

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_sft_packing_parity.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_sft_packing_parity.py
@@ -483,7 +483,7 @@ def test_sft_packing_cp_logprob_parity(ray_init_fixture):
             trainer = SFTTrainer(sft_cfg, skyrl_cfg=skyrl_cfg)
             trainer.collator = trainer._build_collator(tokenizer)
             collated = trainer.collate_batch(examples, batch_size=GLOBAL_BATCH_SIZE)
-            # Recompute flat_bins + align_size deterministically (same FFD call).
+            # Recompute flat_bins + align_size deterministically (same MFFD call).
             flat_bins = _recompute_flat_bins(trainer, examples)
             tp = 1
             transformer_config_kwargs = sft_cfg.megatron_config.transformer_config_kwargs or {}
@@ -581,9 +581,10 @@ def test_sft_packing_cp_logprob_parity(ray_init_fixture):
 
 
 def _recompute_flat_bins(trainer: SFTTrainer, examples: List[dict]) -> List[List[int]]:
-    """Reproduce the collator's flat_bins permutation (shard-major FFD order)
+    """Reproduce the collator's flat_bins permutation (shard-major MFFD order)
     so we can invert the example reordering for the comparison."""
     from skyrl.train.dataset.bin_packing import (
+        PackingStrategy,
         make_seq_packer,
     )
 
@@ -591,7 +592,7 @@ def _recompute_flat_bins(trainer: SFTTrainer, examples: List[dict]) -> List[List
     dp_size = trainer._dp_size()
     bin_count_multiple = dp_size
     packer = make_seq_packer(
-        "first_fit_decreasing",
+        PackingStrategy.MODIFIED_FIRST_FIT_DECREASING,
         bin_capacity=trainer.sft_cfg.resolved_bin_capacity(),
         min_bin_count=bin_count_multiple,
         bin_count_multiple=bin_count_multiple,

--- a/tests/train/test_collation_vectorization_equivalence.py
+++ b/tests/train/test_collation_vectorization_equivalence.py
@@ -5,7 +5,7 @@ layouts for:
 
 * RL: :func:`convert_prompts_responses_to_batch_tensors`
 * SFT (unpacked): :func:`collate_sft_batch` / ``DefaultCollator``
-* SFT (Megatron FFD packing): ``PackedDataCollator``
+* SFT (Megatron MFFD packing): ``PackedDataCollator``
 
 Run with:
   uv run --isolated --extra dev --extra megatron -- \
@@ -257,7 +257,7 @@ def test_sft_collate_bit_identical(seed):
 
 
 # ---------------------------------------------------------------------------
-# SFT packed: PackedDataCollator (Megatron FFD)
+# SFT packed: PackedDataCollator (Megatron MFFD)
 # ---------------------------------------------------------------------------
 
 
@@ -344,11 +344,16 @@ def test_packed_collator_bit_identical(seed, tp, pp, cp, dp):
 
     batch = collator(examples, batch_size=batch_size)
 
-    # Re-derive FFD rows independently before running the loop reference.
-    from skyrl.train.dataset.bin_packing import make_seq_packer
+    # Re-derive MFFD rows independently before running the loop reference.
+    from skyrl.train.dataset.bin_packing import PackingStrategy, make_seq_packer
 
     seq_lengths = [len(ex["input_ids"]) for ex in examples]
-    packer = make_seq_packer("first_fit_decreasing", bin_capacity=bin_capacity, min_bin_count=dp, bin_count_multiple=dp)
+    packer = make_seq_packer(
+        PackingStrategy.MODIFIED_FIRST_FIT_DECREASING,
+        bin_capacity=bin_capacity,
+        min_bin_count=dp,
+        bin_count_multiple=dp,
+    )
     bins = packer.pack(seq_lengths)
     shard_bins: List[List[List[int]]] = [[] for _ in range(dp)]
     for bin_idx, bi in enumerate(bins):

--- a/tests/train/test_sft_config.py
+++ b/tests/train/test_sft_config.py
@@ -293,7 +293,7 @@ class TestFSDPConfigOverrides:
 
 
 class TestMaxTokensPerMicrobatch:
-    """``max_tokens_per_microbatch`` is the FFD bin capacity.
+    """``max_tokens_per_microbatch`` is the MFFD bin capacity.
 
     It must be ``>= max_length`` (any single sequence fits in a bin) but need
     not be a multiple of ``max_length``.

--- a/tests/train/test_sft_packing_collate.py
+++ b/tests/train/test_sft_packing_collate.py
@@ -71,6 +71,24 @@ def _make_example(seq_len: int, num_actions: int, base_token: int = 100) -> dict
 
 
 class TestPackingCollator:
+    def test_uses_modified_first_fit_decreasing(self):
+        lengths = [14, 91, 25, 37, 33, 22, 34, 99, 30]
+        collator = _make_collator(
+            num_gpus=1,
+            batch_size=len(lengths),
+            max_length=100,
+            max_tokens_per_microbatch=100,
+        )
+
+        batch = collator([_make_example(length, length) for length in lengths], batch_size=len(lengths))
+
+        assert [row.tolist() for row in batch["sub_seq_lengths"]] == [
+            [99],
+            [91],
+            [37, 34, 25],
+            [33, 30, 22, 14],
+        ]
+
     def test_bin_count_is_multiple_of_dp(self):
         collator = _make_collator(num_gpus=4, batch_size=8)
         examples = [_make_example(10, 5, base_token=100 + 100 * i) for i in range(8)]
@@ -83,7 +101,7 @@ class TestPackingCollator:
         assert len(batch["sub_seq_lengths"]) == 4
 
     def test_bin_capacity_is_token_budget(self):
-        # max_tokens_per_microbatch is the FFD bin capacity. With dp_size=1 and
+        # max_tokens_per_microbatch is the MFFD bin capacity. With dp_size=1 and
         # four length-100 seqs: a 128-token budget fits one seq per bin (4
         # bins); a 256-token budget fits two seqs per bin (2 bins).
         examples = [_make_example(100, 50, base_token=100 + 100 * i) for i in range(4)]
@@ -184,7 +202,7 @@ class TestPackingCollator:
     def test_pp_padding_makes_rows_uniform(self):
         """With pp_size > 1, all packed rows are padded to the global max."""
         collator = _make_collator(num_gpus=2, batch_size=4, max_length=64, pp=2)
-        # Two different-sized bins after FFD.
+        # Two different-sized bins after MFFD.
         examples = [
             _make_example(30, 15),
             _make_example(28, 14),


### PR DESCRIPTION
## Summary

- add Modified First-Fit Decreasing (MFFD) as a native sequence-packing strategy
- use MFFD for controller-level SFT packing while retaining FFD as an available generic strategy
- use true first-fit placement in MFFD's final phase with a direct, early-exit Python scan
- update SFT documentation and packing references

## Rationale

MFFD refines FFD with size classes and several placement phases, and it is the recommended default strategy in NemoRL. It has a stronger worst-case bound and showed a modest packing improvement on the less-uniform Nemotron math slice without regressing bin count in the sampled batches.

Benchmarks used Nemotron-3.5-Lightning SFT data with global batch size 2048 and 32K maximum sequence length. Across 800 alignment/scenario comparisons per slice:

- chat: MFFD and FFD tied on packing score in all 800 comparisons, though assignments differed
- math proofs: MFFD won 115 comparisons, FFD won 77, and 608 tied; MFFD used fewer bins in 5 batches and never used more

Averaged over all 1,600 comparisons, the five one-bin reductions amount to **0.003125 fewer 32K bins per GBS-2048 batch**: 102.4 token positions of bin capacity per batch, or 0.05 per input example. On the math slice alone, the averages are 0.00625 bins, 204.8 capacity positions per batch, and 0.1 per example. These are capacity-equivalent figures, not changes to the number of input tokens.

The implementation follows the original MFFD paper and is informed by NeMo RL:

- https://www.sciencedirect.com/science/article/pii/0885064X85900226
- https://github.com/NVIDIA-NeMo/RL/blob/main/nemo_rl/data/packing/algorithms.py

## Testing

- `pytest -q tests/backends/skyrl_train/distributed/test_bin_packing.py` (29 passed)
- shared FFD correctness cases are parameterized to run against MFFD as well
- Ruff lint
- Black formatting check



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Packing assignments change for every `use_sequence_packing=true` Megatron SFT run, which can shift micro-batch shapes and training dynamics even when bin counts are similar; logic is well-tested but not user-selectable.
> 
> **Overview**
> Megatron SFT **controller-level sequence packing** now bin-packs with **Modified First-Fit Decreasing (MFFD)** instead of plain FFD. `PackedDataCollator` calls `PackingStrategy.MODIFIED_FIRST_FIT_DECREASING`; FFD stays registered on `PackingStrategy` for other callers.
> 
> The new `ModifiedFirstFitDecreasing` packer adds size-class placement (large/medium/small/tiny), phased filling, and a final **first-fit** pass for leftovers (aligned with Johnson–Garey / NeMo RL). DP symmetry (`min_bin_count` / `bin_count_multiple`) is unchanged via the shared `SeqPacker` base.
> 
> Docs, config docstrings, and comments now say MFFD where they described FFD packing. Tests cover MFFD-specific assignments, parametrize shared packer invariants for FFD and MFFD, and assert the collator’s MFFD bin layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 613a5477eae687079208d2fb31a454134abda3e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->