### PR TITLE
[tinker] Retry transient unavailable inference workers

### DIFF
--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -94,20 +94,30 @@ class SkyRLTrainInferenceForwardingClient:
             await session.commit()
 
     async def _forward_with_retry(self, sample_req, model_id: str, *, base_model: str | None) -> types.SampleOutput:
-        # httpx.RequestError covers ConnectError, ReadError, TimeoutException, etc.
-        # HTTP 4xx/5xx surfaces as RuntimeError below and is NOT retried.
-        try:
-            proxy_url = await self._resolve_proxy_url()
-            return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
-        except httpx.RequestError as e:
-            logger.warning(
-                "Network error talking to %s (%s: %s) — refreshing proxy URL and retrying once",
-                self._cached_proxy_url,
-                type(e).__name__,
-                e,
-            )
-            proxy_url = await self._resolve_proxy_url(force_refresh=True)
-            return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
+        max_attempts = 12
+        delay = 1.0
+        proxy_url = await self._resolve_proxy_url()
+        for attempt in range(max_attempts):
+            try:
+                return await self._forward(proxy_url, sample_req, model_id, base_model=base_model)
+            except (httpx.ConnectError, httpx.ConnectTimeout, RuntimeError) as error:
+                unavailable = isinstance(error, RuntimeError) and "returned 503: No available workers" in str(error)
+                if isinstance(error, RuntimeError) and not unavailable:
+                    raise
+                if attempt + 1 == max_attempts:
+                    raise
+                logger.warning(
+                    "Transient inference forwarding failure (%s: %s); retrying in %.1fs (%d/%d)",
+                    type(error).__name__,
+                    error,
+                    delay,
+                    attempt + 1,
+                    max_attempts,
+                )
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, 10.0)
+                proxy_url = await self._resolve_proxy_url(force_refresh=True)
+        raise AssertionError("unreachable")
 
     async def _forward(
         self, proxy_url: str, sample_req, model_id: str, *, base_model: str | None

--- a/tests/tinker/test_inference_forwarding_retry.py
+++ b/tests/tinker/test_inference_forwarding_retry.py
@@ -1,0 +1,40 @@
+from unittest.mock import AsyncMock, call, patch
+
+import httpx
+import pytest
+
+from skyrl.tinker.extra.skyrl_train_inference_forwarding import (
+    SkyRLTrainInferenceForwardingClient,
+)
+
+
+@pytest.mark.asyncio
+async def test_forwarding_retries_unavailable_worker() -> None:
+    client = object.__new__(SkyRLTrainInferenceForwardingClient)
+    client._cached_proxy_url = "http://old"
+    client._resolve_proxy_url = AsyncMock(side_effect=["http://old", "http://new"])
+    expected = object()
+    client._forward = AsyncMock(
+        side_effect=[RuntimeError("vLLM /v1/completions returned 503: No available workers"), expected]
+    )
+
+    with patch("skyrl.tinker.extra.skyrl_train_inference_forwarding.asyncio.sleep", new=AsyncMock()):
+        result = await client._forward_with_retry(object(), "model", base_model=None)
+
+    assert result is expected
+    client._resolve_proxy_url.assert_has_awaits([call(), call(force_refresh=True)])
+    assert client._forward.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_forwarding_does_not_retry_read_timeout() -> None:
+    client = object.__new__(SkyRLTrainInferenceForwardingClient)
+    client._cached_proxy_url = "http://inference"
+    client._resolve_proxy_url = AsyncMock(return_value="http://inference")
+    client._forward = AsyncMock(side_effect=httpx.ReadTimeout("slow response"))
+
+    with pytest.raises(httpx.ReadTimeout):
+        await client._forward_with_retry(object(), "model", base_model=None)
+
+    client._resolve_proxy_url.assert_awaited_once_with()
+    client._forward.assert_awaited_once()


### PR DESCRIPTION
- Retry connection failures and the router's exact `503: No available workers` response with bounded backoff.\n- Do not retry ambiguous read failures or other runtime errors; timeout configuration remains in a separate PR.\n\n## Testing\n\n```bash\nuv run --no-sync pytest -q tests/tinker/test_inference_forwarding_retry.py\n```\n\n2 passed; Ruff passed on all changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inference request reliability and failure semantics (fewer immediate failures on worker churn, but longer waits and different errors retried vs not).
> 
> **Overview**
> Replaces the **single** proxy-URL refresh retry on generic `httpx.RequestError` with **up to 12 attempts** using exponential backoff (1s → cap 10s) in `_forward_with_retry`.
> 
> Retries are limited to **connection failures** (`ConnectError`, `ConnectTimeout`) and the router’s **`503: No available workers`** `RuntimeError`; other HTTP/runtime errors propagate immediately, and **`ReadTimeout` is not retried**. Each retry refreshes the inference proxy URL from the DB.
> 
> Adds unit tests for the 503 retry path and for no-retry on read timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed580d88cbfa73b3e34e0a9276dd4e172fe8b4c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->