### PR TITLE
[ci skip] Revert "[ci] Keep skipped label-gated runs from masking live GPU CI"

### DIFF
--- a/.github/workflows/gpu_ci_h100.yaml
+++ b/.github/workflows/gpu_ci_h100.yaml
@@ -25,15 +25,6 @@ permissions:
 jobs:
 
   skyrl_train_tests_h100:
-    # A `labeled` event starts a run of every label-gated workflow, so runs fired by
-    # another label skip this job. GitHub keeps only the newest check of a given name,
-    # so a skip published under the real name masks a run that is still going. The
-    # running branch has to stay equal to the job id -- that is the existing check
-    # context, and renaming it would break branch protection pointing at it.
-    name: >-
-      ${{ (github.event_name != 'pull_request_target'
-           || github.event.label.name == 'run_h100_gpu_ci')
-           && 'skyrl_train_tests_h100' || 'skipped (unrelated label)' }}
     # Gate on the label that fired this event. `types: [labeled]` delivers one event
     # per label added, and `contains(...labels.*.name, ...)` tests the whole label
     # set, so labelling in bulk launched one identical GPU run per label.

--- a/.github/workflows/gpu_skyrl_train.yaml
+++ b/.github/workflows/gpu_skyrl_train.yaml
@@ -25,15 +25,6 @@ permissions:
 jobs:
   
   skyrl_train_tests:
-    # A `labeled` event starts a run of every label-gated workflow, so runs fired by
-    # another label skip this job. GitHub keeps only the newest check of a given name,
-    # so a skip published under the real name masks a run that is still going. The
-    # running branch has to stay equal to the job id -- that is the existing check
-    # context, and renaming it would break branch protection pointing at it.
-    name: >-
-      ${{ (github.event_name != 'pull_request_target'
-           || github.event.label.name == 'run_train_gpu_ci')
-           && 'skyrl_train_tests' || 'skipped (unrelated label)' }}
     # Gate on the label that fired this event. `types: [labeled]` delivers one event
     # per label added, and `contains(...labels.*.name, ...)` tests the whole label
     # set, so labelling in bulk launched one identical GPU run per label.

--- a/.github/workflows/gpu_skyrl_train_megatron.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron.yaml
@@ -27,15 +27,6 @@ permissions:
 jobs:
   
   skyrl_train_tests_megatron:
-    # A `labeled` event starts a run of every label-gated workflow, so runs fired by
-    # another label skip this job. GitHub keeps only the newest check of a given name,
-    # so a skip published under the real name masks a run that is still going. The
-    # running branch has to stay equal to the job id -- that is the existing check
-    # context, and renaming it would break branch protection pointing at it.
-    name: >-
-      ${{ (github.event_name != 'pull_request_target'
-           || github.event.label.name == 'run_train_megatron_gpu_ci')
-           && 'skyrl_train_tests_megatron' || 'skipped (unrelated label)' }}
     # Gate on the label that fired this event. `types: [labeled]` delivers one event
     # per label added, and `contains(...labels.*.name, ...)` tests the whole label
     # set, so labelling in bulk launched one identical GPU run per label.

--- a/.github/workflows/gpu_skyrl_train_megatron_models.yaml
+++ b/.github/workflows/gpu_skyrl_train_megatron_models.yaml
@@ -27,15 +27,6 @@ permissions:
 jobs:
   
   skyrl_train_tests_megatron_models:
-    # A `labeled` event starts a run of every label-gated workflow, so runs fired by
-    # another label skip this job. GitHub keeps only the newest check of a given name,
-    # so a skip published under the real name masks a run that is still going. The
-    # running branch has to stay equal to the job id -- that is the existing check
-    # context, and renaming it would break branch protection pointing at it.
-    name: >-
-      ${{ (github.event_name != 'pull_request_target'
-           || github.event.label.name == 'run_train_megatron_gpu_ci_models')
-           && 'skyrl_train_tests_megatron_models' || 'skipped (unrelated label)' }}
     # Gate on the label that fired this event. `types: [labeled]` delivers one event
     # per label added, and `contains(...labels.*.name, ...)` tests the whole label
     # set, so labelling in bulk launched one identical GPU run per label.

--- a/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
+++ b/.github/workflows/tinker_skyrl_train_backend_gpu.yaml
@@ -28,15 +28,6 @@ permissions:
 jobs:
 
   tinker_skyrl_train_backend_gpu_tests:
-    # A `labeled` event starts a run of every label-gated workflow, so runs fired by
-    # another label skip this job. GitHub keeps only the newest check of a given name,
-    # so a skip published under the real name masks a run that is still going. The
-    # running branch has to stay equal to the job id -- that is the existing check
-    # context, and renaming it would break branch protection pointing at it.
-    name: >-
-      ${{ (github.event_name != 'pull_request_target'
-           || github.event.label.name == 'run_tinker_skyrl_train_backend_gpu_ci')
-           && 'tinker_skyrl_train_backend_gpu_tests' || 'skipped (unrelated label)' }}
     # Gate on the label that fired this event. `types: [labeled]` delivers one event
     # per label added, and `contains(...labels.*.name, ...)` tests the whole label
     # set, so labelling in bulk launched one identical GPU run per label.


### PR DESCRIPTION
Reverts NovaSky-AI/SkyRL#2110