### PR TITLE
fix(megatron): release LoRA export before reload

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1425,11 +1425,13 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         )
         from safetensors.torch import save_file
 
+        rank = torch.distributed.get_rank()
+
         adapter_state = {}
         for name, tensor in self.bridge.export_adapter_weights(self.actor_module, cpu=True, show_progress=False):
-            adapter_state[f"base_model.model.{name}"] = tensor.clone().float()
+            if rank == 0:
+                adapter_state[f"base_model.model.{name}"] = tensor.clone().float()
 
-        rank = torch.distributed.get_rank()
         remote_client = False
         lora_request = None
         if rank == 0:
@@ -1535,8 +1537,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         # wanted by an inference engine, so empty regardless.
         if self._weight_transfer_sender.empty_cache_after_send or self.cfg.placement.colocate_all:
             torch.cuda.empty_cache()
-        if not (self._is_lora and not self.cfg.policy.megatron_config.lora_config.merge_lora):
-            torch.distributed.barrier()
+        torch.distributed.barrier()
 
     def _set_pad_token_id(self, pad_token_id):
         # this already gets set in the init_model method

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -1416,6 +1416,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         handled internally by the bridge).  Only rank 0 writes to disk and
         sends the ``LoraLoadRequest``.
         """
+        import gc
         import json
 
         from megatron.bridge.models.conversion.peft_bridge import (
@@ -1428,7 +1429,10 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         for name, tensor in self.bridge.export_adapter_weights(self.actor_module, cpu=True, show_progress=False):
             adapter_state[f"base_model.model.{name}"] = tensor.clone().float()
 
-        if torch.distributed.get_rank() == 0:
+        rank = torch.distributed.get_rank()
+        remote_client = False
+        lora_request = None
+        if rank == 0:
             os.makedirs(lora_sync_path, exist_ok=True)
 
             # Rewrite fused-MoE expert LoRA into vLLM's flat PEFT layout so
@@ -1460,13 +1464,22 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
                 RemoteInferenceClient,
             )
 
-            if isinstance(inference_engine_client, RemoteInferenceClient):
+            remote_client = isinstance(inference_engine_client, RemoteInferenceClient)
+            lora_request = LoraLoadRequest(lora_path=lora_sync_path, lora_name=lora_name)
+
+        adapter_state.clear()
+        # Inference loading materializes another host copy; release the exported tensors first.
+        del adapter_state
+        gc.collect()
+        torch._C._host_emptyCache()
+        torch.distributed.barrier()
+
+        if rank == 0:
+            if remote_client:
                 await inference_engine_client.load_lora_adapter(lora_name, lora_sync_path)
             else:
-                lora_request = LoraLoadRequest(lora_path=lora_sync_path, lora_name=lora_name)
+                assert lora_request is not None
                 await inference_engine_client.update_named_weights(lora_request)
-
-        torch.distributed.barrier()
 
     async def broadcast_to_inference_engines(
         self,
@@ -1522,7 +1535,8 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         # wanted by an inference engine, so empty regardless.
         if self._weight_transfer_sender.empty_cache_after_send or self.cfg.placement.colocate_all:
             torch.cuda.empty_cache()
-        torch.distributed.barrier()
+        if not (self._is_lora and not self.cfg.policy.megatron_config.lora_config.merge_lora):
+            torch.distributed.barrier()
 
     def _set_pad_token_id(self, pad_token_id):
         # this already gets set in the init_model method


### PR DESCRIPTION
## Summary

- Drop exported Megatron LoRA tensors on every policy rank before asking vLLM to load the adapter.
- Flush the pinned-host allocator before inference materializes its copy.
- Avoid a redundant process-group barrier while rank zero performs the disk reload.

## Scope

The original failure occurred during early colocated GLM bring-up: policy rank zero retained roughly 60 GB of exported adapter tensors while every vLLM rank began materializing its own copy, pushing host memory over Ray's kill threshold.

The canonical 32K and 256K GLM services are now disaggregated and do not exercise that host-memory overlap. This is therefore a general colocation candidate, not a dependency of the current GLM recipe.

## Evidence still required

The downstream patch participated in later successful runs, but those runs do not isolate this change. Keep this PR in draft until it has focused unit coverage and a colocated A/B reproduction showing that the cleanup prevents the observed peak-memory failure. Maintainer guidance on allocator cleanup is also needed before review.

`bash format.sh` passes.