### PR TITLE
[tinker] Bound non-colocated forwarding fan-out

### DIFF
--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -5,6 +5,7 @@ Pair to :class:`ExternalInferenceClient`; resolves the target URL from
 """
 
 import asyncio
+import os
 from datetime import datetime, timezone
 
 import httpx
@@ -29,6 +30,9 @@ class SkyRLTrainInferenceForwardingClient:
         # Backpressure layered: httpx pool -> vllm-router -> vLLM max_num_seqs.
         # Default `forwarding_inference_max_connections=None` is unlimited;
         # the only cost is file descriptors (raise `ulimit -n` accordingly).
+        self._fanout_sema = asyncio.Semaphore(
+            int(os.environ.get("SKYRL_FORWARDING_MAX_CONCURRENCY", "256"))
+        )
         max_conn = engine_config.forwarding_inference_max_connections
         max_keepalive = max(max_conn // 4, 32) if max_conn is not None else None
         self._http_client: httpx.AsyncClient = httpx.AsyncClient(
@@ -73,7 +77,8 @@ class SkyRLTrainInferenceForwardingClient:
     ):
         """Forward a sample request to vLLM and write the result to FutureDB."""
         try:
-            result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
+            async with self._fanout_sema:
+                result = await self._forward_with_retry(sample_req, model_id, base_model=base_model)
             status = RequestStatus.COMPLETED
         except Exception as e:
             logger.exception("Backend-forwarded sample failed (request_id=%s)", request_id)


### PR DESCRIPTION
- Bound concurrent non-colocated forwards to 256 by default, configurable with `SKYRL_FORWARDING_MAX_CONCURRENCY`.\n- Promotes the fan-out limiter removed from Trajectory PR #4385 into SkyRL source for isolated review.\n\n## Testing\n\n```bash\nuv run --no-sync ruff check skyrl/tinker/extra/skyrl_train_inference_forwarding.py\n```\n\nRuff passed; the async routing suite collected but its four integration cases were environment-skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency behavior for production inference forwarding; mis-tuning the env var could throttle throughput or still allow overload, but the change is localized and defaults match prior Trajectory intent.
> 
> **Overview**
> Adds an **`asyncio.Semaphore`** on `SkyRLTrainInferenceForwardingClient` so non-colocated EXTERNAL sample forwards do not all run in parallel when the httpx pool is unlimited.
> 
> Default cap is **256** concurrent forwards, overridable via **`SKYRL_FORWARDING_MAX_CONCURRENCY`**. Each `call_and_store_result` acquires the semaphore before `_forward_with_retry`, layering backpressure on top of the existing httpx connection limits and downstream vLLM/router limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e07b1603e6f25797ee8e2cf0ccd5a7af938c9058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->