### PR TITLE
[fix] Enforce trajectory start rate after waiting for concurrency

### DIFF
--- a/skyrl/train/utils/rate_limiter.py
+++ b/skyrl/train/utils/rate_limiter.py
@@ -135,16 +135,20 @@ class AsyncRateLimiter(RateLimiterInterface):
     async def acquire(self) -> None:
         """Acquire permission to proceed, waiting if necessary.
 
-        First applies rate limiting (controls how fast operations start),
-        then acquires concurrency slot (controls how many run simultaneously).
+        Reserves a concurrency slot before applying the rate limit, so queued
+        operations cannot accumulate rate tokens and start in a burst later.
+        The slot is released if waiting for a rate token fails or is cancelled.
         """
-        # Rate limit first (controls start rate)
-        if self._rate is not None:
-            await self._acquire_rate_token()
-
-        # Then concurrency limit (controls concurrent execution)
         if self._max_concurrency is not None:
             await self._semaphore.acquire()
+
+        try:
+            if self._rate is not None:
+                await self._acquire_rate_token()
+        except BaseException:
+            # __aexit__ is not called when acquisition in __aenter__ fails.
+            self.release()
+            raise
 
     def release(self) -> None:
         """Release a concurrency slot.

--- a/tests/train/utils/test_rate_limiter.py
+++ b/tests/train/utils/test_rate_limiter.py
@@ -3,7 +3,9 @@ uv run --isolated --extra dev pytest tests/train/utils/test_rate_limiter.py -v
 """
 
 import asyncio
+import sys
 import time
+from types import SimpleNamespace
 
 import pytest
 from omegaconf import OmegaConf
@@ -268,7 +270,7 @@ class TestAsyncRateLimiterCombined:
         assert max_running <= max_conc
 
     @pytest.mark.asyncio
-    async def test_rate_limit_applies_before_concurrency(self):
+    async def test_rate_limit_applies_with_available_concurrency(self):
         """Rate limiting should control start rate, concurrency limits running."""
         rate = 5.0
         max_conc = 10  # High concurrency, rate should be the bottleneck
@@ -287,6 +289,87 @@ class TestAsyncRateLimiterCombined:
 
         expected_wait = 1.0 / rate
         assert elapsed >= expected_wait * 0.8
+
+    @pytest.mark.asyncio
+    async def test_queued_trials_cannot_bank_rate_tokens(self, monkeypatch):
+        """Time spent waiting for a slot must not turn into a later start burst."""
+        clock = SimpleNamespace(now=0.0)
+        monkeypatch.setattr(
+            sys.modules[AsyncRateLimiter.__module__], "time", SimpleNamespace(monotonic=lambda: clock.now)
+        )
+        limiter = AsyncRateLimiter(rate=1.0, max_concurrency=1)
+        starts = []
+
+        async def trial():
+            async with limiter:
+                starts.append(clock.now)
+
+        await limiter.acquire()
+        tasks = []
+        try:
+            # A long-running trial occupies the only slot while more trials queue.
+            for timestamp in (1.0, 2.0):
+                clock.now = timestamp
+                tasks.append(asyncio.create_task(trial()))
+                await asyncio.sleep(0)
+
+            limiter.release()
+            await tasks[0]
+            await asyncio.sleep(0)
+
+            # The bucket holds one token at t=2. The next trial must wait for refill.
+            assert starts == [2.0]
+            assert not tasks[1].done()
+        finally:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_cancellation_while_rate_limited_releases_concurrency(self, monkeypatch):
+        limiter = AsyncRateLimiter(rate=1.0, max_concurrency=1)
+        waiting_for_rate = asyncio.Event()
+        acquire_rate_token = limiter._acquire_rate_token
+
+        async def wait_for_rate():
+            waiting_for_rate.set()
+            await asyncio.Future()
+
+        async def trial():
+            async with limiter:
+                pytest.fail("The trial should be cancelled before it starts")
+
+        monkeypatch.setattr(limiter, "_acquire_rate_token", wait_for_rate)
+        task = asyncio.create_task(trial())
+        await waiting_for_rate.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        monkeypatch.setattr(limiter, "_acquire_rate_token", acquire_rate_token)
+        await asyncio.wait_for(limiter.acquire(), timeout=1.0)
+        limiter.release()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_while_concurrency_limited_does_not_release_slot(self):
+        limiter = AsyncRateLimiter(rate=3.0, max_concurrency=1)
+        await limiter.acquire()
+        cancelled = asyncio.create_task(limiter.acquire())
+        await asyncio.sleep(0)
+        cancelled.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+
+        waiting = asyncio.create_task(limiter.acquire())
+        try:
+            await asyncio.sleep(0)
+            assert not waiting.done()
+            limiter.release()
+            await asyncio.wait_for(waiting, timeout=1.0)
+            limiter.release()
+        finally:
+            waiting.cancel()
+            await asyncio.gather(waiting, return_exceptions=True)
 
 
 class TestRateLimiterConfig:


### PR DESCRIPTION
When rate and concurrency limits are enabled together, queued trials consume rate tokens before waiting for a concurrency slot. After a long-running trial finishes, they can start in a burst beyond the token bucket's allowed start rate.

For example, with `rate=1` and `max_concurrency=1`, two trials queue at t=1 and t=2 behind an occupied slot. When the slot is released at t=2, both can start at t=2 instead of the second waiting for another token.

Reserve a concurrency slot before acquiring a rate token, and release that slot if the rate-token wait fails or is cancelled. Add a simulated-clock regression for queued start bursts and tests for cancellation at both waiting stages. Rename the existing combined-limit test to match the behavior it checks.

Validation:

- Before the fix: the new burst regression fails; 38 tests pass.
- After the fix: all 39 rate-limiter tests pass.
- Ruff 0.11.9, Black 24.10.0, and `git diff --check` pass for the changed files.
- Gitleaks 8.24.2 passes for the staged changes.

The tests ran on macOS/Python 3.12 using an isolated harness that loads the actual limiter module at its canonical import name and disables parent conftest loading, bypassing unrelated training imports and the Ray fixture. Standard project-environment validation and Harbor end-to-end validation are still pending.
