### PR TITLE
[megatron] pick fla's GDN backend per GPU architecture instead of forcing TileLang

### DIFF
--- a/examples/train/megatron/run_megatron_dapo_qwen3.5_35b_a3b.sh
+++ b/examples/train/megatron/run_megatron_dapo_qwen3.5_35b_a3b.sh
@@ -68,7 +68,8 @@ export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 
 # On Blackwell, use the following env vars:
 # export VLLM_USE_FLASHINFER_MOE_FP16=0   # force triton moe backend since flashinfer trtllm bf16 MoE kernel requires expert intermediate_size to be a multiple of 128
-# export FLA_TILELANG=0   # force triton gdn backend since fla's default TileLang GDN backend aborts in the packed backward. leave unset on hopper, since Triton GDN backward is broken there: https://github.com/fla-org/flash-linear-attention/issues/640#issuecomment-4236520788
+# FLA_TILELANG (fla's GDN backend) is picked per GPU architecture by prepare_runtime_environment:
+# TileLang on Hopper, Triton on Blackwell. Export it only to override that choice.
 
 uv run --isolated --extra megatron -m examples.train.algorithms.dapo.main_dapo \
   data.train_data="['$TRAIN_FILE']" \

--- a/examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora.sh
+++ b/examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora.sh
@@ -72,7 +72,8 @@ export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 
 # On Blackwell, use the following env vars:
 # export VLLM_USE_FLASHINFER_MOE_FP16=0   # force triton moe backend since flashinfer trtllm bf16 MoE kernel requires expert intermediate_size to be a multiple of 128
-# export FLA_TILELANG=0   # force triton gdn backend since fla's default TileLang GDN backend aborts in the packed backward. leave unset on hopper, since Triton GDN backward is broken there: https://github.com/fla-org/flash-linear-attention/issues/640#issuecomment-4236520788
+# FLA_TILELANG (fla's GDN backend) is picked per GPU architecture by prepare_runtime_environment:
+# TileLang on Hopper, Triton on Blackwell. Export it only to override that choice.
 
 uv run --isolated --extra megatron -m examples.train.algorithms.dapo.main_dapo \
   data.train_data="['$TRAIN_FILE']" \

--- a/examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora_int4_qat.sh
+++ b/examples/train/megatron/run_megatron_dapo_qwen3.6_35b_a3b_lora_int4_qat.sh
@@ -94,7 +94,8 @@ export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 
 # On Blackwell, use the following env vars:
 # export VLLM_USE_FLASHINFER_MOE_FP16=0   # force triton moe backend since flashinfer trtllm bf16 MoE kernel requires expert intermediate_size to be a multiple of 128
-# export FLA_TILELANG=0   # force triton gdn backend since fla's default TileLang GDN backend aborts in the packed backward. leave unset on hopper, since Triton GDN backward is broken there: https://github.com/fla-org/flash-linear-attention/issues/640#issuecomment-4236520788
+# FLA_TILELANG (fla's GDN backend) is picked per GPU architecture by prepare_runtime_environment:
+# TileLang on Hopper, Triton on Blackwell. Export it only to override that choice.
 
 uv run --isolated --extra megatron -m examples.train.algorithms.dapo.main_dapo \
   data.train_data="['$TRAIN_FILE']" \

--- a/examples/train/megatron/run_megatron_qwen3.5.sh
+++ b/examples/train/megatron/run_megatron_qwen3.5.sh
@@ -25,7 +25,8 @@ INFERENCE_ENGINE_TP=1
 LANGUAGE_MODEL_ONLY=True  # qwen3-vl in megatron has a separate sequence packing path - if using language_model_only, use the native GPTModel + GDN thd packing path
 
 # On Blackwell, use the following env var:
-# export FLA_TILELANG=0   # force triton gdn backend since fla's default TileLang GDN backend aborts in the packed backward. leave unset on hopper, since Triton GDN backward is broken there: https://github.com/fla-org/flash-linear-attention/issues/640#issuecomment-4236520788
+# FLA_TILELANG (fla's GDN backend) is picked per GPU architecture by prepare_runtime_environment:
+# TileLang on Hopper, Triton on Blackwell. Export it only to override that choice.
 
 
 uv run --isolated --extra megatron -m skyrl.train.entrypoints.main_base \

--- a/examples/train/megatron/run_megatron_qwen3.5_35b_a3b.sh
+++ b/examples/train/megatron/run_megatron_qwen3.5_35b_a3b.sh
@@ -34,7 +34,8 @@ ENGINE_INIT_KWARGS='{"gdn_prefill_backend": "triton"}' # see https://github.com/
 
 # On Blackwell, use the following env vars:
 # export VLLM_USE_FLASHINFER_MOE_FP16=0   # force triton moe backend since flashinfer trtllm bf16 MoE kernel requires expert intermediate_size to be a multiple of 128
-# export FLA_TILELANG=0   # force triton gdn backend since fla's default TileLang GDN backend aborts in the packed backward. leave unset on hopper, since Triton GDN backward is broken there: https://github.com/fla-org/flash-linear-attention/issues/640#issuecomment-4236520788
+# FLA_TILELANG (fla's GDN backend) is picked per GPU architecture by prepare_runtime_environment:
+# TileLang on Hopper, Triton on Blackwell. Export it only to override that choice.
 
 uv run --isolated --extra megatron -m skyrl.train.entrypoints.main_base \
   data.train_data="['$DATA_DIR/train.parquet']" \

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -706,6 +706,21 @@ def get_physical_gpu_id():
     return str(props.uuid)
 
 
+def _default_fla_tilelang() -> str | None:
+    """Pick fla's GatedDeltaNet backend for the visible GPU architecture.
+
+    fla's TileLang kernels are the working GDN backward on Hopper, where its Triton
+    backward is broken (fla-org/flash-linear-attention#640); on Blackwell (SM100+) the
+    TileLang packed backward aborts and the Triton kernels are the working ones. Returns
+    ``"1"`` (TileLang) for pre-Blackwell GPUs, ``"0"`` (Triton) for SM100+, and ``None``
+    when no CUDA device is visible so fla applies its own default in the worker.
+    """
+    if not torch.cuda.is_available():
+        return None
+    major, _minor = torch.cuda.get_device_capability()
+    return "0" if major >= 10 else "1"
+
+
 def prepare_runtime_environment(cfg: SkyRLTrainConfig) -> dict[str, str]:
     """
     Prepare environment variables for Ray runtime environment.
@@ -731,10 +746,9 @@ def prepare_runtime_environment(cfg: SkyRLTrainConfig) -> dict[str, str]:
         # useful when tp > 1 (and thus megatron sequence_parallel is enabled)
         # see: https://github.com/NVIDIA/Megatron-LM/issues/533#issuecomment-1760193239
         env_vars["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
-        # Propagate fla's GDN backend choice to Ray workers. Default 1 keeps fla's
-        # TileLang default (works on Hopper); export FLA_TILELANG=0 on Blackwell (B200),
-        # where the TileLang packed backward aborts, to fall back to the Triton kernels.
-        env_vars["FLA_TILELANG"] = os.environ.get("FLA_TILELANG", "1")
+        fla_tilelang = os.environ.get("FLA_TILELANG") or _default_fla_tilelang()
+        if fla_tilelang is not None:
+            env_vars["FLA_TILELANG"] = fla_tilelang
         if cfg.trainer.flash_attn:
             # disable fused attention for megatron with flash_attn
             # (otherwise flash_attn choice is overridden in TransformerEngine for Hopper+ devices)

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -20,7 +20,12 @@ from skyrl.train.config.config import (
     build_nested_dataclass,
     overrides_dict_to_dotlist,
 )
-from skyrl.train.utils.utils import validate_cfg, validate_inference_engine_cfg
+from skyrl.train.utils import utils as train_utils
+from skyrl.train.utils.utils import (
+    prepare_runtime_environment,
+    validate_cfg,
+    validate_inference_engine_cfg,
+)
 from tests.train.util import example_dummy_config
 
 
@@ -903,3 +908,51 @@ class TestDeltaWeightSyncConfig:
         # `publish_staging_dir` and `local_checkpoint_dir` should be constructed based on `sync_dir`
         assert "my_sync_dir" in cfg.publish_staging_dir
         assert "my_sync_dir" in cfg.local_checkpoint_dir
+
+
+def _megatron_runtime_cfg():
+    cfg = example_dummy_config()
+    cfg.trainer.strategy = "megatron"
+    return cfg
+
+
+def _patch_runtime_probes(monkeypatch, cuda_available: bool, sm_major: int = 9):
+    monkeypatch.setattr(train_utils, "peer_access_supported", lambda **_kwargs: True)
+    monkeypatch.setattr(train_utils.torch.cuda, "is_available", lambda: cuda_available)
+    monkeypatch.setattr(train_utils.torch.cuda, "get_device_capability", lambda *_args: (sm_major, 0))
+
+
+def test_runtime_env_fla_tilelang_explicit_setting_wins(monkeypatch):
+    monkeypatch.setenv("FLA_TILELANG", "0")
+    _patch_runtime_probes(monkeypatch, cuda_available=True, sm_major=9)
+
+    env_vars = prepare_runtime_environment(_megatron_runtime_cfg())
+
+    assert env_vars["FLA_TILELANG"] == "0"
+
+
+def test_runtime_env_fla_tilelang_defaults_to_tilelang_on_hopper(monkeypatch):
+    monkeypatch.delenv("FLA_TILELANG", raising=False)
+    _patch_runtime_probes(monkeypatch, cuda_available=True, sm_major=9)
+
+    env_vars = prepare_runtime_environment(_megatron_runtime_cfg())
+
+    assert env_vars["FLA_TILELANG"] == "1"
+
+
+def test_runtime_env_fla_tilelang_defaults_to_triton_on_blackwell(monkeypatch):
+    monkeypatch.delenv("FLA_TILELANG", raising=False)
+    _patch_runtime_probes(monkeypatch, cuda_available=True, sm_major=10)
+
+    env_vars = prepare_runtime_environment(_megatron_runtime_cfg())
+
+    assert env_vars["FLA_TILELANG"] == "0"
+
+
+def test_runtime_env_fla_tilelang_unset_without_visible_gpu(monkeypatch):
+    monkeypatch.delenv("FLA_TILELANG", raising=False)
+    _patch_runtime_probes(monkeypatch, cuda_available=False)
+
+    env_vars = prepare_runtime_environment(_megatron_runtime_cfg())
+
+    assert "FLA_TILELANG" not in env_vars


### PR DESCRIPTION
## Summary

`prepare_runtime_environment` set `FLA_TILELANG=1` into the Ray worker env whenever the user had not set it, forcing fla's TileLang GatedDeltaNet kernels on every GPU architecture. On Blackwell (B200) the TileLang packed backward aborts, and the failure surfaces one kernel later as

```
RuntimeError: Triton Error [CUDA]: misaligned address
  ... fla/ops/gated_delta_rule/wy_fast.py, prepare_wy_repr_bwd_kernel
```

in the first backward pass of any Qwen3.5 Megatron run (BF16 or FP8). fla 0.5.2's own default is already hardware-aware (TileLang only on Hopper with Triton >= 3.4, where fla's Triton GDN backward is broken, fla-org/flash-linear-attention#640), and the GPU CI test `test_megatron_models.py` already picks `"0" if is_blackwell_or_newer() else "1"`; the runtime env forced the wrong choice for Blackwell.

This PR:

- adds `_default_fla_tilelang()`: `"0"` (Triton) on SM100+, `"1"` (TileLang) on earlier GPUs, `None` when the driver sees no CUDA device (the variable is then left unset so fla applies its own default in the worker);
- keeps an explicit `FLA_TILELANG` from the user's environment as before;
- updates the `# export FLA_TILELANG=0` comments in the Qwen3.5/3.6 Megatron example scripts, which no longer need to be uncommented on B200;
- adds four unit tests in `tests/train/test_config.py` (explicit setting wins, Hopper default, Blackwell default, no visible GPU).

## Validation

- `uv run --extra dev --extra fsdp pytest tests/train/test_config.py` (153 passed).
- Empirically on 8xB200: Qwen3.5-35B-A3B-Base DAPO (`examples/train/fp8/run_fp8_blackwell_mxfp8_qwen35_35b_a3b.sh` and its BF16 variant) crashed in the first backward with the default env and ran 100+ steps each with `FLA_TILELANG=0`; see the run report on `erictang000/SkyRL` branch `fp8-mxfp8-qwen35-35b-a3b-b200-report`.

Related: #1898 (the fp8 example scripts there additionally `export FLA_TILELANG=0` explicitly on Blackwell, which remains valid with this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
