### PR TITLE
Support final normalization of streamed Megatron gradients

### DIFF
--- a/skyrl/backends/skyrl_train/workers/megatron/gradient_scaling.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/gradient_scaling.py
@@ -1,0 +1,12 @@
+import math
+from typing import Any
+
+
+def scale_gradients(model_chunks: list[Any], scale: float) -> None:
+    """Scale reduced DDP buffers once, before clipping and updating Adam moments."""
+    if not math.isfinite(scale) or scale <= 0:
+        raise ValueError("gradient_scale must be finite and positive")
+    if scale != 1.0:
+        for chunk in model_chunks:
+            for buffer in list(chunk.buffers) + list(chunk.expert_parallel_buffers):
+                buffer.grad_data.mul_(scale)

--- a/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
+++ b/skyrl/backends/skyrl_train/workers/megatron/megatron_worker.py
@@ -79,6 +79,7 @@ from skyrl.backends.skyrl_train.workers.megatron.adapter_store import (
     LoraSignature,
     iter_opts,
 )
+from skyrl.backends.skyrl_train.workers.megatron.gradient_scaling import scale_gradients
 from skyrl.backends.skyrl_train.workers.megatron.megatron_model_wrapper import (
     MegatronModelWrapper,
 )
@@ -1487,7 +1488,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
 
         return WorkerOutput(loss_fn_outputs=all_loss_fn_outputs, metrics=status)
 
-    def optim_step(self) -> Optional[float]:
+    def optim_step(self, gradient_scale: float = 1.0) -> float | None:
         """
         Perform optimizer step.
 
@@ -1511,6 +1512,7 @@ class MegatronPolicyWorkerBase(MegatronWorker, PolicyWorkerBase):
         # is not idempotent -- running it per call corrupts gradients once a window
         # spans more than one call.
         self.model.run_pending_grad_sync()
+        scale_gradients(self.actor_module, gradient_scale)
 
         grad_norm = self.strategy.optimizer_step(self.optimizer, self.model, self.scheduler, name="actor")
 

--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -421,7 +421,7 @@ class WorkerDispatch:
         self._save_memory_snapshot(model, "forward_backward")
         return WorkerOutput.cat(self._actor_groups[model].actor_infos, statuses)
 
-    def optim_step(self, model: str, model_id: Optional[str] = None) -> Optional[float]:
+    def optim_step(self, model: str, model_id: str | None = None, gradient_scale: float = 1.0) -> float | None:
         """Run optimizer step. For single-tenant training, the model should already be on GPU from forward_backward.
 
         For multi-tenant LoRA training, ``model_id`` is used to ensure the correct adapter is used.
@@ -432,7 +432,8 @@ class WorkerDispatch:
         """
         self._ensure_on_gpu(model, need_optimizer=True, need_model=True)
         self.ensure_active_adapter(model, model_id)
-        refs = self._actor_groups[model].async_run_ray_method("pass_through", "optim_step")
+        kwargs = {"gradient_scale": gradient_scale} if gradient_scale != 1.0 else {}
+        refs = self._actor_groups[model].async_run_ray_method("pass_through", "optim_step", **kwargs)
         grad_norms = ray.get(refs)
 
         self._save_memory_snapshot(model, "optim_step")

--- a/skyrl/backends/skyrl_train_backend.py
+++ b/skyrl/backends/skyrl_train_backend.py
@@ -1032,7 +1032,7 @@ class SkyRLTrainBackend(AbstractBackend):
         adam_params = request_data.adam_params
         self._dispatch.set_lr(role, adam_params.learning_rate, model_id=model_id)
 
-        grad_norm = self._dispatch.optim_step(role, model_id=model_id)
+        grad_norm = self._dispatch.optim_step(role, model_id=model_id, gradient_scale=request_data.gradient_scale)
         logger.info(f"optim_step: lr={adam_params.learning_rate}, grad_norm={grad_norm}")
 
         metrics: dict[str, float] = {}

--- a/skyrl/tinker/api.py
+++ b/skyrl/tinker/api.py
@@ -718,6 +718,8 @@ class OptimStepRequest(BaseModel):
     adam_params: AdamParams
     seq_id: int | None = None
 
+    gradient_scale: float = Field(default=1.0, gt=0.0, allow_inf_nan=False)
+
 
 class SaveWeightsForSamplerRequest(BaseModel):
     model_id: str
@@ -897,6 +899,8 @@ class SupportedModel(BaseModel):
 
 class GetServerCapabilitiesResponse(BaseModel):
     supported_models: list[SupportedModel]
+
+    streaming_accumulation_v1: bool = False
 
 
 class ListCheckpointsResponse(BaseModel):
@@ -1205,15 +1209,20 @@ async def forward(request: ForwardRequest, raw_request: Request, session: AsyncS
 
 
 @app.post("/api/v1/optim_step", response_model=FutureResponse)
-async def optim_step(request: OptimStepRequest, session: AsyncSession = Depends(get_session)):
+async def optim_step(request: OptimStepRequest, req: Request, session: AsyncSession = Depends(get_session)):
     """Update model using accumulated gradients."""
     await get_model(session, request.model_id)
+
+    if request.gradient_scale != 1.0 and not supports_streaming_accumulation(req.app.state.engine_config):
+        raise HTTPException(status_code=400, detail="Gradient scaling requires non-colocated Megatron training")
 
     request_id = await create_future(
         session=session,
         request_type=types.RequestType.OPTIM_STEP,
         model_id=request.model_id,
-        request_data=types.OptimStepInput(adam_params=request.adam_params.to_types()),
+        request_data=types.OptimStepInput(
+            adam_params=request.adam_params.to_types(), gradient_scale=request.gradient_scale
+        ),
         seq_id=request.seq_id,
     )
 
@@ -1461,13 +1470,23 @@ async def asample(request: SampleRequest, req: Request, session: AsyncSession = 
     return FutureResponse(future_id=str(request_id), status="pending", request_id=str(request_id))
 
 
+def supports_streaming_accumulation(config: EngineConfig) -> bool:
+    return (
+        config.backend == "megatron"
+        and (config.backend_config or {}).get("trainer.placement.colocate_all", True) is False
+    )
+
+
 @app.get("/api/v1/get_server_capabilities", response_model=GetServerCapabilitiesResponse)
 async def get_server_capabilities(request: Request):
     """Retrieve information about supported models and server capabilities."""
     supported_models = [
         SupportedModel(model_name=request.app.state.engine_config.base_model),
     ]
-    return GetServerCapabilitiesResponse(supported_models=supported_models)
+    return GetServerCapabilitiesResponse(
+        supported_models=supported_models,
+        streaming_accumulation_v1=supports_streaming_accumulation(request.app.state.engine_config),
+    )
 
 
 class RetrieveFutureRequest(BaseModel):

--- a/skyrl/tinker/types.py
+++ b/skyrl/tinker/types.py
@@ -177,6 +177,7 @@ class ErrorResponse(BaseModel):
 
 class OptimStepInput(BaseModel):
     adam_params: AdamParams
+    gradient_scale: float = Field(default=1.0, gt=0.0, allow_inf_nan=False)
 
 
 class OptimStepOutput(BaseModel):

--- a/tests/backends/skyrl_train/workers/megatron/test_gradient_scaling.py
+++ b/tests/backends/skyrl_train/workers/megatron/test_gradient_scaling.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from skyrl.backends.skyrl_train.workers.megatron.gradient_scaling import scale_gradients
+
+
+@pytest.mark.parametrize("scale", [0, -1, float("nan"), float("inf")])
+def test_reject_invalid_gradient_scale(scale):
+    with pytest.raises(ValueError, match="finite and positive"):
+        scale_gradients([], scale)
+
+
+def test_accumulation_matches_full_batch_adam_with_expert_gradients():
+    reference = [torch.nn.Parameter(torch.tensor([0.2, -0.3])) for _ in range(2)]
+    streamed = [torch.nn.Parameter(p.detach().clone()) for p in reference]
+    optimizers = [torch.optim.AdamW(params, lr=0.03) for params in (reference, streamed)]
+    for iteration in range(3):
+        chunks = [torch.tensor([1.0, -2.0]), torch.tensor([3.0, 0.5]), torch.tensor([-0.3, 0.7])]
+        for params, optimizer in zip((reference, streamed), optimizers):
+            optimizer.zero_grad()
+            for x in chunks:
+                loss = sum(((p * x - iteration) ** 2).sum() for p in params)
+                (loss / len(chunks) if params is reference else loss).backward()
+            if params is streamed:
+                scale_gradients(
+                    [
+                        SimpleNamespace(
+                            buffers=[SimpleNamespace(grad_data=params[0].grad)],
+                            expert_parallel_buffers=[SimpleNamespace(grad_data=params[1].grad)],
+                        )
+                    ],
+                    1 / len(chunks),
+                )
+            torch.nn.utils.clip_grad_norm_(params, 0.5)
+            optimizer.step()
+        for expected, actual in zip(reference, streamed):
+            torch.testing.assert_close(actual, expected)
+            for key in ("exp_avg", "exp_avg_sq", "step"):
+                torch.testing.assert_close(optimizers[1].state[actual][key], optimizers[0].state[expected][key])

--- a/tests/tinker/test_streaming_capabilities.py
+++ b/tests/tinker/test_streaming_capabilities.py
@@ -1,0 +1,34 @@
+import pytest
+from pydantic import ValidationError
+
+from skyrl.tinker.api import OptimStepRequest, supports_streaming_accumulation
+from skyrl.tinker.config import EngineConfig
+from skyrl.tinker.types import AdamParams, OptimStepInput
+
+
+@pytest.mark.parametrize("scale", [0, -1, float("nan"), float("inf")])
+def test_invalid_scaling_is_rejected_at_both_serialization_boundaries(scale):
+    with pytest.raises(ValidationError):
+        OptimStepRequest(model_id="test", adam_params={}, gradient_scale=scale)
+    with pytest.raises(ValidationError):
+        OptimStepInput(adam_params=AdamParams(), gradient_scale=scale)
+
+
+@pytest.mark.parametrize(
+    "backend,colocated,supported",
+    [
+        ("megatron", False, True),
+        ("megatron", True, False),
+        ("fsdp", False, False),
+        ("jax", False, False),
+    ],
+)
+def test_only_non_colocated_megatron_advertises_streaming(backend, colocated, supported):
+    config = EngineConfig(
+        base_model="test", backend=backend, backend_config={"trainer.placement.colocate_all": colocated}
+    )
+    assert supports_streaming_accumulation(config) is supported
+
+
+def test_unspecified_placement_does_not_advertise_streaming():
+    assert not supports_streaming_accumulation(EngineConfig(base_model="test", backend="megatron"))


### PR DESCRIPTION
- Allow an optimizer request to scale accumulated gradients after distributed reduction and before clipping or Adam updates. This lets GSPO begin backward computation before the full batch denominator is known.
- Advertise `streaming_accumulation_v1` only for non-colocated Megatron; default requests keep their existing behavior, and unsupported runtimes reject non-default scaling.

Testing: 14 CPU tests passed, including Adam parameters/moments and expert buffers; Ruff 0.11.9 and Black 24.10.0 passed. Qwen3.5-4B GPU qualification passed three updates with an interleaved adapter: gradient norms and outputs matched exactly, as did all 55.1M final main parameter entries and both Adam moment arrays with matched request packing. Different packing changes frozen-model numerics.

The [Trajectory integration](https://github.com/Trajectorylabs/trajectory/pull/4928) completed 20 steps on both configurations: streamed run 1050962 versus reference 1050942 reduced median step time **16.5%** and weight-publication intervals **19.0%**, with **9.8%** higher accepted action-token throughput (initial step excluded). Both had zero stale-group rejections. This is one stochastic pair, not bitwise full-batch parity. The temporary runtime was shut down and checkpoints preserved.
