### PR TITLE
fix(megatron): release host model replica after backload

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -35,6 +35,7 @@ from skyrl.backends.skyrl_train.distributed.megatron.megatron_utils import (
     offload_megatron_grads_to_cpu,
     offload_megatron_model_to_cpu,
     offload_megatron_optimizer,
+    release_megatron_model_cpu_copy,
 )
 from skyrl.backends.skyrl_train.distributed.strategy import DistributedStrategy
 from skyrl.backends.skyrl_train.distributed.utils import ModelOrModelOptimPair
@@ -244,6 +245,8 @@ class MegatronStrategy(DistributedStrategy):
             if optimizer is not None:
                 load_megatron_optimizer(optimizer)
         torch.cuda.synchronize()
+        if backload_model:
+            release_megatron_model_cpu_copy(model)
 
     def backward(self, loss: torch.Tensor, model, optimizer: optim.Optimizer, **kwargs) -> None:
         raise NotImplementedError()

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -301,6 +301,22 @@ def load_megatron_model_to_gpu(models):
 
 
 @torch.no_grad()
+def release_megatron_model_cpu_copy(models):
+    """Release host copies after model parameters are restored to GPU."""
+    for model_chunk in models:
+        if not isinstance(model_chunk, DDP):
+            continue
+
+        for buffer in model_chunk.buffers + model_chunk.expert_parallel_buffers:
+            buffer.param_data_cpu = None
+
+        for _, param in model_chunk.named_parameters():
+            if hasattr(param, "_offload_cpu_data"):
+                del param._offload_cpu_data
+                del param._offload_cuda_numel
+
+
+@torch.no_grad()
 def offload_megatron_copy_params(optimizers):
     """
     Offload optimizer parameters to CPU. Supports both Megatron optimizers

--- a/tests/backends/skyrl_train/distributed/test_megatron_correctness.py
+++ b/tests/backends/skyrl_train/distributed/test_megatron_correctness.py
@@ -36,6 +36,32 @@ def _fft_dispatch_cfg(weight_sync_backend: str = "nccl") -> SimpleNamespace:
 _has_megatron = "megatron" in sys.modules or __import__("importlib").util.find_spec("megatron") is not None
 
 
+@pytest.mark.skipif(not _has_megatron, reason="megatron-core not installed")
+def test_release_megatron_model_cpu_copy():
+    from skyrl.backends.skyrl_train.distributed.megatron import megatron_utils
+
+    class FakeDDP:
+        def __init__(self):
+            self.buffers = [SimpleNamespace(param_data_cpu=object())]
+            self.expert_parallel_buffers = [SimpleNamespace(param_data_cpu=object())]
+            self.param = SimpleNamespace(
+                _offload_cpu_data=object(),
+                _offload_cuda_numel=1,
+            )
+
+        def named_parameters(self):
+            return [("weight", self.param)]
+
+    model = FakeDDP()
+    with patch.object(megatron_utils, "DDP", FakeDDP):
+        megatron_utils.release_megatron_model_cpu_copy([model])
+
+    for buffer in model.buffers + model.expert_parallel_buffers:
+        assert buffer.param_data_cpu is None
+    assert not hasattr(model.param, "_offload_cpu_data")
+    assert not hasattr(model.param, "_offload_cuda_numel")
+
+
 # ---------------------------------------------------------------------------
 # C1: grad_scale_func fix
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Release Megatron's pinned CPU parameter replica after the model is restored to GPU.
- Clear both DDP-buffer and non-buffer offload copies so a colocated role does not retain a second host model.

## Scope

This affects Megatron model offload/backload used by colocated SkyRL roles. The current disaggregated GLM 32K and 256K recipes do not exercise this path, so this is a general colocation fix rather than a dependency of those recipes. Optimizer residency is handled separately in #2115.

## Testing

```bash
uv run --isolated --extra dev --extra skyrl-train pytest -q tests/backends/skyrl_train/distributed/test_megatron_correctness.py -k release_megatron_model_cpu_copy
```

The focused lifecycle regression and same-head SkyRL Train CPU CI pass. A new colocated live receipt is still required before treating this as GLM qualification evidence; the public GPU workflow cannot start tests because fork credentials are unavailable.
