### PR TITLE
perf(megatron): preserve LoRA export dtype

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/lora_export.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/lora_export.py
@@ -9,6 +9,7 @@ def build_lora_adapter_state(
     """Clone exported Megatron adapter weights into PEFT's key layout."""
     adapter_state = {}
     for name, tensor in adapter_weights:
-        exported_tensor = tensor.clone() if preserve_dtype else tensor.float()
+        export_dtype = tensor.dtype if preserve_dtype else torch.float32
+        exported_tensor = tensor.to(dtype=export_dtype, copy=True)
         adapter_state[f"base_model.model.{name}"] = exported_tensor
     return adapter_state

--- a/skyrl/backends/skyrl_train/workers/megatron/lora_export.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/lora_export.py
@@ -9,8 +9,6 @@ def build_lora_adapter_state(
     """Clone exported Megatron adapter weights into PEFT's key layout."""
     adapter_state = {}
     for name, tensor in adapter_weights:
-        exported_tensor = tensor.clone()
-        if not preserve_dtype:
-            exported_tensor = exported_tensor.float()
+        exported_tensor = tensor.clone() if preserve_dtype else tensor.float()
         adapter_state[f"base_model.model.{name}"] = exported_tensor
     return adapter_state

--- a/skyrl/backends/skyrl_train/workers/megatron/lora_export.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/lora_export.py
@@ -1,0 +1,16 @@
+from collections.abc import Iterable
+
+import torch
+
+
+def build_lora_adapter_state(
+    adapter_weights: Iterable[tuple[str, torch.Tensor]], *, preserve_dtype: bool
+) -> dict[str, torch.Tensor]:
+    """Clone exported Megatron adapter weights into PEFT's key layout."""
+    adapter_state = {}
+    for name, tensor in adapter_weights:
+        exported_tensor = tensor.clone()
+        if not preserve_dtype:
+            exported_tensor = exported_tensor.float()
+        adapter_state[f"base_model.model.{name}"] = exported_tensor
+    return adapter_state

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -59,6 +59,9 @@ from skyrl.backends.skyrl_train.workers.megatron.adapter_store import (
     LoraSignature,
     iter_opts,
 )
+from skyrl.backends.skyrl_train.workers.megatron.lora_export import (
+    build_lora_adapter_state,
+)
 from skyrl.backends.skyrl_train.workers.megatron.megatron_model_wrapper import (
     MegatronModelWrapper,
 )
@@ -1424,9 +1427,10 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         )
         from safetensors.torch import save_file
 
-        adapter_state = {}
-        for name, tensor in self.bridge.export_adapter_weights(self.actor_module, cpu=True, show_progress=False):
-            adapter_state[f"base_model.model.{name}"] = tensor.clone().float()
+        adapter_state = build_lora_adapter_state(
+            self.bridge.export_adapter_weights(self.actor_module, cpu=True, show_progress=False),
+            preserve_dtype=self.cfg.policy.model.lora.preserve_export_dtype,
+        )
 
         if torch.distributed.get_rank() == 0:
             os.makedirs(lora_sync_path, exist_ok=True)

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -107,6 +107,9 @@ class SkyRLLoraConfig(BaseConfig):
     lora_sync_path: str = "/tmp/skyrl_lora_sync"
     """Directory where LoRA adapter weights are saved and synchronized between the training and inference processes.
     Must be accessible to all workers in distributed setups."""
+    preserve_export_dtype: bool = False
+    """Preserve Megatron adapter tensor dtypes when exporting LoRA weights.
+    By default, Megatron adapters are exported as float32 for backward compatibility."""
     target_modules: str = "all-linear"
     """Modules to apply LoRA to.
     ``"all-linear"`` targets every linear layer for FSDP/PEFT, and is remapped to a fixed module

--- a/tests/backends/skyrl_train/workers/test_lora_export.py
+++ b/tests/backends/skyrl_train/workers/test_lora_export.py
@@ -8,9 +8,7 @@ from skyrl.train.config import SkyRLTrainConfig
 
 
 def test_preserve_export_dtype_cli_override_is_typed() -> None:
-    config = SkyRLTrainConfig.from_cli_overrides(
-        ["trainer.policy.model.lora.preserve_export_dtype=true"]
-    )
+    config = SkyRLTrainConfig.from_cli_overrides(["trainer.policy.model.lora.preserve_export_dtype=true"])
 
     assert config.trainer.policy.model.lora.preserve_export_dtype is True
 
@@ -23,9 +21,7 @@ def test_preserve_export_dtype_cli_override_is_typed() -> None:
         (torch.float32, False, torch.float32),
     ],
 )
-def test_build_lora_adapter_state_preserves_values_and_peft_names(
-    source_dtype, preserve_dtype, expected_dtype
-):
+def test_build_lora_adapter_state_preserves_values_and_peft_names(source_dtype, preserve_dtype, expected_dtype):
     source = torch.tensor([1.25, -2.5], dtype=source_dtype)
     adapter_state = build_lora_adapter_state(
         [("decoder.layers.0.linear.adapter.weight", source)],

--- a/tests/backends/skyrl_train/workers/test_lora_export.py
+++ b/tests/backends/skyrl_train/workers/test_lora_export.py
@@ -8,17 +8,25 @@ from skyrl.train.config import SkyRLTrainConfig
 
 
 def test_preserve_export_dtype_cli_override_is_typed() -> None:
-    config = SkyRLTrainConfig.from_cli_overrides(["trainer.policy.model.lora.preserve_export_dtype=true"])
+    config = SkyRLTrainConfig.from_cli_overrides(
+        ["trainer.policy.model.lora.preserve_export_dtype=true"]
+    )
 
     assert config.trainer.policy.model.lora.preserve_export_dtype is True
 
 
 @pytest.mark.parametrize(
-    ("preserve_dtype", "expected_dtype"),
-    [(False, torch.float32), (True, torch.bfloat16)],
+    ("source_dtype", "preserve_dtype", "expected_dtype"),
+    [
+        (torch.bfloat16, False, torch.float32),
+        (torch.bfloat16, True, torch.bfloat16),
+        (torch.float32, False, torch.float32),
+    ],
 )
-def test_build_lora_adapter_state_preserves_values_and_peft_names(preserve_dtype, expected_dtype):
-    source = torch.tensor([1.25, -2.5], dtype=torch.bfloat16)
+def test_build_lora_adapter_state_preserves_values_and_peft_names(
+    source_dtype, preserve_dtype, expected_dtype
+):
+    source = torch.tensor([1.25, -2.5], dtype=source_dtype)
     adapter_state = build_lora_adapter_state(
         [("decoder.layers.0.linear.adapter.weight", source)],
         preserve_dtype=preserve_dtype,

--- a/tests/backends/skyrl_train/workers/test_lora_export.py
+++ b/tests/backends/skyrl_train/workers/test_lora_export.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+
+from skyrl.backends.skyrl_train.workers.megatron.lora_export import (
+    build_lora_adapter_state,
+)
+from skyrl.train.config import SkyRLTrainConfig
+
+
+def test_preserve_export_dtype_cli_override_is_typed() -> None:
+    config = SkyRLTrainConfig.from_cli_overrides(["trainer.policy.model.lora.preserve_export_dtype=true"])
+
+    assert config.trainer.policy.model.lora.preserve_export_dtype is True
+
+
+@pytest.mark.parametrize(
+    ("preserve_dtype", "expected_dtype"),
+    [(False, torch.float32), (True, torch.bfloat16)],
+)
+def test_build_lora_adapter_state_preserves_values_and_peft_names(preserve_dtype, expected_dtype):
+    source = torch.tensor([1.25, -2.5], dtype=torch.bfloat16)
+    adapter_state = build_lora_adapter_state(
+        [("decoder.layers.0.linear.adapter.weight", source)],
+        preserve_dtype=preserve_dtype,
+    )
+
+    exported = adapter_state["base_model.model.decoder.layers.0.linear.adapter.weight"]
+    assert exported.dtype == expected_dtype
+    assert exported.data_ptr() != source.data_ptr()
+    torch.testing.assert_close(exported.float(), source.float())


### PR DESCRIPTION
## Summary

- Add an opt-in setting that preserves Megatron LoRA tensor dtypes during adapter export.
- Keep FP32 export as the default for backward compatibility.
- Avoid doubling rank-32 BF16 adapter payloads solely for serialization.

Equivalent downstream code reduced the GLM adapter from 61.50 GB to 30.75 GB. GLM 5.2 XID `1049159` completed 10/10 optimizer steps with mean publication falling from 651s to 320s. GLM 5.3 256K XID `1049392` completed four finite optimizer updates and durable checkpoint 4 with native BF16 publication.

This is a performance and capacity change, not evidence that BF16 and FP32 have matched GLM 5.3 learning quality. The setting remains opt-in and FP32 remains the default.

## Testing

```bash
uv run --isolated --extra dev --extra skyrl-train pytest -q tests/backends/skyrl_train/workers/test_lora_export.py
```

All three focused tests and formatting pass. Same-head Train CI reported 1,532 passing tests and one unrelated rate-limiter timing failure (`0.147s < 0.1s`). This fork cannot rerun that workflow without repository-admin permission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default export behavior is unchanged; opt-in dtype preservation only affects LoRA weight serialization and on-policy sync payload size/precision.
> 
> **Overview**
> Adds an opt-in **`preserve_export_dtype`** flag on policy LoRA config (`trainer.policy.model.lora.preserve_export_dtype`, default **false**) so Megatron→PEFT adapter export can keep native tensor dtypes instead of always casting to float32.
> 
> Megatron worker LoRA sync now builds adapter state via **`build_lora_adapter_state`**, which clones exported weights under `base_model.model.{name}` and applies the dtype policy. **FP32 export remains the default** for backward compatibility; enabling preservation cuts serialized adapter size and sync time when training in BF16.
> 
> Tests cover CLI typing for the new flag and export naming/dtype/cloning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e935056506728c395fc7a959970b0994e5faabd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->