### PR TITLE
[tinker] Raise SQLite busy timeout under rollout load

### DIFF
--- a/skyrl/tinker/db_models.py
+++ b/skyrl/tinker/db_models.py
@@ -26,7 +26,7 @@ def enable_sqlite_wal(engine) -> None:
     def _set_sqlite_pragma(dbapi_connection, connection_record):
         cursor = dbapi_connection.cursor()
         cursor.execute("PRAGMA journal_mode=WAL")
-        cursor.execute("PRAGMA busy_timeout=30000")
+        cursor.execute("PRAGMA busy_timeout=300000")
         cursor.close()
 
 


### PR DESCRIPTION
- Raise SQLite's busy timeout from 30 seconds to 300 seconds for sustained rollout write contention.\n- Isolates the lock-timeout patch removed from Trajectory PR #4385; DB-pool sizing remains in a separate PR.\n\n## Testing\n\n```bash\nuv run --no-sync ruff check skyrl/tinker/db_models.py\n```\n\nRuff passed. The focused DB suite could not collect in the shared environment because its `tinker.proto` test dependency is absent.