### PR TITLE
[chore] Restrict speculative decoding to MTP 

### DIFF
--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -1097,6 +1097,18 @@ class DeltaWeightSyncConfig(BaseConfig):
             self.publish_staging_dir = str(_default_publish_staging_dir(self.sync_dir))
 
 
+#: vLLM speculative-decoding methods SkyRL supports, validated in
+#: ``validate_inference_engine_cfg``.
+#:
+#: Only ``mtp``: its drafter weights live in the policy checkpoint, so the weight sync
+#: that reloads the main model also reloads the drafter
+#: (``inference_servers/spec_decode_utils.py``). Every other vLLM method (``eagle``,
+#: ``eagle3``, ``draft_model``, ``medusa``, ...) loads its drafter from a separate
+#: checkpoint whose parameter names the trainer never publishes, so the drafter would
+#: keep drafting with stale weights after the first sync.
+SUPPORTED_SPECULATIVE_DECODING_METHODS = ("mtp",)
+
+
 @dataclass
 class InferenceEngineConfig(BaseConfig):
     """Configuration for inference engine instantiation and management."""
@@ -1197,8 +1209,9 @@ class InferenceEngineConfig(BaseConfig):
     ``trainer.policy.megatron_config.transformer_config_kwargs.rope_parameters`` (Megatron). The two
     must agree, and are validated against each other."""
     speculative_config: Optional[Dict[str, Any]] = None
-    """Speculative-decoding config passed through to vLLM for MTP drafter decoding. 
-    (needs ``policy.megatron_config.mtp_num_layers`` > 0 to train mtp). ``None`` disables it."""
+    """Speculative-decoding config passed through to vLLM for MTP drafter decoding.
+    (needs ``policy.megatron_config.mtp_num_layers`` > 0 to train mtp). ``None`` disables it.
+    ``method`` must be one of :data:`SUPPORTED_SPECULATIVE_DECODING_METHODS`."""
     external_proxy_url: Optional[str] = None
     """Data-plane URL (load-balanced router) for the new inference layer.
     Generation requests are sent here."""

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -1205,8 +1205,7 @@ class InferenceEngineConfig(BaseConfig):
     must agree, and are validated against each other."""
     speculative_config: Optional[Dict[str, Any]] = None
     """Speculative-decoding config passed through to vLLM for MTP drafter decoding.
-    (needs ``policy.megatron_config.mtp_num_layers`` > 0 to train mtp). ``None`` disables it.
-    ``method`` must be one of :data:`SUPPORTED_SPECULATIVE_DECODING_METHODS`."""
+    (needs ``policy.megatron_config.mtp_num_layers`` > 0 to train mtp). ``None`` disables it."""
     external_proxy_url: Optional[str] = None
     """Data-plane URL (load-balanced router) for the new inference layer.
     Generation requests are sent here."""

--- a/skyrl/train/config/config.py
+++ b/skyrl/train/config/config.py
@@ -1100,12 +1100,7 @@ class DeltaWeightSyncConfig(BaseConfig):
 #: vLLM speculative-decoding methods SkyRL supports, validated in
 #: ``validate_inference_engine_cfg``.
 #:
-#: Only ``mtp``: its drafter weights live in the policy checkpoint, so the weight sync
-#: that reloads the main model also reloads the drafter
-#: (``inference_servers/spec_decode_utils.py``). Every other vLLM method (``eagle``,
-#: ``eagle3``, ``draft_model``, ``medusa``, ...) loads its drafter from a separate
-#: checkpoint whose parameter names the trainer never publishes, so the drafter would
-#: keep drafting with stale weights after the first sync.
+#: Only ``mtp`` is supported
 SUPPORTED_SPECULATIVE_DECODING_METHODS = ("mtp",)
 
 

--- a/skyrl/train/utils/utils.py
+++ b/skyrl/train/utils/utils.py
@@ -26,7 +26,11 @@ from skyrl.env_vars import (
     SKYRL_PYTHONPATH_EXPORT,
     SKYRL_RAY_PG_TIMEOUT_IN_S,
 )
-from skyrl.train.config.config import SkyRLTrainConfig
+from skyrl.train.config.config import (
+    SUPPORTED_SPECULATIVE_DECODING_METHODS,
+    SkyRLTrainConfig,
+    get_config_as_dict,
+)
 
 
 class Timer:
@@ -625,6 +629,17 @@ def validate_inference_engine_cfg(cfg: SkyRLTrainConfig):
         assert (
             ie_cfg.weight_sync_backend != "delta"
         ), "Offloading KV cache during weight sync is not supported for delta weight sync"
+
+    # Validate speculative decoding. `method` is required rather than left to vLLM's
+    # inference from the draft model config, so an unsupported drafter cannot reach the
+    # engine implicitly.
+    if ie_cfg.speculative_config is not None:
+        method = get_config_as_dict(ie_cfg.speculative_config).get("method")
+        if method not in SUPPORTED_SPECULATIVE_DECODING_METHODS:
+            raise ValueError(
+                f"invalid `generator.inference_engine.speculative_config.method`: {method!r}. "
+                f"Must be one of {list(SUPPORTED_SPECULATIVE_DECODING_METHODS)}."
+            )
 
     # Validate new inference config options
     _validate_new_inference_cfg(cfg)

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -12,6 +12,7 @@ import pytest
 from omegaconf import OmegaConf
 
 from skyrl.train.config.config import (
+    SUPPORTED_SPECULATIVE_DECODING_METHODS,
     BaseConfig,
     DeltaWeightSyncConfig,
     SkyRLTrainConfig,
@@ -391,6 +392,42 @@ def test_valid_pd_role_init_kwargs_passes():
 
     # Should not raise.
     validate_inference_engine_cfg(cfg)
+
+
+def test_speculative_config_none_passes():
+    cfg = SkyRLTrainConfig()
+    assert cfg.generator.inference_engine.speculative_config is None
+    # Speculative decoding off: nothing to validate.
+    validate_inference_engine_cfg(cfg)
+
+
+def test_speculative_config_mtp_passes():
+    cfg = SkyRLTrainConfig()
+    cfg.generator.inference_engine.speculative_config = {"method": "mtp", "num_speculative_tokens": 1}
+    validate_inference_engine_cfg(cfg)
+
+
+@pytest.mark.parametrize("method", ["eagle", "eagle3", "draft_model", "medusa", "ngram"])
+def test_speculative_config_rejects_unsupported_method(method):
+    """Only MTP keeps its drafter weights in the policy checkpoint, so only MTP survives
+    a weight sync; the rest would draft with stale weights."""
+    cfg = SkyRLTrainConfig()
+    cfg.generator.inference_engine.speculative_config = {"method": method, "num_speculative_tokens": 1}
+    with pytest.raises(ValueError, match="speculative_config.method"):
+        validate_inference_engine_cfg(cfg)
+
+
+def test_speculative_config_requires_an_explicit_method():
+    """vLLM would otherwise infer the method from the draft model config, letting an
+    unsupported drafter through without ever naming itself."""
+    cfg = SkyRLTrainConfig()
+    cfg.generator.inference_engine.speculative_config = {"model": "some/eagle-head", "num_speculative_tokens": 1}
+    with pytest.raises(ValueError, match="speculative_config.method"):
+        validate_inference_engine_cfg(cfg)
+
+
+def test_supported_speculative_decoding_methods_is_mtp_only():
+    assert SUPPORTED_SPECULATIVE_DECODING_METHODS == ("mtp",)
 
 
 def test_offload_kv_for_weight_sync_rejects_colocated():

--- a/tests/train/test_config.py
+++ b/tests/train/test_config.py
@@ -12,7 +12,6 @@ import pytest
 from omegaconf import OmegaConf
 
 from skyrl.train.config.config import (
-    SUPPORTED_SPECULATIVE_DECODING_METHODS,
     BaseConfig,
     DeltaWeightSyncConfig,
     SkyRLTrainConfig,
@@ -424,10 +423,6 @@ def test_speculative_config_requires_an_explicit_method():
     cfg.generator.inference_engine.speculative_config = {"model": "some/eagle-head", "num_speculative_tokens": 1}
     with pytest.raises(ValueError, match="speculative_config.method"):
         validate_inference_engine_cfg(cfg)
-
-
-def test_supported_speculative_decoding_methods_is_mtp_only():
-    assert SUPPORTED_SPECULATIVE_DECODING_METHODS == ("mtp",)
 
 
 def test_offload_kv_for_weight_sync_rejects_colocated():


### PR DESCRIPTION
# What does this PR do?

Restrict speculative decoding to MTP.  For MTP,  drafter weights live in the policy checkpoint, so the weight sync that reloads the main model also reloads the drafter (``inference_servers/spec_decode_utils.py``). Every other vLLM method (``eagle``,``eagle3``, ``draft_model``, ``medusa``, ...) loads its drafter from a separate checkpoint and we have not tested these methods yet. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config validation only; fails fast at startup with a clear error instead of silently running unsupported spec-decode after weight sync.
> 
> **Overview**
> **Restricts** `generator.inference_engine.speculative_config` so only **MTP** (`method: mtp`) is allowed when speculative decoding is enabled.
> 
> Adds `SUPPORTED_SPECULATIVE_DECODING_METHODS` and extends `validate_inference_engine_cfg` to require an explicit `method` and reject anything outside that list (including configs that only set a draft `model`, which vLLM would otherwise infer). Rationale: only MTP drafter weights live in the policy checkpoint and stay in sync on weight reload; other vLLM methods use separate drafters that would go stale after RL weight sync.
> 
> Tests cover `None`, valid MTP, unsupported methods (`eagle`, `medusa`, etc.), and missing `method`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c6b68fa8eea741973795c29a7f2a09ab3d54eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->