### PR TITLE
[fix][lora] Reload adapters with fresh engine IDs

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/lora_reload.py
+++ b/skyrl/backends/skyrl_train/inference_servers/lora_reload.py
@@ -1,0 +1,17 @@
+async def replace_lora_adapter(models, lora_name, lora_path, lora_request_type):
+    """Load an adapter under a fresh id, replacing the prior registration."""
+    async with models.lora_resolver_lock[lora_name]:
+        old_request = models.lora_requests.get(lora_name)
+        if old_request is not None:
+            await models.engine_client.remove_lora(old_request.lora_int_id)
+            del models.lora_requests[lora_name]
+
+        lora_int_id = models.lora_id_counter.inc(1)
+        lora_request = lora_request_type(
+            lora_name=lora_name,
+            lora_int_id=lora_int_id,
+            lora_path=lora_path,
+        )
+        await models.engine_client.add_lora(lora_request)
+        models.lora_requests[lora_name] = lora_request
+        return lora_int_id

--- a/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
+++ b/skyrl/backends/skyrl_train/inference_servers/remote_inference_client.py
@@ -1281,17 +1281,8 @@ class RemoteInferenceClient(InferenceEngineInterface):
         After loading, generation/chat/completion requests can target this LoRA
         by passing ``model=lora_name``.
 
-        TODO(aaron): switch back to vLLM's /v1/load_lora_adapter once the
-        upstream fix in https://github.com/vllm-project/vllm/pull/41482 lands
-        in a vLLM release we depend on.
-
-        The custom endpoint (defined in vllm_server_actor.py) wraps add_lora
-        with load_inplace=True (so the engine reloads the freshly-written
-        safetensors) and then resets the cached LoRARequest's load_inplace=False
-        (so subsequent generates don't reload from disk on every step). This
-        avoids two vLLM 0.19.0 bugs that surface under colocate_all + tp=1 +
-        num_engines>=2 — see vllm_server_actor.py:_skyrl_load_lora_adapter for
-        the detailed explanation.
+        The custom endpoint removes an existing adapter and reloads it under a
+        fresh engine id so cached CUDA graphs cannot retain its old buffers.
 
         Args:
             lora_name: Name to register the adapter under on each server.

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -41,6 +41,9 @@ from skyrl.backends.skyrl_train.inference_servers.generate_wire import (
     build_logprobs_content,
     pack_routed_experts,
 )
+from skyrl.backends.skyrl_train.inference_servers.lora_reload import (
+    replace_lora_adapter,
+)
 from skyrl.backends.skyrl_train.inference_servers.protocols import ServerActorProtocol
 from skyrl.env_vars import (
     SKYRL_HTTP_CONNECTION_LIMIT,
@@ -432,13 +435,7 @@ class VLLMServerActor(ServerActorProtocol):
 
         @app.post("/skyrl/v1/load_lora_adapter")
         async def _skyrl_load_lora_adapter(request: Request):
-            """Load a LoRA adapter from disk, replacing any existing adapter
-            under the same name in place. Used by RemoteInferenceClient.update_lora_from_disk.
-
-            TODO(aaron): remove this endpoint and route update_lora_from_disk back
-            through /v1/load_lora_adapter once the upstream fix in
-            https://github.com/vllm-project/vllm/pull/41482 lands in a vLLM release we depend on.
-            """
+            """Load a LoRA adapter from disk under a fresh engine id."""
             body = await request.json()
             lora_name = body.get("lora_name")
             lora_path = body.get("lora_path")
@@ -449,21 +446,7 @@ class VLLMServerActor(ServerActorProtocol):
                 )
 
             models = request.app.state.openai_serving_models
-            async with models.lora_resolver_lock[lora_name]:
-                lora_int_id = (
-                    models.lora_requests[lora_name].lora_int_id
-                    if lora_name in models.lora_requests
-                    else models.lora_id_counter.inc(1)
-                )
-                lora_request = LoRARequest(
-                    lora_name=lora_name,
-                    lora_int_id=lora_int_id,
-                    lora_path=lora_path,
-                    load_inplace=True,
-                )
-                await models.engine_client.add_lora(lora_request)
-                lora_request.load_inplace = False
-                models.lora_requests[lora_name] = lora_request
+            lora_int_id = await replace_lora_adapter(models, lora_name, lora_path, LoRARequest)
 
             return {
                 "status": "ok",

--- a/tests/backends/skyrl_train/inference_servers/test_lora_reload.py
+++ b/tests/backends/skyrl_train/inference_servers/test_lora_reload.py
@@ -1,0 +1,59 @@
+import asyncio
+from collections import defaultdict
+from types import SimpleNamespace
+
+import pytest
+
+from skyrl.backends.skyrl_train.inference_servers.lora_reload import (
+    replace_lora_adapter,
+)
+
+
+class _Counter:
+    def __init__(self):
+        self.value = 0
+
+    def inc(self, amount):
+        self.value += amount
+        return self.value
+
+
+class _LoRARequest:
+    def __init__(self, lora_name, lora_int_id, lora_path):
+        self.lora_name = lora_name
+        self.lora_int_id = lora_int_id
+        self.lora_path = lora_path
+
+
+class _EngineClient:
+    def __init__(self):
+        self.events = []
+
+    async def add_lora(self, request):
+        self.events.append(("add", request.lora_int_id, request.lora_path))
+
+    async def remove_lora(self, lora_int_id):
+        self.events.append(("remove", lora_int_id))
+
+
+@pytest.mark.asyncio
+async def test_reloading_lora_replaces_engine_id():
+    engine_client = _EngineClient()
+    models = SimpleNamespace(
+        engine_client=engine_client,
+        lora_id_counter=_Counter(),
+        lora_requests={},
+        lora_resolver_lock=defaultdict(asyncio.Lock),
+    )
+
+    first_id = await replace_lora_adapter(models, "policy", "/adapters/step-1", _LoRARequest)
+    second_id = await replace_lora_adapter(models, "policy", "/adapters/step-2", _LoRARequest)
+
+    assert (first_id, second_id) == (1, 2)
+    assert engine_client.events == [
+        ("add", 1, "/adapters/step-1"),
+        ("remove", 1),
+        ("add", 2, "/adapters/step-2"),
+    ]
+    assert models.lora_requests["policy"].lora_int_id == 2
+    assert models.lora_requests["policy"].lora_path == "/adapters/step-2"


### PR DESCRIPTION
## Summary

- Replace same-ID in-place LoRA reloads with remove-then-load under a fresh monotonically increasing engine ID.
- Prevent captured CUDA graphs from retaining old adapter buffers while preserving the existing per-name reload lock.
- Keep IDs unique across multi-LoRA servers instead of relying on the workload overlay's 1/2 rotation.

The device-side assert was reproduced on Nemotron XID [1045367](https://xmanager.trajectory.ai/experiments/1045367). The equivalent remove-and-fresh-ID overlay was used by the successful cold B300 runs [1049103](https://wandb.ai/trajectory-ai/verl_examples/runs/1049103) and [1049126](https://wandb.ai/trajectory-ai/verl_examples/runs/1049126).

## Testing

```bash
uv run --active --no-sync --with cloudpathlib pytest -q --confcutdir=tests/backends/skyrl_train/inference_servers tests/backends/skyrl_train/inference_servers/test_lora_reload.py
```

The focused regression passed; Ruff and Black 24.10.0 pass on all four changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LoRA registration on live vLLM inference workers during training weight sync; incorrect behavior could cause GPU asserts or wrong policy weights, but scope is narrow and covered by a focused test.
> 
> **Overview**
> **LoRA hot-reload** no longer reuses the same vLLM engine id with in-place `load_inplace` updates. Reloads go through shared `replace_lora_adapter`, which **removes** any existing registration for that name, **allocates a new monotonic `lora_int_id`**, and **adds** the adapter from disk—still under the per-name `lora_resolver_lock`.
> 
> The `/skyrl/v1/load_lora_adapter` handler and `RemoteInferenceClient.load_lora_adapter` docs are updated to describe this **remove + fresh-id** behavior (avoiding stale CUDA graph buffers). A unit test asserts reloads emit remove-then-add with incrementing ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fcee5e09f1c82a8e4035103512bcb5fa5124d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->