### PR TITLE
perf(megatron): autotune fused LM-head Triton kernels

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/fused_linear_logprob_triton.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/fused_linear_logprob_triton.py
@@ -1,19 +1,27 @@
 # ==============================================================================
 # Vendored Triton fused linear-cross-entropy / log-prob kernel.
 #
-# Triton kernels and the LinearCrossEntropy wrapper are vendored from:
+# Triton kernels are vendored from:
 #
 #     volcengine/verl  @ commit 29ffe75
 #       verl/utils/kernel/kernels.py
-#       verl/utils/kernel/linear_cross_entropy.py
-#       verl/utils/kernel/__init__.py
 #
 # Original Apache-2.0 attribution is reproduced below.
 #
 # Changes from upstream:
 #   * Replaced ``verl.utils.device`` with local torch.cuda helpers.
 #   * Made triton optional at import time via ``TRITON_AVAILABLE``.
-#   * Added SkyRL's ``FusedLinearLogprobTriton`` adapter.
+#   * Added SkyRL's TP-aware ``FusedLinearLogprobTriton`` adapter.
+#   * Autotune all reachable kernels with cached, bucketed token-shape keys;
+#     exact token counts remain runtime values to avoid recompilation churn.
+#   * Compile out entropy-only work in SkyRL's log-prob-only adapter path.
+#   * Made epilogue outputs distinct from inputs so repeated tuning runs cannot
+#     corrupt reductions.
+#   * Use the true row maximum as the epilogue log-sum-exp shift, including
+#     ``-inf`` padding, so strongly negative logits remain finite.
+#   * Release the oversized d-logits staging buffer before final partial-vocab
+#     backward projections.
+#   * Removed unused VERL wrappers, reductions, and backward strategies.
 #
 # Preserve verl's #2656 OOB-vocab masking lines (search ``vocab_bound`` /
 # ``logits_for_lse``); they are required for TP correctness.
@@ -54,7 +62,6 @@ CUDA + triton.
 """
 
 import typing
-from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -140,93 +147,130 @@ elif SUPPORT_CUDA_TMA:
 
 
 # ======================================================================================
-# Below: vendored verbatim from verl/utils/kernel/kernels.py @ 29ffe75 (Apache-2.0),
-# with only the verl.utils.device imports removed (replaced by the helpers above).
+# Below: adapted from verl/utils/kernel/kernels.py @ 29ffe75 (Apache-2.0).
 # ======================================================================================
 
 
-@dataclass
-class EntropyReductionEnum:
-    """Enum for the reduction method of cross entropy."""
+_AUTOTUNE_MIN_TOKEN_BUCKET = 128
+# This saturates only the autotune cache key. Kernels still receive and launch
+# over the exact num_tokens, so larger batches are neither truncated nor padded.
+_AUTOTUNE_MAX_TOKEN_BUCKET = 1048576
 
-    _None = 0
-    _Sum = 1
-    _Mean = 2
+# Matmul specs adapt Triton 3.6's CUDA matmul set (tile sizes, stages, warps):
+# https://github.com/triton-lang/triton/blob/v3.6.0/python/tutorials/03-matrix-multiplication.py#L164-L199
+_FORWARD_MAINLOOP_CONFIG_SPECS = (
+    (128, 256, 32, 2, 8),
+    (128, 256, 32, 3, 8),
+    (128, 256, 32, 4, 8),
+    (128, 256, 32, 5, 8),
+    (128, 256, 64, 3, 8),
+    (64, 256, 32, 4, 4),
+    (128, 128, 32, 4, 4),
+    (128, 64, 32, 4, 4),
+    (64, 128, 32, 4, 4),
+    (64, 64, 32, 3, 4),
+    (128, 32, 32, 4, 4),
+    (64, 32, 32, 5, 2),
+    (32, 64, 32, 5, 2),
+    (32, 32, 32, 2, 4),
+)
 
+# Reduction tiles follow PyTorch Inductor's max-autotune reduction candidates:
+# https://github.com/pytorch/pytorch/blob/v2.11.0/torch/_inductor/runtime/triton_heuristics.py#L3240-L3253
+# Specs are (BLOCK_M, BLOCK_N, warps); update specs are (BLOCK_M, warps).
+_EPILOGUE_CONFIG_SPECS = (
+    (16, 32, 2),
+    (16, 64, 4),
+    (32, 32, 4),
+    (32, 64, 4),
+    (32, 128, 4),
+    (64, 32, 4),
+    (64, 64, 4),
+    (64, 128, 8),
+    (128, 32, 4),
+    (128, 64, 8),
+)
+_EPILOGUE_UPDATE_CONFIG_SPECS = ((16, 4), (32, 4), (64, 4), (128, 4), (256, 8), (512, 8))
 
-def get_entropy_reduction_enum_number(reduction: str) -> int:
-    """Get the enum number for the reduction method of cross entropy."""
-    _enum = EntropyReductionEnum._None
-    if reduction == "none":
-        _enum = EntropyReductionEnum._None
-    elif reduction == "sum":
-        _enum = EntropyReductionEnum._Sum
-    elif reduction == "mean":
-        _enum = EntropyReductionEnum._Mean
-    else:
-        raise ValueError(f"Invalid reduction: {reduction}")
-    return _enum
-
-
-def get_entropy_reduction_enum(ce_reduction: int) -> EntropyReductionEnum:
-    """Get the enum for the reduction method of cross entropy."""
-    _enum = EntropyReductionEnum._None
-    if ce_reduction == 0:
-        _enum = EntropyReductionEnum._None
-    elif ce_reduction == 1:
-        _enum = EntropyReductionEnum._Sum
-    elif ce_reduction == 2:
-        _enum = EntropyReductionEnum._Mean
-    else:
-        raise ValueError(f"Invalid ce_reduction: {ce_reduction}")
-    return _enum
-
-
-@dataclass
-class BackwardEnum:
-    """Enum for the backward method."""
-
-    _Total_Fuse_MN = (
-        0  # Fuse d_logits & d_hidden & d_weight, no intermediate storage, requires fp32 for d_hidden & d_weight
-    )
-    _Total_Separate = 1  # Store d_logits, no special requirements for d_hidden & d_weight
-    _Split_Dlogits_N = 2  # split d_logits along its N dimension, aka. vocab_size
-    _Split_Dlogits_M = 3  # split d_logits along its M dimension, aka. num_tokens
-
-
-@dataclass
-class Config:
-    """Configuration for efficient entropy kernel operations.
-
-    Args:
-        _backward (BackwardEnum): Backward computation method. Defaults to BackwardEnum._Split_Dlogits_N.
-        _use_triton (bool): Whether to use Triton kernels for computation. Defaults to True.
-    """
-
-    _backward: BackwardEnum = BackwardEnum._Split_Dlogits_N
-    _use_triton: bool = True
+# Backward reuses the Triton matmul ranges above and tunes its grouped ordering;
+# specs are (BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M, stages, warps).
+_BACKWARD_CONFIG_SPECS = (
+    (128, 128, 32, 16, 2, 8),
+    (128, 128, 32, 16, 3, 8),
+    (128, 128, 32, 16, 4, 8),
+    (128, 128, 32, 16, 5, 8),
+    (128, 256, 32, 16, 3, 8),
+    (128, 128, 64, 8, 3, 8),
+    (64, 256, 32, 8, 4, 4),
+    (64, 128, 32, 8, 4, 4),
+    (128, 64, 32, 8, 4, 4),
+    (64, 64, 32, 8, 3, 4),
+    (32, 64, 32, 8, 5, 2),
+)
 
 
-_config = Config()
+def _autotune_token_bucket(num_tokens: int) -> int:
+    """Bucket dynamic counts; shapes above 1M share a tuning decision."""
+    if num_tokens <= 0:
+        raise ValueError(f"num_tokens must be positive, got {num_tokens}")
+    power_of_two = 1 << (num_tokens - 1).bit_length()
+    return min(_AUTOTUNE_MAX_TOKEN_BUCKET, max(_AUTOTUNE_MIN_TOKEN_BUCKET, power_of_two))
 
 
-def set_backward_method(backward_method: BackwardEnum):
-    """Set the backward method."""
-    global _config
-    _config._backward = backward_method
+def _matmul_autotune_configs(specs):
+    return [
+        triton.Config(
+            {"BLOCK_SIZE_M": block_m, "BLOCK_SIZE_N": block_n, "BLOCK_SIZE_K": block_k},
+            num_stages=num_stages,
+            num_warps=num_warps,
+        )
+        for block_m, block_n, block_k, num_stages, num_warps in specs
+    ]
+
+
+def _epilogue_autotune_configs():
+    return [
+        triton.Config({"BLOCK_SIZE_M": block_m, "BLOCK_SIZE_N": block_n}, num_warps=num_warps)
+        for block_m, block_n, num_warps in _EPILOGUE_CONFIG_SPECS
+    ]
+
+
+def _epilogue_update_autotune_configs():
+    return [
+        triton.Config({"BLOCK_SIZE_M": block_m}, num_warps=num_warps)
+        for block_m, num_warps in _EPILOGUE_UPDATE_CONFIG_SPECS
+    ]
+
+
+def _backward_autotune_configs():
+    return [
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": block_m,
+                "BLOCK_SIZE_N": block_n,
+                "BLOCK_SIZE_K": block_k,
+                "GROUP_SIZE_M": group_m,
+            },
+            num_stages=num_stages,
+            num_warps=num_warps,
+        )
+        for block_m, block_n, block_k, group_m, num_stages, num_warps in _BACKWARD_CONFIG_SPECS
+    ]
 
 
 @triton.autotune(
-    configs=[triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 32}, num_stages=3, num_warps=8)],
-    key=["num_tokens", "hidden_size", "vocab_size"],
+    configs=_matmul_autotune_configs(_FORWARD_MAINLOOP_CONFIG_SPECS),
+    key=["num_tokens_bucket", "hidden_size", "vocab_size", "COMPUTE_ENTROPY"],
+    cache_results=True,
 )
-@triton.jit
+@triton.jit(do_not_specialize=["num_tokens", "num_tokens_bucket"])
 def efficient_entropy_kernel_general_mainloop(
     rank,
     hidden_ptr,
     weight_ptr,
     labels_ptr,
     num_tokens,
+    num_tokens_bucket,
     hidden_size,
     vocab_size,
     vocab_per_split,
@@ -245,13 +289,13 @@ def efficient_entropy_kernel_general_mainloop(
     stride_entropy_b_n: tl.int64,
     global_logprobs_ptr,
     stride_global_logprobs: tl.int64,
-    global_logprobs_scalar_ptr,
     rcp_temperature: tl.float32,
     # Meta-parameters
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
     USE_TMA: tl.constexpr,
+    COMPUTE_ENTROPY: tl.constexpr,
     # Tests can force IEEE fp32; production uses Triton's fast default precision.
     INPUT_PRECISION: tl.constexpr,
 ):
@@ -262,9 +306,6 @@ def efficient_entropy_kernel_general_mainloop(
     num_pid_n = tl.cdiv(vocab_per_split, BLOCK_SIZE_N)
     pid_m = pid % num_pid_m
     pid_n = pid // num_pid_m
-
-    if pid_m == 0 and pid_n == 0:
-        tl.store(global_logprobs_scalar_ptr, 0.0)
 
     # create pointers for the first blocks of hidden
     start_offs_am = pid_m * BLOCK_SIZE_M
@@ -297,7 +338,8 @@ def efficient_entropy_kernel_general_mainloop(
     # _max = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
     _max = tl.full((BLOCK_SIZE_M,), -float("inf"), dtype=tl.float32)
     _accu = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
-    _entropy_b = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+    if COMPUTE_ENTROPY:
+        _entropy_b = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
     _logprobs = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
     vocab_bound = min((pid_n + 1) * vocab_per_split, vocab_size)
     for n in range(0, num_pid_n):
@@ -359,7 +401,8 @@ def efficient_entropy_kernel_general_mainloop(
         coeff = tl.exp(_max_old - _max)
         _accu = coeff * _accu + tl.sum(exp_logits, axis=1)
 
-        _entropy_b = _entropy_b * coeff + tl.sum(logits * exp_logits, axis=1)
+        if COMPUTE_ENTROPY:
+            _entropy_b = _entropy_b * coeff + tl.sum(logits * exp_logits, axis=1)
 
         label_mask = (offs_bn + rank * vocab_size)[None, :] == labels[:, None]
         _logprobs += tl.sum(logits * label_mask, axis=1)
@@ -373,8 +416,9 @@ def efficient_entropy_kernel_general_mainloop(
     # store entropy
     accu_ptrs = accu_ptr + offs_max_n * stride_accu_n + offs_max_m * stride_accu_m
     tl.store(accu_ptrs, _accu, mask=(offs_max_m < num_tokens) & (offs_max_n[None] < num_splits))
-    entropy_b_ptrs = entropy_b_ptr + offs_max_n * stride_entropy_b_n + offs_max_m * stride_entropy_b_m
-    tl.store(entropy_b_ptrs, _entropy_b, mask=(offs_max_m < num_tokens) & (offs_max_n < num_splits))
+    if COMPUTE_ENTROPY:
+        entropy_b_ptrs = entropy_b_ptr + offs_max_n * stride_entropy_b_n + offs_max_m * stride_entropy_b_m
+        tl.store(entropy_b_ptrs, _entropy_b, mask=(offs_max_m < num_tokens) & (offs_max_n < num_splits))
     # store logprobs
     vocab_left_idx = pid_n * vocab_per_split + rank * vocab_size
     vocab_right_idx = min((pid_n + 1) * vocab_per_split, vocab_size) + rank * vocab_size
@@ -385,13 +429,18 @@ def efficient_entropy_kernel_general_mainloop(
     tl.store(global_logprobs_ptrs, _logprobs, mask=mask)
 
 
-@triton.autotune(configs=[triton.Config({"BLOCK_SIZE_M": 16, "BLOCK_SIZE_N": 64})], key=["num_tokens", "num_splits"])
-@triton.jit
+@triton.autotune(
+    configs=_epilogue_autotune_configs(),
+    key=["num_tokens_bucket", "num_splits", "COMPUTE_ENTROPY"],
+    cache_results=True,
+)
+@triton.jit(do_not_specialize=["num_tokens", "num_tokens_bucket"])
 def efficient_entropy_triton_kernel_epilogue(
     max_ptr,
     stride_max_m: tl.int64,
     stride_max_n: tl.int64,
     num_tokens,
+    num_tokens_bucket,
     num_splits,
     global_max_ptr,
     stride_global_max: tl.int64,
@@ -409,31 +458,42 @@ def efficient_entropy_triton_kernel_epilogue(
     stride_global_entropy: tl.int64,
     global_logprobs_ptr,
     stride_global_logprobs: tl.int64,
-    global_logprobs_scalar_ptr,
-    reduction: int,
+    result_logprobs_ptr,
+    stride_result_logprobs: tl.int64,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
+    COMPUTE_ENTROPY: tl.constexpr,
 ):
     """foward epilogue"""
     pid_m = tl.program_id(axis=0)
 
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    global_max = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+    # -inf, not 0: a 0 init clamps the softmax shift to max(0, true_max), so a token
+    # whose logits are all strongly negative underflows exp() and yields log(0).
+    global_max = tl.full((BLOCK_SIZE_M,), -float("inf"), dtype=tl.float32)
     global_accu = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
-    global_entropy_b = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+    if COMPUTE_ENTROPY:
+        global_entropy_b = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
     for pid_n in range(0, tl.cdiv(num_splits, BLOCK_SIZE_N)):
         offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
         max_ptrs = max_ptr + offs_m[:, None] * stride_max_m + offs_n[None, :] * stride_max_n
 
-        _max = tl.load(max_ptrs, mask=(offs_m[:, None] < num_tokens) & (offs_n[None, :] < num_splits), other=0.0)
+        # -inf padding: with a negative global_max, a 0.0 pad would make
+        # exp(0 - global_max) overflow and 0*inf produce NaN.
+        _max = tl.load(
+            max_ptrs,
+            mask=(offs_m[:, None] < num_tokens) & (offs_n[None, :] < num_splits),
+            other=-float("inf"),
+        )
 
         accu_ptrs = accu_ptr + offs_m[:, None] * stride_accu_m + offs_n[None, :] * stride_accu_n
         _accu = tl.load(accu_ptrs, mask=(offs_m[:, None] < num_tokens) & (offs_n[None, :] < num_splits), other=0.0)
 
-        entropy_b_ptrs = entropy_b_ptr + offs_m[:, None] * stride_entropy_b_m + offs_n[None, :] * stride_entropy_b_n
-        _entropy_b = tl.load(
-            entropy_b_ptrs, mask=(offs_m[:, None] < num_tokens) & (offs_n[None, :] < num_splits), other=0.0
-        )
+        if COMPUTE_ENTROPY:
+            entropy_b_ptrs = entropy_b_ptr + offs_m[:, None] * stride_entropy_b_m + offs_n[None, :] * stride_entropy_b_n
+            _entropy_b = tl.load(
+                entropy_b_ptrs, mask=(offs_m[:, None] < num_tokens) & (offs_n[None, :] < num_splits), other=0.0
+            )
 
         # local reduction
         _max_old = global_max
@@ -443,42 +503,39 @@ def efficient_entropy_triton_kernel_epilogue(
         _scale = tl.exp(_max - global_max[:, None])
         _coeff = tl.exp(_max_old - global_max)
         global_accu = _coeff * global_accu + tl.sum(_scale * _accu, axis=1)
-        global_entropy_b = _coeff * global_entropy_b + tl.sum(_scale * _entropy_b, axis=1)
+        if COMPUTE_ENTROPY:
+            global_entropy_b = _coeff * global_entropy_b + tl.sum(_scale * _entropy_b, axis=1)
 
     # store
     maximum_ptrs = global_max_ptr + offs_m * stride_global_max
     tl.store(maximum_ptrs, global_max, mask=offs_m < num_tokens)
 
-    # store entropy_b
-    global_entropy_b = tl.fdiv(global_entropy_b, global_accu)  # entropy_b
-    tl.store(global_entropy_b_ptr + offs_m * stride_global_entropy_b, global_entropy_b, mask=offs_m < num_tokens)
-
-    # store entropy
     global_accu_ptrs = global_accu_ptr + offs_m * stride_global_accu
     tl.store(global_accu_ptrs, global_accu, mask=offs_m < num_tokens)
-    global_entropy = tl.log(global_accu) + global_max - global_entropy_b  # entropy_a
-    global_entropy_ptrs = global_entropy_ptr + offs_m * stride_global_entropy
-    tl.store(global_entropy_ptrs, global_entropy, mask=offs_m < num_tokens)
+    if COMPUTE_ENTROPY:
+        global_entropy_b = tl.fdiv(global_entropy_b, global_accu)
+        tl.store(global_entropy_b_ptr + offs_m * stride_global_entropy_b, global_entropy_b, mask=offs_m < num_tokens)
+        global_entropy = tl.log(global_accu) + global_max - global_entropy_b
+        global_entropy_ptrs = global_entropy_ptr + offs_m * stride_global_entropy
+        tl.store(global_entropy_ptrs, global_entropy, mask=offs_m < num_tokens)
     # update logprobs
     global_logprobs_ptrs = global_logprobs_ptr + offs_m * stride_global_logprobs
     global_logprobs = tl.load(global_logprobs_ptrs, mask=offs_m < num_tokens)
     global_logprobs = global_max + tl.log(global_accu) - global_logprobs
 
     global_logprobs = -1 * global_logprobs
-    if reduction == 0:
-        tl.store(global_logprobs_ptrs, global_logprobs, mask=offs_m < num_tokens)
-    elif reduction == 1:
-        global_logprobs_scalar = tl.sum(global_logprobs, axis=0)
-        tl.atomic_add(global_logprobs_scalar_ptr, global_logprobs_scalar)
-    elif reduction == 2:
-        global_logprobs_scalar = tl.sum(global_logprobs, axis=0) / num_tokens.to(tl.float32)
-        tl.atomic_add(global_logprobs_scalar_ptr, global_logprobs_scalar)
+    tl.store(result_logprobs_ptr + offs_m * stride_result_logprobs, global_logprobs, mask=offs_m < num_tokens)
 
 
-@triton.autotune(configs=[triton.Config({"BLOCK_SIZE_M": 16, "BLOCK_SIZE_N": 64})], key=["num_tokens", "num_splits"])
-@triton.jit
+@triton.autotune(
+    configs=_epilogue_autotune_configs(),
+    key=["num_tokens_bucket", "num_splits", "COMPUTE_ENTROPY"],
+    cache_results=True,
+)
+@triton.jit(do_not_specialize=["num_tokens", "num_tokens_bucket"])
 def efficient_entropy_triton_kernel_epilogue_tp(
     num_tokens,
+    num_tokens_bucket,
     num_splits,
     reduced_max_ptr,
     stride_reduced_max_m: tl.int64,
@@ -500,26 +557,29 @@ def efficient_entropy_triton_kernel_epilogue_tp(
     stride_global_entropy_b: tl.int64,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
+    COMPUTE_ENTROPY: tl.constexpr,
 ):
     pid_m = tl.program_id(axis=0)
 
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
 
-    global_max = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+    # See the local epilogue: -inf init, and -inf padding on both max operands.
+    global_max = tl.full((BLOCK_SIZE_M,), -float("inf"), dtype=tl.float32)
     global_accu = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
-    global_entropy_b = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+    if COMPUTE_ENTROPY:
+        global_entropy_b = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
     for pid_n in range(0, tl.cdiv(num_splits, BLOCK_SIZE_N)):
         offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
 
         _reduced_max = tl.load(
             reduced_max_ptr + offs_m[:, None] * stride_reduced_max_m + offs_n[None, :] * stride_reduced_max_n,
             mask=(offs_m[:, None] < num_tokens) & (offs_n[None, :] < num_splits),
-            other=0.0,
+            other=-float("inf"),
         )
         _original_max = tl.load(
             original_max_ptr + offs_m[:, None] * stride_original_max_m + offs_n[None, :] * stride_original_max_n,
             mask=(offs_m[:, None] < num_tokens) & (offs_n[None, :] < num_splits),
-            other=0.0,
+            other=-float("inf"),
         )
         _accu = tl.load(
             accu_ptr + offs_m[:, None] * stride_accu_m + offs_n[None, :] * stride_accu_n,
@@ -537,24 +597,30 @@ def efficient_entropy_triton_kernel_epilogue_tp(
         _scale = tl.exp(_original_max - global_max[:, None])
         global_accu = _coeff * global_accu + tl.sum(_scale * _accu, axis=1)
 
-        # update entropy_b
-        _entropy_b = tl.load(
-            entropy_b_ptr + offs_m[:, None] * stride_entropy_b_m + offs_n[None, :] * stride_entropy_b_n,
-            mask=(offs_m[:, None] < num_tokens) & (offs_n[None, :] < num_splits),
-            other=0.0,
-        )
-        global_entropy_b = _coeff * global_entropy_b + tl.sum(_scale * _entropy_b, axis=1)
+        if COMPUTE_ENTROPY:
+            _entropy_b = tl.load(
+                entropy_b_ptr + offs_m[:, None] * stride_entropy_b_m + offs_n[None, :] * stride_entropy_b_n,
+                mask=(offs_m[:, None] < num_tokens) & (offs_n[None, :] < num_splits),
+                other=0.0,
+            )
+            global_entropy_b = _coeff * global_entropy_b + tl.sum(_scale * _entropy_b, axis=1)
 
     # store
     tl.store(global_max_ptr + offs_m * stride_global_max, global_max, mask=offs_m < num_tokens)
     tl.store(global_accu_ptr + offs_m * stride_global_accu, global_accu, mask=offs_m < num_tokens)
-    tl.store(global_entropy_b_ptr + offs_m * stride_global_entropy_b, global_entropy_b, mask=offs_m < num_tokens)
+    if COMPUTE_ENTROPY:
+        tl.store(global_entropy_b_ptr + offs_m * stride_global_entropy_b, global_entropy_b, mask=offs_m < num_tokens)
 
 
-@triton.autotune(configs=[triton.Config({"BLOCK_SIZE_M": 16})], key=["num_tokens"])
-@triton.jit
+@triton.autotune(
+    configs=_epilogue_update_autotune_configs(),
+    key=["num_tokens_bucket", "COMPUTE_ENTROPY"],
+    cache_results=True,
+)
+@triton.jit(do_not_specialize=["num_tokens", "num_tokens_bucket"])
 def efficient_entropy_triton_epilogue_tp_update(
     num_tokens,
+    num_tokens_bucket,
     logprobs_ptr,
     stride_logprobs: tl.int64,
     maximum_ptr,
@@ -563,11 +629,14 @@ def efficient_entropy_triton_epilogue_tp_update(
     stride_accumulate: tl.int64,
     entropy_b_ptr,
     stride_entropy_b: tl.int64,
+    result_entropy_b_ptr,
+    stride_result_entropy_b: tl.int64,
     entropy_ptr,
     stride_entropy: tl.int64,
-    logprobs_scalar_ptr,
-    reduction: int,
+    result_logprobs_ptr,
+    stride_result_logprobs: tl.int64,
     BLOCK_SIZE_M: tl.constexpr,
+    COMPUTE_ENTROPY: tl.constexpr,
 ):
     pid_m = tl.program_id(axis=0)
 
@@ -576,25 +645,19 @@ def efficient_entropy_triton_epilogue_tp_update(
     maximum = tl.load(maximum_ptr + offs_m * stride_maximum, mask=offs_m < num_tokens)
     accumulate = tl.load(accumulate_ptr + offs_m * stride_accumulate, mask=offs_m < num_tokens)
 
-    entropy_b = tl.load(entropy_b_ptr + offs_m * stride_entropy_b, mask=offs_m < num_tokens)
-    entropy_b = tl.fdiv(entropy_b, accumulate)
-    tl.store(entropy_b_ptr + offs_m * stride_entropy_b, entropy_b, mask=offs_m < num_tokens)
+    if COMPUTE_ENTROPY:
+        entropy_b = tl.load(entropy_b_ptr + offs_m * stride_entropy_b, mask=offs_m < num_tokens)
+        entropy_b = tl.fdiv(entropy_b, accumulate)
+        tl.store(result_entropy_b_ptr + offs_m * stride_result_entropy_b, entropy_b, mask=offs_m < num_tokens)
 
-    entropy = tl.log(accumulate) + maximum - entropy_b
-    tl.store(entropy_ptr + offs_m * stride_entropy, entropy, mask=offs_m < num_tokens)
+        entropy = tl.log(accumulate) + maximum - entropy_b
+        tl.store(entropy_ptr + offs_m * stride_entropy, entropy, mask=offs_m < num_tokens)
 
     logprobs = tl.load(logprobs_ptr + offs_m * stride_logprobs, mask=offs_m < num_tokens)
     logprobs = maximum + tl.log(accumulate) - logprobs
 
     logprobs = -1 * logprobs
-    if reduction == 0:
-        tl.store(logprobs_ptr + offs_m * stride_logprobs, logprobs, mask=offs_m < num_tokens)
-    elif reduction == 1:
-        logprobs_scalar = tl.sum(logprobs, axis=0)
-        tl.atomic_add(logprobs_scalar_ptr, logprobs_scalar)
-    elif reduction == 2:
-        logprobs_scalar = tl.sum(logprobs, axis=0) / num_tokens.to(tl.float32)
-        tl.atomic_add(logprobs_scalar_ptr, logprobs_scalar)
+    tl.store(result_logprobs_ptr + offs_m * stride_result_logprobs, logprobs, mask=offs_m < num_tokens)
 
 
 _dedicated_stream, _dedicated_events = None, None
@@ -615,11 +678,11 @@ def efficient_entropy_forward(
     hidden: torch.Tensor,
     weight: torch.Tensor,
     labels: torch.Tensor,
-    reduction: typing.Optional[int] = 2,
     temperature: typing.Optional[float] = 1.0,
     dist_process_group: typing.Optional[dist.ProcessGroup] = None,
+    compute_entropy: bool = True,
 ) -> list:
-    """forward host function"""
+    """Forward host function; ``compute_entropy=False`` skips entropy-only work."""
     assert hidden.is_cuda and weight.is_cuda and labels.is_cuda
     assert weight.device == hidden.device and labels.device == hidden.device
     assert hidden.dim() == 2 and weight.dim() == 2 and labels.dim() == 1
@@ -641,27 +704,24 @@ def efficient_entropy_forward(
     vocab_size, hidden_size = weight.shape
     assert hidden_size % 128 == 0
 
-    REDUCTION = get_entropy_reduction_enum(reduction)
+    logprobs = torch.empty((num_tokens,), device=hidden.device, dtype=torch.float32)
 
-    if REDUCTION == EntropyReductionEnum._None:
-        if dist_process_group is None:
-            logprobs = torch.empty((num_tokens,), device=hidden.device, dtype=torch.float32)
-        else:
-            logprobs = torch.zeros((num_tokens,), device=hidden.device, dtype=torch.float32)
-    elif REDUCTION in (EntropyReductionEnum._Sum, EntropyReductionEnum._Mean):
-        logprobs = torch.empty((), device=hidden.device, dtype=torch.float32)
-    else:
-        raise ValueError(f"Invalid reduction: {reduction}")
-
-    entropy = torch.empty((num_tokens,), device=hidden.device, dtype=torch.float32)
-    assert logprobs.is_contiguous() and entropy.is_contiguous()
-
-    maximum = torch.empty_like(entropy)
-    accumulate_and_entropy_b = torch.empty((num_tokens * 2,), device=hidden.device, dtype=torch.float32)
-    accumulate_and_entropy_b_view = accumulate_and_entropy_b.view(2, num_tokens)
-    accumulate = accumulate_and_entropy_b_view[0, :]
-    entropy_b = accumulate_and_entropy_b_view[1, :]
-    assert maximum.is_contiguous() and accumulate.is_contiguous() and entropy_b.is_contiguous()
+    maximum = torch.empty((num_tokens,), device=hidden.device, dtype=torch.float32)
+    entropy = torch.empty_like(maximum) if compute_entropy else None
+    reduction_storage = torch.empty(
+        (num_tokens * (2 if compute_entropy else 1),),
+        device=hidden.device,
+        dtype=torch.float32,
+    )
+    reduction_storage_view = reduction_storage.view(-1, num_tokens)
+    accumulate = reduction_storage_view[0, :]
+    reduced_entropy_b = reduction_storage_view[1, :] if compute_entropy else accumulate
+    entropy_b = torch.empty_like(maximum) if compute_entropy else None
+    # Entropy arguments remain valid pointers even when their uses compile out.
+    entropy_output = entropy if entropy is not None else accumulate
+    entropy_b_output = entropy_b if entropy_b is not None else accumulate
+    assert logprobs.is_contiguous() and maximum.is_contiguous()
+    assert accumulate.is_contiguous() and reduced_entropy_b.is_contiguous()
 
     vocab_per_split = 1024
     assert vocab_per_split % 128 == 0
@@ -669,17 +729,17 @@ def efficient_entropy_forward(
 
     _max = torch.empty((num_tokens, num_splits), device=hidden.device, dtype=torch.float32)
     _accu = torch.empty((num_tokens, num_splits), device=hidden.device, dtype=torch.float32)
-    _entropy_b = torch.empty((num_tokens, num_splits), device=hidden.device, dtype=torch.float32)
+    _entropy_b = (
+        torch.empty((num_tokens, num_splits), device=hidden.device, dtype=torch.float32) if compute_entropy else _accu
+    )
 
-    if REDUCTION == EntropyReductionEnum._None:
-        _logprobs = logprobs
-    else:
-        _logprobs = torch.empty((num_tokens,), device=hidden.device, dtype=torch.float32)
+    # Keep raw target logits separate: autotuned epilogues execute repeatedly.
+    _logprobs = torch.zeros((num_tokens,), device=hidden.device, dtype=torch.float32)
 
     assert _accu.is_contiguous() and _entropy_b.is_contiguous() and _max.is_contiguous()
     assert _accu.is_cuda and _entropy_b.is_cuda and _max.is_cuda
 
-    if _config._use_triton:
+    if TRITON_AVAILABLE:
         # 1D kernel launch, then split the tile
         def mainloop_grid(meta):
             return (triton.cdiv(num_tokens, meta["BLOCK_SIZE_M"]) * num_splits,)
@@ -690,6 +750,7 @@ def efficient_entropy_forward(
             weight,
             labels,
             num_tokens,
+            _autotune_token_bucket(num_tokens),
             hidden_size,
             vocab_size,
             vocab_per_split,
@@ -708,9 +769,9 @@ def efficient_entropy_forward(
             _entropy_b.stride(1),
             _logprobs,
             _logprobs.stride(0),
-            logprobs,
             1.0 / temperature,
             USE_TMA=SUPPORT_CUDA_TMA and hidden.stride(1) == 1 and weight.stride(1) == 1,
+            COMPUTE_ENTROPY=compute_entropy,
             INPUT_PRECISION=_dot_input_precision(hidden),
         )
     else:
@@ -726,6 +787,7 @@ def efficient_entropy_forward(
             _max.stride(0),
             _max.stride(1),
             num_tokens,
+            _autotune_token_bucket(num_tokens),
             num_splits,
             maximum,
             maximum.stride(0),
@@ -737,14 +799,15 @@ def efficient_entropy_forward(
             _entropy_b,
             _entropy_b.stride(0),
             _entropy_b.stride(1),
-            entropy_b,
-            entropy_b.stride(0),
-            entropy,
-            entropy.stride(0),
+            entropy_b_output,
+            entropy_b_output.stride(0),
+            entropy_output,
+            entropy_output.stride(0),
             _logprobs,
             _logprobs.stride(0),
             logprobs,
-            REDUCTION,
+            logprobs.stride(0),
+            COMPUTE_ENTROPY=compute_entropy,
         )
     else:
         # tensor-parallel
@@ -759,6 +822,7 @@ def efficient_entropy_forward(
 
         efficient_entropy_triton_kernel_epilogue_tp[epilogue_grid](
             num_tokens,
+            _autotune_token_bucket(num_tokens),
             num_splits,
             _max,
             _max.stride(0),
@@ -776,643 +840,48 @@ def efficient_entropy_forward(
             maximum.stride(0),
             accumulate,
             accumulate.stride(0),
-            entropy_b,
-            entropy_b.stride(0),
+            reduced_entropy_b,
+            reduced_entropy_b.stride(0),
+            COMPUTE_ENTROPY=compute_entropy,
         )
         get_torch_device().current_stream().wait_event(_dedicated_events[1])
 
-        dist.all_reduce(accumulate_and_entropy_b, op=dist.ReduceOp.SUM, group=dist_process_group)
+        dist.all_reduce(reduction_storage, op=dist.ReduceOp.SUM, group=dist_process_group)
 
         # update logprobs & entropy
         efficient_entropy_triton_epilogue_tp_update[epilogue_grid](
             num_tokens,
+            _autotune_token_bucket(num_tokens),
             _logprobs,
             _logprobs.stride(0),
             maximum,
             maximum.stride(0),
             accumulate,
             accumulate.stride(0),
-            entropy_b,
-            entropy_b.stride(0),
-            entropy,
-            entropy.stride(0),
+            reduced_entropy_b,
+            reduced_entropy_b.stride(0),
+            entropy_b_output,
+            entropy_b_output.stride(0),
+            entropy_output,
+            entropy_output.stride(0),
             logprobs,
-            REDUCTION,
+            logprobs.stride(0),
+            COMPUTE_ENTROPY=compute_entropy,
         )
 
     return (logprobs, entropy, maximum, accumulate, entropy_b)
 
 
-# NOTE: merge d_weight & d_hidden here, split along M & N
 @triton.autotune(
-    configs=[
-        triton.Config(
-            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 16},
-            num_stages=3,
-            num_warps=8,
-        )
-    ],
-    key=["num_tokens", "hidden_size", "vocab_size"],
+    configs=_backward_autotune_configs(),
+    key=["num_tokens_bucket", "hidden_size", "vocab_size", "COMPUTE_ENTROPY"],
+    cache_results=True,
 )
-@triton.jit
-def efficient_entropy_backward_kernel_general_mainloop_MN(
-    num_tokens: int,
-    hidden_size: int,
-    vocab_size: int,
-    rank: int,
-    hidden_ptr,
-    stride_hidden_m: tl.int64,
-    stride_hidden_k: tl.int64,
-    weight_ptr,
-    stride_weight_n: tl.int64,
-    stride_weight_k: tl.int64,
-    labels_ptr,
-    stride_labels: tl.int64,
-    maximum_ptr,
-    stride_maximum: tl.int64,
-    accu_ptr,
-    stride_accu: tl.int64,
-    d_entropy_ptr,
-    stride_d_entropy: tl.int64,
-    d_logprobs_ptr,
-    stride_d_logprobs: tl.int64,
-    reduction: int,
-    entropy_b_ptr,
-    stride_entropy_b: tl.int64,
-    d_hidden_ptr,
-    stride_d_hidden_m: tl.int64,
-    stride_d_hidden_k: tl.int64,
-    d_weight_ptr,
-    stride_d_weight_n: tl.int64,
-    stride_d_weight_k: tl.int64,
-    rcp_temperature: tl.float32,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    USE_TMA: tl.constexpr,
-    INPUT_PRECISION: tl.constexpr,
-):
-    """backward mainloop, where d_logits & d_hidden & d_weight are fused"""
-    pid = tl.program_id(axis=0)
-    num_pid_m = tl.cdiv(num_tokens, BLOCK_SIZE_M)
-    num_pid_n = tl.cdiv(vocab_size, BLOCK_SIZE_N)
-    num_pid_in_group = GROUP_SIZE_M * num_pid_n
-    group_id = pid // num_pid_in_group
-    first_pid_m = group_id * GROUP_SIZE_M
-    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
-    pid_n = (pid % num_pid_in_group) // group_size_m
-
-    start_offs_am = pid_m * BLOCK_SIZE_M
-    offs_am = start_offs_am + tl.arange(0, BLOCK_SIZE_M)
-    start_offs_bn = pid_n * BLOCK_SIZE_N
-    offs_bn = start_offs_bn + tl.arange(0, BLOCK_SIZE_N)
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
-    if USE_TMA:
-        # using TMA and device-side descriptor creation
-        hidden_desc = tl.make_tensor_descriptor(
-            hidden_ptr,
-            shape=[num_tokens, hidden_size],
-            strides=[stride_hidden_m, 1],
-            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
-        )
-
-        weight_desc = tl.make_tensor_descriptor(
-            weight_ptr,
-            shape=[vocab_size, hidden_size],
-            strides=[stride_weight_n, 1],
-            block_shape=[BLOCK_SIZE_N, BLOCK_SIZE_K],
-        )
-
-    maximum_ptrs = maximum_ptr + offs_am * stride_maximum
-    maximum = tl.load(maximum_ptrs, mask=offs_am < num_tokens, other=0.0)
-    accu_ptrs = accu_ptr + offs_am * stride_accu
-    accu = tl.load(accu_ptrs, mask=offs_am < num_tokens, other=1e-6)  # epsilon to avoid division by zero
-    accu_rcp = tl.fdiv(1.0, accu)
-
-    d_entropy_ptrs = d_entropy_ptr + offs_am * stride_d_entropy
-    d_entropy = tl.load(d_entropy_ptrs, mask=offs_am < num_tokens, other=0.0)
-    if reduction == 0:  # none
-        d_logprobs_ptrs = d_logprobs_ptr + offs_am * stride_d_logprobs
-        d_logprobs = tl.load(d_logprobs_ptrs, mask=offs_am < num_tokens, other=0.0)
-    elif reduction == 1:  # sum
-        d_logprobs = tl.load(d_logprobs_ptr)
-        d_logprobs = tl.broadcast_to(d_logprobs, (BLOCK_SIZE_M,))
-    else:  # mean
-        d_logprobs = tl.fdiv(tl.load(d_logprobs_ptr), num_tokens.to(tl.float32))
-        d_logprobs = tl.broadcast_to(d_logprobs, (BLOCK_SIZE_M,))
-    d_logprobs = -1 * d_logprobs
-
-    entropy_b_ptrs = entropy_b_ptr + offs_am * stride_entropy_b
-    entropy_b = tl.load(entropy_b_ptrs, mask=offs_am < num_tokens, other=0.0)
-
-    if not USE_TMA:
-        hidden_ptrs = hidden_ptr + (offs_am[:, None] * stride_hidden_m + offs_k[None, :] * stride_hidden_k)
-        # weight_ptrs = weight_ptr + (offs_k[:, None] * stride_weight_k + offs_bn[None, :] * stride_weight_n)
-        weight_ptrs = weight_ptr + (offs_bn[:, None] * stride_weight_n + offs_k[None, :] * stride_weight_k)
-    labels_ptrs = labels_ptr + offs_am * stride_labels
-    labels = tl.load(labels_ptrs, mask=offs_am < num_tokens, other=0)
-
-    d_hidden_ptrs = d_hidden_ptr + offs_am[:, None] * stride_d_hidden_m + offs_k[None, :] * stride_d_hidden_k
-    # d_weight_ptrs = d_weight_ptr + offs_k[:, None] * stride_d_weight_k + offs_bn[None, :] * stride_d_weight_n
-    d_weight_ptrs = d_weight_ptr + offs_bn[:, None] * stride_d_weight_n + offs_k[None, :] * stride_d_weight_k
-
-    logits = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(hidden_size, BLOCK_SIZE_K)):
-        if USE_TMA:
-            start_offs_k = k * BLOCK_SIZE_K
-            _hidden = hidden_desc.load([start_offs_am, start_offs_k])
-            _weight = weight_desc.load([start_offs_bn, start_offs_k])
-        else:
-            _hidden = tl.load(
-                hidden_ptrs,
-                mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_am[:, None] < num_tokens),
-                other=0.0,
-            )
-            _weight = tl.load(
-                weight_ptrs,
-                mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_bn[:, None] < vocab_size),
-                other=0.0,
-            )
-            hidden_ptrs += BLOCK_SIZE_K * stride_hidden_k
-            weight_ptrs += BLOCK_SIZE_K * stride_weight_k
-
-        logits = tl.dot(_hidden, _weight.T, logits, input_precision=INPUT_PRECISION)
-
-    if not USE_TMA:
-        hidden_ptrs -= hidden_size * stride_hidden_k
-        weight_ptrs -= hidden_size * stride_weight_k
-
-    # scale logits by temperature
-    logits *= rcp_temperature
-
-    exp_logits = tl.exp(logits - maximum[:, None])
-
-    mask = (offs_bn + rank * vocab_size)[None, :] == labels[:, None]
-    d_logits = d_logprobs[:, None] * (exp_logits * accu_rcp[:, None] - mask)
-    d_logits += d_entropy[:, None] * (-exp_logits * accu_rcp[:, None]) * (logits - entropy_b[:, None])
-
-    # scale d_logits by temperature
-    d_logits *= rcp_temperature
-
-    # loop for d_weight & d_hidden
-    for k in range(0, tl.cdiv(hidden_size, BLOCK_SIZE_K)):
-        start_offs_k = k * BLOCK_SIZE_K
-        if USE_TMA:
-            _hidden = hidden_desc.load([start_offs_am, start_offs_k])
-        else:
-            _hidden = tl.load(
-                hidden_ptrs,
-                mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_am[:, None] < num_tokens),
-                other=0.0,
-            )
-        _d_weight = tl.dot(d_logits.trans(), _hidden.to(tl.float32), input_precision=INPUT_PRECISION)
-        tl.atomic_add(
-            d_weight_ptrs,
-            _d_weight,
-            mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_bn[:, None] < vocab_size),
-        )
-
-        if USE_TMA:
-            _weight = weight_desc.load([start_offs_bn, start_offs_k])
-        else:
-            _weight = tl.load(
-                weight_ptrs,
-                mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_bn[:, None] < vocab_size),
-                other=0.0,
-            )
-        _d_hidden = tl.dot(d_logits, _weight.to(tl.float32), input_precision=INPUT_PRECISION)
-        tl.atomic_add(
-            d_hidden_ptrs,
-            _d_hidden,
-            mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_am[:, None] < num_tokens),
-        )
-
-        if not USE_TMA:
-            hidden_ptrs += BLOCK_SIZE_K * stride_hidden_k
-            weight_ptrs += BLOCK_SIZE_K * stride_weight_k
-        d_hidden_ptrs += BLOCK_SIZE_K * stride_d_hidden_k
-        d_weight_ptrs += BLOCK_SIZE_K * stride_d_weight_k
-
-
-@triton.autotune(
-    configs=[
-        triton.Config(
-            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 16},
-            num_stages=3,
-            num_warps=8,
-        ),
-    ],
-    key=["num_tokens", "hidden_size", "vocab_size"],
-)
-@triton.jit
-def efficient_entropy_backward_kernel_d_hidden(
-    num_tokens: int,
-    hidden_size: int,
-    vocab_size: int,
-    rank: int,
-    hidden_ptr,
-    stride_hidden_m: tl.int64,
-    stride_hidden_k: tl.int64,
-    weight_ptr,
-    stride_weight_n: tl.int64,
-    stride_weight_k: tl.int64,
-    labels_ptr,
-    stride_labels: tl.int64,
-    maximum_ptr,
-    stride_maximum: tl.int64,
-    accu_ptr,
-    stride_accu: tl.int64,
-    d_entropy_ptr,
-    stride_d_entropy: tl.int64,
-    d_logprobs_ptr,
-    stride_d_logprobs: tl.int64,
-    reduction: int,
-    entropy_b_ptr,
-    stride_entropy_b: tl.int64,
-    d_hidden_ptr,
-    stride_d_hidden_m: tl.int64,
-    stride_d_hidden_k: tl.int64,
-    rcp_temperature: tl.float32,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    INPUT_PRECISION: tl.constexpr,
-):
-    """backward d_hidden"""
-    pid = tl.program_id(axis=0)
-    num_pid_m = tl.cdiv(num_tokens, BLOCK_SIZE_M)
-    pid_m = pid % num_pid_m
-    pid_k = pid // num_pid_m
-
-    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
-    result_offs_k = pid_k * BLOCK_SIZE_K + offs_k
-
-    maximum = tl.load(maximum_ptr + offs_m * stride_maximum, mask=offs_m < num_tokens, other=0.0)
-    accu = tl.load(accu_ptr + offs_m * stride_accu, mask=offs_m < num_tokens, other=1e-6)
-    accu_rcp = tl.fdiv(1.0, accu)
-    d_entropy = tl.load(d_entropy_ptr + offs_m * stride_d_entropy, mask=offs_m < num_tokens, other=0.0)
-    if reduction == 0:
-        d_logprobs = tl.load(d_logprobs_ptr + offs_m * stride_d_logprobs, mask=offs_m < num_tokens, other=0.0)
-    elif reduction == 1:
-        d_logprobs = tl.load(d_logprobs_ptr)
-        d_logprobs = tl.broadcast_to(d_logprobs, (BLOCK_SIZE_M,))
-    else:
-        d_logprobs = tl.fdiv(tl.load(d_logprobs_ptr), num_tokens.to(tl.float32))
-        d_logprobs = tl.broadcast_to(d_logprobs, (BLOCK_SIZE_M,))
-    d_logprobs = -1 * d_logprobs
-
-    entropy_b = tl.load(entropy_b_ptr + offs_m * stride_entropy_b, mask=offs_m < num_tokens, other=0.0)
-    labels = tl.load(labels_ptr + offs_m * stride_labels, mask=offs_m < num_tokens, other=0)
-
-    # iterate over vocab_size
-    d_hidden = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_K), dtype=tl.float32)
-    for n in range(0, tl.cdiv(vocab_size, BLOCK_SIZE_N)):
-        offs_n = n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-
-        hidden_ptrs = hidden_ptr + (offs_m[:, None] * stride_hidden_m + offs_k[None, :] * stride_hidden_k)
-        weight_ptrs = weight_ptr + (offs_n[:, None] * stride_weight_n + offs_k[None, :] * stride_weight_k)
-
-        # iterate over hidden_size to get logits
-        logits = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-        for k in range(0, tl.cdiv(hidden_size, BLOCK_SIZE_K)):
-            _hidden = tl.load(
-                hidden_ptrs,
-                mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_m[:, None] < num_tokens),
-                other=0.0,
-            )
-            _weight = tl.load(
-                weight_ptrs,
-                mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_n[:, None] < vocab_size),
-                other=0.0,
-            )
-
-            logits = tl.dot(_hidden, _weight.trans(), logits, input_precision=INPUT_PRECISION)
-
-            hidden_ptrs += BLOCK_SIZE_K * stride_hidden_k
-            weight_ptrs += BLOCK_SIZE_K * stride_weight_k
-
-        # scale logits by temperature
-        logits *= rcp_temperature
-
-        exp_logits = tl.exp(logits - maximum[:, None])
-
-        mask = (offs_n + rank * vocab_size)[None, :] == labels[:, None]
-        d_logits = d_logprobs[:, None] * (exp_logits * accu_rcp[:, None] - mask)
-        d_logits += d_entropy[:, None] * (-exp_logits * accu_rcp[:, None]) * (logits - entropy_b[:, None])
-
-        # scale d_logits
-        d_logits *= rcp_temperature
-
-        # calculate d_hidden
-        weight_ptrs = weight_ptr + (offs_n[:, None] * stride_weight_n + result_offs_k[None, :] * stride_weight_k)
-        _weight = tl.load(
-            weight_ptrs, mask=(result_offs_k[None, :] < hidden_size) & (offs_n[:, None] < vocab_size), other=0.0
-        )
-        d_hidden = tl.dot(d_logits.to(weight_ptr.dtype.element_ty), _weight, d_hidden, input_precision=INPUT_PRECISION)
-
-    # write back
-    tl.store(
-        d_hidden_ptr + offs_m[:, None] * stride_d_hidden_m + result_offs_k[None, :] * stride_d_hidden_k,
-        d_hidden,
-        mask=(offs_m[:, None] < num_tokens) & (result_offs_k[None, :] < hidden_size),
-    )
-
-
-@triton.autotune(
-    configs=[
-        triton.Config(
-            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 16},
-            num_stages=3,
-            num_warps=8,
-        ),
-    ],
-    key=["num_tokens", "hidden_size", "vocab_size"],
-)
-@triton.jit
-def efficient_entropy_backward_kernel_d_weight(
-    num_tokens: int,
-    hidden_size: int,
-    vocab_size: int,
-    rank: int,
-    hidden_ptr,
-    stride_hidden_m: tl.int64,
-    stride_hidden_k: tl.int64,
-    weight_ptr,
-    stride_weight_n: tl.int64,
-    stride_weight_k: tl.int64,
-    labels_ptr,
-    stride_labels: tl.int64,
-    maximum_ptr,
-    stride_maximum: tl.int64,
-    accu_ptr,
-    stride_accu: tl.int64,
-    d_entropy_ptr,
-    stride_d_entropy: tl.int64,
-    d_logprobs_ptr,
-    stride_d_logprobs: tl.int64,
-    reduction: int,
-    entropy_b_ptr,
-    stride_entropy_b: tl.int64,
-    d_weight_ptr,
-    stride_d_weight_n: tl.int64,
-    stride_d_weight_k: tl.int64,
-    rcp_temperature: tl.float32,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    INPUT_PRECISION: tl.constexpr,
-):
-    pid = tl.program_id(axis=0)
-    num_pid_n = tl.cdiv(vocab_size, BLOCK_SIZE_N)
-    pid_n = pid % num_pid_n
-    pid_k = pid // num_pid_n
-
-    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
-    result_offs_k = pid_k * BLOCK_SIZE_K + offs_k
-
-    d_weight = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_K), dtype=tl.float32)
-    for m in range(0, tl.cdiv(num_tokens, BLOCK_SIZE_M)):
-        offs_m = m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-
-        maximum = tl.load(maximum_ptr + offs_m * stride_maximum, mask=offs_m < num_tokens, other=0.0)
-        accu = tl.load(accu_ptr + offs_m * stride_accu, mask=offs_m < num_tokens, other=1e-6)
-        accu_rcp = tl.fdiv(1.0, accu)
-        d_entropy = tl.load(d_entropy_ptr + offs_m * stride_d_entropy, mask=offs_m < num_tokens, other=0.0)
-        if reduction == 0:
-            d_logprobs = tl.load(d_logprobs_ptr + offs_m * stride_d_logprobs, mask=offs_m < num_tokens, other=0.0)
-        elif reduction == 1:
-            d_logprobs = tl.load(d_logprobs_ptr)
-            d_logprobs = tl.broadcast_to(d_logprobs, (BLOCK_SIZE_M,))
-        else:
-            d_logprobs = tl.fdiv(tl.load(d_logprobs_ptr), num_tokens.to(tl.float32))
-            d_logprobs = tl.broadcast_to(d_logprobs, (BLOCK_SIZE_M,))
-        d_logprobs = -1 * d_logprobs
-
-        entropy_b = tl.load(entropy_b_ptr + offs_m * stride_entropy_b, mask=offs_m < num_tokens, other=0.0)
-        labels = tl.load(labels_ptr + offs_m * stride_labels, mask=offs_m < num_tokens, other=0)
-
-        hidden_ptrs = hidden_ptr + (offs_m[:, None] * stride_hidden_m + offs_k[None, :] * stride_hidden_k)
-        weight_ptrs = weight_ptr + (offs_n[:, None] * stride_weight_n + offs_k[None, :] * stride_weight_k)
-
-        logits = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-        for k in range(0, tl.cdiv(hidden_size, BLOCK_SIZE_K)):
-            _hidden = tl.load(
-                hidden_ptrs,
-                mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_m[:, None] < num_tokens),
-                other=0.0,
-            )
-            _weight = tl.load(
-                weight_ptrs,
-                mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_n[:, None] < vocab_size),
-                other=0.0,
-            )
-
-            logits = tl.dot(_hidden, _weight.trans(), logits, input_precision=INPUT_PRECISION)
-
-            hidden_ptrs += BLOCK_SIZE_K * stride_hidden_k
-            weight_ptrs += BLOCK_SIZE_K * stride_weight_k
-
-        logits *= rcp_temperature
-
-        exp_logits = tl.exp(logits - maximum[:, None])
-
-        mask = (offs_n + rank * vocab_size)[None, :] == labels[:, None]
-        d_logits = d_logprobs[:, None] * (exp_logits * accu_rcp[:, None] - mask)
-        d_logits += d_entropy[:, None] * (-exp_logits * accu_rcp[:, None]) * (logits - entropy_b[:, None])
-
-        d_logits *= rcp_temperature
-
-        hidden_ptrs = hidden_ptr + (offs_m[:, None] * stride_hidden_m + result_offs_k[None, :] * stride_hidden_k)
-        _hidden = tl.load(
-            hidden_ptrs, mask=(result_offs_k[None, :] < hidden_size) & (offs_m[:, None] < num_tokens), other=0.0
-        )
-        d_weight = tl.dot(
-            d_logits.to(d_weight_ptr.dtype.element_ty).trans(), _hidden, d_weight, input_precision=INPUT_PRECISION
-        )
-
-    # write back
-    tl.store(
-        d_weight_ptr + offs_n[:, None] * stride_d_weight_n + result_offs_k[None, :] * stride_d_weight_k,
-        d_weight,
-        mask=(offs_n[:, None] < vocab_size) & (result_offs_k[None, :] < hidden_size),
-    )
-
-
-# NOTE: split tile from d_logits' perspective
-@triton.autotune(
-    configs=[
-        triton.Config(
-            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 16},
-            num_stages=3,
-            num_warps=8,
-        ),
-    ],
-    key=["num_tokens", "hidden_size", "vocab_size"],
-)
-@triton.jit
-def efficient_entropy_backward_kernel_general_d_logits(
-    num_tokens: int,
-    hidden_size: int,
-    vocab_size: int,
-    rank: int,
-    hidden_ptr,
-    stride_hidden_m: tl.int64,
-    stride_hidden_k: tl.int64,
-    weight_ptr,
-    stride_weight_n: tl.int64,
-    stride_weight_k: tl.int64,
-    labels_ptr,
-    stride_labels: tl.int64,
-    maximum_ptr,
-    stride_maximum: tl.int64,
-    accu_ptr,
-    stride_accu: tl.int64,
-    d_entropy_ptr,
-    stride_d_entropy: tl.int64,
-    d_logprobs_ptr,
-    stride_d_logprobs: tl.int64,
-    reduction: int,
-    entropy_b_ptr,
-    stride_entropy_b,
-    d_logits_ptr,
-    stride_d_logits_m: tl.int64,
-    stride_d_logits_n: tl.int64,
-    rcp_temperature: tl.float32,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    USE_TMA: tl.constexpr,
-    INPUT_PRECISION: tl.constexpr,
-):
-    """backward d_logits"""
-    pid = tl.program_id(axis=0)
-    num_pid_m = tl.cdiv(num_tokens, BLOCK_SIZE_M)
-    num_pid_n = tl.cdiv(vocab_size, BLOCK_SIZE_N)
-    num_pid_in_group = GROUP_SIZE_M * num_pid_n
-    group_id = pid // num_pid_in_group
-    first_pid_m = group_id * GROUP_SIZE_M
-    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
-    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
-    pid_n = (pid % num_pid_in_group) // group_size_m
-
-    start_offs_am = pid_m * BLOCK_SIZE_M
-    offs_am = start_offs_am + tl.arange(0, BLOCK_SIZE_M)
-    start_offs_bn = pid_n * BLOCK_SIZE_N
-    offs_bn = start_offs_bn + tl.arange(0, BLOCK_SIZE_N)
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
-
-    maximum_ptrs = maximum_ptr + offs_am * stride_maximum
-    maximum = tl.load(maximum_ptrs, mask=offs_am < num_tokens, other=0.0)
-    accu_ptrs = accu_ptr + offs_am * stride_accu
-    accu = tl.load(accu_ptrs, mask=offs_am < num_tokens, other=1e-6)  # epsilon to avoid division by zero
-    accu_rcp = tl.fdiv(1.0, accu)
-
-    d_entropy_ptrs = d_entropy_ptr + offs_am * stride_d_entropy
-    d_entropy = tl.load(d_entropy_ptrs, mask=offs_am < num_tokens, other=0.0)
-    if reduction == 0:  # none
-        d_logprobs_ptrs = d_logprobs_ptr + offs_am * stride_d_logprobs
-        d_logprobs = tl.load(d_logprobs_ptrs, mask=offs_am < num_tokens, other=0.0)
-    elif reduction == 1:  # sum
-        d_logprobs = tl.load(d_logprobs_ptr)
-        d_logprobs = tl.broadcast_to(d_logprobs, (BLOCK_SIZE_M,))
-    else:  # mean
-        d_logprobs = tl.fdiv(tl.load(d_logprobs_ptr), num_tokens.to(tl.float32))
-        d_logprobs = tl.broadcast_to(d_logprobs, (BLOCK_SIZE_M,))
-    d_logprobs = -1 * d_logprobs
-
-    entropy_b_ptrs = entropy_b_ptr + offs_am * stride_entropy_b
-    entropy_b = tl.load(entropy_b_ptrs, mask=offs_am < num_tokens, other=0.0)
-
-    labels_ptrs = labels_ptr + offs_am * stride_labels
-    labels = tl.load(labels_ptrs, mask=offs_am < num_tokens, other=0)
-
-    logits = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-
-    if USE_TMA:
-        # using TMA and device-side descriptor creation
-        hidden_desc = tl.make_tensor_descriptor(
-            hidden_ptr,
-            shape=[num_tokens, hidden_size],
-            strides=[stride_hidden_m, 1],
-            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
-        )
-        weight_desc = tl.make_tensor_descriptor(
-            weight_ptr,
-            shape=[vocab_size, hidden_size],
-            strides=[stride_weight_n, 1],
-            block_shape=[BLOCK_SIZE_N, BLOCK_SIZE_K],
-        )
-    else:
-        hidden_ptrs = hidden_ptr + (offs_am[:, None] * stride_hidden_m + offs_k[None, :] * stride_hidden_k)
-        # weight_ptrs = weight_ptr + (offs_k[:, None] * stride_weight_k + offs_bn[None, :] * stride_weight_n)
-        weight_ptrs = weight_ptr + (offs_bn[:, None] * stride_weight_n + offs_k[None, :] * stride_weight_k)
-
-    for k in range(0, tl.cdiv(hidden_size, BLOCK_SIZE_K)):
-        if USE_TMA:
-            start_offs_k = k * BLOCK_SIZE_K
-            _hidden = hidden_desc.load([start_offs_am, start_offs_k])
-            _weight = weight_desc.load([start_offs_bn, start_offs_k])
-        else:
-            _hidden = tl.load(
-                hidden_ptrs,
-                mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_am[:, None] < num_tokens),
-                other=0.0,
-            )
-            _weight = tl.load(
-                weight_ptrs,
-                mask=(offs_k[None, :] < hidden_size - k * BLOCK_SIZE_K) & (offs_bn[:, None] < vocab_size),
-                other=0.0,
-            )
-            hidden_ptrs += BLOCK_SIZE_K * stride_hidden_k
-            weight_ptrs += BLOCK_SIZE_K * stride_weight_k
-        logits = tl.dot(_hidden, _weight.T, logits, input_precision=INPUT_PRECISION)
-
-    if not USE_TMA:
-        hidden_ptrs -= hidden_size * stride_hidden_k
-        weight_ptrs -= hidden_size * stride_weight_k
-
-    # scale logits by temperature
-    logits *= rcp_temperature
-
-    exp_logits = tl.exp(logits - maximum[:, None])
-
-    mask = (offs_bn + rank * vocab_size)[None, :] == labels[:, None]
-    d_logits = d_logprobs[:, None] * (exp_logits * accu_rcp[:, None] - mask)
-    d_logits += d_entropy[:, None] * (-exp_logits * accu_rcp[:, None]) * (logits - entropy_b[:, None])
-
-    # scale d_logits by temperature
-    d_logits *= rcp_temperature
-
-    # store d_logits
-    d_logits_ptrs = d_logits_ptr + offs_am[:, None] * stride_d_logits_m + offs_bn[None, :] * stride_d_logits_n
-    tl.store(
-        d_logits_ptrs,
-        d_logits,  # will be implicitly converted to d_logits_ptrs.dtype.element_ty
-        mask=(offs_am[:, None] < num_tokens) & (offs_bn[None, :] < vocab_size),
-    )
-
-
-@triton.autotune(
-    configs=[
-        triton.Config(
-            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 32, "GROUP_SIZE_M": 16},
-            num_stages=3,
-            num_warps=8,
-        ),
-    ],
-    key=["num_tokens", "hidden_size", "vocab_size"],
-)
-@triton.jit
+@triton.jit(do_not_specialize=["split_idx", "num_tokens", "num_tokens_bucket"])
 def efficient_entropy_backward_kernel_general_d_logits_split_N(
     split_idx: int,
     num_tokens: int,
+    num_tokens_bucket: int,
     hidden_size: int,
     vocab_size: int,
     vocab_per_split: int,
@@ -1433,7 +902,6 @@ def efficient_entropy_backward_kernel_general_d_logits_split_N(
     stride_d_entropy: tl.int64,
     d_logprobs_ptr,
     stride_d_logprobs: tl.int64,
-    reduction: int,
     entropy_b_ptr,
     stride_entropy_b,
     d_logits_ptr,
@@ -1445,6 +913,7 @@ def efficient_entropy_backward_kernel_general_d_logits_split_N(
     BLOCK_SIZE_K: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
     USE_TMA: tl.constexpr,
+    COMPUTE_ENTROPY: tl.constexpr,
     INPUT_PRECISION: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
@@ -1466,17 +935,12 @@ def efficient_entropy_backward_kernel_general_d_logits_split_N(
     maximum = tl.load(maximum_ptr + offs_am * stride_maximum, mask=offs_am < num_tokens, other=0.0)
     accu = tl.load(accu_ptr + offs_am * stride_accu, mask=offs_am < num_tokens, other=1e-6)
     accu_rcp = tl.fdiv(1.0, accu)
-    d_entropy = tl.load(d_entropy_ptr + offs_am * stride_d_entropy, mask=offs_am < num_tokens, other=0.0)
-    if reduction == 0:
-        d_logprobs = tl.load(d_logprobs_ptr + offs_am * stride_d_logprobs, mask=offs_am < num_tokens, other=0.0)
-    elif reduction == 1:
-        d_logprobs = tl.load(d_logprobs_ptr)
-        d_logprobs = tl.broadcast_to(d_logprobs, (BLOCK_SIZE_M,))
-    else:
-        d_logprobs = tl.fdiv(tl.load(d_logprobs_ptr), num_tokens.to(tl.float32))
-        d_logprobs = tl.broadcast_to(d_logprobs, (BLOCK_SIZE_M,))
+    if COMPUTE_ENTROPY:
+        d_entropy = tl.load(d_entropy_ptr + offs_am * stride_d_entropy, mask=offs_am < num_tokens, other=0.0)
+    d_logprobs = tl.load(d_logprobs_ptr + offs_am * stride_d_logprobs, mask=offs_am < num_tokens, other=0.0)
     d_logprobs = -1 * d_logprobs
-    entropy_b = tl.load(entropy_b_ptr + offs_am * stride_entropy_b, mask=offs_am < num_tokens, other=0.0)
+    if COMPUTE_ENTROPY:
+        entropy_b = tl.load(entropy_b_ptr + offs_am * stride_entropy_b, mask=offs_am < num_tokens, other=0.0)
     labels = tl.load(labels_ptr + offs_am * stride_labels, mask=offs_am < num_tokens, other=0)
 
     logits = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
@@ -1525,7 +989,8 @@ def efficient_entropy_backward_kernel_general_d_logits_split_N(
 
     mask = (offs_bn + rank * vocab_size)[None, :] == labels[:, None]
     d_logits = d_logprobs[:, None] * (exp_logits * accu_rcp[:, None] - mask)
-    d_logits += d_entropy[:, None] * (-exp_logits * accu_rcp[:, None]) * (logits - entropy_b[:, None])
+    if COMPUTE_ENTROPY:
+        d_logits += d_entropy[:, None] * (-exp_logits * accu_rcp[:, None]) * (logits - entropy_b[:, None])
 
     d_logits *= rcp_temperature
 
@@ -1540,17 +1005,17 @@ def efficient_entropy_backward_kernel_general_d_logits_split_N(
 
 def efficient_entropy_backward(
     dlogprobs: torch.Tensor,
-    dentropy: torch.Tensor,
+    dentropy: typing.Optional[torch.Tensor],
     hidden: torch.Tensor,
     weight: torch.Tensor,
     labels: torch.Tensor,
     maximum: torch.Tensor,
     acc: torch.Tensor,
-    entropy_b: torch.Tensor,
-    reduction: typing.Optional[int] = 2,
+    entropy_b: typing.Optional[torch.Tensor],
     should_return_fp32_grad: bool = False,
     temperature: typing.Optional[float] = 1.0,
     dist_process_group: typing.Optional[dist.ProcessGroup] = None,
+    compute_entropy: bool = True,
 ) -> list:
     """Backward host function; returns shard-local ``d_hidden`` without TP all-reduce."""
     assert hidden.is_cuda and weight.is_cuda and labels.is_cuda
@@ -1559,57 +1024,46 @@ def efficient_entropy_backward(
     assert hidden.is_contiguous() and weight.is_contiguous() and labels.is_contiguous()
     assert hidden.shape[0] == labels.shape[0] and hidden.shape[1] == weight.shape[1]
 
-    _rank = 0 if dist_process_group is None else dist.get_rank(dist_process_group)
-    _world_size = 1 if dist_process_group is None else dist.get_world_size(dist_process_group)
-
+    rank = 0 if dist_process_group is None else dist.get_rank(dist_process_group)
     num_tokens, hidden_size = hidden.shape
-    num_tokens = labels.shape[0]
-    vocab_size, hidden_size = weight.shape
+    vocab_size = weight.shape[0]
     assert hidden_size % 128 == 0
 
-    REDUCTION = get_entropy_reduction_enum(reduction)
+    assert dlogprobs.shape == (num_tokens,)
+    assert dlogprobs.is_contiguous() and dlogprobs.is_cuda
+    assert dlogprobs.device == hidden.device
+    if compute_entropy:
+        assert dentropy is not None and entropy_b is not None
+        assert dentropy.is_contiguous() and dentropy.is_cuda
+        assert dlogprobs.device == dentropy.device
+        assert dentropy.shape == (num_tokens,)
 
-    if REDUCTION == EntropyReductionEnum._None:
-        assert dlogprobs.shape == (num_tokens,)
-    else:
-        assert dlogprobs.dim() == 0
-
-    assert dlogprobs.is_contiguous() and dentropy.is_contiguous()
-    assert dlogprobs.is_cuda and dentropy.is_cuda
-    assert dlogprobs.device == hidden.device and dlogprobs.device == dentropy.device
-    assert dentropy.shape == (num_tokens,)
-
-    d_hidden, d_weight = None, None
-    if _config._backward == BackwardEnum._Total_Fuse_MN or should_return_fp32_grad:
-        d_hidden = torch.zeros_like(hidden, dtype=torch.float32, device=hidden.device)
-        d_weight = torch.zeros_like(weight, dtype=torch.float32, device=weight.device)
-    else:
-        d_hidden = torch.empty_like(hidden, dtype=hidden.dtype, device=hidden.device)
-        d_weight = torch.empty_like(weight, dtype=hidden.dtype, device=weight.device)
-    assert d_hidden.is_contiguous() and d_weight.is_contiguous()
-
-    assert maximum.is_contiguous() and acc.is_contiguous()
-    assert maximum.device == hidden.device and acc.device == hidden.device
+    grad_dtype = torch.float32 if should_return_fp32_grad else hidden.dtype
+    d_hidden = torch.empty_like(hidden, dtype=grad_dtype)
+    d_weight = torch.empty_like(weight, dtype=grad_dtype)
     assert maximum.shape == labels.shape == acc.shape
-    assert maximum.is_cuda and acc.is_cuda
+    assert maximum.is_contiguous() and acc.is_contiguous()
+    if compute_entropy:
+        assert entropy_b is not None and entropy_b.shape == labels.shape and entropy_b.is_contiguous()
+    d_entropy_input = dentropy if dentropy is not None else dlogprobs
+    entropy_b_input = entropy_b if entropy_b is not None else acc
 
-    vocab_per_split = 1024
-    assert vocab_per_split % 128 == 0
+    vocab_per_split = 9504
     num_splits = (vocab_size + vocab_per_split - 1) // vocab_per_split
+    d_logits = torch.empty((num_tokens, vocab_per_split), device=hidden.device, dtype=hidden.dtype).contiguous()
 
-    assert entropy_b.is_contiguous() and entropy_b.is_cuda
-    assert entropy_b.shape == (num_tokens,)
+    def d_logits_grid(meta):
+        return (triton.cdiv(num_tokens, meta["BLOCK_SIZE_M"]) * triton.cdiv(vocab_per_split, meta["BLOCK_SIZE_N"]),)
 
-    if _config._backward == BackwardEnum._Total_Fuse_MN:
-        # --- Triton doesn't materialize d_logits at all. Split tiles at the perspective of d_logits.
-        def mainloop_grid(meta):
-            return (triton.cdiv(num_tokens, meta["BLOCK_SIZE_M"]) * triton.cdiv(vocab_size, meta["BLOCK_SIZE_N"]),)
-
-        efficient_entropy_backward_kernel_general_mainloop_MN[mainloop_grid](
+    for split_idx in range(num_splits):
+        efficient_entropy_backward_kernel_general_d_logits_split_N[d_logits_grid](
+            split_idx,
             num_tokens,
+            _autotune_token_bucket(num_tokens),
             hidden_size,
             vocab_size,
-            _rank,
+            vocab_per_split,
+            rank,
             hidden,
             hidden.stride(0),
             hidden.stride(1),
@@ -1622,206 +1076,47 @@ def efficient_entropy_backward(
             maximum.stride(0),
             acc,
             acc.stride(0),
-            dentropy,
-            dentropy.stride(0),
+            d_entropy_input,
+            d_entropy_input.stride(0),
             dlogprobs,
-            dlogprobs.stride(0) if REDUCTION == EntropyReductionEnum._None else 0,
-            REDUCTION,
-            entropy_b,
-            entropy_b.stride(0),
-            d_hidden,
-            d_hidden.stride(0),
-            d_hidden.stride(1),
-            d_weight,
-            d_weight.stride(0),
-            d_weight.stride(1),
+            dlogprobs.stride(0),
+            entropy_b_input,
+            entropy_b_input.stride(0),
+            d_logits,
+            d_logits.stride(0),
+            d_logits.stride(1),
             1.0 / temperature,
             USE_TMA=SUPPORT_CUDA_TMA and hidden.stride(1) == 1 and weight.stride(1) == 1,
+            COMPUTE_ENTROPY=compute_entropy,
             INPUT_PRECISION=_dot_input_precision(hidden),
         )
 
-    elif _config._backward == BackwardEnum._Total_Separate:
-        _d_logits = torch.empty((num_tokens, vocab_size), device=hidden.device, dtype=hidden.dtype).contiguous()
-        assert _d_logits.is_contiguous()
-
-        if _config._use_triton:
-
-            def d_logits_grid(meta):
-                return (triton.cdiv(num_tokens, meta["BLOCK_SIZE_M"]) * triton.cdiv(vocab_size, meta["BLOCK_SIZE_N"]),)
-
-            efficient_entropy_backward_kernel_general_d_logits[d_logits_grid](
-                num_tokens,
-                hidden_size,
-                vocab_size,
-                _rank,
-                hidden,
-                hidden.stride(0),
-                hidden.stride(1),
-                weight,
-                weight.stride(0),
-                weight.stride(1),
-                labels,
-                labels.stride(0),
-                maximum,
-                maximum.stride(0),
-                acc,
-                acc.stride(0),
-                dentropy,
-                dentropy.stride(0),
-                dlogprobs,
-                dlogprobs.stride(0) if REDUCTION == EntropyReductionEnum._None else 0,
-                REDUCTION,
-                entropy_b,
-                entropy_b.stride(0),
-                _d_logits,
-                _d_logits.stride(0),
-                _d_logits.stride(1),
-                1.0 / temperature,
-                USE_TMA=SUPPORT_CUDA_TMA and hidden.stride(1) == 1 and weight.stride(1) == 1,
-                INPUT_PRECISION=_dot_input_precision(hidden),
-            )
-
-            torch.matmul(_d_logits, weight, out=d_hidden)
-            torch.matmul(_d_logits.T, hidden, out=d_weight)
+        right_bound = min((split_idx + 1) * vocab_per_split, vocab_size)
+        split_width = right_bound - split_idx * vocab_per_split
+        if split_width == vocab_per_split:
+            # Whole staging buffer is live vocabulary; slicing would copy nothing.
+            split_d_logits = d_logits
         else:
-            raise AssertionError("Triton is required for efficient entropy kernel")
-
-    elif _config._backward == BackwardEnum._Split_Dlogits_N:
-        vocab_per_split = 9504
-        num_splits = (vocab_size + vocab_per_split - 1) // vocab_per_split
-
-        _d_logits = torch.empty((num_tokens, vocab_per_split), device=hidden.device, dtype=hidden.dtype).contiguous()
-        assert _d_logits.is_contiguous()
-
-        def d_logits_grid(meta):
-            return (triton.cdiv(num_tokens, meta["BLOCK_SIZE_M"]) * triton.cdiv(vocab_per_split, meta["BLOCK_SIZE_N"]),)
-
-        for split_idx in range(num_splits):
-            efficient_entropy_backward_kernel_general_d_logits_split_N[d_logits_grid](
-                split_idx,
-                num_tokens,
-                hidden_size,
-                vocab_size,
-                vocab_per_split,
-                _rank,
-                hidden,
-                hidden.stride(0),
-                hidden.stride(1),
-                weight,
-                weight.stride(0),
-                weight.stride(1),
-                labels,
-                labels.stride(0),
-                maximum,
-                maximum.stride(0),
-                acc,
-                acc.stride(0),
-                dentropy,
-                dentropy.stride(0),
-                dlogprobs,
-                dlogprobs.stride(0) if REDUCTION == EntropyReductionEnum._None else 0,
-                REDUCTION,
-                entropy_b,
-                entropy_b.stride(0),
-                _d_logits,
-                _d_logits.stride(0),
-                _d_logits.stride(1),
-                1.0 / temperature,
-                USE_TMA=SUPPORT_CUDA_TMA and hidden.stride(1) == 1 and weight.stride(1) == 1,
-                INPUT_PRECISION=_dot_input_precision(hidden),
-            )
-
-            if split_idx == (num_splits - 1):
-                vocab_right_bound = min((split_idx + 1) * vocab_per_split, vocab_size) - split_idx * vocab_per_split
-                _d_logits = _d_logits[:, :vocab_right_bound].contiguous()
-
-            if split_idx == 0:
-                torch.matmul(
-                    _d_logits, weight[split_idx * vocab_per_split : (split_idx + 1) * vocab_per_split, :], out=d_hidden
-                )
-            else:
-                d_hidden += torch.matmul(
-                    _d_logits, weight[split_idx * vocab_per_split : (split_idx + 1) * vocab_per_split, :]
-                )
-            torch.matmul(
-                _d_logits.T, hidden, out=d_weight[split_idx * vocab_per_split : (split_idx + 1) * vocab_per_split, :]
-            )
-
-    elif _config._backward == BackwardEnum._Split_Dlogits_M:
-        raise NotImplementedError("BackwardEnum._Split_Dlogits_M is not implemented yet")
+            # Only the final split can be narrower than the staging buffer, so
+            # nothing launches into ``d_logits`` after this. Pack the live columns
+            # and release the [M, vocab_per_split] buffer before the projections,
+            # otherwise it stays resident across the [M, H] temporary that
+            # ``d_hidden += torch.matmul(...)`` allocates below.
+            assert split_idx == num_splits - 1
+            split_d_logits = d_logits[:, :split_width].contiguous()
+            d_logits = None
+        split_weight = weight[split_idx * vocab_per_split : right_bound]
+        if split_idx == 0:
+            torch.matmul(split_d_logits, split_weight, out=d_hidden)
+        else:
+            d_hidden += torch.matmul(split_d_logits, split_weight)
+        torch.matmul(
+            split_d_logits.T,
+            hidden,
+            out=d_weight[split_idx * vocab_per_split : right_bound],
+        )
 
     return d_hidden, d_weight
-
-
-# ======================================================================================
-# Thin autograd wrapper, vendored from verl/utils/kernel/linear_cross_entropy.py @ 29ffe75.
-# This is verl's interface (labels are GLOBAL vocab ids; returns (logprobs, entropy)).
-# The SkyRL adapter below sits on top of this.
-# ======================================================================================
-
-
-class LinearCrossEntropy(torch.autograd.Function):
-    @staticmethod
-    def forward(  # pyrefly: ignore[bad-override]
-        ctx,
-        hidden: torch.Tensor,
-        weight: torch.Tensor,
-        labels: torch.Tensor,
-        temperature: typing.Optional[float] = 1.0,
-        reduction: typing.Optional[str] = "none",
-        dist_process_group: typing.Optional[dist.ProcessGroup] = None,
-    ) -> list:
-        assert isinstance(temperature, float), f"temperature must be a float, but got {type(temperature)}"
-        assert isinstance(reduction, str), f"reduction must be a str, but got {type(reduction)}"
-
-        REDUCTION = get_entropy_reduction_enum_number(reduction.lower())
-
-        original_hidden_shape = hidden.shape
-        if len(hidden.shape) != 2:
-            hidden = hidden.view(-1, hidden.shape[-1])  # (batch_size * num_tokens, hidden_size)
-        if len(labels.shape) != 1:
-            labels = labels.view(-1)
-
-        logprobs, entropy, _maximum, _accumulate, _entropy_b = efficient_entropy_forward(
-            hidden, weight, labels, REDUCTION, temperature, dist_process_group
-        )
-
-        ctx.save_for_backward(hidden, weight, labels, _maximum, _accumulate, _entropy_b)
-        ctx.original_hidden_shape = original_hidden_shape
-        ctx.REDUCTION = REDUCTION
-        ctx.dist_process_group = dist_process_group
-        ctx.should_return_fp32_grad = False
-        ctx.temperature = temperature
-        return logprobs, entropy
-
-    @staticmethod
-    def backward(ctx, dlogprobs: torch.Tensor, dentropy: torch.Tensor) -> list:
-        hidden, weight, labels, _maximum, _accumulate, _entropy_b = ctx.saved_tensors
-        REDUCTION = ctx.REDUCTION
-        dist_process_group = ctx.dist_process_group
-        should_return_fp32_grad = ctx.should_return_fp32_grad
-        temperature = ctx.temperature
-
-        d_hidden, d_weight = efficient_entropy_backward(
-            dlogprobs,
-            dentropy,
-            hidden,
-            weight,
-            labels,
-            _maximum,
-            _accumulate,
-            _entropy_b,
-            REDUCTION,
-            should_return_fp32_grad,
-            temperature,
-            dist_process_group,
-        )
-        d_hidden = d_hidden.view(ctx.original_hidden_shape)
-
-        return (d_hidden, d_weight, None, None, None, None)
-
-
-linear_cross_entropy = LinearCrossEntropy.apply
 
 
 # ======================================================================================
@@ -1888,11 +1183,11 @@ class FusedLinearLogprobTriton(torch.autograd.Function):
             hidden_2d,
             weight_c,
             labels_verl.reshape(-1),
-            EntropyReductionEnum._None,
             1.0,
             tp_group,
+            compute_entropy=False,
         )
-        # reduction="none" yields per-token log-probs.
+        assert _entropy is None and _entropy_b is None
         log_probs = logprobs_flat.reshape(B, S).to(torch.float32)
 
         # Fully-OOV targets have no label-logit contribution, so verl returns
@@ -1911,7 +1206,6 @@ class FusedLinearLogprobTriton(torch.autograd.Function):
                 labels_verl.reshape(-1),
                 _maximum,
                 _accumulate,
-                _entropy_b,
             )
             ctx.B, ctx.S, ctx.H = B, S, H
             ctx.tp_group = tp_group
@@ -1922,7 +1216,7 @@ class FusedLinearLogprobTriton(torch.autograd.Function):
     @staticmethod
     def backward(ctx: Any, *grad_outputs: torch.Tensor) -> tuple:
         grad_output = grad_outputs[0]  # [B, S], grad of full-vocab logprob
-        hidden_2d, weight_c, labels_verl, _maximum, _accumulate, _entropy_b = ctx.saved_tensors
+        hidden_2d, weight_c, labels_verl, _maximum, _accumulate = ctx.saved_tensors
         B, S, H = ctx.B, ctx.S, ctx.H
         tp_group = ctx.tp_group
 
@@ -1934,22 +1228,19 @@ class FusedLinearLogprobTriton(torch.autograd.Function):
         else:
             dlogprobs = grad_output.reshape(-1).to(torch.float32).contiguous()
 
-        # reduction="none" backward requires a dentropy buffer.
-        dentropy = torch.zeros_like(dlogprobs)
-
         d_hidden_2d, d_weight = efficient_entropy_backward(
             dlogprobs,
-            dentropy,
+            None,
             hidden_2d,
             weight_c,
             labels_verl,
             _maximum,
             _accumulate,
-            _entropy_b,
-            EntropyReductionEnum._None,
+            None,
             False,  # should_return_fp32_grad
             1.0,  # temperature (pre-baked into hidden by the caller)
             tp_group,
+            compute_entropy=False,
         )
 
         # d_hidden is this rank's partial; SP gather backward performs TP reduction.

--- a/skyrl/benchmarks/bench_fused_linear_logprob.py
+++ b/skyrl/benchmarks/bench_fused_linear_logprob.py
@@ -27,11 +27,26 @@ Usage (single GPU; per-rank vocab shard = `vocab`):
         skyrl/benchmarks/bench_fused_linear_logprob.py
 Run with --nproc_per_node=N for a real TP=N measurement (pass --vocab as the full
 vocab; each rank then holds vocab//N).
+
+Use ``--autotune-sweep --output-dir PATH`` to benchmark the Triton mainloop's
+schedule search over representative model, token, TP, and CP shapes. With eight
+processes, each GPU independently receives one eighth of the unique local shapes.
 """
 
+from __future__ import annotations
+
 import argparse
+import functools
+import importlib.util
+import json
+import math
 import os
+import statistics
+import sys
 import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable
 
 import torch
 import torch.distributed as dist
@@ -46,6 +61,32 @@ WARMUP_REPS = 1
 BENCH_REPS = 3
 MODES = ["baseline", "nvidia", "liger", "triton"]
 
+AUTOTUNE_MODELS = {
+    "nemotron-super-120b": (4096, 131072),
+    "nemotron-ultra-550b": (8192, 131072),
+    "glm-5.3-flash": (4096, 154880),
+    "kimi-k3": (7168, 163840),
+}
+AUTOTUNE_TOTAL_TOKEN_COUNTS = (16384, 32768, 65536, 131072, 262144)
+AUTOTUNE_SHARDING_SCHEMES = tuple((tp, cp) for tp in (1, 2, 4, 8) for cp in (1, 2, 4, 8) if tp * cp <= 8)
+AUTOTUNE_VOCAB_PER_SPLIT = 1024
+FIXED_STAGE3 = (128, 256, 32, 3, 8)
+FIXED_STAGE5 = (128, 256, 32, 5, 8)
+
+
+@dataclass(frozen=True)
+class AutotuneLocalShape:
+    model: str
+    hidden_size: int
+    vocab_size: int
+    num_tokens: int
+
+
+def _vocab_bounds(vocab_local, tp_group):
+    tp_rank = dist.get_rank(tp_group)
+    vocab_start = tp_rank * vocab_local
+    return vocab_start, vocab_start + vocab_local
+
 
 def _loss(mode, hidden, weight, target, vocab_local, chunk_size, tp_group):
     """Per-token CE summed to a scalar (so all modes produce identical grads)."""
@@ -58,9 +99,10 @@ def _loss(mode, hidden, weight, target, vocab_local, chunk_size, tp_group):
         FusedLinearChunkedDistributedLogprob,
     )
 
+    vocab_start, vocab_end = _vocab_bounds(vocab_local, tp_group)
     if mode == "liger":
         lp = FusedLinearChunkedDistributedLogprob.apply(
-            hidden, weight, target, 0, vocab_local, chunk_size, tp_group, False
+            hidden, weight, target, vocab_start, vocab_end, chunk_size, tp_group, False
         )
         return (-lp).sum()
     if mode == "triton":
@@ -68,7 +110,7 @@ def _loss(mode, hidden, weight, target, vocab_local, chunk_size, tp_group):
             FusedLinearLogprobTriton,
         )
 
-        lp = FusedLinearLogprobTriton.apply(hidden, weight, target, 0, vocab_local, chunk_size, tp_group, False)
+        lp = FusedLinearLogprobTriton.apply(hidden, weight, target, vocab_start, vocab_end, chunk_size, tp_group, False)
         return (-lp).sum()
     logits = torch.matmul(hidden, weight.t())  # [B, S, vocab//TP]
     if mode == "baseline":
@@ -83,16 +125,41 @@ def _loss(mode, hidden, weight, target, vocab_local, chunk_size, tp_group):
 def _measure(mode, seq_len, vocab_local, chunk_size, tp_group, device, reps):
     """forward+backward; return (mean_ms, mean_peak_bytes) or (None, None) on OOM."""
     times, peaks = [], []
-    for _ in range(reps):
+    tp_rank = dist.get_rank(tp_group)
+    tp_size = dist.get_world_size(tp_group)
+    for repetition in range(reps):
         hidden = weight = target = loss = None
         torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats(device)
         try:
-            hidden = torch.randn(1, seq_len, HIDDEN, dtype=torch.bfloat16, device=device, requires_grad=True)
+            shared_generator = torch.Generator(device=device).manual_seed(1000 + repetition)
+            weight_generator = torch.Generator(device=device).manual_seed(2000 + tp_rank + repetition * tp_size)
+            hidden = torch.randn(
+                1,
+                seq_len,
+                HIDDEN,
+                dtype=torch.bfloat16,
+                device=device,
+                generator=shared_generator,
+                requires_grad=True,
+            )
             weight = (
-                torch.randn(vocab_local, HIDDEN, dtype=torch.bfloat16, device=device) * (HIDDEN**-0.5)
+                torch.randn(
+                    vocab_local,
+                    HIDDEN,
+                    dtype=torch.bfloat16,
+                    device=device,
+                    generator=weight_generator,
+                )
+                * (HIDDEN**-0.5)
             ).requires_grad_(True)
-            target = torch.randint(0, vocab_local, (1, seq_len), device=device)
+            target = torch.randint(
+                0,
+                vocab_local * tp_size,
+                (1, seq_len),
+                device=device,
+                generator=shared_generator,
+            )
             torch.cuda.synchronize(device)
             t0 = time.perf_counter()
             loss = _loss(mode, hidden, weight, target, vocab_local, chunk_size, tp_group)
@@ -121,31 +188,381 @@ def _active_modes():
 
 
 def _correctness(modes, vocab_local, tp_group, device):
-    """All modes must produce the same loss + grad_hidden (fair comparison)."""
-    torch.manual_seed(0)
+    """Validate loss and both gradients on every TP rank before timing."""
+    tp_rank = dist.get_rank(tp_group)
+    tp_size = dist.get_world_size(tp_group)
     S = 64
-    h0 = torch.randn(1, S, HIDDEN, dtype=torch.bfloat16, device=device)
-    w0 = torch.randn(vocab_local, HIDDEN, dtype=torch.bfloat16, device=device) * (HIDDEN**-0.5)
-    tgt = torch.randint(0, vocab_local, (1, S), device=device)
+    shared_generator = torch.Generator(device=device).manual_seed(0)
+    weight_generator = torch.Generator(device=device).manual_seed(100 + tp_rank)
+    h0 = torch.randn(1, S, HIDDEN, dtype=torch.bfloat16, device=device, generator=shared_generator)
+    w0 = torch.randn(
+        vocab_local,
+        HIDDEN,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=weight_generator,
+    ) * (HIDDEN**-0.5)
+    tgt = torch.randint(
+        0,
+        vocab_local * tp_size,
+        (1, S),
+        device=device,
+        generator=shared_generator,
+    )
     ref = {}
     for mode in modes:
         h = h0.clone().requires_grad_(True)
         w = w0.clone().requires_grad_(True)
-        _loss(mode, h, w, tgt, vocab_local, CHUNK_SIZE, tp_group).backward()
-        ref[mode] = (h.grad.float().clone(),)
-    base = ref["baseline"][0]
+        loss = _loss(mode, h, w, tgt, vocab_local, CHUNK_SIZE, tp_group)
+        loss.backward()
+        ref[mode] = (
+            loss.detach().float(),
+            h.grad.detach().float(),
+            w.grad.detach().float(),
+        )
+    base_loss, base_gh, base_gw = ref["baseline"]
     out = []
     for mode in modes:
-        gh = ref[mode][0]
-        out.append(f"{mode}: max|dgrad_hidden vs baseline|={(gh - base).abs().max().item():.2e}")
+        loss, gh, gw = ref[mode]
+        loss_delta = (loss - base_loss).abs().item()
+        gh_delta = (gh - base_gh).abs().max().item()
+        gw_delta = (gw - base_gw).abs().max().item()
+        matches = (
+            torch.allclose(loss, base_loss, atol=2e-2, rtol=2e-2)
+            and torch.allclose(gh, base_gh, atol=2e-2, rtol=2e-2)
+            and torch.allclose(gw, base_gw, atol=2e-2, rtol=2e-2)
+        )
+        if not matches:
+            raise RuntimeError(
+                f"{mode} failed TP correctness on rank {tp_rank}: "
+                f"loss_delta={loss_delta:.2e}, hidden_grad_delta={gh_delta:.2e}, "
+                f"weight_grad_delta={gw_delta:.2e}"
+            )
+        out.append(
+            f"{mode}: max|loss, dgrad_hidden, dgrad_weight deltas|=" f"{loss_delta:.2e}, {gh_delta:.2e}, {gw_delta:.2e}"
+        )
     return out
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--vocab", type=int, default=None, help="full vocab; per-rank shard = vocab // world_size")
-    ap.add_argument("--chunk-size", type=int, default=CHUNK_SIZE)
-    args = ap.parse_args()
+def _load_kernel_module():
+    path = Path(__file__).parents[1] / "backends/skyrl_train/distributed/megatron/fused_linear_logprob_triton.py"
+    name = "skyrl_fused_linear_logprob_triton_benchmark"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _require_triton():
+    try:
+        import triton
+    except ImportError as exc:
+        raise RuntimeError("--autotune-sweep requires Triton") from exc
+    return triton
+
+
+def _config_dict(spec: tuple[int, int, int, int, int]) -> dict[str, int]:
+    block_m, block_n, block_k, num_stages, num_warps = spec
+    return {
+        "block_m": block_m,
+        "block_n": block_n,
+        "block_k": block_k,
+        "num_stages": num_stages,
+        "num_warps": num_warps,
+    }
+
+
+def _triton_config(spec: tuple[int, int, int, int, int]):
+    triton = _require_triton()
+    values = _config_dict(spec)
+    return triton.Config(
+        {
+            "BLOCK_SIZE_M": values["block_m"],
+            "BLOCK_SIZE_N": values["block_n"],
+            "BLOCK_SIZE_K": values["block_k"],
+        },
+        num_stages=values["num_stages"],
+        num_warps=values["num_warps"],
+    )
+
+
+def _spec_from_config(config) -> tuple[int, int, int, int, int]:
+    return (
+        config.kwargs["BLOCK_SIZE_M"],
+        config.kwargs["BLOCK_SIZE_N"],
+        config.kwargs["BLOCK_SIZE_K"],
+        config.num_stages,
+        config.num_warps,
+    )
+
+
+def _logical_autotune_matrix() -> tuple[dict[str, Any], ...]:
+    cases = []
+    for model, (hidden_size, full_vocab_size) in AUTOTUNE_MODELS.items():
+        for total_tokens in AUTOTUNE_TOTAL_TOKEN_COUNTS:
+            for tp, cp in AUTOTUNE_SHARDING_SCHEMES:
+                cases.append(
+                    {
+                        "model": model,
+                        "hidden_size": hidden_size,
+                        "full_vocab_size": full_vocab_size,
+                        "total_tokens": total_tokens,
+                        "tp": tp,
+                        "cp": cp,
+                        "local_shape": AutotuneLocalShape(
+                            model=model,
+                            hidden_size=hidden_size,
+                            vocab_size=full_vocab_size // tp,
+                            num_tokens=total_tokens // cp,
+                        ),
+                    }
+                )
+    return tuple(cases)
+
+
+def _allocate_autotune_buffers(shape: AutotuneLocalShape, device: torch.device):
+    num_splits = math.ceil(shape.vocab_size / AUTOTUNE_VOCAB_PER_SPLIT)
+    return {
+        "num_splits": num_splits,
+        "hidden": torch.zeros((shape.num_tokens, shape.hidden_size), dtype=torch.bfloat16, device=device),
+        "weight": torch.zeros((shape.vocab_size, shape.hidden_size), dtype=torch.bfloat16, device=device),
+        "labels": torch.zeros((shape.num_tokens,), dtype=torch.int64, device=device),
+        "maximum": torch.empty((shape.num_tokens, num_splits), dtype=torch.float32, device=device),
+        "accumulate": torch.empty((shape.num_tokens, num_splits), dtype=torch.float32, device=device),
+        "entropy_b": torch.empty((shape.num_tokens, num_splits), dtype=torch.float32, device=device),
+        "logprobs": torch.empty((shape.num_tokens,), dtype=torch.float32, device=device),
+    }
+
+
+def _kernel_args(module, shape: AutotuneLocalShape, buffers):
+    hidden = buffers["hidden"]
+    weight = buffers["weight"]
+    labels = buffers["labels"]
+    maximum = buffers["maximum"]
+    accumulate = buffers["accumulate"]
+    entropy_b = buffers["entropy_b"]
+    logprobs = buffers["logprobs"]
+    return (
+        0,
+        hidden,
+        weight,
+        labels,
+        shape.num_tokens,
+        module._autotune_token_bucket(shape.num_tokens),
+        shape.hidden_size,
+        shape.vocab_size,
+        AUTOTUNE_VOCAB_PER_SPLIT,
+        hidden.stride(0),
+        hidden.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        maximum,
+        maximum.stride(0),
+        maximum.stride(1),
+        accumulate,
+        accumulate.stride(0),
+        accumulate.stride(1),
+        entropy_b,
+        entropy_b.stride(0),
+        entropy_b.stride(1),
+        logprobs,
+        logprobs.stride(0),
+        1.0,
+    )
+
+
+def _measure_cuda(launch: Callable[[], Any], warmup: int, repetitions: int) -> float:
+    for _ in range(warmup):
+        launch()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(repetitions):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        launch()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end))
+    return statistics.median(samples)
+
+
+def _raw_launch(module, shape: AutotuneLocalShape, buffers, spec):
+    triton = _require_triton()
+    block_m, block_n, block_k, num_stages, num_warps = spec
+    grid = (triton.cdiv(shape.num_tokens, block_m) * buffers["num_splits"],)
+    module.efficient_entropy_kernel_general_mainloop.fn[grid](
+        *_kernel_args(module, shape, buffers),
+        BLOCK_SIZE_M=block_m,
+        BLOCK_SIZE_N=block_n,
+        BLOCK_SIZE_K=block_k,
+        USE_TMA=module.SUPPORT_CUDA_TMA,
+        INPUT_PRECISION="tf32",
+        num_stages=num_stages,
+        num_warps=num_warps,
+    )
+
+
+def _autotuned_launch(module, shape: AutotuneLocalShape, buffers):
+    triton = _require_triton()
+
+    def grid(meta):
+        return (triton.cdiv(shape.num_tokens, meta["BLOCK_SIZE_M"]) * buffers["num_splits"],)
+
+    module.efficient_entropy_kernel_general_mainloop[grid](
+        *_kernel_args(module, shape, buffers),
+        USE_TMA=module.SUPPORT_CUDA_TMA,
+        INPUT_PRECISION="tf32",
+    )
+
+
+def _measure_full_forward(module, shape, buffers, spec, repetitions):
+    autotuner = module.efficient_entropy_kernel_general_mainloop
+    original_configs, original_cache = autotuner.configs, autotuner.cache
+    autotuner.configs, autotuner.cache = [_triton_config(spec)], {}
+    try:
+        return _measure_cuda(
+            lambda: module.efficient_entropy_forward(
+                buffers["hidden"],
+                buffers["weight"],
+                buffers["labels"],
+                dist_process_group=None,
+            ),
+            warmup=1,
+            repetitions=repetitions,
+        )
+    finally:
+        autotuner.configs, autotuner.cache = original_configs, original_cache
+
+
+def _benchmark_autotune_shape(
+    module,
+    shape: AutotuneLocalShape,
+    device: torch.device,
+    repetitions: int,
+):
+    buffers = _allocate_autotune_buffers(shape, device)
+    autotuner = module.efficient_entropy_kernel_general_mainloop
+    torch.cuda.synchronize()
+    started = time.perf_counter()
+    _autotuned_launch(module, shape, buffers)
+    torch.cuda.synchronize()
+    first_autotuned_call_ms = (time.perf_counter() - started) * 1000.0
+    selected_spec = _spec_from_config(autotuner.best_config)
+    cached_autotuned_ms = _measure_cuda(
+        lambda: _autotuned_launch(module, shape, buffers),
+        warmup=1,
+        repetitions=repetitions,
+    )
+
+    timings = {}
+    failures = {}
+    for spec in module._FORWARD_MAINLOOP_CONFIG_SPECS:
+        try:
+            timings[spec] = _measure_cuda(
+                lambda spec=spec: _raw_launch(module, shape, buffers, spec),
+                warmup=1,
+                repetitions=repetitions,
+            )
+        except Exception as exc:  # Invalid-resource configs are reported here.
+            failures[str(spec)] = f"{type(exc).__name__}: {exc}"
+            torch.cuda.synchronize()
+
+    best_spec = min(timings, key=timings.__getitem__)
+    full_repetitions = max(1, repetitions // 2)
+    result = {
+        "kind": "local_shape",
+        "shape": asdict(shape),
+        "token_bucket": module._autotune_token_bucket(shape.num_tokens),
+        "selected_config": _config_dict(selected_spec),
+        "measured_best_config": _config_dict(best_spec),
+        "first_autotuned_call_ms": first_autotuned_call_ms,
+        "cached_autotuned_ms": cached_autotuned_ms,
+        "fixed_stage3_ms": timings[FIXED_STAGE3],
+        "fixed_stage5_ms": timings[FIXED_STAGE5],
+        "measured_best_ms": timings[best_spec],
+        "full_fixed_stage5_ms": _measure_full_forward(module, shape, buffers, FIXED_STAGE5, full_repetitions),
+        "full_measured_best_ms": _measure_full_forward(module, shape, buffers, best_spec, full_repetitions),
+        "all_config_ms": {json.dumps(_config_dict(spec), sort_keys=True): value for spec, value in timings.items()},
+        "failures": failures,
+    }
+    torch.cuda.empty_cache()
+    return result
+
+
+def _recompile_probe(module, device: torch.device):
+    records = []
+    for num_tokens in (20000, 20001, 40000):
+        shape = AutotuneLocalShape("specialization-probe", 4096, 16000, num_tokens)
+        buffers = _allocate_autotune_buffers(shape, device)
+        torch.cuda.synchronize()
+        started = time.perf_counter()
+        _autotuned_launch(module, shape, buffers)
+        torch.cuda.synchronize()
+        best_config = module.efficient_entropy_kernel_general_mainloop.best_config
+        records.append(
+            {
+                "num_tokens": num_tokens,
+                "bucket": module._autotune_token_bucket(num_tokens),
+                "wall_ms": (time.perf_counter() - started) * 1000.0,
+                "selected_config": _config_dict(_spec_from_config(best_config)),
+            }
+        )
+        torch.cuda.empty_cache()
+    return {"kind": "specialization_probe", "calls": records}
+
+
+def _run_autotune_sweep(output_dir: Path, repetitions: int) -> None:
+    triton = _require_triton()
+    rank = int(os.environ.get("LOCAL_RANK", "0"))
+    world_size = int(os.environ.get("LOCAL_WORLD_SIZE", "1"))
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    module = _load_kernel_module()
+
+    logical = _logical_autotune_matrix()
+    shapes = tuple(dict.fromkeys(case["local_shape"] for case in logical))
+    assigned = tuple(shape for index, shape in enumerate(shapes) if index % world_size == rank)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"rank-{rank}.jsonl"
+    metadata = {
+        "kind": "metadata",
+        "rank": rank,
+        "world_size": world_size,
+        "device": torch.cuda.get_device_name(device),
+        "device_capability": torch.cuda.get_device_capability(device),
+        "torch_version": torch.__version__,
+        "triton_version": triton.__version__,
+        "kernel_file": module.__file__,
+        "support_cuda_tma": module.SUPPORT_CUDA_TMA,
+        "logical_case_count": len(logical),
+        "unique_local_shape_count": len(shapes),
+        "assigned_shape_count": len(assigned),
+    }
+    with output_path.open("w") as output:
+        print(json.dumps(metadata, sort_keys=True), file=output, flush=True)
+        if rank == 0:
+            print(
+                json.dumps(_recompile_probe(module, device), sort_keys=True),
+                file=output,
+                flush=True,
+            )
+        for index, shape in enumerate(assigned, start=1):
+            result = _benchmark_autotune_shape(module, shape, device, repetitions)
+            print(json.dumps(result, sort_keys=True), file=output, flush=True)
+            print(
+                f"rank={rank} shape={index}/{len(assigned)} model={shape.model} "
+                f"M={shape.num_tokens} H={shape.hidden_size} V={shape.vocab_size} "
+                f"stage5={result['fixed_stage5_ms']:.3f}ms "
+                f"best={result['measured_best_ms']:.3f}ms",
+                flush=True,
+            )
+
+
+def _run_backend_comparison(args) -> None:
 
     dist.init_process_group(backend="nccl")
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
@@ -173,8 +590,10 @@ def main():
         if "triton" not in modes:
             print("triton mode unavailable; skipping")
         print("all: hidden+weight -> per-token CE -> sum -> backward\n")
-        print("correctness (TP=%d, vocab=%d):" % (world, vocab_shards[0]))
-        for line in _correctness(modes, vocab_shards[0], tp_group, device):
+        print("correctness (TP=%d, vocab=%d):" % (world, vocab_shards[0] * world))
+    correctness = _correctness(modes, vocab_shards[0], tp_group, device)
+    if rank0:
+        for line in correctness:
             print("  " + line)
         print()
 
@@ -215,6 +634,260 @@ def main():
             print()
 
     dist.destroy_process_group()
+
+
+def _entropy_specialization_call(
+    module,
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    labels: torch.Tensor,
+    grad_logprobs: torch.Tensor,
+    tp_group,
+    *,
+    compute_entropy: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    logprobs, _entropy, maximum, accumulate, entropy_b = module.efficient_entropy_forward(
+        hidden,
+        weight,
+        labels,
+        dist_process_group=tp_group,
+        compute_entropy=compute_entropy,
+    )
+    dentropy = torch.zeros_like(grad_logprobs) if compute_entropy else None
+    d_hidden, d_weight = module.efficient_entropy_backward(
+        grad_logprobs,
+        dentropy,
+        hidden,
+        weight,
+        labels,
+        maximum,
+        accumulate,
+        entropy_b,
+        dist_process_group=tp_group,
+        compute_entropy=compute_entropy,
+    )
+    return logprobs, d_hidden, d_weight
+
+
+def _run_entropy_specialization_probe(args) -> None:
+    """Compare the general entropy path with the dense log-prob-only path."""
+    dist.init_process_group(backend="nccl")
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+    import megatron.core.parallel_state as mpu
+
+    world = dist.get_world_size()
+    if world != args.tensor_parallel * args.context_parallel:
+        raise ValueError(
+            f"torchrun world size {world} must equal TP*CP=" f"{args.tensor_parallel * args.context_parallel}"
+        )
+    mpu.initialize_model_parallel(
+        tensor_model_parallel_size=args.tensor_parallel,
+        context_parallel_size=args.context_parallel,
+    )
+    module = _load_kernel_module()
+    tp_group = mpu.get_tensor_model_parallel_group()
+    cp_rank = mpu.get_context_parallel_rank()
+    device = torch.device("cuda", local_rank)
+    rank0 = dist.get_rank() == 0
+
+    check_tokens, check_hidden, check_vocab_local = 257, 256, 2048
+    shared_generator = torch.Generator(device=device).manual_seed(4700 + cp_rank)
+    weight_generator = torch.Generator(device=device).manual_seed(4800 + dist.get_rank())
+    check_hidden_tensor = torch.randn(
+        check_tokens,
+        check_hidden,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=shared_generator,
+    )
+    check_weight = torch.randn(
+        check_vocab_local,
+        check_hidden,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=weight_generator,
+    ) * (check_hidden**-0.5)
+    check_labels = torch.randint(
+        0,
+        check_vocab_local * args.tensor_parallel,
+        (check_tokens,),
+        device=device,
+        generator=shared_generator,
+    )
+    check_grad = torch.linspace(0.5, 1.5, check_tokens, dtype=torch.float32, device=device)
+    with_entropy = _entropy_specialization_call(
+        module,
+        check_hidden_tensor,
+        check_weight,
+        check_labels,
+        check_grad,
+        tp_group,
+        compute_entropy=True,
+    )
+    logprob_only = _entropy_specialization_call(
+        module,
+        check_hidden_tensor,
+        check_weight,
+        check_labels,
+        check_grad,
+        tp_group,
+        compute_entropy=False,
+    )
+    deltas = []
+    for actual, expected in zip(logprob_only, with_entropy):
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+        deltas.append((actual.float() - expected.float()).abs().max().item())
+    if rank0:
+        print(
+            "ENTROPY_SPECIALIZATION_CORRECTNESS="
+            + json.dumps(
+                {
+                    "logprobs_max_abs": deltas[0],
+                    "dhidden_max_abs": deltas[1],
+                    "dweight_max_abs": deltas[2],
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+    vocab_local = args.vocab // args.tensor_parallel
+    weight = torch.randn(
+        vocab_local,
+        args.hidden,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=weight_generator,
+    ) * (args.hidden**-0.5)
+    for total_tokens in args.seq_lens:
+        if total_tokens % args.context_parallel:
+            raise ValueError(f"seq_len={total_tokens} must be divisible by CP={args.context_parallel}")
+        local_tokens = total_tokens // args.context_parallel
+        hidden = torch.randn(
+            local_tokens,
+            args.hidden,
+            dtype=torch.bfloat16,
+            device=device,
+            generator=shared_generator,
+        )
+        labels = torch.randint(
+            0,
+            args.vocab,
+            (local_tokens,),
+            device=device,
+            generator=shared_generator,
+        )
+        grad_logprobs = torch.linspace(0.5, 1.5, local_tokens, dtype=torch.float32, device=device)
+        launch = functools.partial(
+            _entropy_specialization_call,
+            module,
+            hidden,
+            weight,
+            labels,
+            grad_logprobs,
+            tp_group,
+        )
+
+        variants = {"entropy": True, "logprob-only": False}
+        for compute_entropy in variants.values():
+            launch(compute_entropy=compute_entropy)
+        torch.cuda.synchronize(device)
+        samples = {name: [] for name in variants}
+        peaks = {name: [] for name in variants}
+        ordered = list(variants)
+        for repetition in range(args.repetitions):
+            offset = repetition % len(ordered)
+            for name in ordered[offset:] + ordered[:offset]:
+                torch.cuda.reset_peak_memory_stats(device)
+                start = torch.cuda.Event(enable_timing=True)
+                end = torch.cuda.Event(enable_timing=True)
+                start.record()
+                launch(compute_entropy=variants[name])
+                end.record()
+                end.synchronize()
+                samples[name].append(start.elapsed_time(end))
+                peaks[name].append(torch.cuda.max_memory_allocated(device))
+
+        local_metrics = torch.tensor(
+            [
+                metric
+                for name in ordered
+                for metric in (statistics.median(samples[name]), statistics.median(peaks[name]))
+            ],
+            dtype=torch.float64,
+            device=device,
+        )
+        dist.reduce(local_metrics, dst=0, op=dist.ReduceOp.MAX)
+        if rank0:
+            reduced = local_metrics.tolist()
+            metrics = {
+                name: {"ms": reduced[index * 2], "peak_bytes": int(reduced[index * 2 + 1])}
+                for index, name in enumerate(ordered)
+            }
+            metrics["speedup"] = metrics["entropy"]["ms"] / metrics["logprob-only"]["ms"]
+            metrics["peak_saved_bytes"] = metrics["entropy"]["peak_bytes"] - metrics["logprob-only"]["peak_bytes"]
+            print(
+                "ENTROPY_SPECIALIZATION_RESULT="
+                + json.dumps(
+                    {
+                        "total_tokens": total_tokens,
+                        "local_tokens": local_tokens,
+                        "hidden": args.hidden,
+                        "vocab_local": vocab_local,
+                        "tp": args.tensor_parallel,
+                        "cp": args.context_parallel,
+                        **metrics,
+                    },
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+
+    mpu.destroy_model_parallel()
+    dist.destroy_process_group()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--vocab",
+        type=int,
+        default=None,
+        help="full vocab; per-rank shard = vocab // world_size",
+    )
+    parser.add_argument("--chunk-size", type=int, default=CHUNK_SIZE)
+    parser.add_argument("--hidden", type=int, default=HIDDEN)
+    parser.add_argument("--tensor-parallel", type=int, default=1)
+    parser.add_argument("--context-parallel", type=int, default=1)
+    parser.add_argument("--seq-lens", nargs="+", type=int, default=SEQ_LENS)
+    parser.add_argument(
+        "--autotune-sweep",
+        action="store_true",
+        help="sweep Triton schedules over representative local shapes",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="JSONL output directory required by --autotune-sweep",
+    )
+    parser.add_argument("--repetitions", type=int, default=BENCH_REPS)
+    parser.add_argument(
+        "--entropy-specialization-probe",
+        action="store_true",
+        help="compare entropy and dense log-prob-only kernel paths",
+    )
+    args = parser.parse_args()
+    if args.entropy_specialization_probe:
+        if args.vocab is None:
+            parser.error("--entropy-specialization-probe requires --vocab")
+        _run_entropy_specialization_probe(args)
+    elif args.autotune_sweep:
+        if args.output_dir is None:
+            parser.error("--autotune-sweep requires --output-dir")
+        _run_autotune_sweep(args.output_dir, args.repetitions)
+    else:
+        _run_backend_comparison(args)
 
 
 if __name__ == "__main__":

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_fused_linear_logprob_triton.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_fused_linear_logprob_triton.py
@@ -11,7 +11,9 @@ TF32 path with looser tolerances.
         tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_fused_linear_logprob_triton.py
 """
 
+import ast
 import os
+from pathlib import Path
 
 import pytest
 import torch
@@ -35,12 +37,154 @@ pytestmark = [
 ]
 
 
+def _kernel_source() -> str:
+    return Path(fused_linear_logprob_triton.__file__).read_text()
+
+
+def _load_schedule_symbols() -> dict[str, object]:
+    module = ast.parse(_kernel_source())
+    wanted = {
+        "_AUTOTUNE_MIN_TOKEN_BUCKET",
+        "_AUTOTUNE_MAX_TOKEN_BUCKET",
+        "_FORWARD_MAINLOOP_CONFIG_SPECS",
+        "_EPILOGUE_CONFIG_SPECS",
+        "_EPILOGUE_UPDATE_CONFIG_SPECS",
+        "_BACKWARD_CONFIG_SPECS",
+        "_autotune_token_bucket",
+    }
+    nodes = [
+        node
+        for node in module.body
+        if (isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name) and node.targets[0].id in wanted)
+        or (isinstance(node, ast.FunctionDef) and node.name in wanted)
+    ]
+    namespace: dict[str, object] = {}
+    exec(
+        compile(ast.Module(nodes, type_ignores=[]), filename="<schedule>", mode="exec"),
+        namespace,
+    )
+    return namespace
+
+
+_SCHEDULE_SYMBOLS = _load_schedule_symbols()
+_FORWARD_MAINLOOP_CONFIG_SPECS = _SCHEDULE_SYMBOLS["_FORWARD_MAINLOOP_CONFIG_SPECS"]
+_EPILOGUE_CONFIG_SPECS = _SCHEDULE_SYMBOLS["_EPILOGUE_CONFIG_SPECS"]
+_EPILOGUE_UPDATE_CONFIG_SPECS = _SCHEDULE_SYMBOLS["_EPILOGUE_UPDATE_CONFIG_SPECS"]
+_BACKWARD_CONFIG_SPECS = _SCHEDULE_SYMBOLS["_BACKWARD_CONFIG_SPECS"]
+_autotune_token_bucket = _SCHEDULE_SYMBOLS["_autotune_token_bucket"]
+
+
+def test_autotune_schedules_include_incumbents_and_variants() -> None:
+    assert (128, 256, 32, 5, 8) in _FORWARD_MAINLOOP_CONFIG_SPECS
+    assert (128, 256, 32, 3, 8) in _FORWARD_MAINLOOP_CONFIG_SPECS
+    assert (16, 64, 4) in _EPILOGUE_CONFIG_SPECS
+    assert (16, 4) in _EPILOGUE_UPDATE_CONFIG_SPECS
+    assert (128, 256, 32, 16, 3, 8) in _BACKWARD_CONFIG_SPECS
+    for specs in (
+        _FORWARD_MAINLOOP_CONFIG_SPECS,
+        _EPILOGUE_CONFIG_SPECS,
+        _EPILOGUE_UPDATE_CONFIG_SPECS,
+        _BACKWARD_CONFIG_SPECS,
+    ):
+        assert len(specs) == len(set(specs))
+
+
+def test_all_triton_entrypoints_use_bucketed_cached_autotune() -> None:
+    module = ast.parse(_kernel_source())
+    autotune_decorators = [
+        decorator
+        for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        for decorator in node.decorator_list
+        if (
+            isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Attribute)
+            and decorator.func.attr == "autotune"
+        )
+    ]
+    assert len(autotune_decorators) == 5
+    for decorator in autotune_decorators:
+        keywords = {keyword.arg: keyword.value for keyword in decorator.keywords}
+        assert ast.literal_eval(keywords["cache_results"]) is True
+        keys = ast.literal_eval(keywords["key"])
+        assert "num_tokens_bucket" in keys
+        assert "COMPUTE_ENTROPY" in keys
+
+
+def test_skyrl_adapter_disables_unused_entropy() -> None:
+    module = ast.parse(_kernel_source())
+    adapter = next(
+        node for node in module.body if isinstance(node, ast.ClassDef) and node.name == "FusedLinearLogprobTriton"
+    )
+    methods = {node.name: node for node in adapter.body if isinstance(node, ast.FunctionDef)}
+    expected_calls = {
+        "forward": "efficient_entropy_forward",
+        "backward": "efficient_entropy_backward",
+    }
+    for method_name, call_name in expected_calls.items():
+        calls = [
+            node
+            for node in ast.walk(methods[method_name])
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == call_name
+        ]
+        assert len(calls) == 1
+        keywords = {keyword.arg: keyword.value for keyword in calls[0].keywords}
+        assert isinstance(keywords["compute_entropy"], ast.Constant)
+        assert keywords["compute_entropy"].value is False
+
+
+def test_autotuned_epilogues_do_not_overwrite_inputs() -> None:
+    module = ast.parse(_kernel_source())
+    expected_output_arguments = {
+        "efficient_entropy_triton_kernel_epilogue": {"result_logprobs_ptr"},
+        "efficient_entropy_triton_epilogue_tp_update": {
+            "result_entropy_b_ptr",
+            "result_logprobs_ptr",
+        },
+    }
+    for node in module.body:
+        if not isinstance(node, ast.FunctionDef) or node.name not in expected_output_arguments:
+            continue
+        argument_names = {argument.arg for argument in node.args.args}
+        assert expected_output_arguments[node.name] <= argument_names
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "expected_bucket"),
+    [
+        (1, 128),
+        (128, 128),
+        (129, 256),
+        (16384, 16384),
+        (20000, 32768),
+        (262144, 262144),
+        (262145, 524288),
+        (524288, 524288),
+        (1048576, 1048576),
+    ],
+)
+def test_autotune_token_bucket(num_tokens: int, expected_bucket: int) -> None:
+    assert _autotune_token_bucket(num_tokens) == expected_bucket
+
+
+def test_autotune_token_bucket_rejects_empty_input() -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        _autotune_token_bucket(0)
+
+
 def _direct_fused_logprobs(hidden, weight_shard, target_shifted, vstart, vend, chunk_size, grad_seed):
     """Run the Triton Function on already-shifted targets."""
     leaf_h = hidden.detach().clone().requires_grad_(True)
     leaf_w = weight_shard.detach().clone().requires_grad_(True)
     lp = FusedLinearLogprobTriton.apply(
-        leaf_h, leaf_w, target_shifted, vstart, vend, chunk_size, dist.group.WORLD, False
+        leaf_h,
+        leaf_w,
+        target_shifted,
+        vstart,
+        vend,
+        chunk_size,
+        dist.group.WORLD,
+        False,
     )
     lp.backward(grad_seed.clone())
     return lp.detach(), leaf_h.grad.detach(), leaf_w.grad.detach()
@@ -186,3 +330,54 @@ def test_fused_triton_matches_stock_logits_path(dtype_str, world_size, chunk_siz
         assert r["fwd_ok"], f"forward mismatch rank={rank}: {r}"
         assert r["gh_ok"], f"grad-hidden mismatch rank={rank}: {r}"
         assert r["gw_ok"], f"grad-weight mismatch rank={rank}: {r}"
+
+
+@pytest.mark.parametrize("logit_offset", [-20.0, -120.0])
+def test_epilogue_handles_strongly_negative_logits(logit_offset) -> None:
+    """The epilogue's log-sum-exp shift must be the true row max, not max(0, max).
+
+    A zero-initialised ``global_max`` leaves the shift at 0 whenever every logit for
+    a token is negative, so ``exp(logit - 0)`` underflows to 0, ``log(accu)`` becomes
+    -inf, and the log-prob comes back +inf with NaN grads. -20 is the control (it
+    passes either way); -120 reproduces the failure.
+    """
+    device = torch.device("cuda")
+    previous = fused_linear_logprob_triton.FORCE_FP32_IEEE_PRECISION
+    fused_linear_logprob_triton.FORCE_FP32_IEEE_PRECISION = True
+    try:
+        num_tokens, hidden_size, vocab_size = 64, 128, 2048  # 2 forward splits
+        gen = torch.Generator(device=device).manual_seed(0)
+        hidden = torch.rand(num_tokens, hidden_size, device=device, generator=gen) + 0.5
+        weight = torch.randn(vocab_size, hidden_size, device=device, generator=gen) * (hidden_size**-0.5)
+        # Shift every logit of every token below zero (hidden is strictly positive).
+        weight += logit_offset / hidden.sum(-1).min()
+        labels = torch.randint(0, vocab_size, (num_tokens,), device=device, generator=gen)
+        grad_logprobs = torch.linspace(0.5, 1.5, num_tokens, device=device)
+
+        logits = hidden.double() @ weight.double().T
+        assert logits.max().item() < 0.0, "setup must drive every logit negative"
+        expected = logits.gather(1, labels[:, None]).squeeze(1) - torch.logsumexp(logits, dim=-1)
+
+        logprobs, entropy, maximum, accumulate, entropy_b = fused_linear_logprob_triton.efficient_entropy_forward(
+            hidden, weight, labels, 1.0, None
+        )
+        d_hidden, d_weight = fused_linear_logprob_triton.efficient_entropy_backward(
+            grad_logprobs,
+            torch.zeros_like(grad_logprobs),
+            hidden,
+            weight,
+            labels,
+            maximum,
+            accumulate,
+            entropy_b,
+            False,
+            1.0,
+            None,
+        )
+
+        assert torch.isfinite(logprobs).all(), f"non-finite log-probs at max logit {logits.max().item():.1f}"
+        assert torch.isfinite(entropy).all(), "non-finite entropy"
+        assert torch.isfinite(d_hidden).all() and torch.isfinite(d_weight).all(), "non-finite grads"
+        torch.testing.assert_close(logprobs.double(), expected, rtol=1e-3, atol=1e-3)
+    finally:
+        fused_linear_logprob_triton.FORCE_FP32_IEEE_PRECISION = previous


### PR DESCRIPTION
## Summary

The fused Triton LLM head kernel was originally vendored from VERL with basically no changes. This PR does make two performance-improving changes, without changing any of the underlying computation logic:

- Use triton autotune to optimize block sizes, K tiles, pipeline stages, and warp counts rather than keeping one fixed set for every model/context len/hardware.
- Add an option to exclude entropy calculation entirely if the caller doesn't want to know entropy anyway

Other changes in the PR include:

- Make autotuned epilogues non-mutating. Triton executes every candidate during tuning, so overwriting candidate inputs can silently corrupt the selected result.
- Fix an edge case where the kernels could NaN if all incoming logits were strongly negative
- Remove vendored reductions and backward strategies that no SkyRL path can reach.
- Extend the existing standalone fused-LM-head benchmark and GPU tests.

Note: the LoC seems big, but most deletions are removing unused VERL code and most additions are either in the benchmark script or just adding the triton autotune config lines. The scope of relevant logic changes is relatively small.

## H100 benchmark

The standalone sweep used one 8x NVIDIA H100 80GB node with 180 CPU requested and limited. It covered four public LM-head configurations, total token counts from 16K through 256K, and every `(TP, CP)` combination in `{1,2,4,8}` with `TP*CP <= 8`. The 200 logical cases collapse to 104 unique rank-local `(M,H,V)` shapes. This is a synthetic kernel-shape sweep; it does not consume dataset examples.

Compared with the prior fixed five-stage mainloop:

| Metric across 104 local shapes | Autotuned |
|---|---:|
| Mean latency reduction | 5.57% |
| Median latency reduction | 3.63% |
| p90 latency reduction | 14.47% |
| Maximum latency reduction | 26.82% |
| Shapes faster | 88 / 104 |
| Worst regression | 1.40% |

The largest observed win was the Nemotron Ultra 550B shape at local `(M=8192,H=8192,V=131072)`, from 34.91 ms to 25.54 ms. These are isolated fused-mainloop results on one GPU generation, not end-to-end training claims; the candidate set intentionally retains schedule diversity for other models and accelerators.

## Compile and tuning behavior

A specialization probe measured:

- 20,000 tokens, new 32K bucket: 13.27 s cold compile+tune;
- 20,001 tokens, same bucket: 6.13 ms, with no exact-length recompile or retune;
- 40,000 tokens, new 64K bucket: 4.66 s retune.

Crossing a power-of-two bucket intentionally retunes because the winning geometry can change. Broad cold tuning is nontrivial (14.9 s median first call in this sweep), so long-running jobs should warm expected buckets before timing.

## Correctness

Autotuning originally exposed a real hazard: an epilogue overwrote reductions that later candidates consumed. The final kernels use distinct raw, reduced, and result buffers.

Two 8-GPU H100 gates passed against independently materialized fp32 references:

- every one of the 14 forward candidates matched, with maximum absolute error `9.54e-7`;
- odd/non-divisible shapes, TP=8 reductions, entropy compatibility, and split-N backward matched with maximum errors `1.91e-6` for reduced log-probs/entropy, `2.34e-5` for hidden gradients, and `2.80e-5` for weight gradients.

Additional hardening initializes log-sum-exp from the true row maximum (`-inf`) for strongly negative rows and releases the final partial-split d-logits staging buffer before its projections. A pinned-config audit found bit-identical results before and after the lifetime change across 24 TP/dtype/shape cases.

## Vendored VERL history

VERL used `@triton.autotune`, but each config list contained one entry, so it performed no search. The kernel originated in [VERL PR #462](https://github.com/verl-project/verl/pull/462); its comments, discussion, reviews, and commit messages do not explain the singleton sets. The original benchmark covered one bf16 workload, which may explain the narrow schedule but is not documented upstream rationale.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the Megatron fused LM-head hot path (forward/backward numerics, TP reductions, and first-call Triton compile/autotune latency); fixes reduce NaN risk but new tuning behavior can affect performance and timing.
> 
> **Overview**
> Reworks the vendored fused LM-head Triton path for **real schedule search** and a **log-prob-only** training path, plus correctness fixes on the softmax epilogue.
> 
> **Autotuning:** Forward mainloop, epilogues (including TP), and split-N backward now use multi-candidate `@triton.autotune` with `cache_results=True`. Cache keys use power-of-two **token buckets** (`num_tokens_bucket`) while launches still use the exact token count (`do_not_specialize`) to limit recompile churn.
> 
> **Entropy optional:** `compute_entropy` gates entropy buffers and kernel work; `FusedLinearLogprobTriton` sets `compute_entropy=False` on forward/backward. Scalar CE reductions and the unused VERL `LinearCrossEntropy` wrapper / alternate backward kernels are removed; backward is only the split-N d-logits path.
> 
> **Correctness / memory:** Epilogues write final log-probs (and entropy) to **separate result buffers** so autotune replays do not corrupt reductions. Log-sum-exp uses **`-inf` init and padding** for max reductions. The last backward split **drops the full-width d-logits staging buffer** before matmul projections.
> 
> **Tooling:** `bench_fused_linear_logprob.py` adds `--autotune-sweep`, entropy-vs-logprob probes, and stricter multi-rank correctness. GPU tests cover bucket math, autotune metadata, strongly negative logits, and adapter `compute_entropy=False`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfbaff0afe58cd384674a064cd1613bacd1d1641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->