### PR TITLE
perf(fsdp): limit actor LM-head work to the action window

### DIFF
--- a/skyrl/backends/skyrl_train/workers/model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/model_wrapper.py
@@ -6,7 +6,7 @@
 import inspect
 from dataclasses import dataclass
 from numbers import Integral
-from typing import Optional, Union
+from typing import Optional, Union, get_args
 
 import numpy as np
 import torch
@@ -58,14 +58,21 @@ def _scalar_num_actions(num_actions: Union[int, list[int]]) -> Optional[int]:
     return value if value > 0 else None
 
 
-def _model_supports_logits_to_keep(model: nn.Module) -> bool:
-    """Check the actual causal LM signature, unwrapping PEFT when necessary."""
+def _annotation_supports_tensor(annotation) -> bool:
+    """Return whether a forward annotation explicitly includes ``torch.Tensor``."""
+    return annotation is torch.Tensor or any(_annotation_supports_tensor(arg) for arg in get_args(annotation))
+
+
+def _model_supports_logits_to_keep(model: nn.Module, *, require_tensor: bool = False) -> bool:
+    """Check the concrete causal LM signature, unwrapping PEFT when necessary."""
     candidate = model.get_base_model() if isinstance(model, PeftModel) else model
     try:
-        parameters = inspect.signature(candidate.forward).parameters
+        parameter = inspect.signature(candidate.forward).parameters.get("logits_to_keep")
     except (TypeError, ValueError):
         return False
-    return "logits_to_keep" in parameters
+    if parameter is None:
+        return False
+    return not require_tensor or _annotation_supports_tensor(parameter.annotation)
 
 
 def _can_use_action_logits_selection(
@@ -321,6 +328,10 @@ class HFModelWrapper(nn.Module):
             self.model = pretrain_or_model
 
         self._model_supports_logits_to_keep = _model_supports_logits_to_keep(self.model)
+        self._model_supports_tensor_logits_to_keep = _model_supports_logits_to_keep(
+            self.model,
+            require_tensor=True,
+        )
         self.logprobs_chunk_size = logprobs_chunk_size
 
         # TODO (sumanthrh): do the same for `logprobs_from_logits` and test.
@@ -407,6 +418,14 @@ class HFModelWrapper(nn.Module):
                 padded_sequence_length=sequences.shape[1],
                 nnz_indices=nnz_indices if self.remove_microbatch_padding else None,
             )
+            if (
+                logits_selection is not None
+                and isinstance(logits_selection.logits_to_keep, torch.Tensor)
+                and not self._model_supports_tensor_logits_to_keep
+            ):
+                # A named parameter is sufficient for the integer suffix path, but
+                # packed selectors require an explicit tensor-valued contract.
+                logits_selection = None
         model_forward_kwargs = (
             {"logits_to_keep": logits_selection.logits_to_keep} if logits_selection is not None else {}
         )

--- a/skyrl/backends/skyrl_train/workers/model_wrapper.py
+++ b/skyrl/backends/skyrl_train/workers/model_wrapper.py
@@ -3,6 +3,9 @@
 # https://github.com/OpenRLHF/OpenRLHF/blob/main/openrlhf/models/actor.py
 # https://github.com/OpenRLHF/OpenRLHF/blob/main/openrlhf/models/model.py
 
+import inspect
+from dataclasses import dataclass
+from numbers import Integral
 from typing import Optional, Union
 
 import numpy as np
@@ -12,7 +15,7 @@ import transformers
 from flash_attn.bert_padding import pad_input, unpad_input
 from loguru import logger
 from packaging.version import Version
-from peft import LoraConfig, TaskType, get_peft_model
+from peft import LoraConfig, PeftModel, TaskType, get_peft_model
 from peft.tuners.lora import LoraLayer
 from transformers import (
     AutoConfig,
@@ -31,6 +34,95 @@ from skyrl.backends.skyrl_train.utils.torch_utils import (
     chunked_entropy_from_logits,
     logprobs_from_logits,
 )
+
+
+@dataclass(frozen=True)
+class _ActionLogitsSelection:
+    """Positions needed to score the right-aligned action window."""
+
+    logits_to_keep: Union[int, torch.Tensor]
+    target_indices: Union[slice, torch.Tensor]
+    restore_indices: Optional[torch.Tensor]
+    output_sequence_length: int
+
+
+def _scalar_num_actions(num_actions: Union[int, list[int]]) -> Optional[int]:
+    """Return a supported scalar action count without guessing ragged layouts."""
+    if isinstance(num_actions, list):
+        if len(num_actions) != 1:
+            return None
+        num_actions = num_actions[0]
+    if isinstance(num_actions, bool) or not isinstance(num_actions, Integral):
+        return None
+    value = int(num_actions)
+    return value if value > 0 else None
+
+
+def _model_supports_logits_to_keep(model: nn.Module) -> bool:
+    """Check the actual causal LM signature, unwrapping PEFT when necessary."""
+    candidate = model.get_base_model() if isinstance(model, PeftModel) else model
+    try:
+        parameters = inspect.signature(candidate.forward).parameters
+    except (TypeError, ValueError):
+        return False
+    return "logits_to_keep" in parameters
+
+
+def _can_use_action_logits_selection(
+    *,
+    model_supports_logits_to_keep: bool,
+    is_vlm: bool,
+    has_image_inputs: bool,
+    sequence_parallel_size: int,
+) -> bool:
+    """Keep unsupported model, multimodal, and sequence-parallel paths unchanged."""
+    return model_supports_logits_to_keep and not is_vlm and not has_image_inputs and sequence_parallel_size == 1
+
+
+def _build_action_logits_selection(
+    num_actions: Union[int, list[int]],
+    padded_sequence_length: int,
+    nnz_indices: Optional[torch.Tensor] = None,
+) -> Optional[_ActionLogitsSelection]:
+    """Build an integer suffix or packed tensor selector for action logits.
+
+    The selected window has ``num_actions + 1`` positions: the logit immediately
+    before the first action predicts that action, while the final selected logit
+    is discarded by the existing causal shift.  For packed inputs, only valid
+    positions whose original padded columns intersect that suffix are selected.
+    ``restore_indices`` is therefore the matching subset of ``nnz_indices``.
+    """
+    action_count = _scalar_num_actions(num_actions)
+    if action_count is None:
+        return None
+
+    output_sequence_length = action_count + 1
+    if output_sequence_length > padded_sequence_length:
+        return None
+
+    if nnz_indices is None:
+        return _ActionLogitsSelection(
+            logits_to_keep=output_sequence_length,
+            target_indices=slice(-output_sequence_length, None),
+            restore_indices=None,
+            output_sequence_length=output_sequence_length,
+        )
+
+    if nnz_indices.ndim != 1 or nnz_indices.dtype != torch.long:
+        return None
+    first_selected_column = padded_sequence_length - output_sequence_length
+    packed_selector = torch.nonzero(
+        nnz_indices.remainder(padded_sequence_length) >= first_selected_column,
+        as_tuple=False,
+    ).flatten()
+    if packed_selector.numel() == 0:
+        return None
+    return _ActionLogitsSelection(
+        logits_to_keep=packed_selector,
+        target_indices=packed_selector,
+        restore_indices=nnz_indices.index_select(0, packed_selector),
+        output_sequence_length=output_sequence_length,
+    )
 
 
 class HFModelWrapper(nn.Module):
@@ -228,6 +320,7 @@ class HFModelWrapper(nn.Module):
         else:
             self.model = pretrain_or_model
 
+        self._model_supports_logits_to_keep = _model_supports_logits_to_keep(self.model)
         self.logprobs_chunk_size = logprobs_chunk_size
 
         # TODO (sumanthrh): do the same for `logprobs_from_logits` and test.
@@ -302,6 +395,22 @@ class HFModelWrapper(nn.Module):
                 sequences_rolled, None, None, self.sequence_parallel_size
             )
 
+        logits_selection = None
+        if _can_use_action_logits_selection(
+            model_supports_logits_to_keep=self._model_supports_logits_to_keep,
+            is_vlm=self.is_vlm,
+            has_image_inputs=has_image_inputs,
+            sequence_parallel_size=self.sequence_parallel_size,
+        ):
+            logits_selection = _build_action_logits_selection(
+                num_actions,
+                padded_sequence_length=sequences.shape[1],
+                nnz_indices=nnz_indices if self.remove_microbatch_padding else None,
+            )
+        model_forward_kwargs = (
+            {"logits_to_keep": logits_selection.logits_to_keep} if logits_selection is not None else {}
+        )
+
         if self.is_vlm:
             # NOTE: transformers v5 introduced `mm_token_type_ids` to distinguish text
             # vs. multimodal tokens, and expects it to be populated at tokenization.
@@ -321,22 +430,37 @@ class HFModelWrapper(nn.Module):
                 attention_mask=attention_mask_fwd,
                 position_ids=None,
                 **vlm_kwargs,
+                **model_forward_kwargs,
             )
         # NOTE (sumanthrh): Once we have position_ids, we don't need attention mask with flash attention.
         elif self.remove_microbatch_padding and self.attn_implementation == "flash_attention_2":
             # NOTE (sumanthrh): Don't use attention mask. position_ids is enough.
             # Not using attention mask leads to higher perf since flash attention varlen func is enabled
-            output = self.model(sequences_fwd, attention_mask=None, position_ids=position_ids_fwd)
+            output = self.model(
+                sequences_fwd,
+                attention_mask=None,
+                position_ids=position_ids_fwd,
+                **model_forward_kwargs,
+            )
         else:
-            output = self.model(sequences_fwd, attention_mask=attention_mask_fwd, position_ids=position_ids_fwd)
+            output = self.model(
+                sequences_fwd,
+                attention_mask=attention_mask_fwd,
+                position_ids=position_ids_fwd,
+                **model_forward_kwargs,
+            )
 
         logits_BSV = output["logits"]
         logits_BSV.div_(temperature)
 
+        target_tokens = (
+            sequences_rolled[:, logits_selection.target_indices] if logits_selection is not None else sequences_rolled
+        )
         # NOTE: this is slightly inaccurate with sample packing because last token from nth seq -> first token of n+1th seq loss is added.
+        # The final selected position for each row is discarded from action_log_probs below.
         log_probs = logprobs_from_logits(
             logits_BSV,
-            sequences_rolled,
+            target_tokens,
             inplace_backward=True,
         )
 
@@ -350,10 +474,13 @@ class HFModelWrapper(nn.Module):
         if self.remove_microbatch_padding:
             # add padding back - postprocess logprobs to be compatible with original tensor
             batch_size, seqlen = attention_mask.shape
-            # (1, nnz-1) -> (batch_size, seqlen). Pad token ID used by flash attention is 0.
+            restore_indices = logits_selection.restore_indices if logits_selection is not None else nnz_indices
+            # (1, selected_nnz) -> (batch_size, seqlen). Pad token ID used by flash attention is 0.
             log_probs = pad_input(
-                log_probs.transpose(0, 1), indices=nnz_indices, batch=batch_size, seqlen=seqlen
+                log_probs.transpose(0, 1), indices=restore_indices, batch=batch_size, seqlen=seqlen
             ).squeeze(-1)
+            if logits_selection is not None:
+                log_probs = log_probs[:, -logits_selection.output_sequence_length :]
 
         if compute_entropy:
             # For sample packing: entropy is calculated on unpacked data, so no attention mask needed
@@ -363,6 +490,8 @@ class HFModelWrapper(nn.Module):
                 # Non-sample packing: pass attention mask to handle padding
                 # Use attention_mask_fwd which may be sliced (if sequence_parallel_size > 1) or full
                 entropy_mask = attention_mask_fwd
+                if logits_selection is not None:
+                    entropy_mask = entropy_mask[:, logits_selection.target_indices]
 
             entropy_BS = self.chunked_entropy_from_logits_fn(
                 logits_BSV,
@@ -377,15 +506,21 @@ class HFModelWrapper(nn.Module):
                     entropy_BS, gather_dim=dim, unpad_dim=dim, padding_size=pad_size
                 )  # shape can be (1, nnz) - with packing or (B,S) - without packing
             if self.remove_microbatch_padding:
+                restore_indices = logits_selection.restore_indices if logits_selection is not None else nnz_indices
                 entropy_BS = pad_input(
-                    entropy_BS.transpose(0, 1), indices=nnz_indices, batch=batch_size, seqlen=seqlen
+                    entropy_BS.transpose(0, 1), indices=restore_indices, batch=batch_size, seqlen=seqlen
                 ).squeeze(
                     -1
-                )  # (1, nnz) -> (B, S)
+                )  # (1, selected_nnz) -> (B, S)
+                if logits_selection is not None:
+                    entropy_BS = entropy_BS[:, -logits_selection.output_sequence_length :]
 
             output["entropy"] = entropy_BS
 
-        if isinstance(num_actions, list):
+        scalar_num_actions = _scalar_num_actions(num_actions)
+        if scalar_num_actions is not None:
+            num_actions = scalar_num_actions
+        elif isinstance(num_actions, list):
             if len(num_actions) == 1:
                 num_actions = num_actions[0]
             else:

--- a/tests/backends/skyrl_train/gpu/gpu_ci/test_model_wrapper.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/test_model_wrapper.py
@@ -54,15 +54,19 @@ def test_hf_model_wrapper_fwd_with_sample_packing(mock_logprobs_from_logits):
         input_without_padding.to("cuda"),
     )
     # forward is with packed sequence length
-    model.model.forward = MagicMock(return_value={"logits": torch.randn(1, 6, 1000).to("cuda")})
+    model.model.forward = MagicMock(return_value={"logits": torch.randn(1, 4, 1000).to("cuda")})
     # just roll the inputs over for return value. This means that the model is correctly predicting the next token.
     # The last token will be the prediction beyond the eos token, just set to pad token id
     mock_return_value = torch.roll(input_without_padding, shifts=-1, dims=-1)
     mock_return_value[:, -1] = tokenizer.pad_token_id
-    mock_logprobs_from_logits.return_value = mock_return_value
+    mock_logprobs_from_logits.return_value = mock_return_value[:, -4:]
 
     action_log_probs = model(input_ids, num_actions, attention_mask)
     expected_log_probs = actual_actions.to("cuda")
+    assert torch.equal(
+        model.model.forward.call_args.kwargs["logits_to_keep"],
+        torch.tensor([2, 3, 4, 5], device="cuda"),
+    )
     assert torch.equal(
         action_log_probs, expected_log_probs
     ), f"Expected log probs to be {expected_log_probs} but got {action_log_probs}"
@@ -89,15 +93,16 @@ def test_hf_model_wrapper_fwd_without_sample_packing(mock_logprobs_from_logits):
         input_without_padding.to("cuda"),
     )
     # forward is with packed sequence length
-    model.model.forward = MagicMock(return_value={"logits": torch.randn(1, 10, 1000).to("cuda")})
+    model.model.forward = MagicMock(return_value={"logits": torch.randn(1, 5, 1000).to("cuda")})
     # just roll the inputs over. This means that the model is correctly predicting the next token.
     mock_return_value = torch.roll(input_ids, shifts=-1, dims=-1)
     # The last token will be the prediction beyond the eos token, just set to pad token id
     mock_return_value[:, -1] = tokenizer.pad_token_id
-    mock_logprobs_from_logits.return_value = mock_return_value
+    mock_logprobs_from_logits.return_value = mock_return_value[:, -5:]
 
     action_log_probs = model(input_ids, num_actions, attention_mask)
     expected_log_probs = actual_actions.to("cuda")
+    assert model.model.forward.call_args.kwargs["logits_to_keep"] == 5
     assert torch.equal(
         action_log_probs, expected_log_probs
     ), f"Expected log probs to be {expected_log_probs} but got {action_log_probs}"
@@ -190,8 +195,9 @@ def test_actor_model_fwd_with_sequence_parallelism(ray_init_fixture, remove_micr
             logprob_sp, logprobs_no_sp
         ), f"Logprobs with sequence parallelism don't match logprobs without sequence parallelism for rank {i}"
         assert torch.allclose(
-            output_no_sp["entropy"], output_sp["entropy"]
-        ), "Entropy with sequence parallelism doesn't match entropy without sequence parallelism"
+            output_no_sp["entropy"][:, -num_actions - 1 : -1],
+            output_sp["entropy"][:, -num_actions - 1 : -1],
+        ), "Action entropy with sequence parallelism doesn't match action entropy without sequence parallelism"
 
     # Cleanup
     ray.get([actor.cleanup.remote() for actor in actors])

--- a/tests/backends/skyrl_train/test_model_wrapper_logits_to_keep.py
+++ b/tests/backends/skyrl_train/test_model_wrapper_logits_to_keep.py
@@ -52,7 +52,7 @@ class TinyCausalLM(nn.Module):
         input_ids,
         attention_mask=None,
         position_ids=None,
-        logits_to_keep=0,
+        logits_to_keep: int | torch.Tensor = 0,
         **kwargs,
     ):
         del attention_mask, position_ids, kwargs

--- a/tests/backends/skyrl_train/test_model_wrapper_logits_to_keep.py
+++ b/tests/backends/skyrl_train/test_model_wrapper_logits_to_keep.py
@@ -1,0 +1,311 @@
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from peft import LoraConfig, get_peft_model
+from transformers import GPT2Config, GPT2LMHeadModel
+
+from skyrl.backends.skyrl_train.workers import model_wrapper
+from skyrl.backends.skyrl_train.workers.model_wrapper import (
+    HFModelWrapper,
+    _build_action_logits_selection,
+    _can_use_action_logits_selection,
+    _model_supports_logits_to_keep,
+)
+
+
+def _cpu_logprobs(logits, labels, inplace_backward=True):
+    del inplace_backward
+    return F.log_softmax(logits, dim=-1).gather(-1, labels.unsqueeze(-1)).squeeze(-1)
+
+
+@pytest.fixture(autouse=True)
+def use_cpu_logprobs(monkeypatch):
+    monkeypatch.setattr(model_wrapper, "logprobs_from_logits", _cpu_logprobs)
+
+
+class TinyCausalLM(nn.Module):
+    def __init__(self, vocab_size=23, hidden_size=8):
+        super().__init__()
+        self.config = SimpleNamespace(vocab_size=vocab_size, image_token_id=vocab_size - 1)
+        self.embed = nn.Embedding(vocab_size, hidden_size)
+        self.trunk = nn.Linear(hidden_size, hidden_size)
+        self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
+        self.calls = 0
+        self.last_logits_to_keep = None
+        self.last_lm_head_tokens = None
+
+    def _forward_impl(self, input_ids, logits_to_keep):
+        self.calls += 1
+        self.last_logits_to_keep = logits_to_keep
+        hidden = torch.tanh(self.trunk(self.embed(input_ids)))
+        selected = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        selected_hidden = hidden[:, selected, :]
+        self.last_lm_head_tokens = selected_hidden.shape[1]
+        return {"logits": self.lm_head(selected_hidden), "preserved_field": hidden.mean()}
+
+    def forward(
+        self,
+        input_ids,
+        attention_mask=None,
+        position_ids=None,
+        logits_to_keep=0,
+        **kwargs,
+    ):
+        del attention_mask, position_ids, kwargs
+        return self._forward_impl(input_ids, logits_to_keep)
+
+
+class UnsupportedTinyCausalLM(TinyCausalLM):
+    def forward(self, input_ids, attention_mask=None, position_ids=None):
+        del attention_mask, position_ids
+        return self._forward_impl(input_ids, 0)
+
+
+def _wrapper(model, *, packed=False):
+    return HFModelWrapper(
+        model,
+        bf16=False,
+        use_flash_attention_2=packed,
+        sequence_parallel_size=1,
+        remove_microbatch_padding=packed,
+        logprobs_chunk_size=2,
+    )
+
+
+def test_standard_path_passes_integer_and_aligns_targets_and_entropy(monkeypatch):
+    model = TinyCausalLM()
+    wrapper = _wrapper(model)
+    sequences = torch.tensor([[0, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]])
+    attention_mask = torch.tensor([[0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])
+    captured = {}
+
+    def capture_logprobs(logits, labels, inplace_backward=True):
+        captured["logits_shape"] = logits.shape
+        captured["labels"] = labels.detach().clone()
+        return _cpu_logprobs(logits, labels, inplace_backward)
+
+    original_entropy = wrapper.chunked_entropy_from_logits_fn
+
+    def capture_entropy(logits, **kwargs):
+        captured["entropy_mask"] = kwargs["attention_mask"].detach().clone()
+        return original_entropy(logits, **kwargs)
+
+    monkeypatch.setattr(model_wrapper, "logprobs_from_logits", capture_logprobs)
+    wrapper.chunked_entropy_from_logits_fn = capture_entropy
+
+    action_log_probs, output = wrapper(
+        sequences,
+        3,
+        attention_mask=attention_mask,
+        compute_entropy=True,
+        return_output=True,
+    )
+
+    assert model.calls == 1
+    assert model.last_logits_to_keep == 4
+    assert model.last_lm_head_tokens == 4
+    assert captured["logits_shape"][:2] == (2, 4)
+    assert torch.equal(captured["labels"], torch.roll(sequences, -1, dims=1)[:, -4:])
+    assert torch.equal(captured["entropy_mask"], attention_mask[:, -4:])
+    assert action_log_probs.shape == (2, 3)
+    assert output["logits"].shape[:2] == (2, 4)
+    assert output["entropy"].shape == (2, 4)
+    assert "preserved_field" in output
+
+
+def test_standard_outputs_entropy_and_gradients_match_full_logits():
+    torch.manual_seed(1858)
+    optimized_model = TinyCausalLM()
+    baseline_model = deepcopy(optimized_model)
+    optimized = _wrapper(optimized_model)
+    baseline = _wrapper(baseline_model)
+    baseline._model_supports_logits_to_keep = False
+
+    sequences = torch.tensor([[0, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]])
+    attention_mask = torch.tensor([[0, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])
+    num_actions = 3
+
+    baseline_actions, baseline_output = baseline(
+        sequences,
+        num_actions,
+        attention_mask=attention_mask,
+        temperature=0.7,
+        compute_entropy=True,
+        entropy_requires_grad=True,
+        return_output=True,
+    )
+    optimized_actions, optimized_output = optimized(
+        sequences,
+        num_actions,
+        attention_mask=attention_mask,
+        temperature=0.7,
+        compute_entropy=True,
+        entropy_requires_grad=True,
+        return_output=True,
+    )
+    baseline_action_entropy = baseline_output["entropy"][:, -num_actions - 1 : -1]
+    optimized_action_entropy = optimized_output["entropy"][:, -num_actions - 1 : -1]
+
+    torch.testing.assert_close(optimized_actions, baseline_actions, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(optimized_action_entropy, baseline_action_entropy, rtol=1e-6, atol=1e-6)
+
+    (-baseline_actions.mean() - 0.03 * baseline_action_entropy.mean()).backward()
+    (-optimized_actions.mean() - 0.03 * optimized_action_entropy.mean()).backward()
+    torch.testing.assert_close(
+        optimized_model.lm_head.weight.grad,
+        baseline_model.lm_head.weight.grad,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    torch.testing.assert_close(
+        optimized_model.trunk.weight.grad,
+        baseline_model.trunk.weight.grad,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+
+def test_packed_variable_lengths_match_outputs_and_gradients_with_tensor_selector():
+    torch.manual_seed(1858)
+    optimized_model = TinyCausalLM()
+    baseline_model = deepcopy(optimized_model)
+    optimized = _wrapper(optimized_model, packed=True)
+    baseline = _wrapper(baseline_model, packed=True)
+    baseline._model_supports_logits_to_keep = False
+
+    sequences = torch.tensor([[0, 0, 2, 3, 4, 5, 6], [0, 7, 8, 9, 10, 11, 12]])
+    attention_mask = torch.tensor([[0, 0, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1, 1]])
+    num_actions = 2
+
+    baseline_actions, baseline_output = baseline(
+        sequences,
+        num_actions,
+        attention_mask=attention_mask,
+        temperature=0.7,
+        compute_entropy=True,
+        entropy_requires_grad=True,
+        return_output=True,
+    )
+    optimized_actions, optimized_output = optimized(
+        sequences,
+        num_actions,
+        attention_mask=attention_mask,
+        temperature=0.7,
+        compute_entropy=True,
+        entropy_requires_grad=True,
+        return_output=True,
+    )
+    baseline_action_entropy = baseline_output["entropy"][:, -num_actions - 1 : -1]
+    optimized_action_entropy = optimized_output["entropy"][:, -num_actions - 1 : -1]
+
+    assert torch.equal(optimized_model.last_logits_to_keep, torch.tensor([2, 3, 4, 8, 9, 10]))
+    assert optimized_model.last_lm_head_tokens == 6
+    assert optimized_output["logits"].shape[:2] == (1, 6)
+    assert optimized_output["entropy"].shape == (2, 3)
+    assert optimized_actions.shape == (2, 2)
+    torch.testing.assert_close(optimized_actions, baseline_actions, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(
+        optimized_action_entropy,
+        baseline_action_entropy,
+        rtol=1e-6,
+        atol=1e-6,
+    )
+
+    selection = _build_action_logits_selection(
+        num_actions,
+        padded_sequence_length=7,
+        nnz_indices=torch.tensor([2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13]),
+    )
+    assert torch.equal(selection.restore_indices, torch.tensor([4, 5, 6, 11, 12, 13]))
+
+    position_weights = baseline_actions.new_tensor([[0.1, 0.2], [0.3, 0.4]])
+    baseline_loss = -((baseline_actions + 0.03 * baseline_action_entropy) * position_weights).sum()
+    optimized_loss = -((optimized_actions + 0.03 * optimized_action_entropy) * position_weights).sum()
+    baseline_loss.backward()
+    optimized_loss.backward()
+
+    baseline_parameters = dict(baseline_model.named_parameters())
+    optimized_parameters = dict(optimized_model.named_parameters())
+    assert list(optimized_parameters) == list(baseline_parameters)
+    for name, optimized_parameter in optimized_parameters.items():
+        baseline_parameter = baseline_parameters[name]
+        assert optimized_parameter.grad is not None, name
+        assert baseline_parameter.grad is not None, name
+        torch.testing.assert_close(
+            optimized_parameter.grad,
+            baseline_parameter.grad,
+            rtol=1e-5,
+            atol=1e-6,
+            msg=f"gradient mismatch for {name}",
+        )
+
+
+def test_unsupported_model_falls_back_and_runs_forward_once():
+    model = UnsupportedTinyCausalLM()
+    wrapper = _wrapper(model)
+    sequences = torch.tensor([[2, 3, 4, 5]])
+    attention_mask = torch.ones_like(sequences)
+
+    _, output = wrapper(sequences, 2, attention_mask=attention_mask, return_output=True)
+
+    assert not wrapper._model_supports_logits_to_keep
+    assert model.calls == 1
+    assert model.last_lm_head_tokens == sequences.shape[1]
+    assert output["logits"].shape[1] == sequences.shape[1]
+
+
+def test_vlm_and_sequence_parallel_fallback_selection():
+    assert not _can_use_action_logits_selection(
+        model_supports_logits_to_keep=True,
+        is_vlm=True,
+        has_image_inputs=False,
+        sequence_parallel_size=1,
+    )
+    assert not _can_use_action_logits_selection(
+        model_supports_logits_to_keep=True,
+        is_vlm=False,
+        has_image_inputs=False,
+        sequence_parallel_size=2,
+    )
+
+    model = TinyCausalLM()
+    wrapper = _wrapper(model)
+    wrapper.is_vlm = True
+    sequences = torch.tensor([[2, 3, 4, 5]])
+    attention_mask = torch.ones_like(sequences)
+    _, output = wrapper(sequences, 2, attention_mask=attention_mask, return_output=True)
+    assert model.calls == 1
+    assert model.last_logits_to_keep == 0
+    assert output["logits"].shape[1] == sequences.shape[1]
+
+
+def test_single_action_uses_smallest_causal_window_and_runs_once():
+    model = TinyCausalLM()
+    wrapper = _wrapper(model)
+    sequences = torch.tensor([[2, 3]])
+    attention_mask = torch.ones_like(sequences)
+
+    action_log_probs = wrapper(sequences, 1, attention_mask=attention_mask)
+
+    assert model.calls == 1
+    assert model.last_logits_to_keep == 2
+    assert action_log_probs.shape == (1, 1)
+
+
+def test_ambiguous_action_layout_does_not_build_selector():
+    assert _build_action_logits_selection([2, 3], padded_sequence_length=8) is None
+    assert _build_action_logits_selection(8, padded_sequence_length=8) is None
+
+
+def test_peft_capability_check_uses_base_model_signature():
+    config = GPT2Config(vocab_size=23, n_layer=1, n_head=1, n_embd=8, n_positions=8)
+    base_model = GPT2LMHeadModel(config)
+    peft_model = get_peft_model(
+        base_model,
+        LoraConfig(task_type="CAUSAL_LM", r=2, lora_alpha=4, target_modules=["c_attn"]),
+    )
+    assert _model_supports_logits_to_keep(peft_model)


### PR DESCRIPTION
## Summary

- Pass `logits_to_keep=num_actions + 1` on the standard text-only HF/FSDP actor path, avoiding LM-head projection over prompt positions that are discarded immediately afterward.
- Support padding-free packed batches with a tensor-valued selector and restore selected positions to their original rows before applying the existing causal action slice.
- Enable the optimization only for text-only, SP=1 models whose concrete forward signature exposes `logits_to_keep`; packed tensor selectors additionally require an explicit `torch.Tensor` annotation.
- Preserve the full-logits path for VLM/image inputs, sequence parallelism, unsupported models, and ambiguous action layouts.
- Add output and backward-parity coverage for standard and packed paths.

Fixes #1858.

## Why `num_actions + 1`

With causal shifting, the logit immediately before the first action predicts that action. Computing `A` action log-probabilities therefore requires the final `A + 1` hidden-state positions; the last selected logit is removed by the existing `[:, -A-1:-1]` slice.

## Correctness and compatibility

The optimized and full-logits paths produce matching action log-probabilities, entropy, and backward results. Packed-input coverage checks parity for every named parameter gradient; standard coverage checks the LM head and trunk. Packed models with int-only or untyped `logits_to_keep` parameters conservatively retain the full-logits path. The model is invoked exactly once, without catching and retrying failed forwards.

The primary action-log-probability result remains `[B, A]`.

For callers using `return_output=True`, auxiliary tensors are intentionally compact on optimized paths:

- standard logits: `[B, A+1, V]`
- packed logits: `[1, K, V]`, containing selected non-padding positions
- computed entropy: `[B, A+1]` after restoring packed rows

Repository policy-worker consumers use the action window and retain the same values. External callers that require full prompt-length auxiliary tensors need to account for this change.

## Benchmark

A controlled single-H200 run used `Qwen/Qwen3.5-0.8B` at revision `2fc06364715b967f1860aea9cf38778875588b17`, BF16, batch size 1, text-only input, SP=1, no packing, and no gradient checkpointing.

| Sequence / actions | Variant | LM-head tokens | Peak allocated | Peak reserved |
| --- | --- | ---: | ---: | ---: |
| 8,192 / 512 | baseline | 8,192 | 59.354 GiB | 59.840 GiB |
| 8,192 / 512 | optimized | 513 | 52.488 GiB (-11.6%) | 54.162 GiB (-9.5%) |
| 16,384 / 1,024 | baseline | 16,384 | 117.005 GiB | 118.398 GiB |
| 16,384 / 1,024 | optimized | 1,025 | 102.800 GiB (-12.1%) | 104.666 GiB (-11.6%) |

These are PyTorch CUDA allocator peaks, not full-process GPU-memory measurements. The benchmark directly wrapped the Hugging Face model and did not include FSDP sharding, entropy computation, an optimizer step, or end-to-end training. No throughput claim is made from the limited cache-cleared timing samples.

## Testing

- Focused correctness suite: 8 passed, including standard and packed output/entropy/backward parity and all-parameter gradient parity for packed inputs.
- Related CPU regression tests: 21 passed.
- H200 model-wrapper tests: 3 passed.
- Real Qwen3-VL loading and fallback parity: 2 passed.
- Single-rank FSDP2 forward, entropy, backward, gradient clipping, and optimizer-step smoke test: passed.
- Ruff, Black, Gitleaks, and `git diff --check`: passed.

Scoped pytest total: **34 passed, 0 failed, 0 skipped**. Four unrelated or two-GPU cases were intentionally deselected.

## Limitations

- The host exposed one H200, so the existing two-GPU Ulysses cases were not run. SP>1 remains on the unchanged fallback path.
- The benchmark is a single-GPU HF-model microbenchmark and does not measure FSDP, packed batches, VLMs, or end-to-end training.
- Liger Kernel was not installed in the test environment. Packed selection requires an explicit tensor-valued forward annotation, so int-only or untyped implementations fall back. Incorrect third-party annotations cannot be semantically verified without invoking the model.
- Testing covered the changed wrapper and adjacent training paths; the full repository suite was not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core actor forward and training log-prob/entropy math, but gated by capability checks and broad parity tests; main residual risk is external callers expecting full-length auxiliary tensors from `return_output=True`.
> 
> **Overview**
> **Adds an optional `logits_to_keep` fast path** in `HFModelWrapper` so supported text-only actors (SP=1, no image inputs) only run the LM head on the last `num_actions + 1` positions instead of the full sequence, cutting memory and compute on long prompts.
> 
> Capability is detected via `forward` signature inspection (including PEFT base models). **Packed / padding-free batches** get a tensor index selector plus `restore_indices` so log-probs and entropy are re-padded and trimmed to the same action slice as before. **VLM, sequence parallelism, models without `logits_to_keep`, ragged `num_actions` lists, and tensor selectors on models that only accept integer suffixes** stay on the unchanged full-logits path.
> 
> **Action log-probs `[B, A]` are unchanged.** With `return_output=True`, `logits` and `entropy` may be shorter on the optimized path; in-repo RL workers already slice entropy to the action window. Tests assert `logits_to_keep` wiring, parity vs full logits (outputs, entropy, gradients), and GPU CI expectations for packed vs standard forwards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c0ee00ab3df7f15ff2fbe63fccb3e04d0a9e570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->