### PR TITLE
fix(tinker): bound inference forwarding retries

### DIFF
--- a/skyrl/env_vars.py
+++ b/skyrl/env_vars.py
@@ -105,3 +105,13 @@ instead of being redirected to the log file. Useful for debugging startup issues
 Default: False (infrastructure logs go to file only, stdout shows training progress).
 Set ``SKYRL_DUMP_INFRA_LOG_TO_STDOUT=1`` to show all logs on stdout.
 """
+
+SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC = float(os.environ.get("SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC", 300))
+"""
+Read timeout in seconds for API-side requests forwarded to the SkyRL-Train-managed
+inference engine. This is applicable for SkyRL's Tinker server in non-colocated setups.
+
+The timeout must cover time spent queued behind other requests as well as generation time.
+Equivalent to the ``--forwarding-inference-timeout-sec`` flag of the Tinker API server
+(``EngineConfig.forwarding_inference_timeout_sec``); the flag takes precedence when both are set.
+"""

--- a/skyrl/tinker/config.py
+++ b/skyrl/tinker/config.py
@@ -58,6 +58,19 @@ class EngineConfig(BaseModel):
         ),
         json_schema_extra={"argparse_type": lambda v: None if v == "None" else int(v)},
     )
+    forwarding_inference_timeout_sec: float = Field(
+        default=300.0,
+        gt=0,
+        description=(
+            "Read timeout in seconds for API-side requests forwarded to the "
+            "SkyRL-Train-managed inference engine. This must cover time spent "
+            "queued behind other requests as well as generation time."
+        ),
+        json_schema_extra={
+            "argparse_type": float,
+            "env_var": "SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC",
+        },
+    )
     session_cleanup_interval_sec: int = Field(
         default=60,
         description="How often to check for stale sessions (seconds). Set to -1 to disable cleanup.",

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -32,7 +32,7 @@ class SkyRLTrainInferenceForwardingClient:
         max_conn = engine_config.forwarding_inference_max_connections
         max_keepalive = max(max_conn // 4, 32) if max_conn is not None else None
         self._http_client: httpx.AsyncClient = httpx.AsyncClient(
-            timeout=httpx.Timeout(300.0, connect=10.0),
+            timeout=httpx.Timeout(engine_config.forwarding_inference_timeout_sec, connect=10.0),
             limits=httpx.Limits(
                 max_connections=max_conn,
                 max_keepalive_connections=max_keepalive,
@@ -94,14 +94,15 @@ class SkyRLTrainInferenceForwardingClient:
             await session.commit()
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
-        # httpx.RequestError covers ConnectError, ReadError, TimeoutException, etc.
-        # HTTP 4xx/5xx surfaces as RuntimeError below and is NOT retried.
+        # Retry only failures that occur before a request can reach vLLM. Read
+        # and write failures are ambiguous: vLLM may still be executing the
+        # request, so retrying would duplicate generation load.
         try:
             proxy_url = await self._resolve_proxy_url()
             return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
-        except httpx.RequestError as e:
+        except (httpx.ConnectError, httpx.ConnectTimeout) as e:
             logger.warning(
-                "Network error talking to %s (%s: %s) — refreshing proxy URL and retrying once",
+                "Connection error talking to %s (%s: %s) — refreshing proxy URL and retrying once",
                 self._cached_proxy_url,
                 type(e).__name__,
                 e,

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -103,17 +103,31 @@ class SkyRLTrainInferenceForwardingClient:
         # and write failures are ambiguous: vLLM may still be executing the
         # request, so retrying would duplicate generation load.
         try:
-            proxy_url = await self._resolve_proxy_url()
-            return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
-        except (httpx.ConnectError, httpx.ConnectTimeout) as e:
-            logger.warning(
-                "Connection error talking to %s (%s: %s) — refreshing proxy URL and retrying once",
-                self._cached_proxy_url,
-                type(e).__name__,
-                e,
-            )
-            proxy_url = await self._resolve_proxy_url(force_refresh=True)
-            return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
+            try:
+                proxy_url = await self._resolve_proxy_url()
+                return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
+            except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+                logger.warning(
+                    "Connection error talking to %s (%s: %s) — refreshing proxy URL and retrying once",
+                    self._cached_proxy_url,
+                    type(e).__name__,
+                    e,
+                )
+                proxy_url = await self._resolve_proxy_url(force_refresh=True)
+                return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
+        except httpx.ReadTimeout as e:
+            # Not retried (see above). Long-context requests routinely exceed the
+            # default read deadline, so tell the caller how to raise it. The
+            # message is stored in the FutureDB ErrorResponse and shown to clients.
+            timeout_sec = self.engine_config.forwarding_inference_timeout_sec
+            raise RuntimeError(
+                f"Inference request to {self._cached_proxy_url} timed out after {timeout_sec:g}s waiting for "
+                "a response (httpx.ReadTimeout). The request was not retried because vLLM may still be "
+                "executing it. If requests are expected to take this long (long prompts, large max_tokens, "
+                "or queueing behind other requests), increase the deadline with "
+                "`--forwarding-inference-timeout-sec` (EngineConfig.forwarding_inference_timeout_sec) or "
+                "the SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC environment variable."
+            ) from e
 
     async def _forward(
         self, proxy_url: str, sample_req, model_id: str, *, base_model: str | None

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -32,7 +32,12 @@ class SkyRLTrainInferenceForwardingClient:
         max_conn = engine_config.forwarding_inference_max_connections
         max_keepalive = max(max_conn // 4, 32) if max_conn is not None else None
         self._http_client: httpx.AsyncClient = httpx.AsyncClient(
-            timeout=httpx.Timeout(engine_config.forwarding_inference_timeout_sec, connect=10.0),
+            timeout=httpx.Timeout(
+                connect=10.0,
+                read=engine_config.forwarding_inference_timeout_sec,
+                write=300.0,
+                pool=300.0,
+            ),
             limits=httpx.Limits(
                 max_connections=max_conn,
                 max_keepalive_connections=max_keepalive,

--- a/tests/tinker/test_inference_forwarding_config.py
+++ b/tests/tinker/test_inference_forwarding_config.py
@@ -52,15 +52,44 @@ async def test_forwarding_retries_connection_failure() -> None:
     assert client._forward.await_count == 2
 
 
+def _assert_read_timeout_hint(exc: RuntimeError, timeout_sec: float) -> None:
+    message = str(exc)
+    assert isinstance(exc.__cause__, httpx.ReadTimeout)
+    assert f"timed out after {timeout_sec:g}s" in message
+    assert "--forwarding-inference-timeout-sec" in message
+    assert "SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC" in message
+
+
 @pytest.mark.asyncio
 async def test_forwarding_does_not_retry_read_timeout() -> None:
     client = object.__new__(SkyRLTrainInferenceForwardingClient)
+    client.engine_config = EngineConfig(base_model="test-model", forwarding_inference_timeout_sec=123.0)
     client._cached_proxy_url = "http://inference"
     client._resolve_proxy_url = AsyncMock(return_value="http://inference")
     client._forward = AsyncMock(side_effect=httpx.ReadTimeout("slow response"))
 
-    with pytest.raises(httpx.ReadTimeout):
+    with pytest.raises(RuntimeError) as exc_info:
         await client._forward_with_retry(object(), "model", base_model=None)
 
+    _assert_read_timeout_hint(exc_info.value, 123.0)
+    assert "http://inference" in str(exc_info.value)
     client._resolve_proxy_url.assert_awaited_once_with()
     client._forward.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forwarding_read_timeout_on_retry_surfaces_hint() -> None:
+    # A read timeout raised by the *second* attempt (after a connection retry)
+    # must get the same actionable message as one raised by the first attempt.
+    client = object.__new__(SkyRLTrainInferenceForwardingClient)
+    client.engine_config = EngineConfig(base_model="test-model", forwarding_inference_timeout_sec=45.0)
+    client._cached_proxy_url = "http://old"
+    client._resolve_proxy_url = AsyncMock(side_effect=["http://old", "http://new"])
+    client._forward = AsyncMock(side_effect=[httpx.ConnectError("unreachable"), httpx.ReadTimeout("slow response")])
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await client._forward_with_retry(object(), "model", base_model=None)
+
+    _assert_read_timeout_hint(exc_info.value, 45.0)
+    client._resolve_proxy_url.assert_has_awaits([call(), call(force_refresh=True)])
+    assert client._forward.await_count == 2

--- a/tests/tinker/test_inference_forwarding_config.py
+++ b/tests/tinker/test_inference_forwarding_config.py
@@ -1,0 +1,62 @@
+import argparse
+from unittest.mock import AsyncMock, call, patch
+
+import httpx
+import pytest
+
+from skyrl.tinker.config import EngineConfig, add_model
+from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
+    SkyRLTrainInferenceForwardingClient,
+)
+
+
+def test_forwarding_timeout_reads_environment(monkeypatch) -> None:
+    monkeypatch.setenv("SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC", "1800")
+    parser = argparse.ArgumentParser()
+    add_model(parser, EngineConfig)
+
+    args = parser.parse_args(["--base-model", "test-model"])
+    config = EngineConfig.model_validate(vars(args))
+
+    assert config.forwarding_inference_timeout_sec == 1800.0
+
+
+def test_forwarding_client_uses_configured_timeout() -> None:
+    config = EngineConfig(
+        base_model="test-model",
+        forwarding_inference_timeout_sec=1800.0,
+    )
+
+    with patch("skyrl.tinker.extra.skyrl_train_inference_forwarding.httpx.AsyncClient") as async_client:
+        SkyRLTrainInferenceForwardingClient(config, db_engine=None)
+
+    assert async_client.call_args.kwargs["timeout"].read == 1800.0
+
+
+@pytest.mark.asyncio
+async def test_forwarding_retries_connection_failure() -> None:
+    client = object.__new__(SkyRLTrainInferenceForwardingClient)
+    client._cached_proxy_url = "http://old"
+    client._resolve_proxy_url = AsyncMock(side_effect=["http://old", "http://new"])
+    expected = object()
+    client._forward = AsyncMock(side_effect=[httpx.ConnectError("unreachable"), expected])
+
+    result = await client._forward_with_retry(object(), "model", base_model=None)
+
+    assert result is expected
+    client._resolve_proxy_url.assert_has_awaits([call(), call(force_refresh=True)])
+    assert client._forward.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_forwarding_does_not_retry_read_timeout() -> None:
+    client = object.__new__(SkyRLTrainInferenceForwardingClient)
+    client._cached_proxy_url = "http://inference"
+    client._resolve_proxy_url = AsyncMock(return_value="http://inference")
+    client._forward = AsyncMock(side_effect=httpx.ReadTimeout("slow response"))
+
+    with pytest.raises(httpx.ReadTimeout):
+        await client._forward_with_retry(object(), "model", base_model=None)
+
+    client._resolve_proxy_url.assert_awaited_once_with()
+    client._forward.assert_awaited_once()

--- a/tests/tinker/test_inference_forwarding_config.py
+++ b/tests/tinker/test_inference_forwarding_config.py
@@ -52,14 +52,6 @@ async def test_forwarding_retries_connection_failure() -> None:
     assert client._forward.await_count == 2
 
 
-def _assert_read_timeout_hint(exc: RuntimeError, timeout_sec: float) -> None:
-    message = str(exc)
-    assert isinstance(exc.__cause__, httpx.ReadTimeout)
-    assert f"timed out after {timeout_sec:g}s" in message
-    assert "--forwarding-inference-timeout-sec" in message
-    assert "SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC" in message
-
-
 @pytest.mark.asyncio
 async def test_forwarding_does_not_retry_read_timeout() -> None:
     client = object.__new__(SkyRLTrainInferenceForwardingClient)
@@ -71,25 +63,11 @@ async def test_forwarding_does_not_retry_read_timeout() -> None:
     with pytest.raises(RuntimeError) as exc_info:
         await client._forward_with_retry(object(), "model", base_model=None)
 
-    _assert_read_timeout_hint(exc_info.value, 123.0)
-    assert "http://inference" in str(exc_info.value)
+    message = str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, httpx.ReadTimeout)
+    assert "http://inference" in message
+    assert "timed out after 123s" in message
+    assert "--forwarding-inference-timeout-sec" in message
+    assert "SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC" in message
     client._resolve_proxy_url.assert_awaited_once_with()
     client._forward.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_forwarding_read_timeout_on_retry_surfaces_hint() -> None:
-    # A read timeout raised by the *second* attempt (after a connection retry)
-    # must get the same actionable message as one raised by the first attempt.
-    client = object.__new__(SkyRLTrainInferenceForwardingClient)
-    client.engine_config = EngineConfig(base_model="test-model", forwarding_inference_timeout_sec=45.0)
-    client._cached_proxy_url = "http://old"
-    client._resolve_proxy_url = AsyncMock(side_effect=["http://old", "http://new"])
-    client._forward = AsyncMock(side_effect=[httpx.ConnectError("unreachable"), httpx.ReadTimeout("slow response")])
-
-    with pytest.raises(RuntimeError) as exc_info:
-        await client._forward_with_retry(object(), "model", base_model=None)
-
-    _assert_read_timeout_hint(exc_info.value, 45.0)
-    client._resolve_proxy_url.assert_has_awaits([call(), call(force_refresh=True)])
-    assert client._forward.await_count == 2

--- a/tests/tinker/test_inference_forwarding_config.py
+++ b/tests/tinker/test_inference_forwarding_config.py
@@ -67,7 +67,5 @@ async def test_forwarding_does_not_retry_read_timeout() -> None:
     assert isinstance(exc_info.value.__cause__, httpx.ReadTimeout)
     assert "http://inference" in message
     assert "timed out after 123s" in message
-    assert "--forwarding-inference-timeout-sec" in message
-    assert "SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC" in message
     client._resolve_proxy_url.assert_awaited_once_with()
     client._forward.assert_awaited_once()

--- a/tests/tinker/test_inference_forwarding_config.py
+++ b/tests/tinker/test_inference_forwarding_config.py
@@ -30,7 +30,11 @@ def test_forwarding_client_uses_configured_timeout() -> None:
     with patch("skyrl.tinker.extra.skyrl_train_inference_forwarding.httpx.AsyncClient") as async_client:
         SkyRLTrainInferenceForwardingClient(config, db_engine=None)
 
-    assert async_client.call_args.kwargs["timeout"].read == 1800.0
+    timeout = async_client.call_args.kwargs["timeout"]
+    assert timeout.connect == 10.0
+    assert timeout.read == 1800.0
+    assert timeout.write == 300.0
+    assert timeout.pool == 300.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Make the inference-forwarding read deadline configurable for legitimate long-context requests.
- Retry once only when connection establishment fails before dispatch.
- Propagate ambiguous read/write failures instead of risking duplicate generation.

XID `1049062` reproduced the fixed 300-second deadline and at least 84 forwarding failures. XID `1049072` used a 1,800-second deadline; all 2,321 observed forwarding completion calls returned HTTP 2xx, with no missing futures attributed to this path.

XID `1049072` did not reach training because its oversized rollout workload repeatedly rejected zero-signal groups. It validates the forwarding deadline and retry behavior only—not trajectory selection or end-to-end learning.

## Testing

```bash
uv run --isolated --frozen --extra dev --extra tinker --extra ray --extra jax pytest -q tests/tinker/test_inference_forwarding_config.py
```

All four focused tests pass. Ruff, Black, secret detection, and same-head SkyRL CPU and Train CI pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inference forwarding timeouts and retry semantics on a critical training/inference path; misconfiguration could still fail long jobs, but narrowing retries reduces duplicate-load risk.
> 
> **Overview**
> Makes the **read deadline** for Tinker API requests forwarded to SkyRL-Train inference **configurable** (default 300s) via `EngineConfig.forwarding_inference_timeout_sec`, `--forwarding-inference-timeout-sec`, or `SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC`. The forwarding `httpx` client now applies that value only to **read** timeouts while keeping separate connect/write/pool limits.
> 
> **Retry behavior is tightened:** a single proxy-URL refresh retry runs only on **connection** failures (`ConnectError` / `ConnectTimeout`), not on broad `RequestError`. **Read timeouts are not retried**—they surface as a `RuntimeError` with guidance to raise the deadline, avoiding duplicate generation when vLLM may still be running the request.
> 
> Adds focused tests for env/CLI config, client timeout wiring, connection retry, and no-retry on read timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65cc952651fa0c7e540bf3c693227d55130134e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->