### PR TITLE
[skyrl-train] IPv6-safe HTTP URLs and bind hosts for inference servers

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/common.py
+++ b/skyrl/backends/skyrl_train/inference_servers/common.py
@@ -4,8 +4,8 @@ Common utilities for inference servers.
 Uses Ray's public network utilities for consistency with Ray's cluster management.
 """
 
-import logging
 import ipaddress
+import logging
 import socket
 from dataclasses import dataclass
 from typing import Optional, Tuple

--- a/skyrl/backends/skyrl_train/inference_servers/common.py
+++ b/skyrl/backends/skyrl_train/inference_servers/common.py
@@ -5,6 +5,7 @@ Uses Ray's public network utilities for consistency with Ray's cluster managemen
 """
 
 import logging
+import ipaddress
 import socket
 from dataclasses import dataclass
 from typing import Optional, Tuple
@@ -50,7 +51,31 @@ class ServerInfo:
 
     @property
     def url(self) -> str:
-        return f"http://{self.ip}:{self.port}"
+        return format_http_url(self.ip, self.port)
+
+
+def is_ipv6_address(host: str) -> bool:
+    """True if ``host`` is a literal IPv6 address (hostnames and IPv4 return False)."""
+    try:
+        return isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address)
+    except ValueError:
+        return False
+
+
+def format_http_url(host: str, port: int, path: str = "") -> str:
+    """Build ``http://host:port/path`` with IPv6 literals bracketed (RFC 3986).
+
+    On IPv6-only clusters ``ray.util.get_node_ip_address()`` returns a bare IPv6
+    literal; ``f"http://{ip}:{port}"`` then yields e.g. ``http://2602:fb33::5:8100``
+    which URL parsers reject (``Invalid port``).
+    """
+    host_part = f"[{host}]" if is_ipv6_address(host) else host
+    return f"http://{host_part}:{port}{path}"
+
+
+def default_bind_host(node_ip: str) -> str:
+    """Wildcard bind address matching the node's address family (``::`` accepts IPv4 too)."""
+    return "::" if is_ipv6_address(node_ip) else "0.0.0.0"
 
 
 def get_node_ip() -> str:

--- a/skyrl/backends/skyrl_train/inference_servers/utils.py
+++ b/skyrl/backends/skyrl_train/inference_servers/utils.py
@@ -304,14 +304,14 @@ def build_router_args(
     """
     from vllm_router.router_args import RouterArgs
 
-    from skyrl.backends.skyrl_train.inference_servers.common import get_open_port
+    from skyrl.backends.skyrl_train.inference_servers.common import default_bind_host, get_node_ip, get_open_port
 
     is_pd = prefill_urls is not None and decode_urls is not None
 
     port = get_open_port()
 
     kwargs: Dict[str, Any] = dict(
-        host="0.0.0.0",
+        host=default_bind_host(get_node_ip()),
         port=port,
         policy="consistent_hash",
     )

--- a/skyrl/backends/skyrl_train/inference_servers/utils.py
+++ b/skyrl/backends/skyrl_train/inference_servers/utils.py
@@ -304,7 +304,11 @@ def build_router_args(
     """
     from vllm_router.router_args import RouterArgs
 
-    from skyrl.backends.skyrl_train.inference_servers.common import default_bind_host, get_node_ip, get_open_port
+    from skyrl.backends.skyrl_train.inference_servers.common import (
+        default_bind_host,
+        get_node_ip,
+        get_open_port,
+    )
 
     is_pd = prefill_urls is not None and decode_urls is not None
 

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_router.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_router.py
@@ -19,8 +19,8 @@ from vllm_router.launch_router import launch_router
 from vllm_router.router_args import RouterArgs
 
 from skyrl.backends.skyrl_train.inference_servers.common import (
-    format_http_url,
     find_and_reserve_port,
+    format_http_url,
     get_node_ip,
 )
 from skyrl.env_vars import SKYRL_WAIT_UNTIL_INFERENCE_SERVER_HEALTHY_TIMEOUT_S

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_router.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_router.py
@@ -19,6 +19,7 @@ from vllm_router.launch_router import launch_router
 from vllm_router.router_args import RouterArgs
 
 from skyrl.backends.skyrl_train.inference_servers.common import (
+    format_http_url,
     find_and_reserve_port,
     get_node_ip,
 )
@@ -121,7 +122,7 @@ class VLLMRouter:
         self._process.start()
 
         ip = get_node_ip()
-        router_url = f"http://{ip}:{self._router_args.port}"
+        router_url = format_http_url(ip, self._router_args.port)
         self._wait_until_healthy(router_url)
 
         is_pd = self._router_args.vllm_pd_disaggregation or self._router_args.pd_disaggregation

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -31,11 +31,11 @@ from vllm.utils import random_uuid
 from vllm.utils.system_utils import set_ulimit
 
 from skyrl.backends.skyrl_train.inference_servers.common import (
-    default_bind_host,
-    format_http_url,
     ServerInfo,
     compute_dp_master_port,
+    default_bind_host,
     find_and_reserve_port,
+    format_http_url,
     get_node_ip,
 )
 from skyrl.backends.skyrl_train.inference_servers.generate_wire import (

--- a/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
+++ b/skyrl/backends/skyrl_train/inference_servers/vllm_server_actor.py
@@ -31,6 +31,8 @@ from vllm.utils import random_uuid
 from vllm.utils.system_utils import set_ulimit
 
 from skyrl.backends.skyrl_train.inference_servers.common import (
+    default_bind_host,
+    format_http_url,
     ServerInfo,
     compute_dp_master_port,
     find_and_reserve_port,
@@ -169,7 +171,7 @@ class VLLMServerActor(ServerActorProtocol):
         self._cli_args.distributed_executor_backend = distributed_executor_backend
 
         # Update args with our assigned host/port
-        self._cli_args.host = "0.0.0.0"
+        self._cli_args.host = default_bind_host(self._ip)
         self._cli_args.port = self._port
 
         # PD disaggregation: setup the KV-transfer side channel for the P2P
@@ -346,7 +348,7 @@ class VLLMServerActor(ServerActorProtocol):
 
     async def _wait_until_healthy(self, timeout: float = SKYRL_WAIT_UNTIL_INFERENCE_SERVER_HEALTHY_TIMEOUT_S) -> None:
         """Poll the /health endpoint until it responds OK."""
-        url = f"http://{self._ip}:{self._port}/health"
+        url = format_http_url(self._ip, self._port, "/health")
         start_time = time.time()
 
         async with httpx.AsyncClient() as client:
@@ -683,7 +685,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     cli_args = _build_standalone_cli_args(argv)
     if not cli_args.host:
-        cli_args.host = "0.0.0.0"
+        cli_args.host = default_bind_host(get_node_ip())
     set_ulimit()
     logger.info(f"Starting standalone SkyRL vLLM server on {cli_args.host}:{cli_args.port}")
     asyncio.run(_build_and_serve_vllm_server(cli_args, enable_ray_prometheus_stats=False))

--- a/skyrl/train/utils/vllm_metrics_scraper.py
+++ b/skyrl/train/utils/vllm_metrics_scraper.py
@@ -10,7 +10,6 @@ Counters are summed across replicas; gauges are averaged.  Rates and average
 latencies are derived from deltas vs. the previous sample.
 """
 
-from skyrl.backends.skyrl_train.inference_servers.common import format_http_url
 import asyncio
 import re
 import time
@@ -19,6 +18,8 @@ from typing import Dict, FrozenSet, Iterable, List, Optional, Tuple
 import httpx
 import ray
 from loguru import logger
+
+from skyrl.backends.skyrl_train.inference_servers.common import format_http_url
 
 # vLLM metric base names after RayPrometheusStatLogger sanitization (`:` -> `_`)
 # AND the `ray_` prefix that Ray's metrics agent adds to every custom metric.

--- a/skyrl/train/utils/vllm_metrics_scraper.py
+++ b/skyrl/train/utils/vllm_metrics_scraper.py
@@ -10,6 +10,7 @@ Counters are summed across replicas; gauges are averaged.  Rates and average
 latencies are derived from deltas vs. the previous sample.
 """
 
+from skyrl.backends.skyrl_train.inference_servers.common import format_http_url
 import asyncio
 import re
 import time
@@ -163,7 +164,7 @@ def discover_ray_metrics_urls() -> List[str]:
         port = node.get("MetricsExportPort")
         if not ip or not port:
             continue
-        urls.append(f"http://{ip}:{port}/metrics")
+        urls.append(format_http_url(ip, port, "/metrics"))
     return urls
 
 

--- a/tests/backends/skyrl_train/inference_servers/test_common.py
+++ b/tests/backends/skyrl_train/inference_servers/test_common.py
@@ -8,11 +8,15 @@ import pytest
 from skyrl.backends.skyrl_train.inference_servers.common import (
     DP_TCPSTORE_WINDOW,
     SERVER_PORT_STRIDE,
+    ServerInfo,
     compute_dp_master_port,
+    default_bind_host,
     dp_tcpstore_probe_window,
     find_and_reserve_port,
+    format_http_url,
     get_node_ip,
     get_open_port,
+    is_ipv6_address,
 )
 
 
@@ -26,6 +30,50 @@ class TestGetIp:
         assert len(ip) > 0
         assert ip != ""
         assert "." in ip or ":" in ip
+
+
+class TestIPv6SafeAddressing:
+    """
+    On IPv6-only clusters ``ray.util.get_node_ip_address()`` returns a bare
+    IPv6 literal, which must be bracketed in URLs (RFC 3986) and bound with a
+    matching wildcard address.
+    """
+
+    @pytest.mark.parametrize(
+        "host, expected",
+        [
+            ("127.0.0.1", False),
+            ("10.0.0.1", False),
+            ("localhost", False),
+            ("worker-1.internal", False),
+            ("::1", True),
+            ("2602:fb33::5", True),
+            ("fe80::1%eth0", True),
+        ],
+    )
+    def test_is_ipv6_address(self, host, expected):
+        assert is_ipv6_address(host) is expected
+
+    def test_format_http_url_ipv4_unchanged(self):
+        assert format_http_url("10.0.0.1", 8100) == "http://10.0.0.1:8100"
+        assert format_http_url("10.0.0.1", 8100, "/health") == "http://10.0.0.1:8100/health"
+
+    def test_format_http_url_hostname_unchanged(self):
+        assert format_http_url("worker-1", 8000, "/metrics") == "http://worker-1:8000/metrics"
+
+    def test_format_http_url_brackets_ipv6(self):
+        assert format_http_url("2602:fb33::5", 8100) == "http://[2602:fb33::5]:8100"
+        assert format_http_url("::1", 8100, "/health") == "http://[::1]:8100/health"
+
+    def test_server_info_url_brackets_ipv6(self):
+        assert ServerInfo(ip="10.0.0.1", port=8000).url == "http://10.0.0.1:8000"
+        assert ServerInfo(ip="2602:fb33::5", port=8000).url == "http://[2602:fb33::5]:8000"
+
+    def test_default_bind_host_matches_address_family(self):
+        assert default_bind_host("10.0.0.1") == "0.0.0.0"
+        assert default_bind_host("worker-1") == "0.0.0.0"
+        assert default_bind_host("2602:fb33::5") == "::"
+        assert default_bind_host("::1") == "::"
 
 
 class TestGetOpenPort:


### PR DESCRIPTION
## Summary

On IPv6-only clusters (e.g. EKS with IPv6 pod networking) `ray.util.get_node_ip_address()` returns a bare IPv6 literal. The inference-server stack builds HTTP URLs as `f"http://{ip}:{port}"`, which for `2602:fb33::5` and port `8100` yields `http://2602:fb33::5:8100`; httpx rejects it:

```
httpx.InvalidURL: Invalid port: 'fb33:0:11:fc4e::5:8100'
```

raised from `VLLMServerActor.start()`'s health poll, so every run on such a cluster dies at inference-engine startup. The same pattern exists in `ServerInfo.url`, the vllm-router URL and the metrics scraper; the servers/router also bind on `0.0.0.0`, which is not reachable over IPv6.

This adds two helpers to `inference_servers/common.py` and uses them at every site:

- `format_http_url(host, port, path="")` brackets IPv6 hosts per RFC 3986 (`http://[2602:fb33::5]:8100/health`); IPv4 and hostnames are unchanged.
- `default_bind_host(node_ip)` returns `"::"` when the node IP is IPv6, `"0.0.0.0"` otherwise, used for the vLLM server `--host` default and the router bind host.

Behaviour on IPv4 clusters is unchanged (same strings as before). Companion to #612, which fixed the `tcp://` rendezvous URLs.

## Test plan

- [x] `python -m py_compile` on the five touched files against `main`; `ruff` / `black` clean at the repo's pinned versions.
- [x] Unit check of the helpers: `format_http_url("10.0.0.5", 8100)` == `http://10.0.0.5:8100`; `format_http_url("2602:fb33::5", 8100, "/health")` == `http://[2602:fb33::5]:8100/health`; `default_bind_host("2602:fb33::5")` == `::`.
- [x] End-to-end GRPO smoke (Qwen3.5-0.8B, Megatron TP2/CP2, colocated, 1 node) on an IPv6-only EKS cluster (AWS p5, EFA) with this patch applied on top of `skyrl-v0.3.0`: vLLM server start, health poll and router come up on the `2602:fb33:...` pod addresses and the first training step completes. The unpatched tag fails at the same point with the `httpx.InvalidURL` above.
- [x] Unit tests added in `tests/backends/skyrl_train/inference_servers/test_common.py` (`TestIPv6SafeAddressing`, 12 cases); `pytest tests/backends/skyrl_train/inference_servers/ -m "not vllm"` passes (147 tests).
- [x] Same smoke on an IPv4 GKE cluster passes with the unpatched tag (confirming the failure is IPv6-specific).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized networking helper rollout with IPv4 parity preserved; main behavioral change is fixing broken IPv6-only deployments rather than altering existing IPv4 paths.
> 
> **Overview**
> Fixes inference startup on **IPv6-only clusters** (e.g. EKS with IPv6 pod IPs) where bare IPv6 literals in `http://{ip}:{port}` strings cause **httpx `InvalidURL`** during health checks and break router/metrics scraping.
> 
> Adds **`format_http_url`** (RFC 3986 brackets for IPv6) and **`default_bind_host`** (`::` vs `0.0.0.0`) in `inference_servers/common.py`, then wires them through **`ServerInfo.url`**, vLLM server health URLs, **vLLM router** URL construction, **router `RouterArgs.host`**, vLLM **`--host`** defaults (actor + standalone), and **Ray metrics scraper** URLs. IPv4/hostname behavior stays the same.
> 
> **`TestIPv6SafeAddressing`** unit tests cover the helpers and `ServerInfo.url`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d0387b039975985e2bde2a67c6a94cc170313eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->