### PR TITLE
fix(tinker): finalize failed saves for unloaded models

### DIFF
--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -645,20 +645,17 @@ class TinkerEngine:
 
         return types.LoadWeightsOutput(type="load_weights")
 
-    def process_save_weights(
-        self, model_id: str, request_data: types.SaveWeightsInput
-    ) -> types.SaveWeightsOutput | types.ErrorResponse:
+    def process_save_weights(self, model_id: str, request_data: types.SaveWeightsInput) -> types.SaveWeightsOutput:
         """
         Saves a clean training checkpoint by converting the trimmed NNX graph
         to a pure dictionary before serialization, following official Flax docs.
         """
-        if not self.backend.has_model(model_id):
-            return _model_not_found_error(model_id)
-
         checkpoint_id = request_data.path
         output_path = self.config.checkpoints_base / model_id / f"{checkpoint_id}.tar.gz"
 
         with self._checkpoint_status_context(model_id, checkpoint_id, types.CheckpointType.TRAINING):
+            if not self.backend.has_model(model_id):
+                raise ValueError(_model_not_found_error(model_id).error)
             self.backend.save_checkpoint(output_path, model_id)
             logger.info(f"Saved trimmed training checkpoint for model {model_id} to {output_path}")
 
@@ -669,11 +666,8 @@ class TinkerEngine:
 
     def process_save_weights_for_sampler(
         self, model_id: str, request_data: types.SaveWeightsForSamplerInput
-    ) -> types.SaveWeightsForSamplerOutput | types.ErrorResponse:
+    ) -> types.SaveWeightsForSamplerOutput:
         """Process a save_weights_for_sampler request and save model weights."""
-        if not self.backend.has_model(model_id):
-            return _model_not_found_error(model_id)
-
         # Make sure the user cannot store checkpoints in places like ../../<important file>
         checkpoint_id = Path(request_data.path).name
         output_path = self.config.checkpoints_base / model_id / "sampler_weights" / f"{checkpoint_id}.tar.gz"
@@ -684,6 +678,8 @@ class TinkerEngine:
         persist = request_data.sampling_session_seq_id is None
 
         with self._checkpoint_status_context(model_id, checkpoint_id, types.CheckpointType.SAMPLER):
+            if not self.backend.has_model(model_id):
+                raise ValueError(_model_not_found_error(model_id).error)
             self.backend.save_sampler_checkpoint(output_path, model_id, persist=persist)
             logger.info(f"Saved sampler checkpoint for model {model_id} to {output_path}")
 

--- a/skyrl/tinker/engine.py
+++ b/skyrl/tinker/engine.py
@@ -30,6 +30,10 @@ from skyrl.utils.log import logger
 _MAX_IDS_PER_QUERY = 500
 
 
+class _ModelNotLoadedError(ValueError):
+    """A stale request targets a model that is no longer loaded."""
+
+
 def _model_not_found_error(model_id: str) -> types.ErrorResponse:
     """Log and return an ErrorResponse for a request targeting a model that isn't loaded."""
     logger.info(
@@ -321,7 +325,8 @@ class TinkerEngine:
             status = CheckpointStatus.COMPLETED
             error_message = None
         except Exception as e:
-            logger.exception(f"Error saving checkpoint for model {model_id}, checkpoint {checkpoint_id}: {e}")
+            if not isinstance(e, _ModelNotLoadedError):
+                logger.exception(f"Error saving checkpoint for model {model_id}, checkpoint {checkpoint_id}: {e}")
             error_message = str(e)
             raise
         finally:
@@ -655,7 +660,7 @@ class TinkerEngine:
 
         with self._checkpoint_status_context(model_id, checkpoint_id, types.CheckpointType.TRAINING):
             if not self.backend.has_model(model_id):
-                raise ValueError(_model_not_found_error(model_id).error)
+                raise _ModelNotLoadedError(_model_not_found_error(model_id).error)
             self.backend.save_checkpoint(output_path, model_id)
             logger.info(f"Saved trimmed training checkpoint for model {model_id} to {output_path}")
 
@@ -679,7 +684,7 @@ class TinkerEngine:
 
         with self._checkpoint_status_context(model_id, checkpoint_id, types.CheckpointType.SAMPLER):
             if not self.backend.has_model(model_id):
-                raise ValueError(_model_not_found_error(model_id).error)
+                raise _ModelNotLoadedError(_model_not_found_error(model_id).error)
             self.backend.save_sampler_checkpoint(output_path, model_id, persist=persist)
             logger.info(f"Saved sampler checkpoint for model {model_id} to {output_path}")
 
@@ -754,7 +759,8 @@ class TinkerEngine:
                 try:
                     result = self.process_single_request(request_type, model_id, request_data)
                 except Exception as e:
-                    logger.exception(f"Error processing request {request_id}: {e}")
+                    if not isinstance(e, _ModelNotLoadedError):
+                        logger.exception(f"Error processing request {request_id}: {e}")
                     result = types.ErrorResponse(error=str(e), status="failed")
             results[request_id] = result
         self._complete_futures(results)

--- a/tests/tinker/test_checkpoint_status.py
+++ b/tests/tinker/test_checkpoint_status.py
@@ -1,0 +1,158 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import Session, SQLModel, create_engine
+
+from skyrl.tinker import api, types
+from skyrl.tinker.db_models import (
+    CheckpointDB,
+    CheckpointStatus,
+    FutureDB,
+    ModelDB,
+    RequestStatus,
+    SessionDB,
+    get_async_database_url,
+)
+from skyrl.tinker.engine import TinkerEngine
+
+
+@pytest.fixture
+def checkpoint_engine(tmp_path):
+    engine = object.__new__(TinkerEngine)
+    engine.config = SimpleNamespace(checkpoints_base=tmp_path / "checkpoints")
+    engine.backend = MagicMock()
+    engine.db_engine = create_engine(f"sqlite:///{tmp_path / 'checkpoints.db'}")
+    SQLModel.metadata.create_all(engine.db_engine)
+    with Session(engine.db_engine) as session:
+        session.add(SessionDB(session_id="session", sdk_version="test"))
+        session.add(
+            ModelDB(
+                model_id="model",
+                base_model="test-model",
+                lora_config={"rank": 8, "alpha": 16},
+                status="ready",
+                request_id=0,
+                session_id="session",
+            )
+        )
+        session.commit()
+    yield engine
+    engine.db_engine.dispose()
+
+
+@pytest.mark.parametrize("outcome", ["success", "backend_error", "unloaded"])
+@pytest.mark.parametrize("mode", ["training", "sampler", "ephemeral_sampler"])
+def test_checkpoint_and_future_reach_matching_terminal_status(checkpoint_engine, mode, outcome):
+    engine = checkpoint_engine
+    training = mode == "training"
+    request_type = types.RequestType.SAVE_WEIGHTS if training else types.RequestType.SAVE_WEIGHTS_FOR_SAMPLER
+    checkpoint_type = types.CheckpointType.TRAINING if training else types.CheckpointType.SAMPLER
+    request_data = {"path": "checkpoint"}
+    if mode == "ephemeral_sampler":
+        request_data.update(sampling_session_seq_id=1, seq_id=1, sampling_session_id="sampling_session")
+    with Session(engine.db_engine) as session:
+        session.add(
+            CheckpointDB(
+                model_id="model",
+                checkpoint_id="checkpoint",
+                checkpoint_type=checkpoint_type,
+                status=CheckpointStatus.PENDING,
+            )
+        )
+        future = FutureDB(model_id="model", request_type=request_type, request_data=request_data)
+        session.add(future)
+        session.commit()
+        request_id = future.request_id
+
+    engine.backend.has_model.return_value = outcome != "unloaded"
+    save = engine.backend.save_checkpoint if training else engine.backend.save_sampler_checkpoint
+    if outcome == "backend_error":
+        save.side_effect = OSError("checkpoint write failed")
+
+    engine.process_single_requests({str(request_id): ("model", request_type, request_data)})
+
+    with Session(engine.db_engine) as session:
+        future = session.get(FutureDB, request_id)
+        checkpoint = session.get(CheckpointDB, ("model", "checkpoint", checkpoint_type))
+        if outcome == "success":
+            assert future.status == RequestStatus.COMPLETED
+            assert checkpoint.status == CheckpointStatus.COMPLETED
+            assert checkpoint.error_message is None
+        else:
+            assert future.status == RequestStatus.FAILED
+            error = types.ErrorResponse.model_validate_json(future.result_data)
+            expected_error = (
+                "Model model not loaded (likely stale request from previous server)"
+                if outcome == "unloaded"
+                else "checkpoint write failed"
+            )
+            assert error.error == expected_error
+            assert checkpoint.status == CheckpointStatus.FAILED
+            assert checkpoint.error_message == expected_error
+        assert future.completed_at is not None
+        assert checkpoint.completed_at is not None
+
+    if outcome == "unloaded":
+        engine.backend.save_checkpoint.assert_not_called()
+        engine.backend.save_sampler_checkpoint.assert_not_called()
+    elif training:
+        save.assert_called_once_with(engine.config.checkpoints_base / "model" / "checkpoint.tar.gz", "model")
+    else:
+        save.assert_called_once_with(
+            engine.config.checkpoints_base / "model" / "sampler_weights" / "checkpoint.tar.gz",
+            "model",
+            persist=mode != "ephemeral_sampler",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["training", "sampler", "ephemeral_sampler"])
+async def test_failed_save_can_be_deleted_and_retried(checkpoint_engine, monkeypatch, mode):
+    engine = checkpoint_engine
+    engine.backend.has_model.return_value = False
+    async_db = create_async_engine(get_async_database_url(str(engine.db_engine.url)))
+    monkeypatch.setattr(api.app.state, "db_engine", async_db, raising=False)
+    monkeypatch.setattr(api.app.state, "engine_config", engine.config, raising=False)
+    monkeypatch.setattr(api.app.state, "sampler_checkpoint_validation_lock", asyncio.Lock(), raising=False)
+    monkeypatch.setattr(api.app.state, "validated_sampler_checkpoints", set(), raising=False)
+
+    training = mode == "training"
+    endpoint = "/api/v1/save_weights" if training else "/api/v1/save_weights_for_sampler"
+    checkpoint_id = "ss1_seq1" if mode == "ephemeral_sampler" else "checkpoint"
+    payload = {"model_id": "model"}
+    if mode == "ephemeral_sampler":
+        payload.update(sampling_session_seq_id=1, seq_id=1)
+    else:
+        payload["path"] = checkpoint_id
+    path_kind = "weights" if training else "sampler_weights"
+    delete_url = f"/api/v1/training_runs/model/checkpoints/{path_kind}/{checkpoint_id}"
+
+    try:
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=api.app), base_url="http://test") as client:
+            saved = await client.post(endpoint, json=payload)
+            assert saved.status_code == 200, saved.text
+            request_id = saved.json()["request_id"]
+            with Session(engine.db_engine) as session:
+                requests = engine.find_single_requests(session)
+            assert request_id in requests
+            engine.process_single_requests(requests)
+            with Session(engine.db_engine) as session:
+                assert session.get(FutureDB, int(request_id)).status == RequestStatus.FAILED
+
+            duplicate = await client.post(endpoint, json=payload)
+            assert duplicate.status_code == 409
+            deleted = await client.delete(delete_url)
+            assert deleted.status_code == 204, deleted.text
+            assert (await client.delete(delete_url)).status_code == 404
+            retry = await client.post(endpoint, json=payload)
+            assert retry.status_code == 200, retry.text
+            assert retry.json()["request_id"] != request_id
+
+        engine.backend.save_checkpoint.assert_not_called()
+        engine.backend.save_sampler_checkpoint.assert_not_called()
+    finally:
+        await async_db.dispose()

--- a/tests/tinker/test_checkpoint_status.py
+++ b/tests/tinker/test_checkpoint_status.py
@@ -1,6 +1,6 @@
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -44,7 +44,7 @@ def checkpoint_engine(tmp_path):
     engine.db_engine.dispose()
 
 
-@pytest.mark.parametrize("outcome", ["success", "backend_error", "unloaded"])
+@pytest.mark.parametrize("outcome", ["success", "backend_error", "backend_value_error", "unloaded"])
 @pytest.mark.parametrize("mode", ["training", "sampler", "ephemeral_sampler"])
 def test_checkpoint_and_future_reach_matching_terminal_status(checkpoint_engine, mode, outcome):
     engine = checkpoint_engine
@@ -72,8 +72,21 @@ def test_checkpoint_and_future_reach_matching_terminal_status(checkpoint_engine,
     save = engine.backend.save_checkpoint if training else engine.backend.save_sampler_checkpoint
     if outcome == "backend_error":
         save.side_effect = OSError("checkpoint write failed")
+    elif outcome == "backend_value_error":
+        save.side_effect = ValueError("checkpoint write failed")
 
-    engine.process_single_requests({str(request_id): ("model", request_type, request_data)})
+    with patch("skyrl.tinker.engine.logger") as captured_log:
+        engine.process_single_requests({str(request_id): ("model", request_type, request_data)})
+
+    if outcome == "unloaded":
+        captured_log.exception.assert_not_called()
+        captured_log.info.assert_called_once()
+        assert "model not loaded" in captured_log.info.call_args.args[0]
+        captured_log.warning.assert_not_called()
+    elif outcome in ("backend_error", "backend_value_error"):
+        assert captured_log.exception.call_count == 2
+    else:
+        captured_log.exception.assert_not_called()
 
     with Session(engine.db_engine) as session:
         future = session.get(FutureDB, request_id)


### PR DESCRIPTION
## Summary

Move the unloaded-model checks into the existing checkpoint-status context for
training and sampler saves. The request's future and checkpoint then both reach
FAILED with the same error instead of leaving the checkpoint PENDING.

When a queued save is dispatched after its model is no longer loaded, the current
early ErrorResponse completes the future as FAILED but bypasses checkpoint
finalization. Deleting that checkpoint returns 425, and reusing its name returns
409. This change allows the failed checkpoint record to be deleted and retried.

The two-file patch retains successful-save behavior and ephemeral sampler
`persist=False` behavior. It does not repair historical orphan records, change
retention policy (#2116), or implement Megatron checkpoint publication (#2145).

## Validation

- Added 12 CPU regression/control cases: success, backend failure and unloaded
  model across training, persistent sampler and ephemeral sampler saves, plus
  actual ASGI/SQLite delete-and-retry paths. Only the backend is mocked in these
  committed tests.
- Same tests on baseline `0b286bac`: 6 failed / 6 passed. Failures are three
  PENDING-vs-FAILED statuses and three delete responses of 425 instead of 204.
- Signed candidate: all 12 pass. An earlier selected CPU suite including these
  tests passed 94 tests (not an additional 94).
- Supplementary, uncommitted real-JAX lifecycle probe: 6 pass, versus 3 failures
  and 3 passing controls on baseline. This deliberately stages unload before
  dispatch; it does not claim that ordinary FIFO requests reorder themselves.
- Supplementary real TCP smoke: the unmodified API launches its JAX engine child;
  Tinker SDK 0.24.0 creates a tiny-Qwen LoRA model and successfully saves a training
  checkpoint. One test passed in 44.90s. This is a successful-save control, not a
  cross-process reproduction of the unload condition.
- Repository Ruff, Black and secret-detection hooks passed on the reviewed patch;
  signed contents match that patch, and `git diff --check` passes.

Local validation used WSL Ubuntu, Python 3.12 and an independent locked CPU
environment (JAX 0.11.0, Flax 0.12.8, CPU Torch 2.11.0, Tinker 0.24.0), not the
full production dependency installation. Supplementary probes and environment
files are not included in this scoped patch. No GPU training, PostgreSQL,
SDK >=0.25 protobuf compatibility, model quality or performance is claimed.

To run the committed regression suite in a configured JAX development environment:

```bash
uv run --isolated --extra dev --extra jax pytest tests/tinker/test_checkpoint_status.py -q
```

## Attribution

AI-assisted investigation, implementation and test automation with Codex. The
contributor reviewed the patch and personally signed commit `8671853`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint save error handling and DB finalization for training/sampler paths; behavior for successful saves is intended to stay the same but failed-async edge cases are security-adjacent to data lifecycle.
> 
> **Overview**
> **Fixes checkpoint rows stuck in `PENDING` when a queued save runs after the model was unloaded.**
> 
> Training and sampler save handlers used to return an `ErrorResponse` before entering `_checkpoint_status_context`, so the request failed but the checkpoint row never moved to `FAILED`—blocking delete (425) and name reuse (409). The unloaded-model check now runs **inside** that context and raises `_ModelNotLoadedError`, so the same failure path updates the DB and the client still gets a failed result via `process_single_requests`.
> 
> Expected stale-request cases skip full `logger.exception` noise for `_ModelNotLoadedError`. Return types for the two save methods no longer include `ErrorResponse` because failures are exceptional. **Regression tests** cover training/sampler unloaded saves and backend `ValueError`, asserting `FAILED` status and successful checkpoint delete over ASGI/SQLite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d022965b3a35707506447ed1a4475d6f4473fcbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->