### PR TITLE
fix(tinker): align forwarding pool deadline

### DIFF
--- a/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
+++ b/skyrl/tinker/extra/skyrl_train_inference_forwarding.py
@@ -36,7 +36,7 @@ class SkyRLTrainInferenceForwardingClient:
                 connect=10.0,
                 read=engine_config.forwarding_inference_timeout_sec,
                 write=300.0,
-                pool=300.0,
+                pool=engine_config.forwarding_inference_timeout_sec,
             ),
             limits=httpx.Limits(
                 max_connections=max_conn,

--- a/tests/tinker/test_inference_forwarding_config.py
+++ b/tests/tinker/test_inference_forwarding_config.py
@@ -21,7 +21,7 @@ def test_forwarding_timeout_reads_environment(monkeypatch) -> None:
     assert config.forwarding_inference_timeout_sec == 1800.0
 
 
-def test_forwarding_client_uses_configured_timeout() -> None:
+def test_forwarding_client_uses_configured_read_and_pool_timeout() -> None:
     config = EngineConfig(
         base_model="test-model",
         forwarding_inference_timeout_sec=1800.0,
@@ -34,7 +34,7 @@ def test_forwarding_client_uses_configured_timeout() -> None:
     assert timeout.connect == 10.0
     assert timeout.read == 1800.0
     assert timeout.write == 300.0
-    assert timeout.pool == 300.0
+    assert timeout.pool == 1800.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Use the configured inference deadline while a forwarded request waits for an HTTP connection, not only after dispatch.
- Prevent bounded high-concurrency forwarding from failing at an unrelated hard-coded 300-second pool deadline.

## Testing

```bash
uv run --isolated --frozen --extra dev --extra tinker --extra ray --extra jax pytest -q tests/tinker/test_inference_forwarding_config.py
```

The updated timeout-wiring assertion and local static checks pass; upstream CI provides the clean-environment suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow httpx timeout wiring change for inference forwarding; no auth or data-path logic, only avoids failing earlier than the configured inference deadline when the connection pool is saturated.
> 
> **Overview**
> **Fixes premature pool timeouts** when forwarded inference requests wait for a free HTTP connection under high concurrency.
> 
> The forwarding client’s `httpx.Timeout` **pool** deadline was hard-coded to 300s while **read** already used `forwarding_inference_timeout_sec`. Pool is now set to the same configured value, so raising `--forwarding-inference-timeout-sec` / `SKYRL_FORWARDING_INFERENCE_TIMEOUT_SEC` applies while waiting for a connection as well as while reading the vLLM response.
> 
> Tests were updated to assert **read** and **pool** both match the configured timeout (e.g. 1800s).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7c9f42ccb7576c8b532974f030014cd73f85810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->