### PR TITLE
[megatron] Skip frozen-master backload for adapter-only LoRA weight sync

### DIFF
--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_strategy.py
@@ -223,7 +223,7 @@ class MegatronStrategy(DistributedStrategy):
         ``optimizer is None`` (e.g. ``policy.inference_only_init=True`` flows).
         """
         if offload_model:
-            offload_megatron_model_to_cpu(model)
+            offload_megatron_model_to_cpu(model, is_lora=self.is_lora)
         if offload_optimizer:
             offload_megatron_grads_to_cpu(model)
             if optimizer is not None:
@@ -238,7 +238,7 @@ class MegatronStrategy(DistributedStrategy):
         from optimizer existence.
         """
         if backload_model:
-            load_megatron_model_to_gpu(model)
+            load_megatron_model_to_gpu(model, is_lora=self.is_lora)
         if backload_optimizer:
             load_megatron_grads_to_gpu(model)
             if optimizer is not None:

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -230,7 +230,9 @@ def load_megatron_grads_to_gpu(models):
 # and re-read freely, instead of ~1.3TB/node of anonymous/pinned memory that
 # competes with the vLLM engines for physical RAM (the source of repeated
 # NUMA OOM kills and compress-swap stalls on TB-scale colocated models).
-# Files are written once per rank on first offload and reused afterwards.
+# Each param's file is written on first offload, mapped, and immediately
+# unlinked; the mapping keeps the inode alive until the process exits, and
+# sleep/wake cycles reuse the live mapping via ``param._offload_cpu_data``.
 # Set SKYRL_FROZEN_OFFLOAD_DIR=0 (or empty) to restore pinned-RAM offload.
 _FROZEN_OFFLOAD_DIR = os.environ.get("SKYRL_FROZEN_OFFLOAD_DIR", "/data/skyrl/frozen-offload")
 
@@ -239,34 +241,51 @@ def _frozen_offload_enabled() -> bool:
     return bool(_FROZEN_OFFLOAD_DIR) and _FROZEN_OFFLOAD_DIR != "0"
 
 
-def _frozen_offload_file(name: str, tensor) -> str:
+def _frozen_offload_file(name: str) -> str:
     import hashlib
 
     rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
-    key = hashlib.sha1(f"{name}|{tuple(tensor.shape)}|{tensor.dtype}".encode()).hexdigest()[:20]
+    # The name hash is cosmetic (the file lives only until it is mapped); the
+    # pid suffix keeps concurrent processes on one node from sharing a path.
+    key = hashlib.sha1(name.encode()).hexdigest()[:20]
     rank_dir = os.path.join(_FROZEN_OFFLOAD_DIR, f"rank{rank}")
     os.makedirs(rank_dir, exist_ok=True)
-    return os.path.join(rank_dir, f"{key}.bin")
+    return os.path.join(rank_dir, f"{key}-{os.getpid()}.bin")
 
 
 def _offload_frozen_param_to_file(name: str, param) -> bool:
     """Move a frozen param's data to a file-backed mmap CPU tensor.
 
+    The backing file is unlinked as soon as it is mapped: the mapping pins the
+    inode (whose pages stay clean, evictable page cache) until the process
+    exits, at which point the kernel reclaims the space. No other chunk,
+    process, or run can ever open the file, and no cleanup is needed — even on
+    SIGKILL. The space shows up in ``df`` but not in directory listings.
+
     Returns True on success; False to let the caller fall back to pinned RAM.
     """
+    path = None
     try:
         data = param.data.detach()
         nbytes = data.numel() * data.element_size()
-        path = _frozen_offload_file(name, data)
-        if not (os.path.exists(path) and os.path.getsize(path) == nbytes):
-            tmp = f"{path}.tmp{os.getpid()}"
-            with open(tmp, "wb") as f:
-                f.write(data.contiguous().view(torch.uint8).flatten().cpu().numpy().tobytes())
-            os.replace(tmp, path)
-        mapped = torch.from_file(path, shared=False, size=nbytes, dtype=torch.uint8).view(data.dtype).view(data.shape)
+        path = _frozen_offload_file(name)
+        with open(path, "wb") as f:
+            f.write(data.contiguous().view(torch.uint8).flatten().cpu().numpy().tobytes())
+        try:
+            mapped = (
+                torch.from_file(path, shared=False, size=nbytes, dtype=torch.uint8).view(data.dtype).view(data.shape)
+            )
+        finally:
+            os.unlink(path)
+            path = None
         param._offload_cpu_data = mapped
         return True
     except (OSError, RuntimeError) as exc:
+        if path is not None:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
         logging.getLogger(__name__).warning(
             "file-backed frozen offload failed for %s (%s); falling back to pinned RAM", name, exc
         )

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -241,6 +241,12 @@ def _frozen_offload_enabled() -> bool:
     return bool(_FROZEN_OFFLOAD_DIR) and _FROZEN_OFFLOAD_DIR != "0"
 
 
+# Set after the first file-offload failure: later params skip straight to the
+# pinned-RAM fallback instead of retrying the filesystem and re-logging the
+# same warning for every frozen param.
+_frozen_offload_failed = False
+
+
 def _frozen_offload_file(name: str) -> str:
     import hashlib
 
@@ -264,13 +270,19 @@ def _offload_frozen_param_to_file(name: str, param) -> bool:
 
     Returns True on success; False to let the caller fall back to pinned RAM.
     """
+    global _frozen_offload_failed
+    if _frozen_offload_failed:
+        return False
     path = None
     try:
         data = param.data.detach()
         nbytes = data.numel() * data.element_size()
         path = _frozen_offload_file(name)
         with open(path, "wb") as f:
-            f.write(data.contiguous().view(torch.uint8).flatten().cpu().numpy().tobytes())
+            # The numpy array shares the CPU tensor's memory and write() takes
+            # any buffer-protocol object, so no second full-size copy is made
+            # (unlike .tobytes()).
+            f.write(data.contiguous().view(torch.uint8).flatten().cpu().numpy())
         try:
             mapped = (
                 torch.from_file(path, shared=False, size=nbytes, dtype=torch.uint8).view(data.dtype).view(data.shape)
@@ -286,8 +298,11 @@ def _offload_frozen_param_to_file(name: str, param) -> bool:
                 os.unlink(path)
             except OSError:
                 pass
+        _frozen_offload_failed = True
         logging.getLogger(__name__).warning(
-            "file-backed frozen offload failed for %s (%s); falling back to pinned RAM", name, exc
+            "file-backed frozen offload failed for %s (%s); falling back to pinned RAM for all frozen params",
+            name,
+            exc,
         )
         return False
 

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -224,17 +224,6 @@ def load_megatron_grads_to_gpu(models):
                     param.grad = param.grad.to(torch.cuda.current_device(), non_blocking=True)
 
 
-def _chunk_has_lora_adapters(model_chunk) -> bool:
-    """True when the chunk trains LoRA adapters (and only adapters).
-
-    Megatron's fused param/grad buffers only hold grad-requiring params, so
-    for a LoRA model they contain nothing but the adapters (a few GB). The
-    frozen base weights live outside the buffers and are offloaded
-    param-by-param below.
-    """
-    return any("adapter" in name for name, param in model_chunk.named_parameters() if param.requires_grad)
-
-
 # Frozen (requires_grad=False, non-adapter) weights are immutable for the
 # whole run, so their CPU offload copies can live in file-backed mmap storage
 # instead of RAM: the pages are then *clean page cache* the kernel can evict
@@ -274,11 +263,7 @@ def _offload_frozen_param_to_file(name: str, param) -> bool:
             with open(tmp, "wb") as f:
                 f.write(data.contiguous().view(torch.uint8).flatten().cpu().numpy().tobytes())
             os.replace(tmp, path)
-        mapped = (
-            torch.from_file(path, shared=False, size=nbytes, dtype=torch.uint8)
-            .view(data.dtype)
-            .view(data.shape)
-        )
+        mapped = torch.from_file(path, shared=False, size=nbytes, dtype=torch.uint8).view(data.dtype).view(data.shape)
         param._offload_cpu_data = mapped
         return True
     except (OSError, RuntimeError) as exc:
@@ -289,21 +274,24 @@ def _offload_frozen_param_to_file(name: str, param) -> bool:
 
 
 @torch.no_grad()
-def offload_megatron_model_to_cpu(models):
+def offload_megatron_model_to_cpu(models, is_lora: bool = False):
     """
     In megatron, the model and optimizer storage are:
     - bf16 parameter data chunked in model parallel group
     - fp32 grad chunked in model parallel group
     - fp32 main_parameter chunked in model and dp group
     - fp32 optimizer state chunked in model and dp group
+
+    ``is_lora``: the run trains LoRA adapters only (base weights frozen).
     """
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
-            # LoRA: keep the fused buffers (adapters only, a few GB) resident.
-            # The adapter-only weight sync exports straight from these GPU
-            # tensors, so the TB-scale frozen masters never need to round-trip
-            # through the GPU just to sync a rank-32 adapter.
-            if not _chunk_has_lora_adapters(model_chunk):
+            # LoRA: Megatron's fused param/grad buffers only hold grad-requiring
+            # params, so here they contain nothing but the adapters (a few GB) —
+            # keep them resident. The adapter-only weight sync exports straight
+            # from these GPU tensors, so the TB-scale frozen masters never need
+            # to round-trip through the GPU just to sync a rank-32 adapter.
+            if not is_lora:
                 for buffer in model_chunk.buffers + model_chunk.expert_parallel_buffers:
                     # use megatron buffer built in function to offload to cpu
                     # https://github.com/NVIDIA/Megatron-LM/blob/core_v0.16.0/megatron/core/distributed/param_and_grad_buffer.py#L964
@@ -338,11 +326,11 @@ def offload_megatron_model_to_cpu(models):
 
 
 @torch.no_grad()
-def load_megatron_model_to_gpu(models):
+def load_megatron_model_to_gpu(models, is_lora: bool = False):
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
             # LoRA buffers never offload (see offload_megatron_model_to_cpu).
-            if not _chunk_has_lora_adapters(model_chunk):
+            if not is_lora:
                 for buffer in model_chunk.buffers + model_chunk.expert_parallel_buffers:
                     buffer.reload_from_cpu(move_params=True, move_grads=False)
 

--- a/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
+++ b/skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py
@@ -20,6 +20,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import os
 from typing import Any, Dict, List, Optional, Union
 
 import torch
@@ -222,6 +224,70 @@ def load_megatron_grads_to_gpu(models):
                     param.grad = param.grad.to(torch.cuda.current_device(), non_blocking=True)
 
 
+def _chunk_has_lora_adapters(model_chunk) -> bool:
+    """True when the chunk trains LoRA adapters (and only adapters).
+
+    Megatron's fused param/grad buffers only hold grad-requiring params, so
+    for a LoRA model they contain nothing but the adapters (a few GB). The
+    frozen base weights live outside the buffers and are offloaded
+    param-by-param below.
+    """
+    return any("adapter" in name for name, param in model_chunk.named_parameters() if param.requires_grad)
+
+
+# Frozen (requires_grad=False, non-adapter) weights are immutable for the
+# whole run, so their CPU offload copies can live in file-backed mmap storage
+# instead of RAM: the pages are then *clean page cache* the kernel can evict
+# and re-read freely, instead of ~1.3TB/node of anonymous/pinned memory that
+# competes with the vLLM engines for physical RAM (the source of repeated
+# NUMA OOM kills and compress-swap stalls on TB-scale colocated models).
+# Files are written once per rank on first offload and reused afterwards.
+# Set SKYRL_FROZEN_OFFLOAD_DIR=0 (or empty) to restore pinned-RAM offload.
+_FROZEN_OFFLOAD_DIR = os.environ.get("SKYRL_FROZEN_OFFLOAD_DIR", "/data/skyrl/frozen-offload")
+
+
+def _frozen_offload_enabled() -> bool:
+    return bool(_FROZEN_OFFLOAD_DIR) and _FROZEN_OFFLOAD_DIR != "0"
+
+
+def _frozen_offload_file(name: str, tensor) -> str:
+    import hashlib
+
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    key = hashlib.sha1(f"{name}|{tuple(tensor.shape)}|{tensor.dtype}".encode()).hexdigest()[:20]
+    rank_dir = os.path.join(_FROZEN_OFFLOAD_DIR, f"rank{rank}")
+    os.makedirs(rank_dir, exist_ok=True)
+    return os.path.join(rank_dir, f"{key}.bin")
+
+
+def _offload_frozen_param_to_file(name: str, param) -> bool:
+    """Move a frozen param's data to a file-backed mmap CPU tensor.
+
+    Returns True on success; False to let the caller fall back to pinned RAM.
+    """
+    try:
+        data = param.data.detach()
+        nbytes = data.numel() * data.element_size()
+        path = _frozen_offload_file(name, data)
+        if not (os.path.exists(path) and os.path.getsize(path) == nbytes):
+            tmp = f"{path}.tmp{os.getpid()}"
+            with open(tmp, "wb") as f:
+                f.write(data.contiguous().view(torch.uint8).flatten().cpu().numpy().tobytes())
+            os.replace(tmp, path)
+        mapped = (
+            torch.from_file(path, shared=False, size=nbytes, dtype=torch.uint8)
+            .view(data.dtype)
+            .view(data.shape)
+        )
+        param._offload_cpu_data = mapped
+        return True
+    except (OSError, RuntimeError) as exc:
+        logging.getLogger(__name__).warning(
+            "file-backed frozen offload failed for %s (%s); falling back to pinned RAM", name, exc
+        )
+        return False
+
+
 @torch.no_grad()
 def offload_megatron_model_to_cpu(models):
     """
@@ -233,13 +299,22 @@ def offload_megatron_model_to_cpu(models):
     """
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
-            for buffer in model_chunk.buffers + model_chunk.expert_parallel_buffers:
-                # use megatron buffer built in function to offload to cpu
-                # https://github.com/NVIDIA/Megatron-LM/blob/core_v0.16.0/megatron/core/distributed/param_and_grad_buffer.py#L964
-                buffer.offload_to_cpu(move_params=True, move_grads=False)
+            # LoRA: keep the fused buffers (adapters only, a few GB) resident.
+            # The adapter-only weight sync exports straight from these GPU
+            # tensors, so the TB-scale frozen masters never need to round-trip
+            # through the GPU just to sync a rank-32 adapter.
+            if not _chunk_has_lora_adapters(model_chunk):
+                for buffer in model_chunk.buffers + model_chunk.expert_parallel_buffers:
+                    # use megatron buffer built in function to offload to cpu
+                    # https://github.com/NVIDIA/Megatron-LM/blob/core_v0.16.0/megatron/core/distributed/param_and_grad_buffer.py#L964
+                    buffer.offload_to_cpu(move_params=True, move_grads=False)
 
             # LoRA-aware offloading: offload non-lora base weights that live
             # outside the fused Megatron buffers (e.g. HF/bridge "to_wrap" weights).
+            # Frozen weights are immutable, so prefer file-backed mmap copies
+            # (clean, evictable page cache) over pinned RAM; see
+            # _offload_frozen_param_to_file.
+            use_file_offload = _frozen_offload_enabled()
             for name, param in model_chunk.named_parameters():
                 if (
                     param.is_cuda
@@ -247,8 +322,14 @@ def offload_megatron_model_to_cpu(models):
                     and "adapter" not in name
                     and param.data.storage().size() > 0
                 ):
-                    cpu_tensor = param.data.detach().cpu().pin_memory()
-                    param._offload_cpu_data = cpu_tensor
+                    if hasattr(param, "_offload_cpu_data") and param._offload_cpu_data is not None:
+                        # Frozen data never changes: the existing CPU copy
+                        # (file-backed or pinned) is still valid; just free
+                        # the GPU side again.
+                        pass
+                    elif not (use_file_offload and _offload_frozen_param_to_file(name, param)):
+                        cpu_tensor = param.data.detach().cpu().pin_memory()
+                        param._offload_cpu_data = cpu_tensor
                     param._offload_cuda_numel = param.data.numel()
                     param.data = torch.empty(0, dtype=param.data.dtype, device=param.data.device)
         else:
@@ -260,8 +341,10 @@ def offload_megatron_model_to_cpu(models):
 def load_megatron_model_to_gpu(models):
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
-            for buffer in model_chunk.buffers + model_chunk.expert_parallel_buffers:
-                buffer.reload_from_cpu(move_params=True, move_grads=False)
+            # LoRA buffers never offload (see offload_megatron_model_to_cpu).
+            if not _chunk_has_lora_adapters(model_chunk):
+                for buffer in model_chunk.buffers + model_chunk.expert_parallel_buffers:
+                    buffer.reload_from_cpu(move_params=True, move_grads=False)
 
             # Restore any LoRA-frozen base weights that were offloaded above.
             device_id = torch.cuda.current_device()

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -610,12 +610,29 @@ class WorkerDispatch:
             )
         )
 
+    def _weight_sync_needs_model_on_gpu(self) -> bool:
+        """Whether weight sync must backload an offloaded policy model.
+
+        Adapter-only LoRA sync (megatron, ``merge_lora=False``) exports straight
+        from the fused adapter buffers, which stay GPU-resident while the model
+        is offloaded — so the frozen base weights are not needed on GPU. Every
+        other sync path extracts full weights and needs the whole model.
+        """
+        return not (
+            self.cfg.trainer.strategy == "megatron"
+            and self.cfg.trainer.policy.model.lora.rank > 0
+            and not self.cfg.trainer.policy.megatron_config.lora_config.merge_lora
+        )
+
     def _prepare_for_weight_sync(self) -> None:
         """Prepare for weight sync: ensure policy model is on GPU, offload optimizer. Helper for save_weights_for_sampler."""
         if not self.colocate_all:
             return
-        # Ensure policy model is on GPU (will offload others in colocation group)
-        self._ensure_on_gpu("policy", need_optimizer=False, need_model=True)
+        # Ensure policy model is on GPU (will offload others in colocation group).
+        # Adapter-only LoRA sync keeps need_model=False: the offload-others side
+        # effect still runs, but the offloaded frozen base weights are not
+        # round-tripped to GPU just to broadcast the resident adapters.
+        self._ensure_on_gpu("policy", need_optimizer=False, need_model=self._weight_sync_needs_model_on_gpu())
         # Offload optimizer if it's on GPU
         if self._gpu_state["policy"].optimizer_on_gpu:
             self._offload("policy", offload_optimizer=True, offload_model=False)

--- a/tests/backends/skyrl_train/distributed/test_worker_dispatch.py
+++ b/tests/backends/skyrl_train/distributed/test_worker_dispatch.py
@@ -202,3 +202,53 @@ class TestSaveWeights:
 
         dispatch._inference_engine_client.pause_generation.assert_awaited_once()
         dispatch._inference_engine_client.resume_generation.assert_awaited_once()
+
+
+class TestPrepareForWeightSync:
+    """Tests for `WorkerDispatch._prepare_for_weight_sync` model-backload gating."""
+
+    def _make_dispatch(self, strategy: str, lora_rank: int, merge_lora: bool):
+        from skyrl.backends.skyrl_train.workers.worker_dispatch import WorkerDispatch
+
+        cfg = _fft_dispatch_cfg()
+        cfg.trainer.strategy = strategy
+        cfg.trainer.policy.model.lora.rank = lora_rank
+        cfg.trainer.policy.megatron_config.lora_config.merge_lora = merge_lora
+
+        dispatch = WorkerDispatch.__new__(WorkerDispatch)
+        dispatch.colocate_all = True
+        dispatch.cfg = cfg
+        dispatch._ensure_on_gpu = MagicMock()
+        dispatch._offload = MagicMock()
+        dispatch._gpu_state = {"policy": SimpleNamespace(optimizer_on_gpu=False)}
+        return dispatch
+
+    def test_megatron_adapter_only_lora_skips_model_backload(self):
+        """merge_lora=False syncs from the resident adapter buffers, so the
+        offloaded frozen base weights must not round-trip to GPU."""
+        dispatch = self._make_dispatch("megatron", lora_rank=32, merge_lora=False)
+        dispatch._prepare_for_weight_sync()
+        dispatch._ensure_on_gpu.assert_called_once_with("policy", need_optimizer=False, need_model=False)
+
+    def test_megatron_merge_lora_backloads_model(self):
+        """merge_lora=True extracts full merged weights, which needs the base on GPU."""
+        dispatch = self._make_dispatch("megatron", lora_rank=32, merge_lora=True)
+        dispatch._prepare_for_weight_sync()
+        dispatch._ensure_on_gpu.assert_called_once_with("policy", need_optimizer=False, need_model=True)
+
+    def test_megatron_fft_backloads_model(self):
+        dispatch = self._make_dispatch("megatron", lora_rank=0, merge_lora=False)
+        dispatch._prepare_for_weight_sync()
+        dispatch._ensure_on_gpu.assert_called_once_with("policy", need_optimizer=False, need_model=True)
+
+    def test_fsdp_lora_backloads_model(self):
+        """FSDP LoRA offload has no resident-adapter guarantee; stay conservative."""
+        dispatch = self._make_dispatch("fsdp", lora_rank=32, merge_lora=False)
+        dispatch._prepare_for_weight_sync()
+        dispatch._ensure_on_gpu.assert_called_once_with("policy", need_optimizer=False, need_model=True)
+
+    def test_non_colocated_is_untouched(self):
+        dispatch = self._make_dispatch("megatron", lora_rank=32, merge_lora=False)
+        dispatch.colocate_all = False
+        dispatch._prepare_for_weight_sync()
+        dispatch._ensure_on_gpu.assert_not_called()


### PR DESCRIPTION
## What

Under `colocate_all`, `_prepare_for_weight_sync` unconditionally backloads the full policy model to GPU before every weight sync. For adapter-only LoRA sync (megatron, `merge_lora=False`), the broadcast exports straight from the fused adapter buffers — which stay GPU-resident while the model is offloaded (#2062) — so the sync round-trips the TB-scale frozen base weights disk → GPU → discarded for nothing.

This provably happens at least once per colocated run: models are marked offloaded right after build, so the first `save_weights_for_sampler` pays the full backload just to broadcast a rank-32 adapter. It can recur in fully-async flows whenever a sync overlaps a phase where the model is offloaded. (Steady-state synchronous syncs run right after training with the model already on GPU, so they were unaffected.)

## How

`_prepare_for_weight_sync` now gates `need_model` on a new `_weight_sync_needs_model_on_gpu()` check:

- **megatron + LoRA + `merge_lora=False`** → `need_model=False`. `_ensure_on_gpu` still runs, so the offload-others side effect and optimizer offload are preserved — only the model backload is skipped.
- **`merge_lora=True`, full-parameter runs, FSDP** → `need_model=True` unchanged (their sync extracts full weights on GPU; FSDP has no resident-adapter guarantee, so it stays conservative).

`_finish_weight_sync` is intentionally unchanged: offloading an already-offloaded model is a cheap worker-side no-op (empty-storage params are skipped) and keeps `_gpu_state` consistent.

## Notes

- **Stacked on #2062** — correctness of the skip depends on its resident adapter buffers. Draft until that merges; the first commits here are #2062's.
- Follows the config-inspection precedent already in `save_weights_for_sampler`'s non-colocated branch.

## Tests

Added `TestPrepareForWeightSync` (CPU, no Ray needed) covering: adapter-only LoRA skips the backload; `merge_lora=True`, FFT, and FSDP+LoRA keep it; non-colocated is untouched. All 12 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)