### PR TITLE
fix(megatron): honor optimizer offload policy during sync

### DIFF
--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -643,17 +643,24 @@ class WorkerDispatch:
         """Prepare for weight sync: ensure policy model is on GPU, offload optimizer. Helper for save_weights_for_sampler."""
         if not self.colocate_all:
             return
-        # Ensure policy model is on GPU (will offload others in colocation group)
-        self._ensure_on_gpu("policy", need_optimizer=False, need_model=True)
-        # Offload optimizer if it's on GPU
-        if self._gpu_state["policy"].optimizer_on_gpu:
+        offload_optimizer = self.cfg.trainer.policy.optimizer_config.offload_after_step
+        self._ensure_on_gpu(
+            "policy",
+            need_optimizer=not offload_optimizer,
+            need_model=True,
+        )
+        if offload_optimizer and self._gpu_state["policy"].optimizer_on_gpu:
             self._offload("policy", offload_optimizer=True, offload_model=False)
 
     def _finish_weight_sync(self) -> None:
         """Finish weight sync: offload model weights and optimizer state. Helper for save_weights_for_sampler."""
         if not self.colocate_all:
             return
-        self._offload("policy", offload_optimizer=True, offload_model=True)
+        self._offload(
+            "policy",
+            offload_optimizer=self.cfg.trainer.policy.optimizer_config.offload_after_step,
+            offload_model=True,
+        )
 
     async def save_weights_for_sampler(self, model_id: Optional[str] = None) -> None:
         """

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -640,20 +640,20 @@ class WorkerDispatch:
         return {"sync_weights_only_transfer": self.last_weight_sync_seconds}
 
     def _prepare_for_weight_sync(self) -> None:
-        """Prepare for weight sync: ensure policy model is on GPU, offload optimizer. Helper for save_weights_for_sampler."""
+        """Load policy weights and apply the configured optimizer offload policy."""
         if not self.colocate_all:
             return
         offload_optimizer = self.cfg.trainer.policy.optimizer_config.offload_after_step
         self._ensure_on_gpu(
             "policy",
-            need_optimizer=not offload_optimizer,
+            need_optimizer=False,
             need_model=True,
         )
         if offload_optimizer and self._gpu_state["policy"].optimizer_on_gpu:
             self._offload("policy", offload_optimizer=True, offload_model=False)
 
     def _finish_weight_sync(self) -> None:
-        """Finish weight sync: offload model weights and optimizer state. Helper for save_weights_for_sampler."""
+        """Offload policy weights and conditionally offload optimizer state."""
         if not self.colocate_all:
             return
         self._offload(

--- a/tests/backends/skyrl_train/distributed/test_worker_dispatch.py
+++ b/tests/backends/skyrl_train/distributed/test_worker_dispatch.py
@@ -202,3 +202,36 @@ class TestSaveWeights:
 
         dispatch._inference_engine_client.pause_generation.assert_awaited_once()
         dispatch._inference_engine_client.resume_generation.assert_awaited_once()
+
+
+@pytest.mark.parametrize("offload_after_step", [False, True])
+def test_weight_sync_honors_optimizer_offload_policy(offload_after_step):
+    from skyrl.backends.skyrl_train.workers.worker_dispatch import WorkerDispatch
+
+    cfg = _fft_dispatch_cfg()
+    cfg.trainer.policy.optimizer_config = SimpleNamespace(offload_after_step=offload_after_step)
+
+    dispatch = WorkerDispatch.__new__(WorkerDispatch)
+    dispatch.colocate_all = True
+    dispatch.cfg = cfg
+    dispatch._gpu_state = {
+        "policy": SimpleNamespace(optimizer_on_gpu=True),
+    }
+    dispatch._ensure_on_gpu = MagicMock()
+    dispatch._offload = MagicMock()
+
+    dispatch._prepare_for_weight_sync()
+
+    dispatch._ensure_on_gpu.assert_called_once_with(
+        "policy",
+        need_optimizer=not offload_after_step,
+        need_model=True,
+    )
+    if offload_after_step:
+        dispatch._offload.assert_called_once_with("policy", offload_optimizer=True, offload_model=False)
+    else:
+        dispatch._offload.assert_not_called()
+
+    dispatch._offload.reset_mock()
+    dispatch._finish_weight_sync()
+    dispatch._offload.assert_called_once_with("policy", offload_optimizer=offload_after_step, offload_model=True)

--- a/tests/backends/skyrl_train/distributed/test_worker_dispatch.py
+++ b/tests/backends/skyrl_train/distributed/test_worker_dispatch.py
@@ -224,7 +224,7 @@ def test_weight_sync_honors_optimizer_offload_policy(offload_after_step):
 
     dispatch._ensure_on_gpu.assert_called_once_with(
         "policy",
-        need_optimizer=not offload_after_step,
+        need_optimizer=False,
         need_model=True,
     )
     if offload_after_step:


### PR DESCRIPTION
## Summary

- Honor `offload_after_step` while a colocated policy publishes weights.
- Keep optimizer state resident when offload is disabled; preserve existing offload behavior when it is enabled.

## Scope

This code is gated by `trainer.placement.colocate_all`. The current disaggregated GLM 32K and 256K recipes return before this path, so this is a general colocation semantics/performance fix rather than a dependency of those recipes.

## Testing

```bash
uv run --isolated --extra dev --extra skyrl-train pytest -q tests/backends/skyrl_train/distributed/test_worker_dispatch.py -k weight_sync_honors_optimizer_offload_policy
```

The two policy branches pass (`2 passed, 7 deselected`), and same-head code-quality, training, and gym CI pass. A colocated live receipt remains outstanding.
