### PR TITLE
[tinker] Route uvicorn's access log to a plain handler instead of Rich

### DIFF
--- a/skyrl/utils/log.py
+++ b/skyrl/utils/log.py
@@ -53,6 +53,15 @@ def get_uvicorn_log_config() -> dict:
                 **RICH_HANDLER_KWARGS,
                 "formatter": "default",
             },
+            # Plain handler for the per-request access log: RichHandler renders
+            # each record through a rich Table (~1.5ms of event-loop CPU per
+            # record), which at thousands of requests per second is the API
+            # server's single largest CPU cost.
+            "access": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+                "stream": "ext://sys.stderr",
+            },
         },
         "loggers": {
             # Main uvicorn logger (general server messages)
@@ -60,7 +69,7 @@ def get_uvicorn_log_config() -> dict:
             # Uvicorn error logger (startup, shutdown, exceptions)
             "uvicorn.error": {"handlers": ["default"], "level": "INFO", "propagate": False},
             # HTTP access logs (request/response logging)
-            "uvicorn.access": {"handlers": ["default"], "level": "INFO", "propagate": False},
+            "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
         },
     }
 


### PR DESCRIPTION
Stack 1/7. Independent of the rest.

RichHandler renders each access-log record through a rich Table, about 1.5 ms of event-loop CPU per HTTP request. Under rollout load that was 63% of the Tinker API server's CPU: profiling a 4096-sample run showed 12.5 s of its 19.9 s of server CPU inside `rich.logging.emit`. With a plain `StreamHandler` for `uvicorn.access` the same run takes 9.7 s and server throughput goes from 337 to 568 samples/s. Startup and error logging keep the Rich handler.

Measured with the load harness in stack 7/7 (`skyrl/benchmarks/load_test_tinker_sampling.py`).


**Stack** (each PR retargets to `main` as the one below merges)
1. #2160
2. #2161
3. #2162
4. #2163
5. #2164
6. #2165
7. #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging configuration only; no request handling, auth, or data path changes—access output format may look slightly plainer on stderr.
> 
> **Overview**
> **HTTP access logging** for the Tinker API (via `get_uvicorn_log_config`) no longer goes through `RichHandler`. A dedicated **`access`** `StreamHandler` on stderr uses the same text formatter, while **`uvicorn`** and **`uvicorn.error`** still use Rich for startup, errors, and tracebacks.
> 
> This targets per-request access log volume: Rich’s table rendering was a major event-loop CPU cost under high QPS. Access lines should read the same format string but without Rich styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254499afc2906b787be2d3caf79c60722f9c0ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->