### PR TITLE
[fix][lora] Remove unloaded adapters from vLLM engine

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -1319,11 +1319,10 @@ class RemoteInferenceClient(InferenceEngineInterface):
 
     async def unload_lora_adapter(self, lora_name: str) -> Dict[str, Any]:
         """
-        Unload a previously-loaded LoRA adapter on all backend servers via /v1/unload_lora_adapter.
+        Unload a previously-loaded LoRA adapter on all backend servers.
 
         After unloading, ``lora_name`` is no longer accepted as a ``model``
-        target on any server. The underlying CPU/GPU LRU entries on vLLM age
-        out naturally as new adapters are loaded.
+        target on any server.
 
         Args:
             lora_name: Name of the adapter to unload.
@@ -1338,7 +1337,7 @@ class RemoteInferenceClient(InferenceEngineInterface):
         session = await self._get_session()
 
         async def _unload_on_server(server_url: str):
-            url = f"{server_url}/v1/unload_lora_adapter"
+            url = f"{server_url}/skyrl/v1/unload_lora_adapter"
             async with session.post(url, json=payload) as resp:
                 if resp.status >= 400:
                     body = await resp.json()

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -50,6 +50,17 @@ from skyrl.env_vars import (
 logger = logging.getLogger(__name__)
 
 
+async def _remove_lora_adapter(models, lora_name: str) -> int:
+    async with models.lora_resolver_lock[lora_name]:
+        lora_request = models.lora_requests.get(lora_name)
+        if lora_request is None:
+            raise HTTPException(status_code=404, detail=f"LoRA adapter '{lora_name}' cannot be found.")
+
+        await models.engine_client.remove_lora(lora_request.lora_int_id)
+        del models.lora_requests[lora_name]
+        return lora_request.lora_int_id
+
+
 class VLLMServerActor(ServerActorProtocol):
     """
     Ray actor that runs a vLLM OpenAI-compatible API server.
@@ -410,6 +421,26 @@ class VLLMServerActor(ServerActorProtocol):
                 lora_request.load_inplace = False
                 models.lora_requests[lora_name] = lora_request
 
+            return {
+                "status": "ok",
+                "lora_name": lora_name,
+                "lora_int_id": lora_int_id,
+            }
+
+        @app.post("/skyrl/v1/unload_lora_adapter")
+        async def _skyrl_unload_lora_adapter(request: Request):
+            """Remove both serving and engine state for a LoRA adapter.
+
+            TODO: use vLLM's native endpoint once
+            https://github.com/vllm-project/vllm/pull/42634 is released.
+            """
+            body = await request.json()
+            lora_name = body.get("lora_name")
+            if not lora_name:
+                raise HTTPException(status_code=400, detail="'lora_name' must be provided.")
+
+            models = request.app.state.openai_serving_models
+            lora_int_id = await _remove_lora_adapter(models, lora_name)
             return {
                 "status": "ok",
                 "lora_name": lora_name,

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -555,19 +555,10 @@ class SkyRLTrainBackend(AbstractBackend):
         return ResolvedPlacementGroup(pg)
 
     def _unload_inference_adapter(self, model_id: str) -> None:
-        """Drop a deleted tenant's LoRA adapter from the inference engines.
-
-        Only adapters actually registered on vLLM (via save_sampler_checkpoint)
-        are unloaded. Best-effort: vLLM may have LRU-evicted the adapter
-        already, and an inference-side failure must not block the tenant's
-        removal from the training runtime.
-        """
+        """Drop a deleted tenant's LoRA adapter from the inference engines."""
         if model_id not in self._inference_adapter_ids:
             return
-        try:
-            asyncio.run(self._inference_engine_client.unload_lora_adapter(model_id))
-        except Exception as e:
-            logger.warning(f"Failed to unload LoRA adapter '{model_id}' from inference engines: {e}")
+        asyncio.run(self._inference_engine_client.unload_lora_adapter(model_id))
         self._inference_adapter_ids.discard(model_id)
 
     def delete_model(self, model_id: str) -> None:

--- a/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
+++ b/tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py
@@ -285,7 +285,7 @@ def create_mock_vllm_server(server_id: int) -> FastAPI:
         app.state.lora_registry[lora_name] = lora_path
         return PlainTextResponse(f"Success: LoRA adapter '{lora_name}' added successfully on server {server_id}.")
 
-    @app.post("/v1/unload_lora_adapter")
+    @app.post("/skyrl/v1/unload_lora_adapter")
     async def unload_lora_adapter(request: Request):
         body = await request.json()
         lora_name = body.get("lora_name")

--- a/tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
+++ b/tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi import HTTPException
 
-from skyrl.backends.skyrl_train.inference_servers.vllm_server_actor import _remove_lora_adapter
+from skyrl.backends.skyrl_train.inference_servers.vllm_server_actor import (
+    _remove_lora_adapter,
+)
 
 
 @pytest.mark.asyncio

--- a/tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
+++ b/tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
@@ -1,0 +1,56 @@
+import asyncio
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from skyrl.backends.skyrl_train.inference_servers.vllm_server_actor import _remove_lora_adapter
+
+
+@pytest.mark.asyncio
+async def test_remove_lora_adapter_clears_engine_and_registry():
+    engine_client = SimpleNamespace(remove_lora=AsyncMock(return_value=True))
+    models = SimpleNamespace(
+        engine_client=engine_client,
+        lora_requests={"model-a": SimpleNamespace(lora_int_id=7)},
+        lora_resolver_lock=defaultdict(asyncio.Lock),
+    )
+
+    lora_int_id = await _remove_lora_adapter(models, "model-a")
+
+    assert lora_int_id == 7
+    engine_client.remove_lora.assert_awaited_once_with(7)
+    assert "model-a" not in models.lora_requests
+
+
+@pytest.mark.asyncio
+async def test_remove_lora_adapter_keeps_registry_when_engine_removal_fails():
+    engine_client = SimpleNamespace(remove_lora=AsyncMock(side_effect=RuntimeError("engine failed")))
+    models = SimpleNamespace(
+        engine_client=engine_client,
+        lora_requests={"model-a": SimpleNamespace(lora_int_id=7)},
+        lora_resolver_lock=defaultdict(asyncio.Lock),
+    )
+
+    with pytest.raises(RuntimeError, match="engine failed"):
+        await _remove_lora_adapter(models, "model-a")
+
+    assert "model-a" in models.lora_requests
+
+
+@pytest.mark.asyncio
+async def test_remove_lora_adapter_rejects_unknown_adapter():
+    engine_client = SimpleNamespace(remove_lora=AsyncMock())
+    models = SimpleNamespace(
+        engine_client=engine_client,
+        lora_requests={},
+        lora_resolver_lock=defaultdict(asyncio.Lock),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _remove_lora_adapter(models, "missing")
+
+    assert exc_info.value.status_code == 404
+    engine_client.remove_lora.assert_not_awaited()

--- a/tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
+++ b/tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi import HTTPException
 
-from skyrl.backends.skyrl_train.inference_servers.vllm_server_actor import (
+pytest.importorskip("vllm", reason="vllm_server_actor imports vllm at module scope")
+pytestmark = pytest.mark.vllm
+
+from skyrl.backends.skyrl_train.inference_servers.vllm_server_actor import (  # noqa: E402
     _remove_lora_adapter,
 )
 

--- a/tests/tinker/skyrl_train/test_warm_runtime_lifecycle.py
+++ b/tests/tinker/skyrl_train/test_warm_runtime_lifecycle.py
@@ -138,16 +138,17 @@ def test_delete_skips_inference_unload_for_unsynced_adapter():
     backend._inference_engine_client.unload_lora_adapter.assert_not_awaited()
 
 
-def test_delete_proceeds_when_inference_unload_fails():
+def test_delete_preserves_adapter_when_inference_unload_fails():
     backend = _backend(keep_runtime_warm=True)
     backend._inference_adapter_ids.add("model-a")
     backend._inference_engine_client.unload_lora_adapter.side_effect = RuntimeError("vLLM unreachable")
 
-    backend.delete_model("model-a")
+    with pytest.raises(RuntimeError, match="vLLM unreachable"):
+        backend.delete_model("model-a")
 
-    backend._dispatch.delete_adapter.assert_called_once_with("policy", "model-a")
-    assert backend._model_ids_to_role == {}
-    assert backend._inference_adapter_ids == set()
+    backend._dispatch.delete_adapter.assert_not_called()
+    assert backend._model_ids_to_role == {"model-a": "policy"}
+    assert backend._inference_adapter_ids == {"model-a"}
 
 
 def test_create_model_registers_fresh_adapter_against_warm_runtime():


### PR DESCRIPTION
- vLLM's native runtime unload removes only the serving registry entry, so warm reuse can retain engine-side LoRA state that points at an adapter directory SkyRL has deleted.
- Remove the engine entry before the registry entry, and fail model deletion closed when inference cleanup fails.
- Reproduced on GLM 5.3 B300 XID 1049461. This is a compatibility fix until vLLM PR #42634 is released.

## Testing

```
bash format.sh
```

```
pytest tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
pytest tests/backends/skyrl_train/inference_servers/test_remote_inference_client.py::TestLoRAControlPlane
pytest tests/tinker/skyrl_train/test_warm_runtime_lifecycle.py
```

The focused suites passed 3, 5, and 10 tests respectively.