### PR TITLE
[CI] Add metric thresholds to tinker E2E CI scripts

### DIFF
--- a/tests/train/gpu_e2e_test/gsm8k_tinker.sh
+++ b/tests/train/gpu_e2e_test/gsm8k_tinker.sh
@@ -11,9 +11,12 @@ SKYRL_REPO_ROOT=$(realpath "$SCRIPT_DIR/../../..")
 LOG_DIR="$HOME/tinker_logs/$RUN_NAME"
 mkdir -p "$LOG_DIR"
 
-# TODO: tighten thresholds after 3-5 nightly runs (5% allowance from min observed),
-# matching the convention in gsm8k_colocate.sh.
-REWARD_MIN_VALUE=0.0
+# Thresholds: 5% allowance from min/max of the 26 finished nightly runs since 20th Jul 2026
+# (as of 31st Aug 2026), matching the convention in gsm8k_colocate.sh (#1664). Observed:
+# reward in [0.532, 0.559]; kl_sample_train_v2 in [6.6e-4, 7.1e-4] (colocated runs are
+# on-policy, so the sample/train KL stays flat and tight).
+REWARD_MIN_VALUE=0.50
+KL_MAX_VALUE=0.00074
 
 # gpu_memory_utilization: 0.7, not 0.8. Unlike the main trainer entrypoint (engines
 # profile on empty GPUs before models are built), the tinker backend starts engines
@@ -96,4 +99,4 @@ TINKER_API_KEY=tml-dummy uv run --extra tinker --with-editable "$COOKBOOK_DIR[ma
 cd "$SKYRL_REPO_ROOT"
 uv run --isolated --extra fsdp "$SCRIPT_DIR/get_summary.py" \
   --run_name "$RUN_NAME" --project_name "$PROJECT_NAME" \
-  --asserts "env/all/reward/total >= $REWARD_MIN_VALUE"
+  --asserts "env/all/reward/total >= $REWARD_MIN_VALUE" "optim/kl_sample_train_v2 <= $KL_MAX_VALUE"

--- a/tests/train/gpu_e2e_test/gsm8k_tinker_fully_async.sh
+++ b/tests/train/gpu_e2e_test/gsm8k_tinker_fully_async.sh
@@ -11,9 +11,12 @@ SKYRL_REPO_ROOT=$(realpath "$SCRIPT_DIR/../../..")
 LOG_DIR="$HOME/tinker_fully_async_logs/$RUN_NAME"
 mkdir -p "$LOG_DIR"
 
-# TODO: tighten thresholds after 3-5 nightly runs (5% allowance from min observed),
-# matching the convention in gsm8k_colocate.sh.
-REWARD_MIN_VALUE=0.0
+# Thresholds: 5% allowance from min/max of the 26 finished nightly runs since 20th Jul 2026
+# (as of 31st Aug 2026), matching the convention in gsm8k_colocate.sh (#1664). Observed:
+# reward in [0.223, 0.295]; kl_sample_train_v2 in [4.1e-3, 7.5e-3] (an order of magnitude
+# above the colocated run's: max_steps_off_policy=4 trains on stale samples).
+REWARD_MIN_VALUE=0.21
+KL_MAX_VALUE=0.0079
 
 # Non-colocated layout: 2 GPUs for the trainer (FSDP policy) and 2 GPUs for the
 # inference engines (vLLM). colocate_all=false keeps training and inference on
@@ -97,4 +100,4 @@ TINKER_API_KEY=tml-dummy uv run --extra tinker --with-editable "$COOKBOOK_DIR[ma
 cd "$SKYRL_REPO_ROOT"
 uv run --isolated --extra fsdp "$SCRIPT_DIR/get_summary.py" \
   --run_name "$RUN_NAME" --project_name "$PROJECT_NAME" \
-  --asserts "env/all/reward/total >= $REWARD_MIN_VALUE"
+  --asserts "env/all/reward/total >= $REWARD_MIN_VALUE" "optim/kl_sample_train_v2 <= $KL_MAX_VALUE"


### PR DESCRIPTION
# What does this PR do?

Adds metric thresholds to tinker E2E CI scripts. Should close #1664

Uses the same methodology as in #1199 for thresholds: 5% allowance from min/max of previous nightly CI runs - in this case - 26 finished nightly runs since 20th Jul 2026,. Replaces the REWARD_MIN_VALUE=0.0 placeholders and adds an optim/kl_sample_train_v2 upper bound.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only GPU E2E shell thresholds and wandb assertions; no production training or runtime code.
> 
> **Overview**
> Tightens **tinker GSM8K GPU E2E** checks in `gsm8k_tinker.sh` and `gsm8k_tinker_fully_async.sh` so CI fails on regressions instead of only asserting reward ≥ 0.
> 
> Both scripts now set **reward floors** and **`optim/kl_sample_train_v2` ceilings** from 26 nightly runs (5% headroom, same approach as `gsm8k_colocate.sh` / #1664). Colocated tinker uses **0.50** min reward and **0.00074** max KL; fully async uses **0.21** and **0.0079** to reflect lower reward and higher KL with `max_steps_off_policy=4`. `get_summary.py` gets a second `--asserts` for the KL bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849edf54d3a5c52a296e53b93f6658d114136bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->