### PR TITLE
[ci] Install pytest-asyncio for the Tinker SkyRL-Train GPU tests

### DIFF
--- a/ci/gpu_ci_run_tinker_skyrl_train_backend.sh
+++ b/ci/gpu_ci_run_tinker_skyrl_train_backend.sh
@@ -7,5 +7,5 @@ export CI=true
 # SkyRL-Train Megatron and exercise per-adapter swap, signature gating,
 # v1 single-tenant sample guard, per-adapter Adam step isolation, and
 # delete-then-train continuity.
-uv run --directory . --isolated --extra tinker --extra megatron --with pytest --with pytest-timeout \
+uv run --directory . --isolated --extra tinker --extra megatron --with pytest --with pytest-timeout --with pytest-asyncio \
     pytest -s --timeout=600 tests/tinker/skyrl_train/


### PR DESCRIPTION
## Summary

The Tinker-SkyRL-Train-Backend-GPU workflow has been failing on `tests/tinker/skyrl_train/test_profiling.py` since #2190 landed: five of its tests are `@pytest.mark.asyncio`, but `ci/gpu_ci_run_tinker_skyrl_train_backend.sh` only installed `pytest` and `pytest-timeout`, so they failed with

```
Failed: async def functions are not natively supported.
```

This adds `--with pytest-asyncio` to that script. `pytest-forked` is not needed by anything under `tests/tinker/skyrl_train/`, so it is left out.

Verified locally by running `test_profiling.py` with the same `--with` set: 49 passed.

Not addressed here: `test_multi_lora_megatron_colocated.py::test_pending_grads_survive_other_tenant_sample` has been failing on main since Sep 5 on its control-adapter sanity check (one Adam step at lr=1e-2 raises the loss on tiny-Qwen3); that is a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI dependency-only change; no runtime or application code affected.
> 
> **Overview**
> Fixes **Tinker SkyRL-Train GPU CI** failures after async profiling tests landed: the runner now installs **`pytest-asyncio`** alongside `pytest` and `pytest-timeout` in `ci/gpu_ci_run_tinker_skyrl_train_backend.sh`, so `@pytest.mark.asyncio` cases in `test_profiling.py` no longer error with “async def functions are not natively supported.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48330a12931c2a7902d9662a31871be312bb056e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->