### PR TITLE
[fix] Re-enable vLLM's torch.compile cache

### DIFF
--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -749,12 +749,28 @@ def prepare_runtime_environment(cfg: SkyRLTrainConfig) -> dict[str, str]:
         # object and requires pickling.
         env_vars["VLLM_ALLOW_INSECURE_SERIALIZATION"] = "1"
 
-        # NOTE (sumanthrh): In vLLM >= 0.9.0, we've observed compilatiion failures with torch compile.
-        # removing the compilation directory and trying again does not fix the issue. Temporarily we disable
-        # compilation cache, which seems to fix the issue. This should not have any effect on performance -
-        # compilation will still happen, it's just not cached
-        # TODO (sumanthrh): remove this once vLLM fixes the issue
-        env_vars["VLLM_DISABLE_COMPILE_CACHE"] = "1"
+        # vLLM's torch.compile cache is left enabled. It was force-disabled here in #95
+        # (vLLM 0.9.0, July 2025) after multi-node runs failed at compile time with
+        # "corrupted compilation artifact"; single-node was fine, which points at
+        # concurrent engines writing one cache directory on a shared filesystem.
+        #
+        # Since then torch>=2.10 writes inductor artifacts atomically
+        # (pytorch/pytorch#162432), which is the failure mode that produced corrupt
+        # artifacts. We pin torch 2.11, so that fix is in.
+        #
+        # Caveat for multi-node: engines with identical config still resolve to the
+        # same cache directory (VLLM_CACHE_ROOT/torch_compile_cache/<hash>/rank_i_j),
+        # and vLLM's own index file (vllm_compile_cache.py) is still written
+        # non-atomically with no lock -- an upstream write lock was proposed and
+        # rejected in vllm-project/vllm#26521 in favour of atomic writes. If
+        # VLLM_CACHE_ROOT is on a filesystem shared between nodes, point it at
+        # node-local storage, or set VLLM_DISABLE_COMPILE_CACHE=1 to opt back out.
+        if os.environ.get("VLLM_DISABLE_COMPILE_CACHE"):
+            logger.info(
+                "Exporting `VLLM_DISABLE_COMPILE_CACHE` to ray runtime env: "
+                f"{os.environ['VLLM_DISABLE_COMPILE_CACHE']}"
+            )
+            env_vars["VLLM_DISABLE_COMPILE_CACHE"] = os.environ["VLLM_DISABLE_COMPILE_CACHE"]
 
         if not os.environ.get("VLLM_USE_V1", False):
             logger.info(

--- a/tests/train/utils/test_prepare_runtime_environment.py
+++ b/tests/train/utils/test_prepare_runtime_environment.py
@@ -1,0 +1,64 @@
+"""
+uv run --isolated --extra dev pytest tests/train/utils/test_prepare_runtime_environment.py
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from skyrl.train.utils.utils import prepare_runtime_environment
+
+
+def _make_config(backend: str = "vllm", strategy: str = "fsdp"):
+    """Minimal config-like object covering what prepare_runtime_environment reads."""
+    return SimpleNamespace(
+        trainer=SimpleNamespace(
+            strategy=strategy,
+            flash_attn=False,
+            placement=SimpleNamespace(
+                policy_num_gpus_per_node=1,
+                critic_num_gpus_per_node=1,
+                ref_num_gpus_per_node=1,
+            ),
+        ),
+        generator=SimpleNamespace(
+            inference_engine=SimpleNamespace(
+                backend=backend,
+                weight_sync_backend="nccl",
+                tensor_parallel_size=1,
+            )
+        ),
+    )
+
+
+class TestVLLMCompileCache:
+    """vLLM's torch.compile cache is left enabled unless the user opts out.
+
+    It was force-disabled for every run in #95; re-enabling it roughly halves
+    engine startup on a warm cache, and the corrupt-artifact failure that
+    motivated the workaround is fixed upstream (pytorch/pytorch#162432, in the
+    torch 2.11 we pin).
+    """
+
+    def test_cache_is_not_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("VLLM_DISABLE_COMPILE_CACHE", raising=False)
+
+        env_vars = prepare_runtime_environment(_make_config())
+
+        assert "VLLM_DISABLE_COMPILE_CACHE" not in env_vars
+
+    @pytest.mark.parametrize("value", ["1", "0"])
+    def test_explicit_user_setting_is_forwarded(self, monkeypatch, value):
+        """An explicit opt-out (or opt-in) reaches the Ray workers verbatim."""
+        monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", value)
+
+        env_vars = prepare_runtime_environment(_make_config())
+
+        assert env_vars["VLLM_DISABLE_COMPILE_CACHE"] == value
+
+    def test_not_set_for_non_vllm_backends(self, monkeypatch):
+        monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+
+        env_vars = prepare_runtime_environment(_make_config(backend="sglang"))
+
+        assert "VLLM_DISABLE_COMPILE_CACHE" not in env_vars


### PR DESCRIPTION
Closes #2137.

## What

Stops force-setting `VLLM_DISABLE_COMPILE_CACHE=1` for every vLLM run. An explicit user setting is now forwarded to the Ray workers instead.

## Why the workaround existed

Added in #95 (vLLM 0.9.0, July 2025) after multi-node runs failed at compile time with `RuntimeError: vLLM failed to compile the model ... corrupted compilation artifact`. Single-node was fine and deleting `~/.cache/vllm` didn't help — the signature of concurrent engines writing one cache directory on a shared filesystem (delete it, and the next run's engines race and corrupt it again).

## Why it's safe now

`torch >= 2.10` writes inductor artifacts atomically ([pytorch#162432](https://github.com/pytorch/pytorch/pull/162432)) — that's the failure mode that produced corrupt artifacts. We pin **torch 2.11**; verified `CacheCompiledArtifact.save` / `AOTCompiledArtifact.save` both call `write_atomic` in the installed build. vLLM ships the same fix as a backport for older torch.

## Measurements

All on a B200 worker, `vllm 0.28.0` / `torch 2.11.0+cu130`, engines sharing one `VLLM_CACHE_ROOT`.

**Startup — 4 concurrent engines:**

| | eng 0 | 1 | 2 | 3 |
|---|---|---|---|---|
| cold | 63.90s | 63.89s | 63.94s | 63.82s |
| warm | 30.46s | 30.48s | 30.46s | 30.57s |

**~52% faster engine startup**, ~33s saved per engine (Qwen2.5-0.5B; should grow with model size).

**Race hunt — 5 cold rounds × 8 concurrent engines**, cache wiped each round so all 8 compile and write simultaneously:

```
round 1..5: engine_failures=0  index_files=1  corrupt=0
TOTAL_ENGINE_FAILURES=0 over 5 rounds x 8 engines
```

`index_files=1` confirms all 8 engines really do share one cache dir (`rank` is the TP rank within an engine, not a global engine id); `corrupt=0` is an `ast.literal_eval` parse of every index file written under contention.

## Tests

- New `tests/train/utils/test_prepare_runtime_environment.py` — 4 passed (not disabled by default; explicit setting forwarded verbatim for `1` and `0`; not set for non-vLLM backends).
- `test_new_inference_generation.py` — 19 passed cold, 19 passed warm, with a cache file now actually written through SkyRL's path.
- `test_engine_generation.py` fails on my cluster with `NCCL error: internal error` before compilation ever starts. I ran it on unmodified `origin/main` as a control and it fails identically, so it's environmental (TP=2 NCCL under local Ray), not this change.

## Residual risk

Engines with identical config still resolve to one cache directory, and vLLM's own index file (`vllm_compile_cache.py`) is still written **non-atomically with no lock** — an upstream write lock was proposed and [rejected](https://github.com/vllm-project/vllm/pull/26521) in favour of atomic writes. In practice every engine writes identical content, and I never observed a tear.

**This cluster has no shared filesystem, so the original multi-node configuration could not be reproduced.** Single-node evidence is strong; multi-node is argued, not measured. If `VLLM_CACHE_ROOT` is on an NFS/Lustre home shared across nodes, point it at node-local storage (what [vllm#52413](https://github.com/vllm-project/vllm/issues/52413)'s reporter did for the Triton cache) rather than reverting to a blanket disable. `VLLM_DISABLE_COMPILE_CACHE=1` remains as an escape hatch. This is all recorded in the code comment.

I deliberately did not change the `VLLM_CACHE_ROOT` default — that would move where artifacts live for everyone, and some users share it intentionally.

Example scripts under `integrations/arctic_rl/` and `examples/train/thunder_agent/` still set the variable themselves; left alone, since arctic_rl's is for a different problem (a baked-in flashinfer allreduce graph, which also needs `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1`) and thunder_agent's is an overridable default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7RfwMcdvBsVWS5W61wJEZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default vLLM compile-cache behavior for all training runs; residual risk on multi-node shared filesystems is documented but not re-tested here, with `VLLM_DISABLE_COMPILE_CACHE=1` as escape hatch.
> 
> **Overview**
> **Stops forcing `VLLM_DISABLE_COMPILE_CACHE=1` on every vLLM Ray runtime**, so vLLM’s torch.compile cache is on by default again (warm starts are much faster). The old blanket disable from #95 is replaced with **opt-in forwarding**: if the driver already has `VLLM_DISABLE_COMPILE_CACHE` set, that value is logged and passed through to workers unchanged.
> 
> The in-code comment now documents why the workaround existed (shared-cache corruption on multi-node), why it’s considered safe with pinned **torch 2.11** (atomic inductor writes), and remaining caveats (shared `VLLM_CACHE_ROOT`, non-atomic vLLM index files).
> 
> Adds **`tests/train/utils/test_prepare_runtime_environment.py`** to lock in: no key by default, explicit `0`/`1` forwarded for vLLM, and no export when the inference backend isn’t vLLM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d862cea3d3d57f29bc07f619ed55222ae862be1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->