### PR TITLE
fix(sft): exclude first tokens from pretokenized loss windows

### DIFF
--- a/skyrl/train/dataset/pretokenized.py
+++ b/skyrl/train/dataset/pretokenized.py
@@ -18,7 +18,8 @@ Row schema (all rows must be stored unpadded; SkyRL pads at collation time):
 - ``loss_mask`` (list[int], same length as ``input_ids``): 1 for tokens to
   compute loss on, 0 otherwise. Works for instruction-following data (1s on
   the response) and multi-turn conversational data (1s on every assistant
-  turn, 0s in between).
+  turn, 0s in between). The first token is ignored because it has no preceding
+  context from which to predict it.
 - VLM data additionally carries ``pixel_values`` and ``image_grid_thw``
   (Qwen-style image tensors, stored as nested lists).
 
@@ -210,18 +211,18 @@ def _validate_and_plan(dataset: Dataset, max_length: Optional[int]) -> tuple[np.
                     "unpadded (padding is applied at collation time)."
                 )
 
-        # A row is trainable iff a 1 exists in the loss mask before the
-        # (optional) max_length truncation boundary.
+        # A row is trainable iff a 1 exists after the first token and before
+        # the (optional) max_length truncation boundary.
         n = len(ids_len)
         starts = np.zeros(n, dtype=np.int64)
         np.cumsum(mask_len[:-1], out=starts[1:])
         has_loss = np.zeros(n, dtype=bool)
         if flat_mask.size:
+            window = flat_mask.copy()
+            window[starts[mask_len > 0]] = 0
             if max_length is not None:
                 positions = np.arange(flat_mask.size, dtype=np.int64) - np.repeat(starts, mask_len)
-                window = np.where(positions < max_length, flat_mask, 0)
-            else:
-                window = flat_mask
+                window = np.where(positions < max_length, window, 0)
             nonempty = mask_len > 0
             if nonempty.any():
                 # reduceat segments run between consecutive non-empty starts;
@@ -290,7 +291,7 @@ class _NormalizeTransform:
         out = {k: v for k, v in batch.items() if k not in _CONSUMED_KEYS}
         input_ids_out, attention_out, num_actions_out, loss_mask_out = [], [], [], []
         for input_ids, loss_mask in zip(batch["input_ids"], batch["loss_mask"]):
-            first = loss_mask.index(1)
+            first = loss_mask.index(1, 1)
             if max_length is not None and len(input_ids) > max_length:
                 # Text-row truncation, mirroring the online tokenization path:
                 # the prompt prefix is kept and the trailing window shrinks.

--- a/tests/train/dataset/test_pretokenized_causal_mask.py
+++ b/tests/train/dataset/test_pretokenized_causal_mask.py
@@ -1,0 +1,70 @@
+"""Pretokenized loss windows must contain only next-token targets."""
+
+import pytest
+from datasets import Dataset
+
+from skyrl.train.dataset.pretokenized import load_from_pretokenized
+
+
+@pytest.mark.parametrize("file_format", ["parquet", "jsonl", "arrow"])
+@pytest.mark.parametrize(
+    "mask, expected_actions, expected_mask",
+    [
+        ([1, 1, 1], 2, [1, 1]),
+        ([1, 0, 1], 1, [1]),
+        ([0, 1, 1], 2, [1, 1]),
+        ([0, 0, 1], 1, [1]),
+    ],
+)
+def test_loss_window_excludes_first_token(tmp_path, file_format, mask, expected_actions, expected_mask):
+    path = tmp_path / f"data.{file_format}"
+    data = Dataset.from_list([{"input_ids": [10, 20, 30], "loss_mask": mask}])
+    if file_format == "parquet":
+        data.to_parquet(str(path))
+    elif file_format == "jsonl":
+        data.to_json(str(path))
+    else:
+        data.save_to_disk(str(path))
+
+    dataset = load_from_pretokenized(str(path))
+    assert len(dataset) == 1
+    row = dataset[0]
+    assert row["input_ids"] == [10, 20, 30]
+    assert row["attention_mask"] == [1, 1, 1]
+    assert row["num_actions"] == expected_actions
+    assert row["loss_mask"] == expected_mask
+    assert dataset.__getitems__([0]) == [row]
+
+
+@pytest.mark.parametrize("max_length", [None, 2, 3])
+def test_first_token_only_rows_are_dropped(tmp_path, max_length):
+    path = str(tmp_path / "data.parquet")
+    Dataset.from_list(
+        [
+            {"input_ids": [10], "loss_mask": [1]},
+            {"input_ids": [10, 20, 30], "loss_mask": [1, 0, 0]},
+            {"input_ids": [], "loss_mask": []},
+            {"input_ids": [40, 50], "loss_mask": [0, 1]},
+        ]
+    ).to_parquet(path)
+
+    dataset = load_from_pretokenized(path, max_length=max_length)
+    assert len(dataset) == 1
+    assert dataset[0]["input_ids"] == [40, 50]
+    assert dataset[0]["num_actions"] == 1
+    assert dataset[0]["loss_mask"] == [1]
+
+
+@pytest.mark.parametrize("max_length", [1, 2, 3])
+def test_truncated_loss_window_excludes_first_token(tmp_path, max_length):
+    path = str(tmp_path / "data.parquet")
+    Dataset.from_list([{"input_ids": [10, 20, 30], "loss_mask": [1, 1, 1]}]).to_parquet(path)
+
+    if max_length == 1:
+        with pytest.raises(ValueError, match="0 usable examples"):
+            load_from_pretokenized(path, max_length=max_length)
+    else:
+        row = load_from_pretokenized(path, max_length=max_length)[0]
+        assert row["input_ids"] == [10, 20, 30][:max_length]
+        assert row["num_actions"] == max_length - 1
+        assert row["loss_mask"] == [1] * (max_length - 1)


### PR DESCRIPTION
## Problem

A pretokenized row with `input_ids=[1, 2, 3]` and `loss_mask=[1, 1, 1]` is currently normalized to `num_actions=3`. There are only two next-token predictions. The unpacked collator allocates three mask entries while the model wrapper's `[-num_actions-1:-1]` slice yields two log probabilities (verified by inspecting these two call sites; a full GPU training failure was not executed). Rows whose only marked target is the first token also survive filtering, including after truncation.

Ignore the first position when deciding whether a row has usable targets and when deriving its action window. Later targets and the input tokens are preserved. This agrees with the packed collator's existing causal shift.

## Validation

- New tests use real Hugging Face datasets saved as Parquet, JSONL, and Arrow-backed `save_to_disk` stores. They cover all-token and sparse masks, existing response-only masks, batched retrieval, empty/single-token rows, and truncation. On the unmodified source: **12 failed, 6 passed**.
- `uv run --isolated --no-project --python <python3.12> --with-editable . --with-requirements <cpu-requirements.txt> pytest --confcutdir=tests/train/dataset tests/train/dataset/test_pretokenized_causal_mask.py tests/train/dataset/test_dataset.py -k 'not hf_real_dataset' -q`: **25 passed, 1 deselected**. The CPU-only invocation bypasses the parent autouse Ray fixture; the deselected existing test downloads a public HF dataset. No target implementation is mocked in the new tests.
- A tiny actual Transformers GPT-2 model consumed a row from the fixed SkyRL loader: one CPU optimizer step completed, gradients were finite, and the masked next-token loss matched Transformers' native causal LM loss. This is a component smoke check, not a SkyRL GPU training run.
- Configured pre-commit checks on the changed files: Ruff, Black, and Gitleaks all passed.

Tested on macOS ARM64, Python 3.12.14, PyTorch 2.13.0, Transformers 5.16.1, datasets 5.0.1. Core package dependencies were resolved without the repository's Linux-only Transformers override. Full GPU training and the full repository suite were not run.

Checked open PRs and related issues before proposing this fix. Related #1933, #1970, #1990, and #2144 do not change the loader's handling of first-position targets.

AI assistance: OpenAI Codex assisted with investigation, implementation, and test execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SFT pretokenized dataset filtering and `num_actions`/`loss_mask` derivation, which directly affects training targets and batch shapes; behavior is intentionally different for rows that only marked the first token or used all-ones full-sequence masks.
> 
> **Overview**
> Fixes pretokenized SFT rows so **action windows match causal next-token prediction**: the first sequence position is never treated as a loss target, even when `loss_mask` marks it with `1`.
> 
> **Loader validation** now treats a row as trainable only if `loss_mask` has a `1` **after** the first token (within `max_length`), so rows with loss only on the first token are dropped. **Lazy normalization** finds the first `1` starting at index 1 (`loss_mask.index(1, 1)`), which sets `num_actions` and the trailing `loss_mask` slice to the correct count (e.g. three tokens with all-ones mask → two actions, not three). This aligns with the trainer’s existing `log_probs[:, -num_actions-1:-1]` slicing.
> 
> Docs note that the first token is ignored because it has no preceding context. **New tests** cover Parquet/JSONL/Arrow loads, sparse masks, batched `__getitems__`, first-token-only filtering, and truncation (including `max_length=1` yielding no usable examples).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5bd1e795a6754394085e2e706046ec339017e59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->