### PR TITLE
[tinker] Make inference forwarding timeout configurable

### DIFF
--- a/skyrl/tinker/config.py
+++ b/skyrl/tinker/config.py
@@ -58,6 +58,18 @@ class EngineConfig(BaseModel):
         ),
         json_schema_extra={"argparse_type": lambda v: None if v == "None" else int(v)},
     )
+    forwarding_inference_timeout_sec: float = Field(
+        default=300.0,
+        gt=0,
+        description=(
+            "Read timeout in seconds for API-side requests forwarded to the "
+            "SkyRL-Train-managed inference engine."
+        ),
+        json_schema_extra={
+            "argparse_type": float,
+            "env_var": "SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC",
+        },
+    )
     session_cleanup_interval_sec: int = Field(
         default=60,
         description="How often to check for stale sessions (seconds). Set to -1 to disable cleanup.",

--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -32,7 +32,12 @@ class SkyRLTrainInferenceForwardingClient:
         max_conn = engine_config.forwarding_inference_max_connections
         max_keepalive = max(max_conn // 4, 32) if max_conn is not None else None
         self._http_client: httpx.AsyncClient = httpx.AsyncClient(
-            timeout=httpx.Timeout(300.0, connect=10.0),
+            timeout=httpx.Timeout(
+                connect=10.0,
+                read=engine_config.forwarding_inference_timeout_sec,
+                write=300.0,
+                pool=300.0,
+            ),
             limits=httpx.Limits(
                 max_connections=max_conn,
                 max_keepalive_connections=max_keepalive,

--- a/tests/tinker/test_inference_forwarding_timeout.py
+++ b/tests/tinker/test_inference_forwarding_timeout.py
@@ -1,0 +1,34 @@
+import argparse
+from unittest.mock import patch
+
+from skyrl.tinker.config import EngineConfig, add_model
+from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
+    SkyRLTrainInferenceForwardingClient,
+)
+
+
+def test_forwarding_timeout_reads_environment(monkeypatch) -> None:
+    monkeypatch.setenv("SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC", "1800")
+    parser = argparse.ArgumentParser()
+    add_model(parser, EngineConfig)
+
+    args = parser.parse_args(["--base-model", "test-model"])
+    config = EngineConfig.model_validate(vars(args))
+
+    assert config.forwarding_inference_timeout_sec == 1800.0
+
+
+def test_forwarding_client_uses_configured_timeout() -> None:
+    config = EngineConfig(
+        base_model="test-model",
+        forwarding_inference_timeout_sec=1800.0,
+    )
+
+    with patch("skyrl.tinker.extra.skyrl_train_inference_forwarding.httpx.AsyncClient") as async_client:
+        SkyRLTrainInferenceForwardingClient(config, db_engine=None)
+
+    timeout = async_client.call_args.kwargs["timeout"]
+    assert timeout.connect == 10.0
+    assert timeout.read == 1800.0
+    assert timeout.write == 300.0
+    assert timeout.pool == 300.0


### PR DESCRIPTION
- Add a typed forwarding read-timeout setting with `SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC` support.\n- Isolates the long-context timeout patch removed from Trajectory PR #4385; retry behavior remains in a separate PR.\n\n## Testing\n\n```bash\nuv run --no-sync pytest -q tests/tinker/test_inference_forwarding_timeout.py\n```\n\n2 passed; Ruff passed on all changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational tuning only; default read timeout matches prior behavior, with tests for env and client wiring.
> 
> **Overview**
> Adds **`forwarding_inference_timeout_sec`** on `EngineConfig` (default **300s**, CLI **`--forwarding-inference-timeout-sec`**, env **`SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC`**) so long-running forwarded samples can wait longer without editing code.
> 
> **`SkyRLTrainInferenceForwardingClient`** now builds an explicit **`httpx.Timeout`**: **read** comes from that setting; **connect** stays **10s**; **write** and **pool** stay **300s** (replacing a single 300s default for all phases).
> 
> New tests cover env-based config loading and that the forwarding client passes the configured read timeout into **`httpx.AsyncClient`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e393919f65290bf2515326507d2fe71f94184a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->