### PR TITLE
[fix][megatron] Isolate DSA index-share holder across checkpointed forwards

### DIFF
--- a/skyrl/backends/skyrl_train/patches/megatron/patch_dsa_index_share.py
+++ b/skyrl/backends/skyrl_train/patches/megatron/patch_dsa_index_share.py
@@ -1,0 +1,255 @@
+"""Backport of NVIDIA/Megatron-LM#6793 for megatron-core 0.20.0.
+
+DSA (the sparse-attention variant GLM 5 uses) lets a source layer compute top-k
+indices that later layers reuse. The holder for that state is chosen per forward
+by ``DSAttention._get_index_share_carrier``. On the packed path it is the
+``PackedSeqParams`` object, which is genuinely per-forward. On the **non-packed**
+path the fallback is ``attention_mask`` -- or ``self.config`` when there is no
+mask -- and both outlive a single forward.
+
+With activation recompute there can be several outstanding checkpointed forwards
+at once (F1, F2, then B1, B2). A later forward overwrites the shared holder
+before an earlier one is recomputed, so the earlier recompute consumes top-k
+support belonging to the wrong forward -- silently wrong logits, no error.
+
+Upstream fixes this by creating one private carrier per ``checkpointed_forward``
+invocation and capturing it in each activation-checkpoint closure, so the
+carrier is re-entered at recompute time. This module applies exactly that
+change at runtime.
+
+Scope: this only bites when ``packed_seq_params is None`` (SkyRL RL training
+defaults to ``trainer.remove_microbatch_padding=True``, which packs), the model
+is DSA, and ``dsa_indexer_topk_freq > 1``. It is a no-op everywhere else, which
+is why it is safe to apply unconditionally from the Megatron worker.
+
+Applied as a source-level rebind rather than an edit to the installed package:
+megatron-core is installed from a pinned git rev and ``uv run --isolated``
+builds a throwaway environment per invocation, so a site-packages edit would not
+survive a run (nor reach other Ray nodes). ``checkpointed_forward`` is a ~170
+line function and both edits land on inner closures, so there is no sub-function
+seam to override -- we recompile that one function with upstream's two edits
+applied and rebind it on every module that imported it by name.
+
+DELETE THIS PATCH once the megatron-core pin includes NVIDIA/Megatron-LM#6793.
+It is a temporary backport of an upstream fix, not a SkyRL behavior change. It
+fails safe in the meantime: the anchors below are literal 0.20.0 source text, so
+on a restructured megatron-core this logs and no-ops rather than misfiring, and
+it detects the real fix and steps aside. Check this file when bumping the pin.
+"""
+
+import inspect
+import sys
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator, Optional
+
+from loguru import logger
+
+_PATCHED_FLAG = "_skyrl_dsa_index_share_patched"
+
+# Set by upstream once NVIDIA/Megatron-LM#6793 lands; its presence means the
+# installed megatron-core already has the fix and this module should be deleted.
+_UPSTREAM_SENTINEL = "_dsa_index_share_carrier_scope"
+
+# Modules that do `from megatron.core.recompute import checkpointed_forward`,
+# and so hold their own reference that a rebind on `recompute` alone would miss.
+_IMPORTERS = (
+    "megatron.core.transformer.transformer_block",
+    "megatron.core.models.hybrid.hybrid_block",
+)
+
+# --- anchors, verbatim from megatron-core 0.20.0 recompute.py -----------------
+
+_ANCHOR_CARRIER_SETUP = """    if extract_layer_indices is None:
+        extract_layer_indices = set()
+    intermediate_hidden_states: List[Tensor] = []
+"""
+
+_REPLACEMENT_CARRIER_SETUP = """    if extract_layer_indices is None:
+        extract_layer_indices = set()
+    intermediate_hidden_states: List[Tensor] = []
+
+    dsa_index_share_carrier = None
+    dsa_index_share_carrier_scope = None
+    if (
+        packed_seq_params is None
+        and getattr(self.config, "experimental_attention_variant", None) == "dsa"
+        and (getattr(self.config, "dsa_indexer_topk_freq", 1) or 1) > 1
+    ):
+        from megatron.core.transformer.experimental_attention_variant.dsa import (
+            _dsa_index_share_carrier_scope,
+            _DSAIndexShareCarrier,
+        )
+
+        dsa_index_share_carrier = _DSAIndexShareCarrier()
+        dsa_index_share_carrier_scope = _dsa_index_share_carrier_scope
+"""
+
+_ANCHOR_RETURN_CLOSURE = """        return custom_forward
+
+    def chunk_runner(start: int, end: int, use_checkpoint: bool):
+"""
+
+_REPLACEMENT_RETURN_CLOSURE = """        if dsa_index_share_carrier_scope is None:
+            return custom_forward
+
+        def carrier_scoped_forward(*args):
+            with dsa_index_share_carrier_scope(dsa_index_share_carrier):
+                return custom_forward(*args)
+
+        return carrier_scoped_forward
+
+    def chunk_runner(start: int, end: int, use_checkpoint: bool):
+"""
+
+
+class _DSAIndexShareCarrier:
+    """Per-forward DSA index-share carrier for non-packed activation recompute."""
+
+
+_CURRENT_DSA_INDEX_SHARE_CARRIER: ContextVar[Optional[object]] = ContextVar(
+    "current_dsa_index_share_carrier", default=None
+)
+
+
+@contextmanager
+def _dsa_index_share_carrier_scope(carrier: object) -> Iterator[None]:
+    """Expose one non-packed forward's index-share carrier to its checkpoint closures."""
+    token = _CURRENT_DSA_INDEX_SHARE_CARRIER.set(carrier)
+    try:
+        yield
+    finally:
+        _CURRENT_DSA_INDEX_SHARE_CARRIER.reset(token)
+
+
+def _make_index_share_carrier_getter(original):
+    """Build the replacement ``DSAttention._get_index_share_carrier``.
+
+    Identical to upstream: the packed carrier still wins, the per-forward carrier
+    is consulted next, and the pre-existing ``attention_mask``/``config`` fallback
+    is kept for forwards outside a checkpointed scope.
+    """
+
+    def _get_index_share_carrier(self, packed_seq_params, attention_mask):
+        """Return the object that carries DSA top-k sharing state for this forward."""
+        if packed_seq_params is not None:
+            return packed_seq_params
+        carrier = _CURRENT_DSA_INDEX_SHARE_CARRIER.get()
+        if carrier is not None:
+            return carrier
+        return attention_mask if attention_mask is not None else self.config
+
+    _get_index_share_carrier.__doc__ = original.__doc__ or _get_index_share_carrier.__doc__
+    return _get_index_share_carrier
+
+
+def patch_dsa_index_share(force: bool = False) -> bool:
+    """Isolate the DSA index-share holder per checkpointed forward.
+
+    No-ops (returning False) when megatron-core is not importable, when it has no
+    DSA attention variant, when it already contains NVIDIA/Megatron-LM#6793, or
+    when ``checkpointed_forward`` no longer matches the 0.20.0 source form.
+
+    Pass ``force=True`` to patch even when the upstream fix is detected; this
+    exists for tests and has no reason to be used in production.
+
+    Safe to call more than once; the second call is a no-op returning True.
+    """
+    try:
+        from megatron.core import recompute
+    except ImportError:
+        logger.debug("megatron.core not importable; skipping DSA index-share patch")
+        return False
+
+    target = getattr(recompute, "checkpointed_forward", None)
+    if target is None:
+        logger.warning("megatron.core.recompute has no checkpointed_forward; skipping DSA index-share patch")
+        return False
+
+    if getattr(target, _PATCHED_FLAG, False):
+        return True
+
+    try:
+        from megatron.core.transformer.experimental_attention_variant import (
+            dsa as dsa_module,
+        )
+    except ImportError:
+        logger.debug("megatron-core has no DSA attention variant; skipping DSA index-share patch")
+        return False
+
+    if not force and hasattr(dsa_module, _UPSTREAM_SENTINEL):
+        # The pin moved past NVIDIA/Megatron-LM#6793, so this module is dead weight.
+        logger.info(
+            "megatron-core already isolates the DSA index-share carrier "
+            "(NVIDIA/Megatron-LM#6793); skipping DSA index-share patch. "
+            "Delete skyrl/backends/skyrl_train/patches/megatron/patch_dsa_index_share.py."
+        )
+        return False
+
+    attention_cls = getattr(dsa_module, "DSAttention", None)
+    if attention_cls is None or not hasattr(attention_cls, "_get_index_share_carrier"):
+        logger.warning("DSAttention._get_index_share_carrier is missing; skipping DSA index-share patch")
+        return False
+
+    try:
+        source = inspect.getsource(target)
+    except (OSError, TypeError):
+        logger.warning("Cannot read megatron-core checkpointed_forward source; skipping DSA index-share patch")
+        return False
+
+    # Verify both anchors before mutating anything, so a source drift cannot
+    # leave the DSA module half-patched.
+    missing = [
+        name
+        for name, anchor in (
+            ("carrier setup", _ANCHOR_CARRIER_SETUP),
+            ("closure return", _ANCHOR_RETURN_CLOSURE),
+        )
+        if anchor not in source
+    ]
+    if missing:
+        logger.info(
+            "megatron-core checkpointed_forward does not match the 0.20.0 form "
+            "({} anchor(s) not found: {}); skipping DSA index-share patch. "
+            "If megatron-core now includes NVIDIA/Megatron-LM#6793, delete this patch module.",
+            len(missing),
+            ", ".join(missing),
+        )
+        return False
+
+    # Publish the carrier machinery on megatron-core's own DSA module: the
+    # recompiled function imports these names from there, exactly as upstream does.
+    dsa_module._DSAIndexShareCarrier = _DSAIndexShareCarrier
+    dsa_module._CURRENT_DSA_INDEX_SHARE_CARRIER = _CURRENT_DSA_INDEX_SHARE_CARRIER
+    dsa_module._dsa_index_share_carrier_scope = _dsa_index_share_carrier_scope
+    attention_cls._get_index_share_carrier = _make_index_share_carrier_getter(attention_cls._get_index_share_carrier)
+
+    patched_source = source.replace(_ANCHOR_CARRIER_SETUP, _REPLACEMENT_CARRIER_SETUP).replace(
+        _ANCHOR_RETURN_CLOSURE, _REPLACEMENT_RETURN_CLOSURE
+    )
+    # Execute in megatron-core's own module namespace so the recompiled function
+    # keeps the live module globals it depends on (tensor_parallel, te_checkpoint,
+    # get_fp8_context, ...), and so the rebind lands on the module.
+    filename = getattr(recompute, "__file__", None) or "<string>"
+    exec(compile(patched_source, filename, "exec"), recompute.__dict__)  # noqa: S102
+
+    patched = recompute.checkpointed_forward
+    if patched is target:
+        logger.warning("Failed to rebind megatron-core checkpointed_forward; DSA index-share patch not applied")
+        return False
+    setattr(patched, _PATCHED_FLAG, True)
+
+    # TransformerBlock and HybridStack bound `checkpointed_forward` by name at
+    # import time, so rebinding `recompute` alone would leave them on the
+    # unpatched function.
+    for module_name in _IMPORTERS:
+        module = sys.modules.get(module_name)
+        if module is None:
+            # Not imported yet; its own `from ... import` will pick up the patched
+            # function when it is.
+            continue
+        if getattr(module, "checkpointed_forward", None) is target:
+            module.checkpointed_forward = patched
+
+    logger.info("Applied megatron-core DSA index-share patch (NVIDIA/Megatron-LM#6793 backport)")
+    return True

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -40,6 +40,9 @@ from skyrl.backends.skyrl_train.distributed.megatron.optimizer import (
 from skyrl.backends.skyrl_train.inference_servers.remote_inference_client import (
     SKYRL_LORA_ADAPTER_NAME,
 )
+from skyrl.backends.skyrl_train.patches.megatron.patch_dsa_index_share import (
+    patch_dsa_index_share,
+)
 from skyrl.backends.skyrl_train.patches.te.patch_fa2_head_dim import (
     patch_fa2_head_dim_allowlist,
 )
@@ -633,6 +636,12 @@ class MegatronWorker:
         # TE patch to allow FA2 for head_dim 256 on SM103 (B300)
         # Delete along with the patch module once the TE pin includes NVIDIA/TransformerEngine#3360.
         patch_fa2_head_dim_allowlist()
+
+        # Isolate the DSA index-share holder per checkpointed forward (GLM 5 and
+        # other DSA models under activation recompute on the non-packed path).
+        # Delete along with the patch module once the megatron-core pin includes
+        # NVIDIA/Megatron-LM#6793.
+        patch_dsa_index_share()
 
         if lora_config is not None:
             self.configure_lora(lora_config, lora_type)

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_dsa_index_share_recompute.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_dsa_index_share_recompute.py
@@ -1,0 +1,163 @@
+"""Regression test for the DSA index-share recompute patch.
+
+Ported from the test added in NVIDIA/Megatron-LM#6793 so SkyRL verifies the
+underlying issue is actually fixed by
+``skyrl.backends.skyrl_train.patches.megatron.patch_dsa_index_share``, rather
+than only that the patch applies cleanly.
+
+The scenario is two outstanding non-packed checkpointed forwards followed by
+their two recomputes (F1 -> F2 -> B1 -> B2). Without the patch both forwards
+share one holder (hung off ``attention_mask``), so F2 overwrites F1's top-k
+support and B1 recomputes against the wrong forward's state -- the assertion
+below sees ``[2, 2]`` instead of ``[1, 2]``.
+
+Needs no GPU, but does need the ``megatron`` extra, so it lives with the rest of
+the Megatron GPU CI suite.
+
+Run with:
+uv run --isolated --extra dev --extra megatron -- pytest -s tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_dsa_index_share_recompute.py
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from skyrl.backends.skyrl_train.patches.megatron.patch_dsa_index_share import (
+    patch_dsa_index_share,
+)
+
+pytestmark = pytest.mark.megatron
+
+
+@pytest.fixture(scope="module")
+def patched_megatron():
+    """Apply the backport, skipping if this megatron-core does not need it."""
+    if not patch_dsa_index_share():
+        pytest.skip(
+            "DSA index-share patch did not apply -- megatron-core either already "
+            "contains NVIDIA/Megatron-LM#6793 or no longer matches the 0.20.0 source form"
+        )
+
+
+def _build_attention():
+    from megatron.core.transformer.enums import AttnMaskType
+    from megatron.core.transformer.experimental_attention_variant.dsa import (
+        DSAttention,
+        DSAttentionSubmodules,
+    )
+
+    config = SimpleNamespace(
+        dsa_indexer_topk=8,
+        dsa_indexer_topk_freq=4,
+        dsa_indexer_skip_topk_offset=1,
+        kv_channels=16,
+    )
+    return DSAttention(
+        config=config,
+        submodules=DSAttentionSubmodules(indexer=object()),
+        layer_number=2,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type="self",
+        softmax_scale=1.0,
+        pg_collection=SimpleNamespace(),
+    )
+
+
+def test_nonpacked_checkpointed_forwards_keep_index_share_holders_isolated(patched_megatron, monkeypatch):
+    """Each checkpointed forward recomputes against its own top-k support."""
+    from megatron.core import recompute
+    from megatron.core.transformer.experimental_attention_variant.dsa import DSAttention
+
+    attention = _build_attention()
+    recomputed_supports = []
+
+    class HolderLayer:
+        layer_number = 2
+
+        def __call__(self, hidden_states, attention_mask, packed_seq_params, **_kwargs):
+            topk_holder = attention._get_index_share_topk_holder(packed_seq_params, attention_mask)
+            length_holder = attention._get_index_share_topk_length_holder(packed_seq_params, attention_mask)
+            if torch.is_grad_enabled():
+                recomputed_supports.append((topk_holder[1].clone(), length_holder[1].clone()))
+            else:
+                topk_holder[1] = hidden_states.detach().to(torch.int64)
+                length_holder[1] = hidden_states.detach().to(torch.int32)
+            return hidden_states
+
+    block = SimpleNamespace(
+        config=SimpleNamespace(
+            experimental_attention_variant="dsa",
+            dsa_indexer_topk_freq=4,
+            fp8=False,
+            fp4=False,
+            distribute_saved_activations=False,
+            recompute_method="block",
+            recompute_num_layers=1,
+        ),
+        layers=[HolderLayer()],
+        num_layers_per_pipeline_rank=1,
+        pg_collection=SimpleNamespace(tp=None),
+    )
+    checkpoint_calls = []
+
+    def fake_checkpoint(function, _distribute_saved_activations, *args):
+        checkpoint_calls.append((function, args))
+        with torch.no_grad():
+            return function(*args)
+
+    monkeypatch.setattr("megatron.core.recompute.tensor_parallel.checkpoint", fake_checkpoint)
+    shared_attention_mask = torch.empty(1)
+
+    # F1 then F2: both stage their top-k support before either is recomputed.
+    for value in (1.0, 2.0):
+        recompute.checkpointed_forward(
+            block,
+            hidden_states=torch.tensor([value]),
+            attention_mask=shared_attention_mask,
+            context=None,
+            context_mask=None,
+            rotary_pos_emb=torch.empty(1),
+            attention_bias=None,
+            packed_seq_params=None,
+            use_inner_quantization_context=False,
+        )
+
+    # B1 then B2.
+    for function, args in checkpoint_calls:
+        with torch.enable_grad():
+            function(*args)
+
+    assert [support.item() for support, _length in recomputed_supports] == [1, 2]
+    assert [length.item() for _support, length in recomputed_supports] == [1, 2]
+
+    # The shared mask must never have been used as a carrier.
+    assert not hasattr(shared_attention_mask, DSAttention._HOLDER_ATTR)
+    assert not hasattr(shared_attention_mask, DSAttention._LENGTH_HOLDER_ATTR)
+
+
+def test_packed_forward_still_uses_packed_seq_params(patched_megatron):
+    """The packed path is untouched: PackedSeqParams stays the carrier."""
+    attention = _build_attention()
+    packed_seq_params = SimpleNamespace()
+
+    carrier = attention._get_index_share_carrier(packed_seq_params, torch.empty(1))
+
+    assert carrier is packed_seq_params
+
+
+def test_patch_is_idempotent(patched_megatron):
+    """Re-applying is a no-op that still reports success."""
+    from megatron.core import recompute
+
+    before = recompute.checkpointed_forward
+    assert patch_dsa_index_share() is True
+    assert recompute.checkpointed_forward is before
+
+
+def test_importers_see_the_patched_function(patched_megatron):
+    """TransformerBlock bound the function by name, so it must be rebound too."""
+    from megatron.core import recompute
+    from megatron.core.transformer import transformer_block
+
+    assert transformer_block.checkpointed_forward is recompute.checkpointed_forward


### PR DESCRIPTION
## What

Backports [NVIDIA/Megatron-LM#6793](https://github.com/NVIDIA/Megatron-LM/pull/6793) as a runtime patch applied by the Megatron worker, plus the regression test from that PR.

## Why

DSA (the sparse-attention variant GLM 5 uses) lets a source layer compute top-k indices that later layers reuse. `DSAttention._get_index_share_carrier` picks the holder per forward: `PackedSeqParams` on the packed path, which is genuinely per-forward, but `attention_mask` — or `self.config` when there is no mask — on the **non-packed** path. Both outlive a single forward.

Under activation recompute several checkpointed forwards can be outstanding at once (F1, F2, then B1, B2). A later forward overwrites the shared holder before an earlier one is recomputed, so the earlier recompute consumes top-k support from the wrong forward — **silently wrong logits, no error**.

Measured against megatron-core 0.20.0 with the upstream scenario:

| | recomputed top-k support | carrier leaked onto `attention_mask` |
|---|---|---|
| unpatched | `[2, 2]` ❌ | yes |
| patched | `[1, 2]` ✅ | no |

## Why a runtime patch

The fix is upstream but **still unmerged**, and it lives in megatron-core's forward path — `recompute.checkpointed_forward` plus the DSA module — not in the conversion layer. A custom bridge only governs HF↔Megatron weight conversion and has no hook into `checkpointed_forward`, so it cannot express this fix.

Following the existing `patches/te/patch_fa2_head_dim.py` convention, the patch recompiles that one function with upstream's two edits applied. Two details worth noting:

- The recompiled source is verified **byte-identical** to upstream's fixed version.
- `checkpointed_forward` is imported *by name* into `transformer_block` and `hybrid_block`, so rebinding `megatron.core.recompute` alone would silently do nothing. The patch rebinds all three.

## Scope

Only bites when `packed_seq_params is None` (RL training defaults to `remove_microbatch_padding=True`, which packs), the model is DSA, and `dsa_indexer_topk_freq > 1`. A no-op everywhere else, which is why it is safe to apply unconditionally from `make_megatron_module`.

It fails safe: anchors are literal 0.20.0 source text, so a restructured megatron-core logs and no-ops rather than misfiring, and it detects the upstream fix and steps aside once the pin includes it. **Delete this patch when the megatron-core pin picks up #6793.**

## Testing

Run on a B200 worker against megatron-core 0.20.0 / torch 2.11.0+cu130.

- New `test_dsa_index_share_recompute.py` (ported from the upstream PR, plus packed-path, idempotence, and rebind coverage): **4 passed**
- Bug reproduced without the patch (`[2, 2]` instead of `[1, 2]`), confirming the test is meaningful
- Applying through the real worker import path: patch applies, `transformer_block` rebound, idempotent
- CPU suite `tests/train/ tests/backends/skyrl_train/ --ignore=gpu/`: **1751 passed, 5 failed** — identical with and without this change, so the 5 (`test_megatron_correctness.py`, `_TENSOR_MODEL_PARALLEL_GROUP is not None`) are pre-existing and unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7RfwMcdvBsVWS5W61wJEZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Megatron’s activation-checkpoint forward path via runtime `exec` and global rebinding, but only when DSA + non-packed recompute conditions match and otherwise fails safe with anchor/upstream checks.
> 
> **Overview**
> Backports **NVIDIA/Megatron-LM#6793** as a runtime Megatron patch so DSA models (e.g. GLM 5) do not corrupt top-k index sharing when **activation recompute** runs on the **non-packed** path.
> 
> On that path, `DSAttention` reused `attention_mask`/`config` as the index-share carrier across overlapping checkpointed forwards (F1→F2→B1→B2), so a later forward could overwrite state before an earlier recompute — **wrong logits with no error**. The patch creates a per-`checkpointed_forward` carrier (via `ContextVar`), recompiles `megatron.core.recompute.checkpointed_forward` from anchored 0.20.0 source, patches `DSAttention._get_index_share_carrier`, and **rebinds** importers (`transformer_block`, `hybrid_block`) that imported the function by name.
> 
> `patch_dsa_index_share()` is invoked from `make_megatron_module` alongside the existing TE FA2 patch. It **no-ops** when megatron-core already has the upstream fix, source anchors drift, or DSA is absent; SkyRL RL’s default packed training path is unaffected unless `packed_seq_params is None` with `dsa_indexer_topk_freq > 1`.
> 
> Adds GPU CI regression tests (F1/F2 recompute isolation, packed path, idempotence, importer rebind) ported from the upstream PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce87bba87f6e27862fc86b5fe954a0f1a90b6ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->