### PR TITLE
[fix] Make WorkerDispatch GPU residency state explicit

### DIFF
--- a/skyrl/backends/skyrl_train/workers/worker_dispatch.py
+++ b/skyrl/backends/skyrl_train/workers/worker_dispatch.py
@@ -34,10 +34,17 @@ if TYPE_CHECKING:
 
 @dataclass
 class GPUState:
-    """Tracks what's on GPU for a model."""
+    """Tracks what's on GPU for a model.
 
-    model_on_gpu: bool = False
-    optimizer_on_gpu: bool = False
+    Has no defaults: every construction site states both fields. Recording
+    "resident" for an offloaded model skips a needed backload and runs the model
+    from CPU; recording "offloaded" for a resident one costs a redundant backload,
+    which also breaks ``torch.profiler`` because the backload swaps parameters the
+    profiler holds references to.
+    """
+
+    model_on_gpu: bool
+    optimizer_on_gpu: bool
 
 
 class WorkerDispatch:
@@ -74,12 +81,19 @@ class WorkerDispatch:
         if ref_actor_group is not None:
             self._actor_groups["ref"] = ref_actor_group
 
-        # GPU state tracking (only matters when colocated)
-        self._gpu_state: Dict[str, GPUState] = {name: GPUState() for name in self._actor_groups.keys()}
+        # GPU state tracking (only matters when colocated). Every caller builds and
+        # initializes its actor groups on GPU before constructing the dispatch;
+        # colocated callers offload first and then immediately mark_all_offloaded(),
+        # so "resident" is the correct starting assumption here.
+        self._gpu_state: Dict[str, GPUState] = {
+            name: GPUState(model_on_gpu=True, optimizer_on_gpu=True) for name in self._actor_groups.keys()
+        }
 
     def register_actor_group(self, model: str, actor_group: PPORayActorGroup) -> None:
         self._actor_groups[model] = actor_group
-        self._gpu_state[model] = GPUState()
+        # Not initialized yet -- callers register, then call init_model(), which
+        # records the model as resident.
+        self._gpu_state[model] = GPUState(model_on_gpu=False, optimizer_on_gpu=False)
 
     # ------------------------------------------------------------------
     # Multi-LoRA: per-model adapter swap orchestration.
@@ -148,7 +162,7 @@ class WorkerDispatch:
     def _offload_inactive_model(self, model: str) -> None:
         """Offload an inactive colocated model to CPU."""
         self._actor_groups[model].offload_to_cpu()
-        self._gpu_state[model] = GPUState()
+        self._gpu_state[model] = GPUState(model_on_gpu=False, optimizer_on_gpu=False)
 
     def _ensure_on_gpu(self, model: str, need_optimizer: bool = True, need_model: bool = True) -> None:
         """Ensure model is on GPU, offloading others in same colocation group if needed."""
@@ -210,7 +224,7 @@ class WorkerDispatch:
         """Mark a specific model as offloaded without changing others."""
         if model not in self._actor_groups:
             return
-        self._gpu_state[model] = GPUState()
+        self._gpu_state[model] = GPUState(model_on_gpu=False, optimizer_on_gpu=False)
 
     def forward(
         self,

--- a/tests/backends/skyrl_train/distributed/test_worker_dispatch.py
+++ b/tests/backends/skyrl_train/distributed/test_worker_dispatch.py
@@ -235,3 +235,35 @@ def test_weight_sync_honors_optimizer_offload_policy(offload_after_step):
     dispatch._offload.reset_mock()
     dispatch._finish_weight_sync()
     dispatch._offload.assert_called_once_with("policy", offload_optimizer=offload_after_step, offload_model=True)
+
+
+def test_offload_inactive_model_records_offloaded_state():
+    """
+    ``_offload_inactive_model`` performs a real ``offload_to_cpu()``, so it must
+    record the model as not resident. Recording "resident" would make the next
+    ``_ensure_on_gpu`` skip the backload and run the model from CPU.
+    """
+    from skyrl.backends.skyrl_train.workers.worker_dispatch import (
+        GPUState,
+        WorkerDispatch,
+    )
+
+    calls = []
+    group = SimpleNamespace(offload_to_cpu=lambda *a, **k: calls.append("offload"))
+    stub = SimpleNamespace(
+        _actor_groups={"policy": group},
+        _gpu_state={"policy": GPUState(model_on_gpu=True, optimizer_on_gpu=True)},
+    )
+
+    WorkerDispatch._offload_inactive_model(stub, "policy")
+
+    assert calls == ["offload"]
+    assert stub._gpu_state["policy"] == GPUState(model_on_gpu=False, optimizer_on_gpu=False)
+
+
+def test_gpu_state_requires_explicit_intent():
+    """GPUState must not be constructible without stating both fields."""
+    from skyrl.backends.skyrl_train.workers.worker_dispatch import GPUState
+
+    with pytest.raises(TypeError):
+        GPUState()


### PR DESCRIPTION
## Summary

`GPUState` defaulted `model_on_gpu`/`optimizer_on_gpu` to `False`, so `WorkerDispatch.__init__` recorded every model as offloaded — even though all three callers (`RayPPOTrainer`, `SFTTrainer`, `SkyRLTrainBackend`) initialize their actor groups on GPU *before* constructing the dispatch.

On a non-colocated run the policy's state is never corrected: `WorkerDispatch.init_model()` records residency, but the policy is initialized directly on the actor group beforehand (`skyrl_train_backend.py:291`, `trainer.py:~800`) and `init_model` is only called for critic. So the first `_ensure_on_gpu` backloads a model that never left the GPU.

## Why it matters

The redundant backload is close to a no-op for ordinary training, which is why nothing noticed. But it moves parameters with `torch.utils.swap_tensors`, which fails while `torch.profiler` holds references to them:

```
RuntimeError: Expected no weakrefs to t1's Tensor object but got 6
```

That reproduces on a Tinker FSDP server with `colocate_all=false` as soon as profiling is active — `colocate_policy_ref` defaults to `true`, so the policy is still under offload management via `_should_manage_offload`'s second clause.

## Change

`GPUState` now has **no defaults**, so all four construction sites state which state they mean:

| Site | Value | Rationale |
|---|---|---|
| `__init__` | `True, True` | Callers initialize on GPU before constructing the dispatch; colocated ones offload and then immediately `mark_all_offloaded()` |
| `register_actor_group` | `False, False` | Not initialized yet; `init_model()` follows |
| `_offload_inactive_model` | `False, False` | **Also a fix** — it performed a real `offload_to_cpu()` then recorded `GPUState()` |
| `mark_as_offloaded` | `False, False` | Unchanged behaviour, now explicit |

`_offload_inactive_model` is worth calling out: with the old defaults it happened to be correct, but it is the one site where getting this wrong is *unsafe* rather than merely wasteful — it would skip a needed backload and run the model from CPU. Requiring explicit fields makes that class of bug non-silent.

## Testing

- `tests/backends/skyrl_train/distributed/test_worker_dispatch.py` — 11 passed, including two new cases: `_offload_inactive_model` records "not resident", and `GPUState()` raises `TypeError`.
- **Single B200:** `tests/backends/skyrl_train/gpu/gpu_ci/test_worker_dispatch_offload.py` — 4 passed (1 deselected via `-m "not megatron"`). Covers the colocated offload/backload paths that route through `_offload_inactive_model`: `test_colocate_all_only_one_model_on_gpu`, `test_gpu_state_tracking_accuracy`, `test_colocate_policy_critic_training_switch`.

## Notes

Split out of a torch-profiler feature branch; it stands alone and needs no profiler changes. The megatron-marked GPU case was not run (needs the `megatron` extra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaTcV4JRCFJrVCwFf37YM8