### PR TITLE
[fix] Include device index for vLLM compile cache directory names

### DIFF
--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -62,13 +62,12 @@ try:
 except ModuleNotFoundError:
     pass
 
-# vLLM stores its AOT compile artifact under a directory keyed only by rank and
-# DP rank, so every TP=1 engine on a node is `rank_0_0` and they overwrite each
-# other's artifact even when they sit on different GPUs; a reused artifact then
-# dies with "CUDA driver error: invalid argument". Scope that directory to the
-# running device. Installed here for the same reason as the registrations above:
-# this module is loaded in every worker process before model init, and the device
-# is read lazily at compile time, once it is live.
+# vLLM's AOT compile artifact directory carries no device, so engines on
+# different GPUs can overwrite each other's artifact and die with "CUDA driver
+# error: invalid argument". Scope it to the running device. Installed here for
+# the same reason as the registrations above: this module is loaded in every
+# worker process before model init, and the device is read lazily at compile
+# time, once it is live.
 from skyrl.backends.skyrl_train.patches.vllm.patch_compile_cache_device_path import (  # noqa: E402
     apply_compile_cache_device_path_patch,
 )

--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -62,6 +62,19 @@ try:
 except ModuleNotFoundError:
     pass
 
+# vLLM stores its AOT compile artifact under a directory keyed only by rank and
+# DP rank, so every TP=1 engine on a node is `rank_0_0` and they overwrite each
+# other's artifact even when they sit on different GPUs; a reused artifact then
+# dies with "CUDA driver error: invalid argument". Scope that directory to the
+# running device. Installed here for the same reason as the registrations above:
+# this module is loaded in every worker process before model init, and the device
+# is read lazily at compile time, once it is live.
+from skyrl.backends.skyrl_train.patches.vllm.patch_compile_cache_device_path import (  # noqa: E402
+    apply_compile_cache_device_path_patch,
+)
+
+apply_compile_cache_device_path_patch()
+
 VLLM_NEW_INFERENCE_WORKER_EXTENSION_CLS = f"{__name__}.NewInferenceWorkerWrap"
 
 

--- a/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
+++ b/skyrl/backends/skyrl_train/inference_servers/new_inference_worker_wrap.py
@@ -68,6 +68,7 @@ except ModuleNotFoundError:
 # the same reason as the registrations above: this module is loaded in every
 # worker process before model init, and the device is read lazily at compile
 # time, once it is live.
+# TODO (sumanthrh): Remove the patch after https://github.com/vllm-project/vllm/pull/53312 lands.
 from skyrl.backends.skyrl_train.patches.vllm.patch_compile_cache_device_path import (  # noqa: E402
     apply_compile_cache_device_path_patch,
 )

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_compile_cache_device_path.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_compile_cache_device_path.py
@@ -85,12 +85,7 @@ def _install_save_redirect(cls: type) -> None:
     cls.save_aot_compiled_function = save_aot_compiled_function
 
 
-def apply_compile_cache_device_path_patch() -> None:
-    """Redirect both halves of the AOT artifact round trip, once per process.
-
-    vLLM resolves the loader by name at call time, so replacing it covers the
-    load; the loader in turn installs the save redirect on the model's class.
-    """
+def _apply_compile_cache_device_path_patch() -> None:
     global _PATCHED
     if _PATCHED:
         return
@@ -114,3 +109,16 @@ def apply_compile_cache_device_path_patch() -> None:
     decorators._try_load_aot_compiled_fn = try_load_aot_compiled_fn
     _PATCHED = True
     logger.info("Patched vLLM AOT compile cache to use a per-device artifact directory")
+
+
+def apply_compile_cache_device_path_patch() -> None:
+    """Redirect both halves of the AOT artifact round trip, once per process.
+
+    vLLM resolves the loader by name at call time, so replacing it covers the
+    load; the loader in turn installs the save redirect on the model's class.
+    """
+    try:
+        _apply_compile_cache_device_path_patch()
+    except ModuleNotFoundError as e:
+        logger.info(f"Skipping compile cache device path due to exception: {e}")
+        pass

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_compile_cache_device_path.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_compile_cache_device_path.py
@@ -1,0 +1,206 @@
+"""Runtime patch: give vLLM's AOT compile artifact a per-device directory.
+
+Problem
+-------
+vLLM keys its AOT compile artifact on everything *except* the GPU it was built
+for, then stores it under a directory that only distinguishes rank and DP rank
+(``vllm/compilation/decorators.py``)::
+
+    factors = aot_compile_hash_factors(self.vllm_config)     # [env_hash, config_hash]
+    factors.append(_model_hash_key(self.forward))
+    hash_key = hashlib.sha256(str(factors).encode()).hexdigest()
+    cache_dir = os.path.join(envs.VLLM_CACHE_ROOT, "torch_compile_cache",
+                             "torch_aot_compile", hash_key)
+    ...
+    rank = self.vllm_config.parallel_config.rank
+    dp_rank = self.vllm_config.parallel_config.data_parallel_index
+    cache_dir = os.path.join(cache_dir, f"rank_{rank}_{dp_rank}")
+    aot_compilation_path = os.path.join(cache_dir, "model")
+
+Every ``TP=1`` engine on a node is ``rank_0_0``, so *all* of them share the one
+path ``<hash>/rank_0_0/model`` even when they sit on different GPUs. Saves race
+and the last one wins (``os.replace``); every later engine loads it, and any
+engine that is not on the last saver's GPU dies::
+
+    [decorators.py:311] Directly load AOT compilation from path .../rank_0_0/model
+    RuntimeError: CUDA driver error: invalid argument
+        static_triton_launcher._launch_kernel  <-  profile_run -> _dummy_run
+
+Why the *path* and not the key
+------------------------------
+The artifact blob itself is device-agnostic -- measured, it is a plain protocol-4
+pickle with zero ``get_raw_stream`` occurrences. What makes it device-specific is
+that it references Inductor cache entries *by key*, and the generated wrapper
+behind each key does bake the device in (``get_raw_stream(<index>)``). Loading
+the blob on another GPU resolves those keys to the saver's wrappers.
+
+That means the shared, hash-level ``inductor_cache/`` is **not** the problem and
+must stay shared: it is already device-partitioned internally. Measured for one
+TP=2 engine, a single ``inductor_cache/`` held
+
+  * ``triton/0/...`` and ``triton/1/...``   -- Triton keys its own cache by device
+    index already (164 each of ``.ptx`` / ``.cubin`` / ``.ttir`` / ``.ttgir`` /
+    ``.llir`` / ``.source``, 328 ``.json``)
+  * 45 generated ``.py`` wrappers baking ``get_raw_stream(0)`` **and** 45 baking
+    ``get_raw_stream(1)`` -- Inductor's graph hash covers input tensor devices, so
+    the two devices never collide
+  * device-independent leftovers shared by both ranks: ``fxgraph/``,
+    ``aotautograd/``, ``.best_config``, ``.kernel_perf``
+
+So exactly one thing needs a device component: the per-rank artifact directory.
+Suffixing it keeps the hash-level directory -- and all of the above sharing --
+intact, which is both cheaper and tidier than moving the whole tree.
+
+The sharing is sound because the node's GPUs are the same model: Inductor's
+``get_system()`` records the device *name*, not the index or UUID, so two
+different GPU models on one node would collide over ``.best_config`` and the
+``triton/<idx>/`` cubins. That is an upstream torch/vLLM property, unchanged by
+this patch, and it does not arise on SkyRL's homogeneous CI and training nodes.
+
+Why the device *index* and not the UUID
+---------------------------------------
+The index is precisely the quantity that gets baked into the generated code, so
+it is exactly the right equivalence class. Two workers that both run on their own
+device 0 under ``CUDA_VISIBLE_DEVICES`` masking (vLLM's ``mp`` executor) emit
+``get_raw_stream(0)`` and their artifacts *are* interchangeable -- keying on UUID
+would split those needlessly. Two workers on true indices 1 and 2 (vLLM's ``ray``
+executor, which sets ``RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES`` and then
+"CUDA_VISIBLE_DEVICES is never modified" -- ``v1/executor/ray_executor_v2.py``)
+emit different handles and must be split. Indexing gets both cases right.
+
+Scope of the bug
+----------------
+Only the AOT tree is affected. The Dynamo tree (``torch_compile_cache/<10-hex>/``)
+is keyed on ``code_hash``, which covers the traced files' absolute paths; under
+``uv run --isolated`` every process gets a fresh ``~/.cache/uv/builds-v0/.tmpXXXX``
+venv, so that tree never gets a hit at all (measured: a warm re-run minted a new
+top-level directory). And TP>1 within a *single* engine was always safe -- ranks
+differ, so the directories differ (measured: warm TP=2 loaded
+``rank_0_0/model`` and ``rank_1_0/model`` respectively, zero errors).
+
+Reproduced 2026-09-08 on 4x L40S (sm_89, matching the L4 CI box), vLLM 0.28.0,
+torch 2.11.0+cu130, at SkyRL 0b286bac. It needs the *whole*
+``tests/tinker/skyrl_train/`` directory: a single test file starts one engine, so
+nothing is ever reused and the suite passes. Five engines, all ``rank_0_0``, one
+byte-identical AOT key, spread over devices 1, 2, 1, 2, 3::
+
+    12:23:47  dev 2  saved
+    12:33:19  dev 1  saved      <- overwrote it
+    12:36:19  dev 1  loaded  -> ok        (loader == last saver)
+    12:40:46  dev 2  loaded  -> CUDA driver error
+    12:42:00  dev 3  loaded  -> CUDA driver error
+
+Same-device reuse is fine, which is why this presents as a flake: it turns purely
+on whether an engine lands on the last saver's GPU.
+
+Regressed by SkyRL #2167 (599ff343, "Re-enable vllm compile cache"), which stopped
+force-setting ``VLLM_DISABLE_COMPILE_CACHE=1``. vLLM then enables AOT compile by
+default on torch >= 2.10 (``envs.use_aot_compile``), which is what put the AOT tree
+in play. That PR's own experiments did not surface it: exp2 was TP=2 (per-rank
+directories differ) and exp1 was 8 TP=1 engines on 8 GPUs, one engine per GPU.
+
+Upstream vllm#38962 fixed this the same way -- device index in the per-rank cache
+path -- but it was reverted four hours later by vllm#53304 (it broke CPU startup by
+querying ``torch.accelerator``), and the re-land vllm#53312 is still open. No
+released vLLM, nor current main, has a device component here.
+
+TODO: drop once vllm#53312 (or equivalent) ships.
+"""
+
+import os
+from typing import Any
+
+from loguru import logger
+
+_PATCHED = False
+_DEVICE_ATTR = "_skyrl_aot_device_path"
+_WRAPPED_FLAG = "_skyrl_aot_save_wrapped"
+
+
+def _device_tag() -> str | None:
+    """Tag for the device this worker compiles on, or None when there is no GPU."""
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        return f"dev{torch.cuda.current_device()}"
+    except Exception as e:
+        # Never let cache pathing break engine startup; without the tag we only
+        # lose the isolation this patch adds.
+        logger.debug(f"compile-cache device path: could not resolve device ({e})")
+        return None
+
+
+def _device_scoped_path(path: str) -> str:
+    """``.../rank_0_0/model`` -> ``.../rank_0_0_dev1/model`` (unchanged on CPU)."""
+    tag = _device_tag()
+    if tag is None:
+        return path
+    parent, name = os.path.split(path)
+    rank_dir = os.path.basename(parent)
+    if not rank_dir.startswith("rank_"):
+        # Layout moved under us; leave it alone rather than invent a directory.
+        logger.warning(f"compile-cache device path: unexpected AOT layout {path!r}, not scoping")
+        return path
+    if rank_dir.endswith(f"_{tag}"):
+        return path
+    return os.path.join(os.path.dirname(parent), f"{rank_dir}_{tag}", name)
+
+
+def _install_save_redirect(cls: type) -> None:
+    """Point ``save_aot_compiled_function`` at the device-scoped path.
+
+    ``support_torch_compile`` attaches this method per decorated class, so there
+    is no module-level function to patch; we wrap it on first load instead, which
+    is safe because vLLM always attempts the load before it compiles and saves.
+    """
+    # Flag the wrapper rather than the class: a subclass that merely *inherits*
+    # an already-wrapped method resolves to it and is skipped, while a subclass
+    # that `support_torch_compile` gave its own unwrapped method still gets
+    # wrapped. A class-level flag would confuse those two cases.
+    original_save = cls.save_aot_compiled_function
+    if getattr(original_save, _WRAPPED_FLAG, False):
+        return
+
+    def save_aot_compiled_function(self: Any) -> None:
+        scoped = getattr(self, _DEVICE_ATTR, None)
+        if scoped is not None:
+            self._aot_compilation_path = scoped
+            self._aot_cache_dir = os.path.dirname(scoped)
+        return original_save(self)
+
+    setattr(save_aot_compiled_function, _WRAPPED_FLAG, True)
+    cls.save_aot_compiled_function = save_aot_compiled_function
+
+
+def apply_compile_cache_device_path_patch() -> None:
+    """Scope vLLM's AOT compile artifact directory to the running GPU (idempotent).
+
+    Wraps the module-level loader, which vLLM looks up by name at call time, so
+    the redirect covers both halves of the round trip: the load reads the
+    device-scoped directory, and the save is redirected to write it.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    import vllm.compilation.decorators as decorators
+
+    original_try_load = decorators._try_load_aot_compiled_fn
+
+    def try_load_aot_compiled_fn(model: Any, path: str) -> Any:
+        scoped = _device_scoped_path(path)
+        # Stash before loading: on a miss vLLM compiles and then saves, and the
+        # save must land in the same place the load looked.
+        try:
+            setattr(model, _DEVICE_ATTR, scoped)
+            _install_save_redirect(type(model))
+        except Exception as e:
+            logger.debug(f"compile-cache device path: could not install save redirect ({e})")
+            return original_try_load(model, path)
+        return original_try_load(model, scoped)
+
+    decorators._try_load_aot_compiled_fn = try_load_aot_compiled_fn
+    _PATCHED = True
+    logger.info("Patched vLLM AOT compile cache to use a per-device artifact directory")

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_compile_cache_device_path.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_compile_cache_device_path.py
@@ -1,110 +1,24 @@
-"""Runtime patch: give vLLM's AOT compile artifact a per-device directory.
+"""Runtime patch: scope vLLM's AOT compile artifact directory to the running GPU.
 
-Problem
--------
-vLLM keys its AOT compile artifact on everything *except* the GPU it was built
-for, then stores it under a directory that only distinguishes rank and DP rank
-(``vllm/compilation/decorators.py``)::
+vLLM stores the artifact at ``torch_aot_compile/<hash>/rank_{rank}_{dp_rank}/model``
+(``vllm/compilation/decorators.py``). The hash covers env and config factors but
+carries no device, and the directory distinguishes only rank and DP rank, so two
+engines that agree on both -- separate placement groups, or separate runs sharing
+a cache root, each holding bundle index 0 -- resolve to one path while sitting on
+different GPUs. The last save wins, and a load on any other GPU runs Inductor
+wrappers holding the saver's stream handle::
 
-    factors = aot_compile_hash_factors(self.vllm_config)     # [env_hash, config_hash]
-    factors.append(_model_hash_key(self.forward))
-    hash_key = hashlib.sha256(str(factors).encode()).hexdigest()
-    cache_dir = os.path.join(envs.VLLM_CACHE_ROOT, "torch_compile_cache",
-                             "torch_aot_compile", hash_key)
-    ...
-    rank = self.vllm_config.parallel_config.rank
-    dp_rank = self.vllm_config.parallel_config.data_parallel_index
-    cache_dir = os.path.join(cache_dir, f"rank_{rank}_{dp_rank}")
-    aot_compilation_path = os.path.join(cache_dir, "model")
-
-Every ``TP=1`` engine on a node is ``rank_0_0``, so *all* of them share the one
-path ``<hash>/rank_0_0/model`` even when they sit on different GPUs. Saves race
-and the last one wins (``os.replace``); every later engine loads it, and any
-engine that is not on the last saver's GPU dies::
-
-    [decorators.py:311] Directly load AOT compilation from path .../rank_0_0/model
     RuntimeError: CUDA driver error: invalid argument
-        static_triton_launcher._launch_kernel  <-  profile_run -> _dummy_run
+        static_triton_launcher._launch_kernel <- profile_run -> _dummy_run
 
-Why the *path* and not the key
-------------------------------
-The artifact blob itself is device-agnostic -- measured, it is a plain protocol-4
-pickle with zero ``get_raw_stream`` occurrences. What makes it device-specific is
-that it references Inductor cache entries *by key*, and the generated wrapper
-behind each key does bake the device in (``get_raw_stream(<index>)``). Loading
-the blob on another GPU resolves those keys to the saver's wrappers.
+This inserts the device into that directory (``rank_0_0`` -> ``rank_0_0_dev1``).
+The hash-level directory and the ``inductor_cache/`` beneath it stay shared:
+Triton keys its own cache by device index, and Inductor's graph hash covers input
+tensor devices, so that tree is already partitioned by device. Keying on the
+device index rather than the UUID matches what the generated code bakes in, so
+workers masked onto their own device 0 keep sharing one artifact.
 
-That means the shared, hash-level ``inductor_cache/`` is **not** the problem and
-must stay shared: it is already device-partitioned internally. Measured for one
-TP=2 engine, a single ``inductor_cache/`` held
-
-  * ``triton/0/...`` and ``triton/1/...``   -- Triton keys its own cache by device
-    index already (164 each of ``.ptx`` / ``.cubin`` / ``.ttir`` / ``.ttgir`` /
-    ``.llir`` / ``.source``, 328 ``.json``)
-  * 45 generated ``.py`` wrappers baking ``get_raw_stream(0)`` **and** 45 baking
-    ``get_raw_stream(1)`` -- Inductor's graph hash covers input tensor devices, so
-    the two devices never collide
-  * device-independent leftovers shared by both ranks: ``fxgraph/``,
-    ``aotautograd/``, ``.best_config``, ``.kernel_perf``
-
-So exactly one thing needs a device component: the per-rank artifact directory.
-Suffixing it keeps the hash-level directory -- and all of the above sharing --
-intact, which is both cheaper and tidier than moving the whole tree.
-
-The sharing is sound because the node's GPUs are the same model: Inductor's
-``get_system()`` records the device *name*, not the index or UUID, so two
-different GPU models on one node would collide over ``.best_config`` and the
-``triton/<idx>/`` cubins. That is an upstream torch/vLLM property, unchanged by
-this patch, and it does not arise on SkyRL's homogeneous CI and training nodes.
-
-Why the device *index* and not the UUID
----------------------------------------
-The index is precisely the quantity that gets baked into the generated code, so
-it is exactly the right equivalence class. Two workers that both run on their own
-device 0 under ``CUDA_VISIBLE_DEVICES`` masking (vLLM's ``mp`` executor) emit
-``get_raw_stream(0)`` and their artifacts *are* interchangeable -- keying on UUID
-would split those needlessly. Two workers on true indices 1 and 2 (vLLM's ``ray``
-executor, which sets ``RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES`` and then
-"CUDA_VISIBLE_DEVICES is never modified" -- ``v1/executor/ray_executor_v2.py``)
-emit different handles and must be split. Indexing gets both cases right.
-
-Scope of the bug
-----------------
-Only the AOT tree is affected. The Dynamo tree (``torch_compile_cache/<10-hex>/``)
-is keyed on ``code_hash``, which covers the traced files' absolute paths; under
-``uv run --isolated`` every process gets a fresh ``~/.cache/uv/builds-v0/.tmpXXXX``
-venv, so that tree never gets a hit at all (measured: a warm re-run minted a new
-top-level directory). And TP>1 within a *single* engine was always safe -- ranks
-differ, so the directories differ (measured: warm TP=2 loaded
-``rank_0_0/model`` and ``rank_1_0/model`` respectively, zero errors).
-
-Reproduced 2026-09-08 on 4x L40S (sm_89, matching the L4 CI box), vLLM 0.28.0,
-torch 2.11.0+cu130, at SkyRL 0b286bac. It needs the *whole*
-``tests/tinker/skyrl_train/`` directory: a single test file starts one engine, so
-nothing is ever reused and the suite passes. Five engines, all ``rank_0_0``, one
-byte-identical AOT key, spread over devices 1, 2, 1, 2, 3::
-
-    12:23:47  dev 2  saved
-    12:33:19  dev 1  saved      <- overwrote it
-    12:36:19  dev 1  loaded  -> ok        (loader == last saver)
-    12:40:46  dev 2  loaded  -> CUDA driver error
-    12:42:00  dev 3  loaded  -> CUDA driver error
-
-Same-device reuse is fine, which is why this presents as a flake: it turns purely
-on whether an engine lands on the last saver's GPU.
-
-Regressed by SkyRL #2167 (599ff343, "Re-enable vllm compile cache"), which stopped
-force-setting ``VLLM_DISABLE_COMPILE_CACHE=1``. vLLM then enables AOT compile by
-default on torch >= 2.10 (``envs.use_aot_compile``), which is what put the AOT tree
-in play. That PR's own experiments did not surface it: exp2 was TP=2 (per-rank
-directories differ) and exp1 was 8 TP=1 engines on 8 GPUs, one engine per GPU.
-
-Upstream vllm#38962 fixed this the same way -- device index in the per-rank cache
-path -- but it was reverted four hours later by vllm#53304 (it broke CPU startup by
-querying ``torch.accelerator``), and the re-land vllm#53312 is still open. No
-released vLLM, nor current main, has a device component here.
-
-TODO: drop once vllm#53312 (or equivalent) ships.
+Remove once vllm#53312 (device index in the per-rank cache path) ships.
 """
 
 import os
@@ -126,8 +40,7 @@ def _device_tag() -> str | None:
             return None
         return f"dev{torch.cuda.current_device()}"
     except Exception as e:
-        # Never let cache pathing break engine startup; without the tag we only
-        # lose the isolation this patch adds.
+        # A missing tag costs only the isolation, so it must not break startup.
         logger.debug(f"compile-cache device path: could not resolve device ({e})")
         return None
 
@@ -140,7 +53,6 @@ def _device_scoped_path(path: str) -> str:
     parent, name = os.path.split(path)
     rank_dir = os.path.basename(parent)
     if not rank_dir.startswith("rank_"):
-        # Layout moved under us; leave it alone rather than invent a directory.
         logger.warning(f"compile-cache device path: unexpected AOT layout {path!r}, not scoping")
         return path
     if rank_dir.endswith(f"_{tag}"):
@@ -149,16 +61,15 @@ def _device_scoped_path(path: str) -> str:
 
 
 def _install_save_redirect(cls: type) -> None:
-    """Point ``save_aot_compiled_function`` at the device-scoped path.
+    """Point ``cls.save_aot_compiled_function`` at the device-scoped path.
 
     ``support_torch_compile`` attaches this method per decorated class, so there
-    is no module-level function to patch; we wrap it on first load instead, which
-    is safe because vLLM always attempts the load before it compiles and saves.
+    is no module-level function to wrap. Wrapping happens on the first load
+    attempt, which vLLM always makes before it compiles and saves.
     """
-    # Flag the wrapper rather than the class: a subclass that merely *inherits*
-    # an already-wrapped method resolves to it and is skipped, while a subclass
-    # that `support_torch_compile` gave its own unwrapped method still gets
-    # wrapped. A class-level flag would confuse those two cases.
+    # Flagging the wrapper rather than the class distinguishes a subclass that
+    # inherits an already-wrapped method from one that `support_torch_compile`
+    # gave its own unwrapped method.
     original_save = cls.save_aot_compiled_function
     if getattr(original_save, _WRAPPED_FLAG, False):
         return
@@ -175,11 +86,10 @@ def _install_save_redirect(cls: type) -> None:
 
 
 def apply_compile_cache_device_path_patch() -> None:
-    """Scope vLLM's AOT compile artifact directory to the running GPU (idempotent).
+    """Redirect both halves of the AOT artifact round trip, once per process.
 
-    Wraps the module-level loader, which vLLM looks up by name at call time, so
-    the redirect covers both halves of the round trip: the load reads the
-    device-scoped directory, and the save is redirected to write it.
+    vLLM resolves the loader by name at call time, so replacing it covers the
+    load; the loader in turn installs the save redirect on the model's class.
     """
     global _PATCHED
     if _PATCHED:
@@ -191,8 +101,8 @@ def apply_compile_cache_device_path_patch() -> None:
 
     def try_load_aot_compiled_fn(model: Any, path: str) -> Any:
         scoped = _device_scoped_path(path)
-        # Stash before loading: on a miss vLLM compiles and then saves, and the
-        # save must land in the same place the load looked.
+        # Stashed before the load because a miss leads to a compile and a save,
+        # which has to land where the load looked.
         try:
             setattr(model, _DEVICE_ATTR, scoped)
             _install_save_redirect(type(model))

--- a/skyrl/backends/skyrl_train/patches/vllm/patch_compile_cache_device_path.py
+++ b/skyrl/backends/skyrl_train/patches/vllm/patch_compile_cache_device_path.py
@@ -86,6 +86,11 @@ def _install_save_redirect(cls: type) -> None:
 
 
 def _apply_compile_cache_device_path_patch() -> None:
+    """Redirect both halves of the AOT artifact round trip, once per process.
+
+    vLLM resolves the loader by name at call time, so replacing it covers the
+    load; the loader in turn installs the save redirect on the model's class.
+    """
     global _PATCHED
     if _PATCHED:
         return
@@ -116,6 +121,8 @@ def apply_compile_cache_device_path_patch() -> None:
 
     vLLM resolves the loader by name at call time, so replacing it covers the
     load; the loader in turn installs the save redirect on the model's class.
+
+    Additionally, guards against import errors if vLLM is not installed
     """
     try:
         _apply_compile_cache_device_path_patch()


### PR DESCRIPTION
# What does this PR do? 

Fixes the `Tinker-SkyRL-Train-Backend-GPU` failures introduced by #2167 . 

Job link: https://github.com/NovaSky-AI/SkyRL/actions/runs/33979525618/job/101342122872

3 tests failed, all three dying with `RuntimeError: CUDA driver error: invalid argument` inside  `static_triton_launcher._launch_kernel` during vLLM worker initialization.

 <details>
 <summary> Stacktrace </summary> 
 
```bash
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return self._call_impl(*args, **kwargs)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/nn/modules/module.py\", line 1790, in _call_impl\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return forward_call(*args, **kwargs)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/vllm/model_executor/models/qwen3.py\", line 325, in forward\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     hidden_states = self.model(\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]                     ^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/vllm/compilation/decorators.py\", line 573, in __call__\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     output = self.aot_compiled_fn(self, *args, **kwargs)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_dynamo/aot_compile.py\", line 224, in __call__\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return self.fn(*args, **kwargs)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpU1syjr/lib/python3.12/site-packages/vllm/model_executor/models/qwen2.py\", line 397, in forward\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     def forward(\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/vllm/compilation/caching.py\", line 225, in __call__\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return self.optimized_call(*args, **kwargs)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"<string>\", line 15, in execution_fn\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/vllm/compilation/cuda_graph.py\", line 254, in __call__\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return self.runnable(*args, **kwargs)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/vllm/compilation/piecewise_backend.py\", line 380, in __call__\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return range_entry.runnable(*args)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_inductor/standalone_compile.py\", line 122, in __call__\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return self._compiled_fn(*args)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py\", line 1263, in _fn\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return fn(*args, **kwargs)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_functorch/aot_autograd.py\", line 1200, in forward\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return compiled_fn(full_args)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py\", line 2298, in __call__\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return self.compiled_fn(*args, **kwargs)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py\", line 580, in runtime_wrapper\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     all_outs = call_func_at_runtime_with_args(\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/utils.py\", line 138, in call_func_at_runtime_with_args\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     out = normalize_as_list(f(args))\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]                             ^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py\", line 783, in wrapper\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return compiled_fn(runtime_args)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_inductor/output_code.py\", line 656, in __call__\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     return self.current_callable(inputs)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_inductor/utils.py\", line 3401, in run\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     out = model(new_inputs)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]           ^^^^^^^^^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/vllm/torch_compile_cache/torch_aot_compile/4b084d9f5aee598cb0530c65a6ec318bf437dd0f5330d5fa03e7389b1b22de9c/inductor_cache/6u/c6ul7l2u5xq45625jk7rbcejqtyj2rymiylagtvyyenfk5cn4qe5.py\", line 947, in call\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     triton_poi_fused__to_copy_add_embedding_select_slice_0.run(arg2_1, arg4_1, arg0_1, arg3_1, buf0, buf1, s72, 8, stream=stream1)\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_inductor/runtime/triton_heuristics.py\", line 1495, in run\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     result = launcher(\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]              ^^^^^^^^^\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"<string>\", line 5, in launcher\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]   File \"/home/ray/.cache/uv/builds-v0/.tmpaJ0pbf/lib/python3.12/site-packages/torch/_inductor/runtime/static_triton_launcher.py\", line 291, in run\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047]     self.C_impl._launch_kernel(\r"}
{"filename":"worker-2e9a455601cec5e1f04ea744d21f6dc8c57a12615de0c72b980155f9-07000000-20692.out","message":"(Worker pid=20692) ERROR 09-05 10:48:28 [multiproc_executor.py:1047] RuntimeError: CUDA driver error: invalid argument\r"}
```
</details>

## Why it happens

vLLM stores the artifact at `torch_aot_compile/<hash>/rank_{rank}_{dp_rank}/model`. The hash covers env and config factors but no device, and the directory distinguishes only rank and DP rank. With SkyRL, when multiple engines are launched in the same training run, we set the CUDA_VISIBLE_DEVICES with mp and we also set `VLLM_RAY_BUNDLE_INDICES` with ray backend. In both these cases, different engines write and read from different directories. 
However, there are corner cases where different engines can read from the same directories, and the engine can crash. Take the following example:

1. A placement group of 1 GPU is requested and GPU 0 is allocated. Engine A with TP=1 is initialized with it. The cache is empty, so A compiles from scratch.
2. A writes two things: the artifact at `<hash>/rank_0_0/model`, and the kernels it points at, into the shared `inductor_cache/`. Those kernels have `get_raw_stream(0)` baked in. A is torn down.
3. A placement group of 1 GPU is requested and GPU 1 is allocated. Engine B is initialized with the same configuration, so it computes the same hash. Nothing in the hash or the path says which GPU — even `VLLM_RAY_BUNDLE_INDICES` matches, since both engines hold bundle `0` of their own placement group.
4. B finds `<hash>/rank_0_0/model` and loads it. The artifact itself has no device code in it; it just points at A's kernels.
5. B follows those pointers, gets A's device-0 kernels, and dies on the first launch with `CUDA driver error: invalid argument`.

#2167 exposed this by no longer force-setting `VLLM_DISABLE_COMPILE_CACHE=1`; vLLM then enables AOT compile by default on torch >= 2.10.

## Solution

The solution is simple: include the device index in the rank-specific directory path.  When Engine A writes its per rank directories, it will write to `rank_0_0_dev1` instead of `rank_0_0`. 

There is an open vLLM PR with the same fix: https://github.com/vllm-project/vllm/pull/53312 . 

There are other possible solutions :
1.  Changing the vLLM cache directory key itself: I.e change the hash used for `torch_aot_compile_cache/<hash>/rank_0_0/` etc and make it device specific. However, it is best to preserve the current hierarchy of vLLM cache folder (rank specific folders nested in top-level folder) . 
2.  Change`inductor_cache/` and make device specific subfolders: This is not needed because it is already partitioned by device: Triton keys its own cache under `inductor_cache/triton/<device index>/`, and Inductor's graph hash covers input tensor devices, so wrappers for different devices get different keys.

## Validation

4x L40S vLLM 0.28.0 / torch 2.11.0+cu130, running the whole `tests/tinker/skyrl_train/` directory.

| | result | `CUDA driver error` |
|---|---|---|
| cache on, before | 4 failed / 40 passed | 4 |
| cache on, after | 1 failed / 43 passed | 0 |

All three tests that fail in CI pass. The remaining failure is failure in test `test_pending_grads_survive_other_tenant_sample` with  the error`control adapter C did not learn` . This seems flaky. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Monkey-patches vLLM compilation internals on every inference worker at startup, so behavior depends on vLLM’s private APIs and layout staying compatible until the upstream fix ships.
> 
> **Overview**
> Fixes multi-engine GPU CI failures where vLLM workers crash with **`CUDA driver error: invalid argument`** during AOT/torch-compile startup when different processes share the same per-rank compile artifact path but run on different GPUs.
> 
> Adds a **runtime monkey-patch** (`patch_compile_cache_device_path.py`) that rewrites vLLM’s AOT load/save paths from `rank_{rank}_{dp_rank}` to `rank_{rank}_{dp_rank}_dev{index}` using the worker’s current CUDA device, and wraps `save_aot_compiled_function` so compile misses write to the same scoped directory. **`new_inference_worker_wrap.py`** invokes `apply_compile_cache_device_path_patch()` at import time in every vLLM worker (same pattern as other pre-init registrations). The patch is idempotent, no-ops without CUDA, and skips cleanly if vLLM is missing; intended as a temporary workaround until upstream vLLM PR 53312 lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 305efbc75e38a84eb2a796cdafd2c83a0180844b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->