### PR TITLE
[ci] Keep skipped label-gated runs from masking live GPU CI

### DIFF
--- a/.github/workflows/gpu_ci_h100.yaml
+++ b/.github/workflows/gpu_ci_h100.yaml
@@ -25,6 +25,15 @@ permissions:
 jobs:
 
   skyrl_train_tests_h100:
+    # A `labeled` event starts a run of every label-gated workflow, so runs fired by
+    # another label skip this job. GitHub keeps only the newest check of a given name,
+    # so a skip published under the real name masks a run that is still going. The
+    # running branch has to stay equal to the job id -- that is the existing check
+    # context, and renaming it would break branch protection pointing at it.
+    name: >-
+      ${{ (github.event_name != 'pull_request_target'
+           || github.event.label.name == 'run_h100_gpu_ci')
+           && 'skyrl_train_tests_h100' || 'skipped (unrelated label)' }}
     # Gate on the label that fired this event. `types: [labeled]` delivers one event
     # per label added, and `contains(...labels.*.name, ...)` tests the whole label
     # set, so labelling in bulk launched one identical GPU run per label.

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -25,6 +25,15 @@ permissions:
 jobs:
   
   skyrl_train_tests:
+    # A `labeled` event starts a run of every label-gated workflow, so runs fired by
+    # another label skip this job. GitHub keeps only the newest check of a given name,
+    # so a skip published under the real name masks a run that is still going. The
+    # running branch has to stay equal to the job id -- that is the existing check
+    # context, and renaming it would break branch protection pointing at it.
+    name: >-
+      ${{ (github.event_name != 'pull_request_target'
+           || github.event.label.name == 'run_train_gpu_ci')
+           && 'skyrl_train_tests' || 'skipped (unrelated label)' }}
     # Gate on the label that fired this event. `types: [labeled]` delivers one event
     # per label added, and `contains(...labels.*.name, ...)` tests the whole label
     # set, so labelling in bulk launched one identical GPU run per label.

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -27,6 +27,15 @@ permissions:
 jobs:
   
   skyrl_train_tests_megatron:
+    # A `labeled` event starts a run of every label-gated workflow, so runs fired by
+    # another label skip this job. GitHub keeps only the newest check of a given name,
+    # so a skip published under the real name masks a run that is still going. The
+    # running branch has to stay equal to the job id -- that is the existing check
+    # context, and renaming it would break branch protection pointing at it.
+    name: >-
+      ${{ (github.event_name != 'pull_request_target'
+           || github.event.label.name == 'run_train_megatron_gpu_ci')
+           && 'skyrl_train_tests_megatron' || 'skipped (unrelated label)' }}
     # Gate on the label that fired this event. `types: [labeled]` delivers one event
     # per label added, and `contains(...labels.*.name, ...)` tests the whole label
     # set, so labelling in bulk launched one identical GPU run per label.

--- a/.github/workflows/gpu_skyrl_train_megatron_models.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron_models.yaml
@@ -27,6 +27,15 @@ permissions:
 jobs:
   
   skyrl_train_tests_megatron_models:
+    # A `labeled` event starts a run of every label-gated workflow, so runs fired by
+    # another label skip this job. GitHub keeps only the newest check of a given name,
+    # so a skip published under the real name masks a run that is still going. The
+    # running branch has to stay equal to the job id -- that is the existing check
+    # context, and renaming it would break branch protection pointing at it.
+    name: >-
+      ${{ (github.event_name != 'pull_request_target'
+           || github.event.label.name == 'run_train_megatron_gpu_ci_models')
+           && 'skyrl_train_tests_megatron_models' || 'skipped (unrelated label)' }}
     # Gate on the label that fired this event. `types: [labeled]` delivers one event
     # per label added, and `contains(...labels.*.name, ...)` tests the whole label
     # set, so labelling in bulk launched one identical GPU run per label.

--- a/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
+++ b/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
@@ -28,6 +28,15 @@ permissions:
 jobs:
 
   tinker_skyrl_train_backend_gpu_tests:
+    # A `labeled` event starts a run of every label-gated workflow, so runs fired by
+    # another label skip this job. GitHub keeps only the newest check of a given name,
+    # so a skip published under the real name masks a run that is still going. The
+    # running branch has to stay equal to the job id -- that is the existing check
+    # context, and renaming it would break branch protection pointing at it.
+    name: >-
+      ${{ (github.event_name != 'pull_request_target'
+           || github.event.label.name == 'run_tinker_skyrl_train_backend_gpu_ci')
+           && 'tinker_skyrl_train_backend_gpu_tests' || 'skipped (unrelated label)' }}
     # Gate on the label that fired this event. `types: [labeled]` delivers one event
     # per label added, and `contains(...labels.*.name, ...)` tests the whole label
     # set, so labelling in bulk launched one identical GPU run per label.


### PR DESCRIPTION
A `labeled` event starts a run of every workflow triggered on `labeled`, whatever the label was -- applying three labels to #1898 produced 15 runs, of which 3 did work. The other 12 skip, which is correct, but they published their skip under the same check name as the real run. GitHub keeps only the newest check of a given name, so whether a live suite showed as running came down to whether its own run happened to be created last. Two of the three running suites reported "skipped" on the PR.

Name the job by whether it is going to run, so a skip lands on its own check context and can only ever supersede another skip. The running branch is the job id -- the existing context name -- so any branch protection pointing at it is unaffected.