### PR TITLE
[tinker] Size the API database pool for rollout bursts

### DIFF
--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -233,7 +233,9 @@ async def lifespan(app: FastAPI):
     """Lifespan event handler for startup and shutdown."""
 
     db_url = get_async_database_url(app.state.engine_config.database_url)
-    app.state.db_engine = create_async_engine(db_url, echo=False)
+    app.state.db_engine = create_async_engine(
+        db_url, echo=False, pool_size=50, max_overflow=100, pool_timeout=120
+    )
     enable_sqlite_wal(app.state.db_engine.sync_engine)
 
     async with app.state.db_engine.begin() as conn:


### PR DESCRIPTION
- Raise the Tinker API SQLAlchemy pool to 50 connections with 100 overflow and a 120-second checkout timeout.\n- Isolates the DB-pool patch removed from Trajectory PR #4385; SQLite lock timing remains in a separate PR.\n\n## Testing\n\n```bash\nuv run --no-sync ruff check skyrl/tinker/api.py\n```\n\nRuff passed. The focused DB suite could not collect in the shared environment because its `tinker.proto` test dependency is absent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single startup configuration change with no query or auth logic; main operational risk is higher peak DB connection use under burst load.
> 
> **Overview**
> **Sizes the Tinker API’s async SQLAlchemy pool** so short-lived rollout traffic (many concurrent `retrieve_future` waiters and per-request `AsyncSession` checkouts) is less likely to exhaust connections or fail while waiting for a slot.
> 
> On startup in `lifespan`, `create_async_engine` now uses **`pool_size=50`**, **`max_overflow=100`**, and **`pool_timeout=120`** seconds instead of SQLAlchemy’s smaller defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd03551c8227b893ea20fbb6049c4f9fa69ea1a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->