### PR TITLE
[fix][inference] Cancel abandoned generation

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/request_cancellation.py
+++ b/skyrl/backends/skyrl_train/inference_servers/request_cancellation.py
@@ -1,0 +1,45 @@
+"""Tie non-streaming inference work to the lifetime of its HTTP caller."""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from fastapi import Request
+
+T = TypeVar("T")
+
+
+class RequestDisconnectedError(Exception):
+    """The HTTP caller disconnected before inference completed."""
+
+
+async def _wait_for_disconnect(request: Request) -> None:
+    while True:
+        if (await request.receive())["type"] == "http.disconnect":
+            return
+
+
+async def run_until_disconnected(request: Request, operation: Callable[[], Awaitable[T]]) -> T:
+    """Run an operation until it finishes or its HTTP caller disconnects."""
+    await request.body()
+    work = asyncio.ensure_future(operation())
+    disconnected = asyncio.create_task(_wait_for_disconnect(request))
+    try:
+        done, _ = await asyncio.wait({work, disconnected}, return_when=asyncio.FIRST_COMPLETED)
+        if work in done:
+            return work.result()
+        disconnected.result()
+        raise RequestDisconnectedError("HTTP caller disconnected")
+    finally:
+        for task in (work, disconnected):
+            if not task.done():
+                task.cancel()
+        cleanup = asyncio.gather(work, disconnected, return_exceptions=True)
+        cancelled = False
+        while not cleanup.done():
+            try:
+                await asyncio.shield(cleanup)
+            except asyncio.CancelledError:
+                cancelled = True
+        if cancelled:
+            raise asyncio.CancelledError

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -42,6 +42,10 @@ from skyrl.backends.skyrl_train.inference_servers.generate_wire import (
     pack_routed_experts,
 )
 from skyrl.backends.skyrl_train.inference_servers.protocols import ServerActorProtocol
+from skyrl.backends.skyrl_train.inference_servers.request_cancellation import (
+    RequestDisconnectedError,
+    run_until_disconnected,
+)
 from skyrl.env_vars import (
     SKYRL_HTTP_CONNECTION_LIMIT,
     SKYRL_VLLM_DP_PORT_OFFSET,
@@ -493,9 +497,16 @@ class VLLMServerActor(ServerActorProtocol):
                 prompt = TokensPrompt(prompt_token_ids=token_ids)
             request_id = random_uuid()
 
-            final_res = None
-            async for res in engine.generate(prompt, sampling_params, request_id=request_id):
-                final_res = res
+            async def generate_output():
+                final_res = None
+                async for res in engine.generate(prompt, sampling_params, request_id=request_id):
+                    final_res = res
+                return final_res
+
+            try:
+                final_res = await run_until_disconnected(request, generate_output)
+            except RequestDisconnectedError as exc:
+                raise HTTPException(status_code=499, detail="Client disconnected") from exc
 
             if final_res is None:
                 raise HTTPException(status_code=500, detail="vLLM returned no output")

--- a/tests/backends/skyrl_train/inference_servers/test_request_cancellation.py
+++ b/tests/backends/skyrl_train/inference_servers/test_request_cancellation.py
@@ -1,0 +1,73 @@
+import asyncio
+
+import pytest
+from starlette.requests import Request
+
+from skyrl.backends.skyrl_train.inference_servers.request_cancellation import (
+    RequestDisconnectedError,
+    run_until_disconnected,
+)
+
+
+def _request() -> tuple[Request, asyncio.Queue[dict]]:
+    messages = asyncio.Queue()
+    messages.put_nowait({"type": "http.request", "body": b"{}", "more_body": False})
+    return Request({"type": "http", "headers": []}, messages.get), messages
+
+
+@pytest.mark.asyncio
+async def test_operation_result_wins_while_client_remains_connected():
+    request, _ = _request()
+
+    assert await run_until_disconnected(request, lambda: asyncio.sleep(0, result=42)) == 42
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_and_drains_operation():
+    request, messages = _request()
+    started = asyncio.Event()
+    cleaned_up = asyncio.Event()
+
+    async def operation():
+        started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            cleaned_up.set()
+
+    call = asyncio.create_task(run_until_disconnected(request, operation))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    messages.put_nowait({"type": "http.disconnect"})
+
+    with pytest.raises(RequestDisconnectedError):
+        await asyncio.wait_for(call, timeout=1)
+    assert cleaned_up.is_set()
+
+
+@pytest.mark.asyncio
+async def test_handler_cancellation_waits_for_operation_cleanup():
+    request, _ = _request()
+    started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    cleanup_release = asyncio.Event()
+
+    async def operation():
+        started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cleanup_started.set()
+            await cleanup_release.wait()
+            raise
+
+    call = asyncio.create_task(run_until_disconnected(request, operation))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    call.cancel()
+    await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+    call.cancel()
+    await asyncio.sleep(0)
+    assert not call.done()
+
+    cleanup_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(call, timeout=1)

--- a/tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
+++ b/tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
@@ -5,6 +5,8 @@ from argparse import Namespace
 import pytest
 from fastapi import FastAPI, HTTPException, Request
 
+pytest.importorskip("vllm", reason="vllm_server_actor imports vllm at module scope")
+
 from skyrl.backends.skyrl_train.inference_servers.vllm_server_actor import (
     VLLMServerActor,
 )

--- a/tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
+++ b/tests/backends/skyrl_train/inference_servers/test_vllm_server_actor.py
@@ -1,0 +1,55 @@
+import asyncio
+import json
+from argparse import Namespace
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+
+from skyrl.backends.skyrl_train.inference_servers.vllm_server_actor import (
+    VLLMServerActor,
+)
+
+pytestmark = pytest.mark.vllm
+
+
+@pytest.mark.asyncio
+async def test_skyrl_generate_disconnect_cancels_engine_generation():
+    class _Engine:
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.cancelled = asyncio.Event()
+
+        async def generate(self, *args, **kwargs):
+            self.started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                raise
+            yield
+
+    engine = _Engine()
+    app = FastAPI()
+    VLLMServerActor._add_custom_endpoints(app, engine, Namespace(enable_lora=False))
+    endpoint = next(route.endpoint for route in app.routes if route.path == "/skyrl/v1/generate")
+
+    messages = asyncio.Queue()
+    messages.put_nowait(
+        {
+            "type": "http.request",
+            "body": json.dumps({"token_ids": [1], "sampling_params": {}}).encode(),
+            "more_body": False,
+        }
+    )
+    request = Request(
+        {"type": "http", "method": "POST", "path": "/skyrl/v1/generate", "headers": []},
+        messages.get,
+    )
+    call = asyncio.create_task(endpoint(request))
+    await asyncio.wait_for(engine.started.wait(), timeout=1)
+    messages.put_nowait({"type": "http.disconnect"})
+
+    with pytest.raises(HTTPException, match="Client disconnected") as exc_info:
+        await asyncio.wait_for(call, timeout=1)
+    assert exc_info.value.status_code == 499
+    assert engine.cancelled.is_set()


### PR DESCRIPTION
## Summary

Cancel work started by `/skyrl/v1/generate` when its HTTP caller disconnects. Today a replay or evaluation timeout can close the connection while `engine.generate()` keeps running and consuming scheduler/KV-cache capacity.

## Changes

- Race generation against the request disconnect signal after consuming the body.
- Cancel and drain only that request's generation task. This lets vLLM's existing generator cancellation path abort its internal request ID.
- Shield cleanup from repeated handler cancellation.
- Return status 499 when SkyRL observes a disconnected caller. Connected callers and normal generation remain unchanged.

## Testing

- `39 passed`: disconnect cleanup, repeated handler cancellation, normal completion, endpoint integration, and existing generate-wire coverage.
- Full pre-commit suite passed: Ruff, Black, and Gitleaks.
- `uv lock --check` passed.

## Scope

This covers the non-streaming SkyRL replay endpoint. It does not add request timeouts or change streaming endpoints. Local tests prove cancellation reaches the engine generator; TP/GPU abort latency remains for hosted validation.

## Did this cause any problems?

Revert this commit to restore the previous endpoint behavior.