### PR TITLE
Chore/small improvements

### DIFF
--- a/skyrl-agent/skyrl_agent/auto.py
+++ b/skyrl-agent/skyrl_agent/auto.py
@@ -8,6 +8,10 @@ from skyrl_agent.agents import AgentRunner
 
 
 def _import_object(path: str):
+    if "." not in path:
+        raise ValueError(
+            f"Invalid import path '{path}'. Expected a dotted 'module.path.ClassName', e.g. 'skyrl_agent.agents.runner.AgentRunner'."
+        )
     module_path, class_name = path.rsplit(".", 1)
     return getattr(import_module(module_path), class_name)
 

--- a/skyrl-gym/skyrl_gym/core.py
+++ b/skyrl-gym/skyrl_gym/core.py
@@ -57,7 +57,7 @@ class Env(Generic[ObsType, ActType]):
         """
         raise NotImplementedError
 
-    def init(self, *kwargs) -> Tuple[ObsType, Dict[str, Any]]:
+    def init(self, **kwargs) -> Tuple[ObsType, Dict[str, Any]]:
         """
         Initialize the environment, returning initial observation and optional metadata.
 

--- a/skyrl-gym/skyrl_gym/envs/registration.py
+++ b/skyrl-gym/skyrl_gym/envs/registration.py
@@ -164,6 +164,10 @@ def load_env_creator(name: str) -> EnvCreator:
     Returns:
         The environment constructor for the given environment name.
     """
+    if name.count(":") != 1:
+        raise error.Error(
+            f"Malformed entry point '{name}'. Expected the form '(import path):(environment name)', e.g. 'my_pkg.envs:MyEnv'."
+        )
     mod_name, attr_name = name.split(":")
     mod = importlib.import_module(mod_name)
     fn = getattr(mod, attr_name)

--- a/skyrl-gym/skyrl_gym/metrics.py
+++ b/skyrl-gym/skyrl_gym/metrics.py
@@ -8,16 +8,13 @@ def default_aggregate_metrics(metrics: List[Dict[str, Any]]) -> Dict[str, float]
     """
     if not metrics:
         return {}
-    aggregated_metrics: Dict[str, list[float]] = {}
+    aggregated_metrics: Dict[str, List[float]] = {}
     for m in metrics:
         for k, v in m.items():
-            if isinstance(v, bool):
-                v = float(v)
-            elif isinstance(v, (int, float)):
-                v = float(v)
-            else:
+            # bool is a subclass of int, so this also covers boolean flags.
+            if not isinstance(v, (int, float)):
                 continue
-            aggregated_metrics.setdefault(k, []).append(v)
+            aggregated_metrics.setdefault(k, []).append(float(v))
     return {k: sum(vals) / len(vals) for k, vals in aggregated_metrics.items()}
 
 

--- a/skyrl-gym/tests/test_gsm8k.py
+++ b/skyrl-gym/tests/test_gsm8k.py
@@ -6,18 +6,36 @@ from omegaconf import DictConfig
 @pytest.mark.parametrize(
     "output, ground_truth, expected",
     [
+        # Correct answer in the GSM8K-required format.
         ("The answer is #### 42", "42", 1.0),
+
+        # Correct format, but the extracted answer does not match ground truth.
         ("The answer is #### 42", "43", 0.0),
-        # answer is not in the expected format
+
+        # Numerically correct, but missing the required "#### <answer>" format.
         ("The answer is 42", "42", 0.0),
     ],
 )
 def test_compute_score(output, ground_truth, expected):
+    """Verify that GSM8K's rule-based reward checks both format and correctness."""
+
+    # Create a GSM8K environment configured to score the model output
+    # against the supplied ground-truth answer using the rule-based reward.
     env = skyrl_gym.make(
         "gsm8k",
         env_config=DictConfig({"env_class": "gsm8k"}),
-        extras={"reward_spec": {"method": "rule", "ground_truth": ground_truth}},
+        extras={
+            "reward_spec": {
+                "method": "rule",
+                "ground_truth": ground_truth,
+            }
+        },
     )
-    # Skip init() since it's not used in this test
+
+    # env.step() evaluates the model's response and returns the reward.
+    # No separate env.init() call is needed because this test only exercises
+    # the scoring behavior and does not depend on initialized episode state.
     step_output = env.step(output)
+
+    # A valid, correct answer should receive 1.0; all other cases receive 0.0.
     assert step_output["reward"] == expected

--- a/skyrl/env_vars.py
+++ b/skyrl/env_vars.py
@@ -6,6 +6,14 @@ All environment variables used by SkyRL should be defined here for discoverabili
 
 import os
 
+_TRUTHY = ("true", "1", "yes")
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    """Parse a boolean environment variable, treating "true"/"1"/"yes" as True."""
+    return os.environ.get(name, str(default)).strip().lower() in _TRUTHY
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Ray / Placement Group
 # ─────────────────────────────────────────────────────────────────────────────
@@ -67,22 +75,14 @@ Set to 0 to disable throttling (all tasks fire immediately).
 # Runtime Environment Exports
 # ─────────────────────────────────────────────────────────────────────────────
 
-SKYRL_LD_LIBRARY_PATH_EXPORT = str(os.environ.get("SKYRL_LD_LIBRARY_PATH_EXPORT", "False")).lower() in (
-    "true",
-    "1",
-    "yes",
-)
+SKYRL_LD_LIBRARY_PATH_EXPORT = _env_flag("SKYRL_LD_LIBRARY_PATH_EXPORT")
 """
 Whether to export ``LD_LIBRARY_PATH`` environment variable from the driver to the workers with Ray's runtime env.
 
 For example, if you are using RDMA, you may need to customize the ``LD_LIBRARY_PATH`` to include the RDMA libraries (Ex: EFA on AWS).
 """
 
-SKYRL_PYTHONPATH_EXPORT = str(os.environ.get("SKYRL_PYTHONPATH_EXPORT", "False")).lower() in (
-    "true",
-    "1",
-    "yes",
-)
+SKYRL_PYTHONPATH_EXPORT = _env_flag("SKYRL_PYTHONPATH_EXPORT")
 """
 Whether to export ``PYTHONPATH`` environment variable from the driver to the workers with Ray's runtime env.
 
@@ -93,11 +93,7 @@ See https://github.com/ray-project/ray/issues/56697 for details on why this is n
 # Logging
 # ─────────────────────────────────────────────────────────────────────────────
 
-SKYRL_DUMP_INFRA_LOG_TO_STDOUT = str(os.environ.get("SKYRL_DUMP_INFRA_LOG_TO_STDOUT", "False")).lower() in (
-    "true",
-    "1",
-    "yes",
-)
+SKYRL_DUMP_INFRA_LOG_TO_STDOUT = _env_flag("SKYRL_DUMP_INFRA_LOG_TO_STDOUT")
 """
 When enabled, infrastructure logs (vLLM, Ray, workers) are shown on stdout
 instead of being redirected to the log file. Useful for debugging startup issues.

--- a/skyrl/utils/tok.py
+++ b/skyrl/utils/tok.py
@@ -38,7 +38,7 @@ def check_is_vlm(model_config_or_path) -> bool:
         model_config = AutoConfig.from_pretrained(model_config_or_path, trust_remote_code=True)
     else:
         model_config = model_config_or_path
-    return hasattr(model_config, "vision_config") and getattr(model_config, "vision_config") is not None
+    return getattr(model_config, "vision_config", None) is not None
 
 
 def get_processor(model_name_or_path, **tokenizer_kwargs) -> AutoProcessor:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are mostly validation, typing, and DRY refactors; the `Env.init` `**kwargs` change is a minor signature fix with existing subclasses using named parameters.
> 
> **Overview**
> This PR tightens configuration and API ergonomics with clearer validation and small refactors, plus clearer GSM8K test documentation.
> 
> **Validation:** `_import_object` in the agent auto-loader now rejects import paths without a dot with an explicit error. `load_env_creator` rejects malformed registry entry points unless they contain exactly one `:`.
> 
> **API / behavior:** The base `Env.init` signature is updated from `*kwargs` to `**kwargs`. Metric aggregation in `default_aggregate_metrics` is simplified to average any `int`/`float` (including bools) and skip other types. `check_is_vlm` uses a single `getattr(..., None)` check.
> 
> **Refactor:** Boolean SkyRL env vars (`SKYRL_LD_LIBRARY_PATH_EXPORT`, `SKYRL_PYTHONPATH_EXPORT`, `SKYRL_DUMP_INFRA_LOG_TO_STDOUT`) share a new `_env_flag` helper. GSM8K scoring tests gain comments explaining format vs correctness expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3426c472a8cb6262f61230884e73e079c214bb28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->