### PR TITLE
[fix][megatron] Fix the 4 failing tests in the Megatron GPU CI suite

### DIFF
--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -639,8 +639,9 @@ class PolicyConfig(BaseConfig):
     Backend-specific behavior:
     - FSDP: initialize weights in bf16 instead of fp32 (skipping the fp32 master weights
       that mixed-precision training requires) and skip optimizer/LR-scheduler construction.
-    - Megatron: skip optimizer/LR-scheduler construction (DistributedOptimizer eagerly
-      materializes fp32 master + AdamW state on GPU)."""
+    - Megatron: skip the DDP wrap, whose ``_ParamAndGradBuffer`` holds a param and a
+      grad copy of the model, and skip optimizer/LR-scheduler construction
+      (DistributedOptimizer eagerly materializes fp32 master + AdamW state on GPU)."""
 
 
 @dataclass

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_lora_gdn_targets.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_lora_gdn_targets.py
@@ -57,7 +57,13 @@ QWEN35_NAMES = [
 
 
 def _bridge_with_registry(registry: MegatronMappingRegistry):
-    return SimpleNamespace(_model_bridge=SimpleNamespace(mapping_registry=lambda: registry))
+    # `gdn_in_proj_lora_is_safe` installs the bridge's `hf_pretrained` onto the
+    # model bridge before the lookup, for the bridges whose `mapping_registry`
+    # probes the checkpoint. These registries are built directly and never read it.
+    return SimpleNamespace(
+        hf_pretrained=None,
+        _model_bridge=SimpleNamespace(mapping_registry=lambda: registry),
+    )
 
 
 def _fused_in_proj_adapter() -> AdapterWeight:

--- a/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_vlm_init.py
+++ b/tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_vlm_init.py
@@ -185,6 +185,10 @@ async def test_vlm_sft_hf_parity(ray_init_fixture):
     cfg.trainer.policy.megatron_config.expert_model_parallel_size = 1
     cfg.trainer.policy.megatron_config.expert_tensor_parallel_size = None
     cfg.trainer.remove_microbatch_padding = False
+    # fp32 on a single GPU: the DDP param/grad buffers and the optimizer's fp32
+    # master + AdamW state add ~15GB on top of the 8GB model, overflowing a 22GB
+    # L4. This test only forwards, so skip that training state.
+    cfg.trainer.policy.inference_only_init = True
     batch = get_test_training_batch(batch_size=4)
 
     actor_group = init_worker_with_type(


### PR DESCRIPTION
## What

Fixes the 4 tests failing in `gpu_skyrl_train_megatron`. That workflow has been red on
every push to `main` since at least Sept 1; both failures predate the transformers 5.16.1
bump (#2155) and reproduce on `main` before it.

### 1. `test_lora_gdn_targets.py` — 3 assertions that never ran

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'hf_pretrained'
skyrl/backends/skyrl_train/distributed/megatron/megatron_utils.py:216
```

`gdn_in_proj_lora_is_safe` installs the bridge's `hf_pretrained` onto the model bridge
before the mapping lookup, for the bridges whose `mapping_registry` probes the
checkpoint. The fake bridge these tests build carries only `_model_bridge`, so all three
cases raised before reaching their assertion — since #2093, where the read and the
fixture landed together.

Fixed by giving the fake the attribute. These registries are constructed directly and
never read it, so `None` is the honest value.

### 2. `test_vlm_sft_hf_parity` — OOM on CI's 22GB L4

```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 7.93 GiB.
GPU 0 has a total capacity of 22.03 GiB of which 5.62 GiB is free.
  ... in _ParamAndGradBuffer.__init__ -> self.grad_data = torch.zeros(...)
```

The test runs fp32 (deliberately — it needs numerical comparability with the HF forward)
on a single GPU with tp=pp=1, so nothing shards. It still built the DDP param/grad
buffers and the optimizer's fp32 master + AdamW state, which add ~15GB on top of the 8GB
model. It only ever forwards, so it now takes `inference_only_init`, matching what the
other forward-only Megatron tests do (`test_megatron_models.py`, `test_mtp_*.py`).

Measured on one GPU:

| | peak GPU memory |
| --- | --- |
| before | 31,100 MiB (30.4 GiB) — over the L4's 22.03 GiB |
| after | 15,250 MiB (14.9 GiB) |

The parity numbers are identical either way — `max_abs_diff=0.009659`,
`mean_abs_diff=0.002209` — so this drops only training state, nothing the test measures.

### 3. Docstring

`inference_only_init`'s docstring described only the optimizer half of what the Megatron
path skips. It also skips the DDP wrap, which is where most of the memory goes.

## Testing

```
tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_megatron_vlm_init.py
tests/backends/skyrl_train/gpu/gpu_ci/megatron/test_lora_gdn_targets.py
15 passed in 1065.59s (0:17:45)
```

`test_lora_gdn_targets.py` alone goes 3 failed / 3 passed -> 6 passed.

Full `-m megatron` suite on `l4_ci`, the hardware that actually OOMs, same compute config
and entrypoint as the workflow:

```
== 163 passed, 4 skipped, 152 deselected, 263 warnings in 12628.18s (3:30:28) ==
```

vs the `main` baseline through the same harness — 159 passed / 4 failed, with the same 4
skipped and 152 deselected. The four failures converted to passes and nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
